### PR TITLE
Fix fan control attributes to enums.

### DIFF
--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -82,11 +82,14 @@ class uint56_t(uint_t):  # noqa: N801
 class uint64_t(uint_t):  # noqa: N801
     _size = 8
 
+
 class enum8(uint8_t):  # noqa: N801
     pass
 
+
 class enum16(uint16_t):  # noqa: N801
     pass
+
 
 class Single(float):
     def serialize(self):

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -82,6 +82,11 @@ class uint56_t(uint_t):  # noqa: N801
 class uint64_t(uint_t):  # noqa: N801
     _size = 8
 
+class enum8(uint8_t):  # noqa: N801
+    pass
+
+class enum16(uint16_t):  # noqa: N801
+    pass
 
 class Single(float):
     def serialize(self):

--- a/zigpy/zcl/clusters/hvac.py
+++ b/zigpy/zcl/clusters/hvac.py
@@ -116,8 +116,8 @@ class Fan(Cluster):
     ep_attribute = 'fan'
     attributes = {
         # Fan Control Status
-        0x0000: ('fan_mode', t.uint8_t),  # enum8
-        0x0001: ('fan_mode_sequence', t.uint8_t),  # enum8
+        0x0000: ('fan_mode', t.enum8),  # enum8
+        0x0001: ('fan_mode_sequence', t.enum8),  # enum8
     }
     server_commands = {}
     client_commands = {}

--- a/zigpy/zcl/clusters/hvac.py
+++ b/zigpy/zcl/clusters/hvac.py
@@ -116,8 +116,8 @@ class Fan(Cluster):
     ep_attribute = 'fan'
     attributes = {
         # Fan Control Status
-        0x0000: ('fan_mode', t.enum8),  # enum8
-        0x0001: ('fan_mode_sequence', t.enum8),  # enum8
+        0x0000: ('fan_mode', t.enum8),
+        0x0001: ('fan_mode_sequence', t.enum8),
     }
     server_commands = {}
     client_commands = {}

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -84,8 +84,8 @@ DATA_TYPES = {
     0x2d: ('Signed Integer', t.int48s, Analog),
     0x2e: ('Signed Integer', t.int56s, Analog),
     0x2f: ('Signed Integer', t.int64s, Analog),
-    0x30: ('Enumeration', t.uint8_t, Discrete),
-    0x31: ('Enumeration', t.uint16_t, Discrete),
+    0x30: ('Enumeration', t.enum8, Discrete),
+    0x31: ('Enumeration', t.enum16, Discrete),
     # 0x38: ('Floating point', t.Half, Analog),
     0x39: ('Floating point', t.Single, Analog),
     0x3a: ('Floating point', t.Double, Analog),
@@ -111,7 +111,7 @@ DATA_TYPES = {
 DATA_TYPE_IDX = {
     t: tidx
     for tidx, (tname, t, ad) in DATA_TYPES.items()
-    if ad is Analog
+    if ad is Analog or tname == 'Enumeration'
 }
 DATA_TYPE_IDX[t.uint32_t] = 0x23
 DATA_TYPE_IDX[t.EUI64] = 0xf0


### PR DESCRIPTION
According to ZigBee Cluster Library Specification Revision 6 Draft Version 1.0. The Fan Control cluster (0x0202) has 2 attributes both are enum8.
Currently zigpy treats all enums as unit8_t & unit16_t, which causes the following error when those attributes are written:
`[[<WriteAttributesStatusRecord status=Status.INVALID_DATA_TYPE attrid=0>]]`

This change has been verified to work on the following fan receiver:
https://www.homedepot.com/p/Hampton-Bay-Universal-Wink-Enabled-White-Ceiling-Fan-Premier-Remote-Control-99432/206591100.

This change is based on:
https://github.com/zigpy/bellows/pull/71
