### PR TITLE
Add device_initialized to application

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -39,6 +39,10 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         self.devices[ieee] = dev
         return dev
 
+    def device_initialized(self, device):
+        """Used by a device to signal that it is initialized"""
+        self.listener_event('device_initialized', device)
+
     async def remove(self, ieee):
         assert isinstance(ieee, t.EUI64)
         dev = self.devices.pop(ieee, None)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -69,7 +69,7 @@ class Device(zigpy.util.LocalLogMixin):
 
         self.status = Status.ENDPOINTS_INIT
         self.initializing = False
-        self._application.listener_event('device_initialized', self)
+        self._application.device_initialized(self)
 
     def add_endpoint(self, endpoint_id):
         ep = zigpy.endpoint.Endpoint(self, endpoint_id)


### PR DESCRIPTION
This provides a better interface for device to signal to the application that it is initialized, and allows the application to perform any operations which may be useful, other than beginning persistence.