### PR TITLE
Strip anything starting with 0x00 in manufacturer/model attributes values

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -208,3 +208,46 @@ def test_init_endpoint_info_unicode(ep):
     clus.request = mockrequest
 
     test_initialize_zha(ep)
+
+
+def _init_endpoint_info(ep, test_manuf=None, test_model=None):
+    clus = ep.add_input_cluster(0)
+    assert 0 in ep.in_clusters
+    assert ep.in_clusters[0] is clus
+
+    async def mockrequest(foundation, command, schema, args, manufacturer=None):
+        assert foundation is True
+        assert command == 0
+        rar4 = _mk_rar(4, test_manuf)
+        rar5 = _mk_rar(5, test_model)
+        return [[rar4, rar5]]
+    clus.request = mockrequest
+
+    return test_initialize_zha(ep)
+
+
+def test_init_endpoint_info_null_padded_manuf(ep):
+    manufacturer = b'Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07'
+    model = b'Mock Model'
+    _init_endpoint_info(ep, manufacturer, model)
+
+    assert ep.manufacturer == 'Mock Manufacturer'
+    assert ep.model == 'Mock Model'
+
+
+def test_init_endpoint_info_null_padded_model(ep):
+    manufacturer = b'Mock Manufacturer'
+    model = b'Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    _init_endpoint_info(ep, manufacturer, model)
+
+    assert ep.manufacturer == 'Mock Manufacturer'
+    assert ep.model == 'Mock Model'
+
+
+def test_init_endpoint_info_null_padded_manuf_model(ep):
+    manufacturer = b'Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07'
+    model = b'Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    _init_endpoint_info(ep, manufacturer, model)
+
+    assert ep.manufacturer == 'Mock Manufacturer'
+    assert ep.model == 'Mock Model'

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -219,8 +219,10 @@ class PersistingListener:
                     clus._attr_cache[attrid] = value
                     LOGGER.debug("Attribute id: %s value: %s", attrid, value)
                     if cluster == Basic.cluster_id and attrid == 4:
+                        value = value.split(b'\x00')[0]
                         ep.manufacturer = value.decode('ascii').strip()
                     if cluster == Basic.cluster_id and attrid == 5:
+                        value = value.split(b'\x00')[0]
                         ep.model = value.decode('ascii').strip()
 
 

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -132,6 +132,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         for key, value in attributes.items():
             if isinstance(value, bytes):
                 try:
+                    value = value.split(b'\x00')[0]
                     attributes[key] = value.decode('ascii').strip()
                 except UnicodeDecodeError:
                     # Unsure what the best behaviour here is. Unset the key?


### PR DESCRIPTION
There're some vendor which don't provide clean manufacturer/model attribute values, eg Stelpro STZB402 thermostat. With #56  it breaks zha component in homeassistant:
```
2018-08-06 20:56:59 DEBUG (MainThread) [zigpy.appdb] Attribute id: 32 value: 28
2018-08-06 20:56:59 DEBUG (MainThread) [zigpy.appdb] Attribute id: 4 value: b'Stelpro\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
2018-08-06 20:56:59 DEBUG (MainThread) [zigpy.appdb] Attribute id: 5 value: b'STZB402+\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07\x07\x00\x00\x00\x00\x00\x07\x07\x00\xde\x15\x00'
2018-08-06 20:56:59 ERROR (MainThread) [homeassistant.setup] Error during setup of component zha
Traceback (most recent call last):
  File "/home/lex/lex/src/ac-hass/homeassistant/setup.py", line 145, in _async_setup_component
    hass, processed_config)
  File "/home/lex/lex/src/ac-hass/homeassistant/components/zha/__init__.py", line 115, in async_setup
    APPLICATION_CONTROLLER = ControllerApplication(radio, database)
  File "/home/lex/lex/src/bellows/bellows/zigbee/application.py", line 23, in __init__
    super().__init__(database_file=database_file)
  File "/home/lex/lex/src/zigpy/zigpy/application.py", line 25, in __init__
    self._dblistener.load()
  File "/home/lex/lex/src/zigpy/zigpy/appdb.py", line 224, in load
    ep.model = value.decode('ascii').strip()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xde in position 28: ordinal not in range(128)
2018-08-06 20:56:59 INFO (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: service=create, service_data=notification_id=invalid_config, message=The following components and platforms could not be set up:

 - [zha](https://home-assistant.io/components/zha/)
```

I'm opening this for discussion, as this could be done via quirks as well. From my point of view, no matter what zigpy get for an attribute value, it shouldn't crash. 
