### PR TITLE
add a quirk for king of fans zigbee receiver

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -141,3 +141,33 @@ def test_custom_device():
     assert isinstance(test_device[3], zigpy.endpoint.Endpoint)
 
     assert zigpy.quirks._DEVICE_REGISTRY.pop() == Device  # :-/
+
+
+def test_kof_no_reply():
+    class TestCluster(zigpy.quirks.kof.NoReplyMixin, zigpy.quirks.CustomCluster):
+        cluster_id = 0x1234
+        void_input_commands = [0x0002]
+        server_commands = {
+            0x0001: ('noop', (), False),
+            0x0002: ('noop_noreply', (), False),
+        }
+        client_commands = {}
+
+    ep = mock.MagicMock()
+    cluster = TestCluster(ep)
+
+    cluster.command(0x0001)
+    ep.request.assert_called_with(mock.ANY, mock.ANY, mock.ANY, expect_reply=True)
+    ep.reset_mock()
+
+    cluster.command(0x0001, expect_reply=False)
+    ep.request.assert_called_with(mock.ANY, mock.ANY, mock.ANY, expect_reply=False)
+    ep.reset_mock()
+
+    cluster.command(0x0002)
+    ep.request.assert_called_with(mock.ANY, mock.ANY, mock.ANY, expect_reply=False)
+    ep.reset_mock()
+
+    cluster.command(0x0002, expect_reply=True)
+    ep.request.assert_called_with(mock.ANY, mock.ANY, mock.ANY, expect_reply=True)
+    ep.reset_mock()

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -133,3 +133,4 @@ def _match(a, b):
 
 from . import xiaomi  # noqa: F401, F402
 from . import smartthings  # noqa: F401, F402
+from . import kof  # noqa: F401, F402

--- a/zigpy/quirks/kof/__init__.py
+++ b/zigpy/quirks/kof/__init__.py
@@ -6,7 +6,7 @@ module overrides all server commands that do not have a mandatory reply to not
  expect replies at all.
 """
 from zigpy.quirks import CustomDevice, CustomCluster
-from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, OnOff, LevelControl
+from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, OnOff, LevelControl, Ota
 from zigpy.zcl.clusters.hvac import Fan
 
 
@@ -21,12 +21,10 @@ class NoReplyMixin(object):
         """
         Overrides Cluster#command to configure expect_reply behavior based on
         void_input_commands. Note that this method changes the default value of
-        expect_reply to None. This allows allows the caller to explicitly force
+        expect_reply to None. This allows the caller to explicitly force
         expect_reply to true.
         """
-        if expect_reply is not None:
-            pass
-        else:
+        if expect_reply is None:
             expect_reply = command not in self.void_input_commands
 
         return super(NoReplyMixin, self).command(command, *args, manufacturer=manufacturer, expect_reply=expect_reply)
@@ -66,8 +64,19 @@ class CeilingFan(CustomDevice):
         1: {
             'profile_id': 0x0104,
             'device_type': 14,
-            'input_clusters': [0, 3, 4, 5, 6, 8, 514],
-            'output_clusters': [3, 25],
+            'input_clusters': [
+                Basic.cluster_id,
+                Identify.cluster_id,
+                Groups.cluster_id,
+                Scenes.cluster_id,
+                OnOff.cluster_id,
+                LevelControl.cluster_id,
+                Fan.cluster_id,
+            ],
+            'output_clusters': [
+                Identify.cluster_id,
+                Ota.cluster_id,
+            ],
         },
     }
 
@@ -81,8 +90,12 @@ class CeilingFan(CustomDevice):
                     KofScenes,
                     KofOnOff,
                     KofLevelControl,
-                    Fan
+                    Fan,
                 ],
+                'output_clusters': [
+                    Identify,
+                    Ota,
+                ]
             }
         },
     }

--- a/zigpy/quirks/kof/__init__.py
+++ b/zigpy/quirks/kof/__init__.py
@@ -1,0 +1,88 @@
+"""
+This module handles quirks of the King of Fans MR101Z ceiling fan receiver.
+
+The King of Fans ceiling fan receiver does not generate default replies. This
+module overrides all server commands that do not have a mandatory reply to not
+ expect replies at all.
+"""
+from zigpy.quirks import CustomDevice, CustomCluster
+from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, OnOff, LevelControl
+from zigpy.zcl.clusters.hvac import Fan
+
+
+class NoReplyMixin(object):
+    """
+    A simple mixin that allows a cluster to have configureable list of command
+    ids that do not generate an explicit reply.
+    """
+    void_input_commands = []
+
+    def command(self, command, *args, manufacturer=None, expect_reply=None):
+        """
+        Overrides Cluster#command to configure expect_reply behavior based on
+        void_input_commands. Note that this method changes the default value of
+        expect_reply to None. This allows allows the caller to explicitly force
+        expect_reply to true.
+        """
+        if expect_reply is not None:
+            pass
+        else:
+            expect_reply = command not in self.void_input_commands
+
+        return super(NoReplyMixin, self).command(command, *args, manufacturer=manufacturer, expect_reply=expect_reply)
+
+
+class KofBasic(NoReplyMixin, CustomCluster, Basic):
+    void_input_commands = [0x00]
+
+
+class KofIdentify(NoReplyMixin, CustomCluster, Identify):
+    # Identify, Trigger Effect
+    void_input_commands = [0x00, 0x40]
+
+
+class KofGroups(NoReplyMixin, CustomCluster, Groups):
+    # Remove All Groups, Add Group If Identifying
+    void_input_commands = [0x04, 0x05]
+
+
+class KofScenes(NoReplyMixin, CustomCluster, Scenes):
+    # Recall Scene
+    void_input_commands = [0x05]
+
+
+class KofOnOff(NoReplyMixin, CustomCluster, OnOff):
+    # All
+    void_input_commands = [0x00, 0x01, 0x02, 0x40, 0x41, 0x42]
+
+
+class KofLevelControl(NoReplyMixin, CustomCluster, LevelControl):
+    # All
+    void_input_commands = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+
+
+class CeilingFan(CustomDevice):
+    signature = {
+        1: {
+            'profile_id': 0x0104,
+            'device_type': 14,
+            'input_clusters': [0, 3, 4, 5, 6, 8, 514],
+            'output_clusters': [3, 25],
+        },
+    }
+
+    replacement = {
+        'endpoints': {
+            1: {
+                'input_clusters': [
+                    KofBasic,
+                    KofIdentify,
+                    KofGroups,
+                    KofScenes,
+                    KofOnOff,
+                    KofLevelControl,
+                    Fan
+                ],
+            }
+        },
+    }


### PR DESCRIPTION
The King of Fans ceiling fan receiver does not generate default replies. This module overrides all server commands that do not have a mandatory reply to not expect replies at all.