### PR TITLE
Add Smartthings multipurpose sensor quirks.

### DIFF
--- a/zigpy/quirks/smartthings/__init__.py
+++ b/zigpy/quirks/smartthings/__init__.py
@@ -33,3 +33,46 @@ class SmartthingsTemperatureHumiditySensor(CustomDevice):
             }
         }
     }
+
+
+class SmartThingsAccelCluster(CustomCluster):
+    cluster_id = 0xfc02
+    name = "Smartthings Accelerometer"
+    ep_attribute = 'accelerometer'
+    attributes = {
+        0x0000: ('motion_threshold_multiplier', t.uint8_t),
+        0x0002: ('motion_threshold', t.uint16_t),
+        0x0010: ('acceleration', t.bitmap8),  # acceleration detected
+        0x0012: ('x_axis', t.int16s),
+        0x0013: ('y_axis', t.int16s),
+        0x0014: ('z_axis', t.int16s),
+    }
+
+    client_commands = {}
+    server_commands = {}
+
+
+class SmartthingsMultiPurposeSensor(CustomDevice):
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+        # device_version=0 input_clusters=[0, 1, 3, 32, 1026, 1280, 64514]
+        # output_clusters=[3, 25]>
+        1: {
+            'profile_id': 0x0104,
+            'device_type': 0x0402,
+            'input_clusters': [
+                0, 1, 3, 32, 1026, 1280, SmartThingsAccelCluster.cluster_id
+            ],
+            'output_clusters': [3, 25],
+        }
+    }
+
+    replacement = {
+        'endpoints': {
+            1: {
+                'input_clusters': [0x0000, 0x0001, 0x0003, 0x0020, 0x0402,
+                                   0x0500, SmartThingsAccelCluster],
+                'output_clusters': [0x0003, 0x0019]
+            }
+        }
+    }


### PR DESCRIPTION
Implement vendor specific `acceleremoter` cluster for [Smartthings multipurpose sensor](https://www.samsung.com/us/smart-home/smartthings/sensors/samsung-smartthings-multipurpose-sensor-2018-gp-u999sjvlaaa/) Per [Smartthings device handler](https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/PROD_2018.09.11/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy)  there are multiple vendors for the similar sensor, but I was able only to test with sensor from 'samjin' manufacturer.

Configuring reporting for `0xfc02` cluster requires specific manufacturer_id be supplied with all ZCL requests and this functionality is in #82 