### PR TITLE
Deserialize using device/endpoint/cluster object tree

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -131,12 +131,13 @@ def test_nwk(app):
     assert app.nwk == app._nwk
 
 
+def test_deserialize(app, ieee):
+    dev = mock.MagicMock()
+    app.deserialize(dev, 1, 1, b'')
+    assert dev.deserialize.call_count == 1
+
+
 def test_handle_message(app, ieee):
-    dev = app.devices[ieee] = mock.MagicMock()
-    dev.nwk = 8
-    app.handle_message(False, 8, 260, 1, 1, 1, 1, 1, [])
+    dev = mock.MagicMock()
+    app.handle_message(dev, False, 260, 1, 1, 1, 1, 1, [])
     assert dev.handle_message.call_count == 1
-
-
-def test_handle_message_unknown(app, ieee):
-    app.handle_message(False, 8, 260, 1, 1, 1, 1, 1, [])

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -68,11 +68,18 @@ def test_radio_details(dev):
     assert dev.rssi == 2
 
 
-def test_handle_request_no_endpoint(dev):
+def test_deserialize(dev):
+    ep = dev.add_endpoint(3)
+    ep.deserialize = mock.MagicMock()
+    dev.deserialize(3, 1, b'')
+    assert ep.deserialize.call_count == 1
+
+
+def test_handle_message_no_endpoint(dev):
     dev.handle_message(False, 99, 98, 97, 97, 1, 0, [])
 
 
-def test_handle_request(dev):
+def test_handle_message(dev):
     ep = dev.add_endpoint(3)
     ep.handle_message = mock.MagicMock()
     dev.handle_message(False, 99, 98, 3, 3, 1, 0, [])

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2,48 +2,57 @@ from unittest import mock
 
 import pytest
 
+import zigpy.endpoint
 import zigpy.types as t
 import zigpy.zcl as zcl
 
 
-def test_deserialize_general():
-    tsn, command_id, is_reply, args = zcl.deserialize(0, b'\x00\x01\x00')
+@pytest.fixture
+def endpoint():
+    ep = zigpy.endpoint.Endpoint(mock.MagicMock(), 1)
+    ep.add_input_cluster(0)
+    ep.add_input_cluster(3)
+    return ep
+
+
+def test_deserialize_general(endpoint):
+    tsn, command_id, is_reply, args = endpoint.deserialize(0, b'\x00\x01\x00')
     assert tsn == 1
     assert command_id == 0
     assert is_reply is False
 
 
-def test_deserialize_general_unknown():
-    tsn, command_id, is_reply, args = zcl.deserialize(0, b'\x00\x01\xff')
+def test_deserialize_general_unknown(endpoint):
+    tsn, command_id, is_reply, args = endpoint.deserialize(0, b'\x00\x01\xff')
     assert tsn == 1
     assert command_id == 255
     assert is_reply is False
 
 
-def test_deserialize_cluster():
-    tsn, command_id, is_reply, args = zcl.deserialize(0, b'\x01\x01\x00xxx')
+def test_deserialize_cluster(endpoint):
+    tsn, command_id, is_reply, args = endpoint.deserialize(0, b'\x01\x01\x00xxx')
     assert tsn == 1
     assert command_id == 256
     assert is_reply is False
 
 
-def test_deserialize_cluster_client():
-    tsn, command_id, is_reply, args = zcl.deserialize(3, b'\x09\x01\x00AB')
+def test_deserialize_cluster_client(endpoint):
+    tsn, command_id, is_reply, args = endpoint.deserialize(3, b'\x09\x01\x00AB')
     assert tsn == 1
     assert command_id == 256
     assert is_reply is True
     assert args == [0x4241]
 
 
-def test_deserialize_cluster_unknown():
-    tsn, command_id, is_reply, args = zcl.deserialize(0xff00, b'\x05\x00\x00\x01\x00')
+def test_deserialize_cluster_unknown(endpoint):
+    tsn, command_id, is_reply, args = endpoint.deserialize(0xff00, b'\x05\x00\x00\x01\x00')
     assert tsn == 1
     assert command_id == 256
     assert is_reply is False
 
 
-def test_deserialize_cluster_command_unknown():
-    tsn, command_id, is_reply, args = zcl.deserialize(0, b'\x01\x01\xff')
+def test_deserialize_cluster_command_unknown(endpoint):
+    tsn, command_id, is_reply, args = endpoint.deserialize(0, b'\x01\x01\xff')
     assert tsn == 1
     assert command_id == 255 + 256
     assert is_reply is False

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -19,19 +19,6 @@ def test_commands():
             assert hasattr(paramtype, 'deserialize')
 
 
-def test_deserialize():
-    tsn, command_id, is_reply, args = zdo.deserialize(2, b'\x01\x02\x03xx')
-    assert tsn == 1
-    assert is_reply is False
-    assert args == [0x0302]
-
-
-def test_deserialize_unknown():
-    tsn, command_id, is_reply, args = zdo.deserialize(0x0100, b'\x01')
-    assert tsn == 1
-    assert is_reply is False
-
-
 @pytest.fixture
 def zdo_f():
     app = mock.MagicMock()
@@ -41,6 +28,19 @@ def zdo_f():
     ieee = t.EUI64(map(t.uint8_t, [0, 1, 2, 3, 4, 5, 6, 7]))
     dev = zigpy.device.Device(app, ieee, 65535)
     return zdo.ZDO(dev)
+
+
+def test_deserialize(zdo_f):
+    tsn, command_id, is_reply, args = zdo_f.deserialize(2, b'\x01\x02\x03xx')
+    assert tsn == 1
+    assert is_reply is False
+    assert args == [0x0302]
+
+
+def test_deserialize_unknown(zdo_f):
+    tsn, command_id, is_reply, args = zdo_f.deserialize(0x0100, b'\x01')
+    assert tsn == 1
+    assert is_reply is False
 
 
 @pytest.mark.asyncio

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -65,14 +65,11 @@ class ControllerApplication(zigpy.util.ListenableMixin):
     async def force_remove(self, dev):
         raise NotImplementedError
 
-    def handle_message(self, is_reply, sender, profile, cluster, src_ep, dst_ep, tsn, command_id, args):
-        try:
-            device = self.get_device(nwk=sender)
-        except KeyError:
-            LOGGER.warning("Message on unknown device 0x%04x", sender)
-            return
+    def deserialize(self, sender, endpoint_id, cluster_id, data):
+        return sender.deserialize(endpoint_id, cluster_id, data)
 
-        return device.handle_message(is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args)
+    def handle_message(self, sender, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args):
+        return sender.handle_message(is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args)
 
     def handle_join(self, nwk, ieee, parent_nwk):
         LOGGER.info("Device 0x%04x (%s) joined the network", nwk, ieee)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -93,6 +93,9 @@ class Device(zigpy.util.LocalLogMixin):
         self.last_seen = time.time()
         return result
 
+    def deserialize(self, endpoint_id, cluster_id, data):
+        return self.endpoints[endpoint_id].deserialize(cluster_id, data)
+
     def handle_message(self, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args):
         self.last_seen = time.time()
         try:


### PR DESCRIPTION
To allow custom devices with custom deserialization strategies, we can't rely on a global registry.