### PR TITLE
Cache output cluster attributes

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -43,12 +43,13 @@ async def test_database(tmpdir):
     ep.profile_id = 260
     ep.device_type = 0xfffd  # Invalid
     clus = ep.add_input_cluster(0)
-    ep.add_output_cluster(1)
+    out_clus = ep.add_output_cluster(1)
     ep = dev.add_endpoint(3)
     ep.profile_id = 49246
     ep.device_type = profiles.zll.DeviceType.COLOR_LIGHT
     app.device_initialized(dev)
     clus._update_attribute(0, 99)
+    out_clus._update_attribute(0, 99)
     clus.listener_event('cluster_command', 0)
     clus.listener_event('zdo_command')
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -216,6 +216,9 @@ class PersistingListener:
                 if cluster in ep.in_clusters:
                     clus = ep.in_clusters[cluster]
                     clus._attr_cache[attrid] = value
+                if cluster in ep.out_clusters:
+                    clus = ep.out_clusters[cluster]
+                    clus._attr_cache[attrid] = value
 
 
 class ClusterPersistingListener:

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -35,6 +35,7 @@ class PersistingListener:
         self._create_table_clusters()
         self._create_table_output_clusters()
         self._create_table_attributes()
+        self._create_table_output_cluster_attributes()
 
         self._application = application
 
@@ -57,13 +58,23 @@ class PersistingListener:
         self._remove_device(device)
 
     def attribute_updated(self, cluster, attrid, value):
-        self._save_attribute(
-            cluster.endpoint.device.ieee,
-            cluster.endpoint.endpoint_id,
-            cluster.cluster_id,
-            attrid,
-            value,
-        )
+        if cluster.cluster_id in cluster.endpoint.in_clusters and \
+                cluster.endpoint.in_clusters[cluster.cluster_id] == cluster:
+            self._save_attribute(
+                cluster.endpoint.device.ieee,
+                cluster.endpoint.endpoint_id,
+                cluster.cluster_id,
+                attrid,
+                value,
+            )
+        else:
+            self._save_output_cluster_attribute(
+                cluster.endpoint.device.ieee,
+                cluster.endpoint.endpoint_id,
+                cluster.cluster_id,
+                attrid,
+                value,
+            )
 
     def _create_table(self, table_name, spec):
         self.execute("CREATE TABLE IF NOT EXISTS %s %s" % (table_name, spec))
@@ -111,8 +122,20 @@ class PersistingListener:
             "ieee, endpoint_id, cluster, attrid"
         )
 
+    def _create_table_output_cluster_attributes(self):
+        self._create_table(
+            "output_cluster_attributes",
+            "(ieee ieee, endpoint_id, cluster, attrid, value)",
+        )
+        self._create_index(
+            "oc_attribute_idx",
+            "output_cluster_attributes",
+            "ieee, endpoint_id, cluster, attrid"
+        )
+
     def _remove_device(self, device):
         self.execute("DELETE FROM attributes WHERE ieee = ?", (device.ieee, ))
+        self.execute("DELETE FROM output_cluster_attributes WHERE ieee = ?", (device.ieee, ))
         self.execute("DELETE FROM clusters WHERE ieee = ?", (device.ieee, ))
         self.execute("DELETE FROM output_clusters WHERE ieee = ?", (device.ieee, ))
         self.execute("DELETE FROM endpoints WHERE ieee = ?", (device.ieee, ))
@@ -172,6 +195,11 @@ class PersistingListener:
         self.execute(q, (ieee, endpoint_id, cluster_id, attrid, value))
         self._db.commit()
 
+    def _save_output_cluster_attribute(self, ieee, endpoint_id, cluster_id, attrid, value):
+        q = "INSERT OR REPLACE INTO output_cluster_attributes VALUES (?, ?, ?, ?, ?)"
+        self.execute(q, (ieee, endpoint_id, cluster_id, attrid, value))
+        self._db.commit()
+
     def _scan(self, table):
         return self.execute("SELECT * FROM %s" % (table, ))
 
@@ -216,6 +244,11 @@ class PersistingListener:
                 if cluster in ep.in_clusters:
                     clus = ep.in_clusters[cluster]
                     clus._attr_cache[attrid] = value
+
+        for (ieee, endpoint_id, cluster, attrid, value) in self._scan("output_cluster_attributes"):
+            dev = self._application.get_device(ieee)
+            if endpoint_id in dev.endpoints:
+                ep = dev.endpoints[endpoint_id]
                 if cluster in ep.out_clusters:
                     clus = ep.out_clusters[cluster]
                     clus._attr_cache[attrid] = value

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -100,6 +100,15 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         if cluster is None:
             cluster = zigpy.zcl.Cluster.from_id(self, cluster_id)
         self.out_clusters[cluster_id] = cluster
+        if hasattr(cluster, 'ep_attribute'):
+            self._cluster_attr[cluster.ep_attribute] = cluster
+
+        if hasattr(self._device.application, '_dblistener'):
+            listener = zigpy.appdb.ClusterPersistingListener(
+                self._device.application._dblistener,
+                cluster,
+            )
+            cluster.add_listener(listener)
         return cluster
 
     def deserialize(self, cluster_id, data):


### PR DESCRIPTION
This adds the ClusterPersistingListener to output clusters. It stores attribute values in the db and also restores  their values when the db is loaded. 

This will allow us to restore the last known state of devices like the Osram lightly dimmer.