### PR TITLE
Bubble expect_reply parameter up to clusters (was:Stop expecting replies for commands.)

### DIFF
--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -77,8 +77,8 @@ class Device(zigpy.util.LocalLogMixin):
         self.endpoints[endpoint_id] = ep
         return ep
 
-    def request(self, profile, cluster, src_ep, dst_ep, sequence, data, **kwargs):
-        return self._application.request(self.nwk, profile, cluster, src_ep, dst_ep, sequence, data, **kwargs)
+    def request(self, profile, cluster, src_ep, dst_ep, sequence, data, expect_reply=True):
+        return self._application.request(self.nwk, profile, cluster, src_ep, dst_ep, sequence, data, expect_reply=expect_reply)
 
     def handle_message(self, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args):
         try:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -77,8 +77,8 @@ class Device(zigpy.util.LocalLogMixin):
         self.endpoints[endpoint_id] = ep
         return ep
 
-    def request(self, profile, cluster, src_ep, dst_ep, sequence, data):
-        return self._application.request(self.nwk, profile, cluster, src_ep, dst_ep, sequence, data)
+    def request(self, profile, cluster, src_ep, dst_ep, sequence, data, **kwargs):
+        return self._application.request(self.nwk, profile, cluster, src_ep, dst_ep, sequence, data, **kwargs)
 
     def handle_message(self, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args):
         try:

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -123,7 +123,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self._endpoint_id,
             sequence,
             data,
-            **kwargs,
+            **kwargs
         )
 
     def reply(self, cluster, sequence, data):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -115,7 +115,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         handler(is_reply, tsn, command_id, args)
 
-    def request(self, cluster, sequence, data, **kwargs):
+    def request(self, cluster, sequence, data, expect_reply=True):
         return self.device.request(
             self.profile_id,
             cluster,
@@ -123,7 +123,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self._endpoint_id,
             sequence,
             data,
-            **kwargs
+            expect_reply=expect_reply
         )
 
     def reply(self, cluster, sequence, data):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -115,7 +115,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         handler(is_reply, tsn, command_id, args)
 
-    def request(self, cluster, sequence, data):
+    def request(self, cluster, sequence, data, **kwargs):
         return self.device.request(
             self.profile_id,
             cluster,
@@ -123,6 +123,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self._endpoint_id,
             sequence,
             data,
+            **kwargs,
         )
 
     def reply(self, cluster, sequence, data):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -113,7 +113,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         return c
 
     @util.retryable_request
-    def request(self, general, command_id, schema, *args, manufacturer=None, **kwargs):
+    def request(self, general, command_id, schema, *args, manufacturer=None, expect_reply=True):
         if len(schema) != len(args):
             self.error("Schema and args lengths do not match in request")
             error = asyncio.Future()
@@ -133,7 +133,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         data = bytes([frame_control]) + manufacturer + bytes([sequence, command_id])
         data += t.serialize(args, schema)
 
-        return self._endpoint.request(self.cluster_id, sequence, data, **kwargs)
+        return self._endpoint.request(self.cluster_id, sequence, data, expect_reply=expect_reply)
 
     def reply(self, general, command_id, schema, *args, manufacturer=None):
         if len(schema) != len(args):
@@ -295,13 +295,13 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         cfg.reportable_change = reportable_change
         return self.request(True, 0x06, schema, [cfg])
 
-    def command(self, command, *args, manufacturer=None):
+    def command(self, command, *args, manufacturer=None, expect_reply=True):
         schema = self.server_commands[command][1]
         return self.request(False, command, schema, *args, manufacturer=manufacturer, expect_reply=False)
 
     def client_command(self, command, *args):
         schema = self.client_commands[command][1]
-        return self.reply(False, command, schema, *args)
+        return self.reply(False, command, schema, *args, expect_reply=expect_reply)
 
     @property
     def name(self):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -297,7 +297,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
 
     def command(self, command, *args, manufacturer=None, expect_reply=True):
         schema = self.server_commands[command][1]
-        return self.request(False, command, schema, *args, manufacturer=manufacturer, expect_reply=False)
+        return self.request(False, command, schema, *args, manufacturer=manufacturer, expect_reply=expect_reply)
 
     def client_command(self, command, *args):
         schema = self.client_commands[command][1]

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -113,7 +113,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         return c
 
     @util.retryable_request
-    def request(self, general, command_id, schema, *args):
+    def request(self, general, command_id, schema, *args, **kwargs):
         if len(schema) != len(args):
             self.error("Schema and args lengths do not match in request")
             error = asyncio.Future()
@@ -128,7 +128,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         data = bytes([frame_control, sequence, command_id])
         data += t.serialize(args, schema)
 
-        return self._endpoint.request(self.cluster_id, sequence, data)
+        return self._endpoint.request(self.cluster_id, sequence, data, **kwargs)
 
     def reply(self, command_id, schema, *args):
         if len(schema) != len(args):
@@ -285,7 +285,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
 
     def command(self, command, *args):
         schema = self.server_commands[command][1]
-        return self.request(False, command, schema, *args)
+        return self.request(False, command, schema, *args, expect_reply=False)
 
     def client_command(self, command, *args):
         schema = self.client_commands[command][1]

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -301,7 +301,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
 
     def client_command(self, command, *args):
         schema = self.client_commands[command][1]
-        return self.reply(False, command, schema, *args, expect_reply=expect_reply)
+        return self.reply(False, command, schema, *args)
 
     @property
     def name(self):


### PR DESCRIPTION
Allow for commands to disable waiting for replies. This can be used to workaround devices that improperly implement the zigbee zha spec

Original:
According to ZigBee Cluster Library SpecificationRevision 6 Draft Version 1.0, Section 2.5.12.2 "When Generated", zigbee is not required to issue an explicit reply. If the initiating request is expecting a Default Response then any message sent with the same Transaction sequence number can act as a reply. The implementation to track what counts as a stand-in for a Default Response would be nontrivial.

This change fixes the behavior for the most common case of sending commands by setting expect_reply=False for all commands. This will most likely break other use cases where a command requires a response (ie. the Get Alarm request). In the longer term, the detection of the Default Response stand-in needs to be implemented or the commands in cluster definitions need to be annotated to specify if they require a reply.

This fix allows zigpy to control https://www.homedepot.com/p/Hampton-Bay-Universal-Wink-Enabled-White-Ceiling-Fan-Premier-Remote-Control-99432/206591100.

This fixes https://github.com/zigpy/bellows/issues/92