### PR TITLE
Add support for targeted permit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ ENV/
 
 # Editor temp files
 .*.swp
+
+# Visual Studio Code
+.vscode

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -48,6 +48,16 @@ async def test_permit(app):
         await app.permit()
 
 
+@pytest.mark.asyncio
+async def test_permit_targeted(app, ieee):
+    app.devices[ieee] = mock.MagicMock()
+    app.devices[ieee].zdo.request = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    await app.permit_targeted((1, 1, 1, 1, 1, 1, 1, 1))
+    assert app.devices[ieee].zdo.request.call_count == 0
+    await app.permit_targeted(ieee)
+    assert app.devices[ieee].zdo.request.call_count == 1
+
+
 def test_permit_with_key(app):
     with pytest.raises(NotImplementedError):
         app.permit_with_key(None, None)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -104,6 +104,18 @@ class ControllerApplication(zigpy.util.ListenableMixin):
     def permit(self, time_s=60):
         raise NotImplementedError
 
+    async def permit_targeted(self, node, time_s=60):
+        assert 0 <= time_s <= 254
+        if not isinstance(node, t.EUI64):
+            node = t.EUI64([t.uint8_t(p) for p in node])
+        dev = self.devices.get(node, None)
+        if not dev:
+            LOGGER.warning("Device to permit join not found: %s", node)
+            return
+        r = await dev.zdo.request(0x0036, time_s)
+        if r[0] != 0:
+            LOGGER.warning("Targeted permit failed: %s", r)
+
     def permit_with_key(self, node, code, time_s=60):
         raise NotImplementedError
 


### PR DESCRIPTION
This can be used to request that a remote device (router) allows associations.