### PR TITLE
add manufacturer and model to endpoint

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -49,6 +49,8 @@ async def test_database(tmpdir):
     ep.device_type = profiles.zll.DeviceType.COLOR_LIGHT
     app.device_initialized(dev)
     clus._update_attribute(0, 99)
+    clus._update_attribute(4, bytes('Custom', 'ascii'))
+    clus._update_attribute(5, bytes('Model', 'ascii'))
     clus.listener_event('cluster_command', 0)
     clus.listener_event('zdo_command')
 
@@ -69,6 +71,10 @@ async def test_database(tmpdir):
     assert dev.endpoints[1].device_type == profiles.zha.DeviceType.PUMP
     assert dev.endpoints[2].device_type == 0xfffd
     assert dev.endpoints[2].in_clusters[0]._attr_cache[0] == 99
+    assert dev.endpoints[2].in_clusters[0]._attr_cache[4] == bytes('Custom', 'ascii')
+    assert dev.endpoints[2].in_clusters[0]._attr_cache[5] == bytes('Model', 'ascii')
+    assert dev.endpoints[2].manufacturer == 'Custom'
+    assert dev.endpoints[2].model == 'Model'
     assert dev.endpoints[2].out_clusters[1].cluster_id == 1
     assert dev.endpoints[3].device_type == profiles.zll.DeviceType.COLOR_LIGHT
     dev = app2.get_device(custom_ieee)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -216,6 +216,11 @@ class PersistingListener:
                 if cluster in ep.in_clusters:
                     clus = ep.in_clusters[cluster]
                     clus._attr_cache[attrid] = value
+                    LOGGER.debug("Attribute id: %s value: %s", attrid, value)
+                    if cluster == 0 and attrid == 4:
+                        ep.manufacturer = value.decode('ascii').strip()
+                    if cluster == 0 and attrid == 5:
+                        ep.model = value.decode('ascii').strip()
 
 
 class ClusterPersistingListener:

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -6,6 +6,7 @@ import zigpy.endpoint
 import zigpy.profiles
 import zigpy.quirks
 import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic
 
 
 LOGGER = logging.getLogger(__name__)
@@ -217,9 +218,9 @@ class PersistingListener:
                     clus = ep.in_clusters[cluster]
                     clus._attr_cache[attrid] = value
                     LOGGER.debug("Attribute id: %s value: %s", attrid, value)
-                    if cluster == 0 and attrid == 4:
+                    if cluster == Basic.cluster_id and attrid == 4:
                         ep.manufacturer = value.decode('ascii').strip()
-                    if cluster == 0 and attrid == 5:
+                    if cluster == Basic.cluster_id and attrid == 5:
                         ep.model = value.decode('ascii').strip()
 
 

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -5,6 +5,7 @@ import zigpy.appdb
 import zigpy.profiles
 import zigpy.util
 import zigpy.zcl
+from zigpy.zcl.clusters.general import Basic
 
 LOGGER = logging.getLogger(__name__)
 
@@ -66,7 +67,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         for cluster in sd.output_clusters:
             self.add_output_cluster(cluster)
 
-        if 0 in self.in_clusters:
+        if Basic.cluster_id in self.in_clusters:
             await self.initialize_endpoint_info()
 
         self.status = Status.ZDO_INIT


### PR DESCRIPTION
This adds manufacturer and model to the endpoint object. The values are initially read on device join while the device should be in a responsive state. They are restored from the attribute cache on restarts. This allows HA to avoid "asking" for them when devices are added because they are already set before the device is given to HA.