### PR TITLE
Add model/manufacturer attributes to CustomEndpoint

### DIFF
--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -102,6 +102,8 @@ class CustomEndpoint(Endpoint):
 
         set_device_attr('profile_id')
         set_device_attr('device_type')
+        set_device_attr('manufacturer')
+        set_device_attr('model')
         self.status = EndpointStatus.ZDO_INIT
 
         for c in replacement_data.get('input_clusters', []):


### PR DESCRIPTION
Copy (or replace) manufacturer and model attributes to CustomEndpoint. Otherwise those are always 'none' for quirky devices.