### PR TITLE
Support manufacturer id for configure_reporting().

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -282,6 +282,24 @@ def test_configure_reporting_wrong_attrid(cluster):
     assert cluster._endpoint.request.call_count == 0
 
 
+def test_configure_reporting_manuf():
+    ep = mock.MagicMock()
+    cluster = zcl.Cluster.from_id(ep, 6)
+    cluster.request = mock.MagicMock(name='request')
+    cluster.configure_reporting(0, 10, 20, 1)
+    cluster.request.assert_called_with(
+        mock.ANY, mock.ANY, mock.ANY, mock.ANY, manufacturer=None
+    )
+
+    cluster.request.reset_mock()
+    manufacturer_id = 0xfcfc
+    cluster.configure_reporting(0, 10, 20, 1, manufacturer=manufacturer_id)
+    cluster.request.assert_called_with(
+        mock.ANY, mock.ANY, mock.ANY, mock.ANY, manufacturer=manufacturer_id
+    )
+    assert cluster.request.call_count == 1
+
+
 def test_command(cluster):
     cluster.command(0x00)
     assert cluster._endpoint.request.call_count == 1

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -266,7 +266,8 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
     def unbind(self):
         return self._endpoint.device.zdo.unbind(self._endpoint.endpoint_id, self.cluster_id)
 
-    def configure_reporting(self, attribute, min_interval, max_interval, reportable_change):
+    def configure_reporting(self, attribute, min_interval, max_interval,
+                            reportable_change, manufacturer=None):
         if isinstance(attribute, str):
             attrid = self._attridx.get(attribute, None)
         else:
@@ -285,7 +286,9 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         cfg.min_interval = min_interval
         cfg.max_interval = max_interval
         cfg.reportable_change = reportable_change
-        return self.request(True, 0x06, schema, [cfg])
+        return self.request(
+            True, 0x06, schema, [cfg], manufacturer=manufacturer
+        )
 
     def command(self, command, *args, manufacturer=None, expect_reply=True):
         schema = self.server_commands[command][1]


### PR DESCRIPTION
Support `manufacturer` for `Cluster.configure_reporting()` method.

I've got [SmartThings multipurpose sensor](https://www.samsung.com/us/smart-home/smartthings/sensors/samsung-smartthings-multipurpose-sensor-2018-gp-u999sjvlaaa/), mine being specifically PN IM6001-MPP01 and it reject `configure_reporting()` request for the acceleration manufacturer specific cluster, unless configure_reporting() request uses `manufacturer_id` specific to this vendor.