### PR TITLE
support zha window covering devices

### DIFF
--- a/zigpy/profiles/zha.py
+++ b/zigpy/profiles/zha.py
@@ -73,4 +73,6 @@ CLUSTERS = {
     DeviceType.COLOR_DIMMER_SWITCH: ([0x0007], [0x0004, 0x0005, 0x0006, 0x0008, 0x0300]),
     DeviceType.LIGHT_SENSOR: ([0x0400], []),
     DeviceType.OCCUPANCY_SENSOR: ([0x0406], []),
+    # Closures
+    DeviceType.WINDOW_COVERING_DEVICE: ([0x0004, 0x0005, 0x0102], []),
 }

--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -15,7 +15,7 @@ class Shade(Cluster):
         0x0001: ('motor_step_size', t.uint8_t),
         0x0002: ('status', t.uint8_t),  # bitmap8
         # Shade Settings
-        0x0010: ('losed_limit', t.uint16_t),
+        0x0010: ('closed_limit', t.uint16_t),
         0x0012: ('mode', t.enum8),
     }
     server_commands = {}
@@ -161,9 +161,9 @@ class WindowCovering(Cluster):
         0x0000: ('up_open', (), False),
         0x0001: ('down_close', (), False),
         0x0002: ('stop', (), False),
-        0x0004: ('go_to_lift_value', (), False),
-        0x0005: ('go_to_lift_percentage', (), False),
-        0x0007: ('go_to_tilt_value', (), False),
-        0x0008: ('go_to_tilt_percentage', (), False),
+        0x0004: ('go_to_lift_value', (t.uint16_t), False),
+        0x0005: ('go_to_lift_percentage', (t.uint8_t), False),
+        0x0007: ('go_to_tilt_value', (t.uint16_t), False),
+        0x0008: ('go_to_tilt_percentage', (t.uint8_t), False),
     }
     client_commands = {}

--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -161,9 +161,9 @@ class WindowCovering(Cluster):
         0x0000: ('up_open', (), False),
         0x0001: ('down_close', (), False),
         0x0002: ('stop', (), False),
-        0x0004: ('go_to_lift_value', (t.uint16_t), False),
-        0x0005: ('go_to_lift_percentage', (t.uint8_t), False),
-        0x0007: ('go_to_tilt_value', (t.uint16_t), False),
-        0x0008: ('go_to_tilt_percentage', (t.uint8_t), False),
+        0x0004: ('go_to_lift_value', (t.uint16_t, ), False),
+        0x0005: ('go_to_lift_percentage', (t.uint8_t, ), False),
+        0x0007: ('go_to_tilt_value', (t.uint16_t, ), False),
+        0x0008: ('go_to_tilt_percentage', (t.uint8_t, ), False),
     }
     client_commands = {}


### PR DESCRIPTION
This allows to communicate with the clusters of ZHA window covering devices (like the ubisys shutter control J1) and fixes a few minor typos / issues within these cluster specifications.