### PR TITLE
WIP - refresh previously cached attributes when a device rejoins

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -83,7 +83,8 @@ class ControllerApplication(zigpy.util.ListenableMixin):
                 LOGGER.debug("Device %s changed id (0x%04x => 0x%04x)", ieee, dev.nwk, nwk)
                 dev.nwk = nwk
             elif dev.initializing or dev.status == zigpy.device.Status.ENDPOINTS_INIT:
-                LOGGER.debug("Skip initialization for existing device %s", ieee)
+                LOGGER.debug("Refreshing state for existing device %s", ieee)
+                dev.schedule_refresh()
                 return
         else:
             dev = self.add_device(ieee, nwk)

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -66,6 +66,14 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         self.status = Status.ZDO_INIT
 
+    async def refresh(self):
+        if self.status != Status.ZDO_INIT:
+            return
+        for cluster_id in self.in_clusters:
+            await self.in_clusters[cluster_id].update_cached_attributes()
+        for cluster_id in self.out_clusters:
+            await self.out_clusters[cluster_id].update_cached_attributes()
+
     def add_input_cluster(self, cluster_id, cluster=None):
         """Adds an endpoint's input cluster
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -258,6 +258,26 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
             schema = foundation.COMMANDS[0x02][1]
             return self.request(True, 0x02, schema, args, manufacturer=manufacturer)
 
+    def read_attributes_from_cache(self, attributes):
+        success = {}
+        attribute_ids = []
+        for attribute in attributes:
+            if isinstance(attribute, str):
+                attrid = self._attridx[attribute]
+            else:
+                attrid = attribute
+            attribute_ids.append(attrid)
+        for idx, attribute in enumerate(attribute_ids):
+            if attribute in self._attr_cache:
+                success[attributes[idx]] = self._attr_cache[attribute]
+        return success
+
+    async def update_cached_attributes(self):
+        to_read = []
+        for attribute in self._attr_cache:
+            to_read.append(attribute)
+        await self.read_attributes(to_read)
+
     def bind(self):
         return self._endpoint.device.zdo.bind(self._endpoint.endpoint_id, self.cluster_id)
 


### PR DESCRIPTION
This PR changes the current behavior of skipping initialization for an existing device. It instead updates all previously cached attributes by calling a a new schedule_refresh function. This propagates from device -> endpoints -> clusters -> cluster attributes. The device should be in a state where it is looking for messages when it joins and it should be able to respond. Doing this allows zigpy to hand an already initialized device off to the host application (EX: Home Assistant). The PR also adds a new function: read_attributes_from_cache to the cluster object. This allows a host application to directly access cached values for previously read attributes.  The combination of these 2 changes should make initializing devices in host applications cleaner and more consistent. 

That being said, an argument can be made that this functionality doesn't belong in zigpy but rather in the host application(s) themselves. I am opening this PR to start a discussion around this topic and to see what thoughts people have on this subject. 

CC: @damarco @Adminiuga 
