### PR TITLE
Change logic to support quirks based on model

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -34,12 +34,16 @@ def test_get_device():
     real_device = zigpy.device.Device(application, ieee, nwk)
 
     real_device.add_endpoint(1)
+    real_device[1].manufacturer = 'test'
+    real_device[1].model = 'test_model'
     real_device[1].profile_id = 255
     real_device[1].device_type = 255
     real_device[1].add_input_cluster(3)
     real_device[1].add_output_cluster(6)
 
     class TestDevice:
+        manufacturer = ['']
+        model = ['']
         signature = {
         }
 
@@ -66,6 +70,10 @@ def test_get_device():
     assert get_device(real_device, registry) is real_device
 
     TestDevice.signature[1]['output_clusters'] = [6]
+    assert isinstance(get_device(real_device, registry), TestDevice)
+
+    TestDevice.manufacturer = ['test']
+    TestDevice.model = ['test_model']
     assert isinstance(get_device(real_device, registry), TestDevice)
 
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -206,10 +206,6 @@ class PersistingListener:
             ep = dev.endpoints[endpoint_id]
             ep.add_output_cluster(cluster)
 
-        for device in self._application.devices.values():
-            device = zigpy.quirks.get_device(device)
-            self._application.devices[device.ieee] = device
-
         for (ieee, endpoint_id, cluster, attrid, value) in self._scan("attributes"):
             dev = self._application.get_device(ieee)
             if endpoint_id in dev.endpoints:
@@ -224,6 +220,10 @@ class PersistingListener:
                     if cluster == Basic.cluster_id and attrid == 5:
                         value = value.split(b'\x00')[0]
                         ep.model = value.decode().strip()
+
+        for device in self._application.devices.values():
+            device = zigpy.quirks.get_device(device)
+            self._application.devices[device.ieee] = device
 
 
 class ClusterPersistingListener:

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -21,26 +21,16 @@ def get_device(device, registry=_DEVICE_REGISTRY):
         _LOGGER.debug("Considering %s", candidate)
         sig = candidate.signature
 
-        if hasattr(candidate, 'manufacturer') and not any([device[eid].manufacturer in candidate.manufacturer for eid in sig.keys()]):
-            _LOGGER.debug("Fail because manufacturer mismatch")
-            continue
-
-        if hasattr(candidate, 'model') and not any([device[eid].model in candidate.model for eid in sig.keys()]):
-            _LOGGER.debug("Fail because model mismatch")
-            continue
-
-        _LOGGER.debug("Found custom device replacement for %s: %s",
-                      device.ieee, candidate)
-        device = candidate(device._application, device.ieee, device.nwk, device)
-        return device
-
-    for candidate in registry:
-        _LOGGER.debug("Considering %s", candidate)
-        sig = candidate.signature
-
         if not _match(sig.keys(), dev_ep):
             _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig.keys(), dev_ep)
             continue
+
+        if hasattr(candidate, 'manufacturer') and any([device[eid].manufacturer in candidate.manufacturer for eid in sig.keys()]):
+            if hasattr(candidate, 'model') and any([device[eid].model in candidate.model for eid in sig.keys()]):
+                _LOGGER.debug("Found custom device replacement for %s: %s",
+                              device.ieee, candidate)
+                device = candidate(device._application, device.ieee, device.nwk, device)
+                return device
 
         if not all([device[eid].profile_id == sig[eid].get('profile_id', device[eid].profile_id) for eid in sig.keys()]):
             _LOGGER.debug("Fail because profile_id mismatch on at least one endpoint")

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -24,11 +24,11 @@ def get_device(device, registry=_DEVICE_REGISTRY):
             _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig.keys(), dev_ep)
             continue
 
-        if hasattr(candidate, 'manufacturer') and not any([device[eid].manufacturer == candidate.manufacturer for eid in sig.keys()]):
+        if hasattr(candidate, 'manufacturer') and not any([candidate.manufacturer in device[eid].manufacturer for eid in sig.keys()]):
             _LOGGER.debug("Fail because manufacturer mismatch")
             continue
 
