### PR TITLE
Fix zll profile in zha cluster2

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -121,6 +121,7 @@ def test_request(ep):
     ep.request(7, 8, b'')
     assert ep._device.request.call_count == 1
 
+
 def test_request_change_profileid(ep):
     ep.profile_id = 49246
     ep.request(7, 9, b'')

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -119,13 +119,16 @@ def test_cluster_attr(ep):
 def test_request(ep):
     ep.profile_id = 260
     ep.request(7, 8, b'')
+    assert ep._device.request.call_count == 1
+
+def test_request_change_profileid(ep):
     ep.profile_id = 49246
     ep.request(7, 9, b'')
     ep.profile_id = 49246
     ep.request(0x1000, 10, b'')
     ep.profile_id = 260
     ep.request(0x1000, 11, b'')
-    assert ep._device.request.call_count == 4
+    assert ep._device.request.call_count == 3
 
 
 def test_reply(ep):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -119,7 +119,13 @@ def test_cluster_attr(ep):
 def test_request(ep):
     ep.profile_id = 260
     ep.request(7, 8, b'')
-    assert ep._device.request.call_count == 1
+    ep.profile_id = 49246
+    ep.request(7, 9, b'')
+    ep.profile_id = 49246
+    ep.request(0x1000, 10, b'')
+    ep.profile_id = 260
+    ep.request(0x1000, 11, b'')
+    assert ep._device.request.call_count == 4
 
 
 def test_reply(ep):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -116,8 +116,14 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         handler(is_reply, tsn, command_id, args)
 
     def request(self, cluster, sequence, data, expect_reply=True):
+        if (self.profile_id == zigpy.profiles.zll.PROFILE_ID 
+            and cluster != zigpy.zcl.clusters.lightlink.LightLink.cluster_id):
+            profile_id = zigpy.profiles.zha.PROFILE_ID
+        else:
+            profile_id = self.profile_id
+            
         return self.device.request(
-            self.profile_id,
+            profile_id,
             cluster,
             self._endpoint_id,
             self._endpoint_id,

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -116,12 +116,12 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         handler(is_reply, tsn, command_id, args)
 
     def request(self, cluster, sequence, data, expect_reply=True):
-        if (self.profile_id == zigpy.profiles.zll.PROFILE_ID 
-            and cluster != zigpy.zcl.clusters.lightlink.LightLink.cluster_id):
+        if (self.profile_id == zigpy.profiles.zll.PROFILE_ID and
+                cluster != zigpy.zcl.clusters.lightlink.LightLink.cluster_id):
             profile_id = zigpy.profiles.zha.PROFILE_ID
         else:
             profile_id = self.profile_id
-            
+
         return self.device.request(
             profile_id,
             cluster,


### PR DESCRIPTION
packets to zll devices should use the  zha profile id in frames if the cluster is not 0x1000 
See https://www.silabs.com/documents/public/user-guides/UG103.9.pdf section 3.1

This fixes issue #17 and also other bulbs with same behavior. 
Second try with  a new  branch