### PR TITLE
cleanup zdo.leave() method and remove unneeded extra parameter from cmd request

### DIFF
--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -97,11 +97,7 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return self.request(0x0022, self._device.ieee, endpoint, cluster, dstaddr)
 
     def leave(self):
-        dstaddr = types.MultiAddress()
-        dstaddr.addrmode = 3
-        dstaddr.ieee = self._device.application.ieee
-        dstaddr.endpoint = 1
-        return self.request(0x0034, self._device.ieee, 0x02, dstaddr)
+        return self.request(0x0034, self._device.ieee, 0x02)
 
     def log(self, lvl, msg, *args):
         msg = '[0x%04x:zdo] ' + msg


### PR DESCRIPTION
Per definition of [Mgmt_leave_req](https://github.com/zigpy/zigpy/blob/a452c1c61778b116447ab36d1bf7e08b8820ebbf/zigpy/zdo/types.py#L124) of ZDO clusters, Mgmt_leave_req only takes two arguments:
1. device address
2. options
however current implementation also provides an extra parameter which seems to be just a copy'n'paste artifact from the above bind/unbind methods.

Same arguments for Mgmt_leave_req were defined in ZDO specs
![image](https://user-images.githubusercontent.com/5826160/42050723-bb2b3598-7ad7-11e8-9966-97f04cd43dd6.png)