-        if hasattr(candidate, 'model') and not any([device[eid].model == candidate.model for eid in sig.keys()]):
+        if hasattr(candidate, 'model') and not any([candidate.model in device[eid].model for eid in sig.keys()]):
             _LOGGER.debug("Fail because model mismatch")
             continue
 

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -19,25 +19,17 @@ def get_device(device, registry=_DEVICE_REGISTRY):
     for candidate in registry:
         _LOGGER.debug("Considering %s", candidate)
         sig = candidate.signature
-        manufacturer = None
-        model = None
-
-        if hasattr(candidate, 'manufacturer'):
-            manufacturer = candidate.manufacturer
-
-        if hasattr(candidate, 'model'):
-            model = candidate.model
-
-        if not (manufacturer is None) and not any([device[eid].manufacturer == manufacturer for eid in sig.keys()]):
-            _LOGGER.debug("Fail because manufacturer mismatch")
-            continue
-
-        if not (model is None) and not any([device[eid].model == model for eid in sig.keys()]):
-            _LOGGER.debug("Fail because model mismatch")
-            continue
 
         if not _match(sig.keys(), dev_ep):
             _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig.keys(), dev_ep)
+            continue
+
+        if hasattr(candidate, 'manufacturer') and not any([device[eid].manufacturer == candidate.manufacturer for eid in sig.keys()]):
+            _LOGGER.debug("Fail because manufacturer mismatch")
+            continue
+
+        if hasattr(candidate, 'model') and not any([device[eid].model == candidate.model for eid in sig.keys()]):
+            _LOGGER.debug("Fail because model mismatch")
             continue
 
         if not all([device[eid].profile_id == sig[eid].get('profile_id', device[eid].profile_id) for eid in sig.keys()]):

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -19,6 +19,19 @@ def get_device(device, registry=_DEVICE_REGISTRY):
     for candidate in registry:
         _LOGGER.debug("Considering %s", candidate)
         sig = candidate.signature
+        manufacturer = None
+        model = None
+
+        if hasattr(candidate, 'manufacturer'):
+            manufacturer =  candidate.manufacturer
+
+        if hasattr(candidate, 'model'):
+            model = candidate.model
+
+        if not (model == None) and not any([device[eid].model == model for eid in sig.keys()]):
+            _LOGGER.debug("Fail because model mismatch")
+            continue
+
         if not _match(sig.keys(), dev_ep):
             _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig.keys(), dev_ep)
             continue

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -24,11 +24,11 @@ def get_device(device, registry=_DEVICE_REGISTRY):
             _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig.keys(), dev_ep)
             continue
 
-        if hasattr(candidate, 'manufacturer') and not any([candidate.manufacturer in device[eid].manufacturer for eid in sig.keys()]):
+        if hasattr(candidate, 'manufacturer') and not any([device[eid].manufacturer in candidate.manufacturer for eid in sig.keys()]):
             _LOGGER.debug("Fail because manufacturer mismatch")
             continue
 
-        if hasattr(candidate, 'model') and not any([candidate.model in device[eid].model for eid in sig.keys()]):
+        if hasattr(candidate, 'model') and not any([device[eid].model in candidate.model for eid in sig.keys()]):
             _LOGGER.debug("Fail because model mismatch")
             continue
 

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -23,12 +23,16 @@ def get_device(device, registry=_DEVICE_REGISTRY):
         model = None
 
         if hasattr(candidate, 'manufacturer'):
-            manufacturer =  candidate.manufacturer
+            manufacturer = candidate.manufacturer
 
         if hasattr(candidate, 'model'):
             model = candidate.model
 
