### PR TITLE
Allow attribute to be (optionally) passed as name string in configure_reporting to avoid having to manually look up index->attribute mapping

### DIFF
--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -286,6 +286,8 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         schema = foundation.COMMANDS[0x06][1]
         cfg = foundation.AttributeReportingConfig()
         cfg.direction = 0
+        if isinstance(attribute,str):
+            attribute = self._attridx[attribute]
         cfg.attrid = attribute
         cfg.datatype = foundation.DATA_TYPE_IDX.get(
             self.attributes.get(attribute, (None, None))[1],

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -474,7 +474,7 @@ class BinaryInput(Cluster):
         0x002e: ('inactive_text', t.LVBytes),
         0x0051: ('out_of_service', t.Bool),
         0x0054: ('polarity', t.enum8),
-        0x0055: ('present_value', t.Single),
+        0x0055: ('present_value', t.Bool),
         0x0067: ('reliability', t.enum8),
         0x006f: ('status_flags', t.uint8_t),  # bitmap8
         0x0100: ('application_type', t.uint32_t),
@@ -494,10 +494,10 @@ class BinaryOutput(Cluster):
         0x0043: ('minimum_on_time', t.uint32_t),
         0x0051: ('out_of_service', t.Bool),
         0x0054: ('polarity', t.enum8),
-        0x0055: ('present_value', t.Single),
+        0x0055: ('present_value', t.Bool),
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean, single precision)
         0x0067: ('reliability', t.enum8),
-        0x0068: ('relinquish_default', t.Single),
+        0x0068: ('relinquish_default', t.Bool),
         0x006f: ('status_flags', t.uint8_t),  # bitmap8
         0x0100: ('application_type', t.uint32_t),
     }


### PR DESCRIPTION
Resubmitted with fixed test for configure_reporting