### PR TITLE
Add bitmap type for 'occupancy' attribute of OccupancySensing  cluster.

### DIFF
--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -89,6 +89,38 @@ class enum16(uint16_t):  # noqa: N801
     pass
 
 
+class bitmap8(uint8_t):  # noqa: N801
+    pass
+
+
+class bitmap16(uint16_t):  # noqa: N801
+    pass
+
+
+class bitmap24(uint24_t):  # noqa: N801
+    pass
+
+
+class bitmap32(uint32_t):  # noqa: N801
+    pass
+
+
+class bitmap40(uint40_t):  # noqa: N801
+    pass
+
+
+class bitmap48(uint48_t):  # noqa: N801
+    pass
+
+
+class bitmap56(uint56_t):  # noqa: N801
+    pass
+
+
+class bitmap64(uint64_t):  # noqa: N801
+    pass
+
+
 class Single(float):
     def serialize(self):
         return struct.pack('<f', self)

--- a/zigpy/zcl/clusters/measurement.py
+++ b/zigpy/zcl/clusters/measurement.py
@@ -103,7 +103,7 @@ class OccupancySensing(Cluster):
     ep_attribute = 'occupancy'
     attributes = {
         # Occupancy Sensor Information
-        0x0000: ('occupancy', t.uint8_t),  # bitmap8
+        0x0000: ('occupancy', t.bitmap8),
         0x0001: ('occupancy_sensor_type', t.enum8),
         # PIR Configuration
         0x0010: ('pir_o_to_u_delay', t.uint16_t),

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -84,14 +84,14 @@ DATA_TYPES = {
     0x0e: ('General', t.fixed_list(7, t.uint8_t), Discrete),
     0x0f: ('General', t.fixed_list(8, t.uint8_t), Discrete),
     0x10: ('Boolean', t.Bool, Discrete),
-    0x18: ('Bitmap', t.uint8_t, Discrete),
-    0x19: ('Bitmap', t.uint16_t, Discrete),
-    0x1a: ('Bitmap', t.uint24_t, Discrete),
-    0x1b: ('Bitmap', t.uint32_t, Discrete),
-    0x1c: ('Bitmap', t.uint40_t, Discrete),
-    0x1d: ('Bitmap', t.uint48_t, Discrete),
-    0x1e: ('Bitmap', t.uint56_t, Discrete),
-    0x1f: ('Bitmap', t.uint64_t, Discrete),
+    0x18: ('Bitmap', t.bitmap8, Discrete),
+    0x19: ('Bitmap', t.bitmap16, Discrete),
+    0x1a: ('Bitmap', t.bitmap24, Discrete),
+    0x1b: ('Bitmap', t.bitmap32, Discrete),
+    0x1c: ('Bitmap', t.bitmap40, Discrete),
+    0x1d: ('Bitmap', t.bitmap48, Discrete),
+    0x1e: ('Bitmap', t.bitmap56, Discrete),
+    0x1f: ('Bitmap', t.bitmap64, Discrete),
     0x20: ('Unsigned Integer', t.uint8_t, Analog),
     0x21: ('Unsigned Integer', t.uint16_t, Analog),
     0x22: ('Unsigned Integer', t.uint24_t, Analog),
@@ -135,7 +135,7 @@ DATA_TYPES = {
 DATA_TYPE_IDX = {
     t: tidx
     for tidx, (tname, t, ad) in DATA_TYPES.items()
-    if ad is Analog or tname == 'Enumeration'
+    if ad is Analog or tname == 'Enumeration' or tname == 'Bitmap'
 }
 DATA_TYPE_IDX[t.uint32_t] = 0x23
 DATA_TYPE_IDX[t.EUI64] = 0xf0


### PR DESCRIPTION
According to ZigBee Cluster Library Specification Revision 6 Draft Version 1.0 the OccupancySensing cluster (0x0406) has attribute 'occupancy' of bitmap8 type. Currently zigpy treats this attribute as uint8 and when I try to configure reporting I get status 141 -- Invalid data type:
```
2018-05-22 20:49:08 DEBUG (MainThread) [homeassistant.components.binary_sensor.zha] Configured reporting for attr_id 0 on 00:0d:6f:00:0e:38:22:dc-1030: 300/900/1: [[<ConfigureReportingResponseRecord status=141 direction=0 attrid=0>]]
```
if using bitmap8 data type (id 0x18) then report configuration succeeds:
```
2018-05-22 21:17:10 DEBUG (MainThread) [homeassistant.components.binary_sensor.zha] Configured reporting for attr_id 0 on 00:0d:6f:00:0e:38:22:dc-1030: 300/900/1: [[<ConfigureReportingResponseRecord status=0 direction=0 attrid=0>]]
```

The change was verified to work with Centralite Motion Sensor. 