-        if not (model == None) and not any([device[eid].model == model for eid in sig.keys()]):
+        if not (manufacturer is None) and not any([device[eid].manufacturer == manufacturer for eid in sig.keys()]):
+            _LOGGER.debug("Fail because manufacturer mismatch")
+            continue
+
+        if not (model is None) and not any([device[eid].model == model for eid in sig.keys()]):
             _LOGGER.debug("Fail because model mismatch")
             continue
 

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -16,13 +16,10 @@ def add_to_registry(device):
 def get_device(device, registry=_DEVICE_REGISTRY):
     """Get a CustomDevice object, if one is available"""
     dev_ep = set(device.endpoints.keys()) - set([0])
+
     for candidate in registry:
         _LOGGER.debug("Considering %s", candidate)
         sig = candidate.signature
-
-        if not _match(sig.keys(), dev_ep):
-            _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig.keys(), dev_ep)
-            continue
 
         if hasattr(candidate, 'manufacturer') and not any([device[eid].manufacturer in candidate.manufacturer for eid in sig.keys()]):
             _LOGGER.debug("Fail because manufacturer mismatch")
@@ -30,6 +27,19 @@ def get_device(device, registry=_DEVICE_REGISTRY):
 
         if hasattr(candidate, 'model') and not any([device[eid].model in candidate.model for eid in sig.keys()]):
             _LOGGER.debug("Fail because model mismatch")
+            continue
+
+        _LOGGER.debug("Found custom device replacement for %s: %s",
+                      device.ieee, candidate)
+        device = candidate(device._application, device.ieee, device.nwk, device)
+        return device
+
+    for candidate in registry:
+        _LOGGER.debug("Considering %s", candidate)
+        sig = candidate.signature
+
+        if not _match(sig.keys(), dev_ep):
+            _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig.keys(), dev_ep)
             continue
 
         if not all([device[eid].profile_id == sig[eid].get('profile_id', device[eid].profile_id) for eid in sig.keys()]):

--- a/zigpy/quirks/xiaomi/__init__.py
+++ b/zigpy/quirks/xiaomi/__init__.py
@@ -2,51 +2,10 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, \
     MultistateInput, AnalogInput, Ota
 
-class AqaraDualButtonSwitch(CustomDevice):
-    manufacturer = ['LUMI', 'Ikea']
-    model = ['lumi.remote.b286acn01']
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 25, 65535, 18] output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f01,
-            'input_clusters': [Basic.cluster_id, Identify.cluster_id, Ota.cluster_id, 65535, MultistateInput.cluster_id],
-            'output_clusters': [Basic.cluster_id, Groups.cluster_id, Identify.cluster_id, Scenes.cluster_id, Ota.cluster_id, 65535, MultistateInput.cluster_id],
-        },
-        # <SimpleDescriptor endpoint=2 profile=260 device_type=24322 device_version=1 input_clusters=[3, 18] output_clusters=[4, 3, 5, 18]>
-        2: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f02,
-            'input_clusters': [Identify.cluster_id, MultistateInput.cluster_id],
-            'output_clusters': [Groups.cluster_id, Identify.cluster_id, Scenes.cluster_id, MultistateInput.cluster_id],
-        },
-        # <SimpleDescriptor endpoint=3 profile=260 device_type=24323 device_version=1 input_clusters=[3, 12] output_clusters=[4, 3, 5, 12]>
-        3: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f03,
-            'input_clusters': [Identify.cluster_id, AnalogInput.cluster_id],
-            'output_clusters': [Groups.cluster_id, Identify.cluster_id, Scenes.cluster_id, AnalogInput.cluster_id],
-        },
-    }
-
-    replacement = {
-        'endpoints': {
-            1: {
-                'input_clusters': [Basic.cluster_id, Identify.cluster_id],
-            },
-            2: {
-                'input_clusters': [MultistateInput.cluster_id],
-            },
-            3: {
-                'input_clusters': [AnalogInput.cluster_id],
-            },
-        },
-    }
-
 
 class TemperatureHumiditySensor(CustomDevice):
