### PR TITLE
Update README.md to also mention and link to zigpy-deconz

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ zigpy works with separate radio libraries which can each interface with multiple
 
 Such radio libraries includes **[bellows](https://github.com/zigpy/bellows)** (which communicates with EZSP/EmberZNet based radios) and **[zigpy-xbee](https://github.com/zigpy/zigpy-xbee)** (which communicates with XBee based Zigbee radios). 
 
-There is also an experimental radio library called **[pyconz](https://github.com/Equidamoid/pyconz/)** available for deCONZ serial protocol (for communicating with ConBee and RaspBee USB and GPIO radios from Dresden-Elektronik).
+There is also experimental radio libraries called **[pyconz](https://github.com/Equidamoid/pyconz/)** and **[zigpy-deconz](https://github.com/damarco/zigpy-deconz)** available for deCONZ serial protocol (for communicating with ConBee and RaspBee USB and GPIO radios from Dresden-Elektronik).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/zigpy/zigpy.svg?branch=master)](https://travis-ci.org/zigpy/zigpy)
 [![Coverage](https://coveralls.io/repos/github/zigpy/zigpy/badge.svg?branch=master)](https://coveralls.io/github/zigpy/zigpy?branch=master)
 
-**[zigpy](https://github.com/zigpy/zigpy)** is a Python 3 project to implement **[Zigbee Home Automation](https://www.zigbee.org/)** integration. 
+**[zigpy](https://github.com/zigpy/zigpy)** is **[Zigbee protocol stack](https://en.wikipedia.org/wiki/Zigbee)** integration project to implement the **[Zigbee Home Automation](https://www.zigbee.org/)** standard as a Python 3 library. 
 
 zigpy works with separate radio libraries which can each interface with multiple USB and GPIO radio adapters/modules over different native UART serial UART protocols.
 


### PR DESCRIPTION
Update README.md to also mention and link to zigpy-deconz

https://github.com/damarco/zigpy-deconz

zigpy-deconz is another library for deCONZ serial protocol

https://github.com/dresden-elektronik/deconz-rest-plugin/issues/158