### PR TITLE
Pop device from registry after ZDO leave request.

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from zigpy.application import ControllerApplication
+from zigpy.exceptions import DeliveryError
 from zigpy import device
 import zigpy.types as t
 
@@ -107,11 +108,14 @@ def test_join_handler_change_id(app, ieee):
     assert app.devices[ieee].nwk == 2
 
 
-async def _remove(app, ieee, retval):
+async def _remove(app, ieee, retval, zdo_reply=True):
     app.devices[ieee] = mock.MagicMock()
 
     async def leave():
-        return retval
+        if zdo_reply:
+            return retval
+        else:
+            raise DeliveryError
 
     app.devices[ieee].zdo.leave.side_effect = leave
     await app.remove(ieee)
@@ -128,7 +132,7 @@ async def test_remove(app, ieee):
 @pytest.mark.asyncio
 async def test_remove_with_failed_zdo(app, ieee):
     app.force_remove = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
-    await _remove(app, ieee, 1)
+    await _remove(app, ieee, [1])
     assert app.force_remove.call_count == 1
 
 
@@ -136,6 +140,13 @@ async def test_remove_with_failed_zdo(app, ieee):
 async def test_remove_nonexistent(app, ieee):
     await app.remove(ieee)
     assert ieee not in app.devices
+
+
+@pytest.mark.asyncio
+async def test_remove_with_undreachable_device(app, ieee):
+    app.force_remove = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    await _remove(app, ieee, [0], zdo_reply=False)
+    assert app.force_remove.call_count == 1
 
 
 def test_add_device(app, ieee):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -143,7 +143,7 @@ async def test_remove_nonexistent(app, ieee):
 
 
 @pytest.mark.asyncio
-async def test_remove_with_undreachable_device(app, ieee):
+async def test_remove_with_unreachable_device(app, ieee):
     app.force_remove = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
     await _remove(app, ieee, [0], zdo_reply=False)
     assert app.force_remove.call_count == 1


### PR DESCRIPTION
When removing a device, pop it from device registry after issuing ZDO leave request.

Currently we're poping the device too soon, so we never get a proper reply to "ZDO leave req" since device is gone and deserialization is not happening. 
Here's a log, for a few devices being issued a `ZDO leave` request, however when we get an `incomingMessageHandler` with a reply to leave request, we fail to process it, because it comes from an unknown device
```
2019-01-02 17:57:51 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: service=remove, service_data=ieee_address=f0:d1:b8:00:00:05:13:93, domain=zha>
2019-01-02 17:57:51 INFO (MainThread) [homeassistant.components.zha] Removing node f0:d1:b8:00:00:05:13:93
2019-01-02 17:57:51 INFO (MainThread) [zigpy.application] Removing device 0x40e6 (f0:d1:b8:00:00:05:13:93)
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.ezsp] Send command sendUnicast
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Sending: b'61542157541e155419944a7d31aa5592099d4e27aaecc4667d38eec3638944afcfa5168a7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Data frame: b'1754a157541e15ee31637e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Sending: b'82503a7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.ezsp] Application frame 52 (sendUnicast) received
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Data frame: b'2754b157546f15b259a0ca25aa1593499c80d8660b8e9874ffc763d7017e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Sending: b'83401b7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.ezsp] Application frame 69 (incomingMessageHandler) received
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.zigbee.application] No such device 16614
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Data frame: b'3754b157540ef3f2ca874f25aaed43b99e4dd854100e7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Sending: b'8430fc7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.ezsp] Application frame 36 (trustCenterJoinHandler) received
2019-01-02 17:57:51 INFO (MainThread) [zigpy.application] Device 0x40e6 (f0:d1:b8:00:00:05:13:93) left the network
```
Same device after it was rejoined
```
2019-01-02 17:57:51 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: service=remove, service_data=ieee_address=f0:d1:b8:00:00:05:13:93, domain=zha>
2019-01-02 17:57:51 INFO (MainThread) [homeassistant.components.zha] Removing node f0:d1:b8:00:00:05:13:93
2019-01-02 17:57:51 INFO (MainThread) [zigpy.application] Removing device 0x40e6 (f0:d1:b8:00:00:05:13:93)
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.ezsp] Send command sendUnicast
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Sending: b'61542157541e155419944a7d31aa5592099d4e27aaecc4667d38eec3638944afcfa5168a7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Data frame: b'1754a157541e15ee31637e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Sending: b'82503a7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.ezsp] Application frame 52 (sendUnicast) received
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Data frame: b'2754b157546f15b259a0ca25aa1593499c80d8660b8e9874ffc763d7017e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Sending: b'83401b7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.ezsp] Application frame 69 (incomingMessageHandler) received
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.zigbee.application] No such device 16614
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Data frame: b'3754b157540ef3f2ca874f25aaed43b99e4dd854100e7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.uart] Sending: b'8430fc7e'
2019-01-02 17:57:51 DEBUG (MainThread) [bellows.ezsp] Application frame 36 (trustCenterJoinHandler) received
2019-01-02 17:57:51 INFO (MainThread) [zigpy.application] Device 0x40e6 (f0:d1:b8:00:00:05:13:93) left the network
```

a different device, but same "No such device" to incoming 'incomingMessageHandler`
```
019-01-02 20:00:02 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: service_data=ieee_address=00:22:a3:00:00:1b:94:bb, domain=zha, service=remove>
2019-01-02 20:00:02 INFO (MainThread) [homeassistant.components.zha] Removing node 00:22:a3:00:00:1b:94:bb
2019-01-02 20:00:02 INFO (MainThread) [zigpy.application] Removing device 0x5991 (00:22:a3:00:00:1b:94:bb)
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.ezsp] Send command sendUnicast
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.uart] Sending: b'735d2157541e152300944a7d31aa5592099d4e27a2e4c46e3069dd63895f5c3fa5cc957e'
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.uart] Data frame: b'305da157541e1535dcc97e'
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.uart] Sending: b'8430fc7e'
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.ezsp] Application frame 52 (sendUnicast) received
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.uart] Data frame: b'405db157540e84ebe2005125aaf6b0499e4dd854ea817e'
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.uart] Sending: b'8520dd7e'
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.ezsp] Application frame 36 (trustCenterJoinHandler) received
2019-01-02 20:00:02 INFO (MainThread) [zigpy.application] Device 0x5991 (00:22:a3:00:00:1b:94:bb) left the network
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.uart] Data frame: b'505db157546f15b259a0ca25aa1593499c50d87a7c979874ffcf638b68427e'
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.uart] Sending: b'8610be7e'
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.ezsp] Application frame 69 (incomingMessageHandler) received
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.zigbee.application] No such device 22929
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.uart] Data frame: b'605db1575415152300944a11aa5592099d4e272ce4ce6726d87e'
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.uart] Sending: b'87009f7e'
2019-01-02 20:00:02 DEBUG (MainThread) [bellows.ezsp] Application frame 63 (messageSentHandler) received
```