-    manufacturer = ['LUMI', 'Test']
-    model = ['lumi.sensor_ht', 'test_model']
+    manufacturer = ['LUMI']
+    model = ['lumi.sensor_ht']
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 25, 65535, 18] output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
         1: {

--- a/zigpy/quirks/xiaomi/__init__.py
+++ b/zigpy/quirks/xiaomi/__init__.py
@@ -4,6 +4,7 @@ from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, \
 
 
 class TemperatureHumiditySensor(CustomDevice):
+    model = 'lumi.sensor_ht'
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 25, 65535, 18] output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
         1: {

--- a/zigpy/quirks/xiaomi/__init__.py
+++ b/zigpy/quirks/xiaomi/__init__.py
@@ -4,6 +4,7 @@ from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, \
 
 
 class TemperatureHumiditySensor(CustomDevice):
+    manufacturer = 'LUMI'
     model = 'lumi.sensor_ht'
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 25, 65535, 18] output_clusters=[0, 4, 3, 5, 25, 65535, 18]>

--- a/zigpy/quirks/xiaomi/__init__.py
+++ b/zigpy/quirks/xiaomi/__init__.py
@@ -2,10 +2,51 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, \
     MultistateInput, AnalogInput, Ota
 
+class AqaraDualButtonSwitch(CustomDevice):
+    manufacturer = ['LUMI', 'Ikea']
+    model = ['lumi.remote.b286acn01']
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 25, 65535, 18] output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
+        1: {
+            'profile_id': 0x0104,
+            'device_type': 0x5f01,
+            'input_clusters': [Basic.cluster_id, Identify.cluster_id, Ota.cluster_id, 65535, MultistateInput.cluster_id],
+            'output_clusters': [Basic.cluster_id, Groups.cluster_id, Identify.cluster_id, Scenes.cluster_id, Ota.cluster_id, 65535, MultistateInput.cluster_id],
+        },
+        # <SimpleDescriptor endpoint=2 profile=260 device_type=24322 device_version=1 input_clusters=[3, 18] output_clusters=[4, 3, 5, 18]>
+        2: {
+            'profile_id': 0x0104,
+            'device_type': 0x5f02,
+            'input_clusters': [Identify.cluster_id, MultistateInput.cluster_id],
+            'output_clusters': [Groups.cluster_id, Identify.cluster_id, Scenes.cluster_id, MultistateInput.cluster_id],
+        },
+        # <SimpleDescriptor endpoint=3 profile=260 device_type=24323 device_version=1 input_clusters=[3, 12] output_clusters=[4, 3, 5, 12]>
+        3: {
+            'profile_id': 0x0104,
+            'device_type': 0x5f03,
+            'input_clusters': [Identify.cluster_id, AnalogInput.cluster_id],
+            'output_clusters': [Groups.cluster_id, Identify.cluster_id, Scenes.cluster_id, AnalogInput.cluster_id],
+        },
+    }
+
+    replacement = {
+        'endpoints': {
+            1: {
+                'input_clusters': [Basic.cluster_id, Identify.cluster_id],
+            },
+            2: {
+                'input_clusters': [MultistateInput.cluster_id],
+            },
+            3: {
+                'input_clusters': [AnalogInput.cluster_id],
+            },
+        },
+    }
+
 
 class TemperatureHumiditySensor(CustomDevice):
-    manufacturer = 'LUMI'
-    model = 'lumi.sensor_ht'
+    manufacturer = ['LUMI', 'Test']
+    model = ['lumi.sensor_ht', 'test_model']
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 25, 65535, 18] output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
         1: {


### PR DESCRIPTION
This change the appdb load logic to fetch the manufacturer and model information prior to loading the quirks. It also adds logic to the quirks to match based on model name.

These changes  combined allow for devices with the same endpoint and cluster setup to be matched more fine grained.

