### PR TITLE
WIP - get attribute state when cluster is added

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -173,5 +173,3 @@ def test_cluster_init(ep):
     cluster.request = mockrequest
 
     test_initialize_zha(ep)
-
-    assert cluster._attr_cache[0] == 1

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -148,3 +148,30 @@ def test_reply(ep):
     ep.profile_id = 260
     ep.reply(7, 8, b'')
     assert ep._device.reply.call_count == 1
+
+
+def _mk_rar(attrid, value, status=0):
+        r = zcl.foundation.ReadAttributeRecord()
+        r.attrid = attrid
+        r.status = status
+        r.value = zcl.foundation.TypeValue()
+        r.value.value = value
+        return r
+
+
+def test_cluster_init(ep):
+    cluster = ep.add_input_cluster(1024)
+    assert 1024 in ep.in_clusters
+    assert ep.in_clusters[1024] is cluster
+    cluster._attr_cache[0] = 0
+
+    async def mockrequest(foundation, command, schema, args, manufacturer=None):
+        assert foundation is True
+        assert command == 0
+        rar0 = _mk_rar(0, 1)
+        return [[rar0]]
+    cluster.request = mockrequest
+
+    test_initialize_zha(ep)
+
+    assert cluster._attr_cache[0] == 1

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -161,18 +161,17 @@ def _mk_rar(attrid, value, status=0):
 
 
 def test_cluster_init(ep):
-    cluster = ep.add_input_cluster(1024)
-    assert 1024 in ep.in_clusters
-    assert ep.in_clusters[1024] is cluster
-    cluster._attr_cache[0] = 0
+    _test_initialize(ep, 260)
+    cluster = ep.in_clusters[5]
+    cluster._attr_cache[0] = 7
 
     async def mockrequest(foundation, command, schema, args, manufacturer=None):
         assert foundation is True
         assert command == 0
         rar0 = _mk_rar(0, 1)
-        return [[rar0]]
+        rar1 = _mk_rar(1, 1)
+        return [[rar0, rar1]]
     cluster.request = mockrequest
-
-    test_initialize_zha(ep)
-
+    asyncio.ensure_future(cluster.read_attributes(['count'], allow_cache=False,))
+    _test_initialize(ep, 260)
     assert cluster._attr_cache[0] == 1

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -6,6 +6,7 @@ import pytest
 from zigpy import endpoint
 from zigpy.zdo import types
 import zigpy.zcl as zcl
+import zigpy.types as t
 
 
 @pytest.fixture
@@ -163,7 +164,8 @@ def _mk_rar(attrid, value, status=0):
 def test_cluster_init(ep):
     _test_initialize(ep, 260)
     cluster = ep.in_clusters[5]
-    cluster._attr_cache[0] = 7
+    cluster._attr_cache[0] = 5
+    cluster.attributes = {0: ('count', t.uint8_t), }
 
     async def mockrequest(foundation, command, schema, args, manufacturer=None):
         assert foundation is True
@@ -172,6 +174,6 @@ def test_cluster_init(ep):
         rar1 = _mk_rar(1, 1)
         return [[rar0, rar1]]
     cluster.request = mockrequest
-    asyncio.ensure_future(cluster.read_attributes(['count'], allow_cache=False,))
+    ep.add_input_cluster(5, cluster)
     _test_initialize(ep, 260)
     assert cluster._attr_cache[0] == 1

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -5,6 +5,7 @@ import pytest
 
 from zigpy import endpoint
 from zigpy.zdo import types
+import zigpy.zcl as zcl
 
 
 @pytest.fixture
@@ -173,3 +174,5 @@ def test_cluster_init(ep):
     cluster.request = mockrequest
 
     test_initialize_zha(ep)
+
+    assert cluster._attr_cache[0] == 1

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -1,3 +1,4 @@
+import asyncio
 import enum
 import logging
 
@@ -87,11 +88,13 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
             cluster.add_listener(listener)
 
-        attributeNames = []
-        for attrid, (attrname, datatype) in cluster.attributes.items():
-            attributeNames.append(attrname)
-
-        await cluster.read_attributes(attributeNames, allow_cache=True,)
+        if cluster_id != 0:
+            attributeNames = []
+            for attrid, (attrname, datatype) in cluster.attributes.items():
+                if attrid in cluster._attr_cache:
+                    attributeNames.append(attrname)
+    
+            asyncio.ensure_future(cluster.read_attributes(attributeNames, allow_cache=False,))
 
         return cluster
 

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -87,6 +87,12 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
             cluster.add_listener(listener)
 
+        attributeNames = []
+        for attrid, (attrname, datatype) in cluster.attributes.items():
+            attributeNames.append(attrname)
+
+        await cluster.read_attributes(attributeNames, allow_cache=True,)
+
         return cluster
 
     def add_output_cluster(self, cluster_id, cluster=None):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -88,12 +88,12 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
             cluster.add_listener(listener)
 
-        if cluster_id != 0:
+        if cluster_id != 0 and hasattr(cluster, 'attributes'):
             attributeNames = []
             for attrid, (attrname, datatype) in cluster.attributes.items():
                 if attrid in cluster._attr_cache:
                     attributeNames.append(attrname)
-    
+
             asyncio.ensure_future(cluster.read_attributes(attributeNames, allow_cache=False,))
 
         return cluster


### PR DESCRIPTION
This will allow the correct state to be displayed when devices are added and avoids HA having to poll the cluster or issue a read on add to get the state of the cluster. 