### PR TITLE
update quirks test to handle cluster id ranges

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -69,6 +69,12 @@ def test_get_device():
 
 
 def test_custom_devices():
+    def _check_range(cluster):
+        for range in Cluster._registry_range.keys():
+            if range[0] <= cluster <= range[1]:
+                return True
+        return False
+
     # Validate that all CustomDevices look sane
     for device in zigpy.quirks._DEVICE_REGISTRY:
         # Check that the signature data is OK
@@ -93,6 +99,7 @@ def test_custom_devices():
             for cluster in all_clusters:
                 assert (
                     (isinstance(cluster, int) and cluster in Cluster._registry) or
+                    (isinstance(cluster, int) and _check_range(cluster)) or
                     issubclass(cluster, Cluster)
                 )
 


### PR DESCRIPTION
Currently test_quirks.py fails if a custom endpoint replacement contains a cluster ID registered in "cluster ID range", like a manufacturer cluster ID. For example, a custom device with the following replacement:
```
    replacement = {
        'endpoints': {
            1: {
                'input_clusters': [0, 3, 4, 5, 513, 0xff01],
                'output_clusters': [0x16, 0xff01]
            },
            196: {
                 'input_clusters': [PowerConfiguration]}
        }
```

fails with 
```
_______________________________________ test_custom_devices _______________________________________

    def test_custom_devices():
        # Validate that all CustomDevices look sane
        for device in zigpy.quirks._DEVICE_REGISTRY:
            # Check that the signature data is OK
            for profile_id, profile_data in device.signature.items():
                assert isinstance(profile_id, int)
                assert set(profile_data.keys()) - ALLOWED_SIGNATURE == set()
    
            # Check that the replacement data is OK
            assert set(device.replacement.keys()) - ALLOWED_REPLACEMENT == set()
            for epid, epdata in device.replacement.get('endpoints', {}).items():
                assert (epid in device.signature) or (
                    'profile' in epdata and 'device_type' in epdata)
                if 'profile' in epdata:
                    profile = epdata['profile']
                    assert isinstance(profile, int) and 0 <= profile <= 0xffff
                if 'device_type' in epdata:
                    device_type = epdata['device_type']
                    assert isinstance(device_type, int) and 0 <= device_type <= 0xffff
    
                all_clusters = (epdata.get('input_clusters', []) +
                                epdata.get('output_clusters', []))
                for cluster in all_clusters:
>                   assert (
                        (isinstance(cluster, int) and cluster in Cluster._registry) or
                        issubclass(cluster, Cluster)
                    )
E                   TypeError: issubclass() arg 1 must be a class

tests/test_quirks.py:94: TypeError
```

because replacement cluster is a numeric value, but is not present in the Cluster._registry because it is a manufacturer specific cluster ID which is in (0xfc00 -- 0xffff) range.
This pull request checks the ID ranges as well. 
