### PR TITLE
update Cluster.configure_reporiting to accept named attributes

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -267,6 +267,21 @@ def test_configure_reporting(cluster):
     cluster.configure_reporting(0, 10, 20, 1)
 
 
+def test_configure_reporting_named(cluster):
+    cluster.configure_reporting('zcl_version', 10, 20, 1)
+    assert cluster._endpoint.request.call_count == 1
+
+
+def test_configure_reporting_wrong_named(cluster):
+    cluster.configure_reporting('wrong_attr_name', 10, 20, 1)
+    assert cluster._endpoint.request.call_count == 0
+
+
+def test_configure_reporting_wrong_attrid(cluster):
+    cluster.configure_reporting(0xfffe, 10, 20, 1)
+    assert cluster._endpoint.request.call_count == 0
+
+
 def test_command(cluster):
     cluster.command(0x00)
     assert cluster._endpoint.request.call_count == 1

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -267,12 +267,20 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         return self._endpoint.device.zdo.unbind(self._endpoint.endpoint_id, self.cluster_id)
 
     def configure_reporting(self, attribute, min_interval, max_interval, reportable_change):
+        if isinstance(attribute, str):
+            attrid = self._attridx.get(attribute, None)
+        else:
+            attrid = attribute
+        if attrid not in self.attributes or attrid is None:
+            self.error("{} is not a valid attribute id".format(attribute))
+            return
+
         schema = foundation.COMMANDS[0x06][1]
         cfg = foundation.AttributeReportingConfig()
         cfg.direction = 0
-        cfg.attrid = attribute
+        cfg.attrid = attrid
         cfg.datatype = foundation.DATA_TYPE_IDX.get(
-            self.attributes.get(attribute, (None, None))[1],
+            self.attributes.get(attrid, (None, None))[1],
             None)
         cfg.min_interval = min_interval
         cfg.max_interval = max_interval


### PR DESCRIPTION
zcl.Cluster.read_attributes() and zcl.Cluster.write_attribute() methods both accept attributes either as attribute ID or attribute name. This PR makes zcl.Cluster.configure_reporting() to behave the same.