### PR TITLE
Add ZCL discovery commands.

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -336,3 +336,14 @@ def test_name(cluster):
 
 def test_commands(cluster):
     assert cluster.commands == ["reset_fact_default"]
+
+
+def test_discover(cluster):
+    cluster.request = mock.MagicMock()
+    s = mock.sentinel
+    cmd_id = 0x0c
+    cluster._discover(cmd_id, s.start, s.items, s.manuf)
+
+    assert cluster.request.call_count == 1
+    cluster.request.assert_called_with(
+        True, cmd_id, mock.ANY, s.start, s.items, manufacturer=s.manuf)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -340,6 +340,19 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
     def __getitem__(self, key):
         return self.read_attributes([key], allow_cache=True, raw=True)
 
+    @util.retryable_request
+    def _discover(self, cmd_id, start_item, num_of_items,
+                  manufacturer=None, tries=3):
+        schema = foundation.COMMANDS[cmd_id][1]
+        return self.request(
+            True, cmd_id, schema, start_item, num_of_items,
+            manufacturer=manufacturer)
+
+    discover_attributes = functools.partialmethod(_discover, 0x0c)
+    discover_attributes_extended = functools.partialmethod(_discover, 0x15)
+    discover_commands_received = functools.partialmethod(_discover, 0x11)
+    discover_commands_generated = functools.partialmethod(_discover, 0x13)
+
 
 # Import to populate the registry
 from . import clusters  # noqa: F401, F402

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -243,6 +243,25 @@ class DiscoverAttributesResponseRecord(t.Struct):
     ]
 
 
+class AttributeAccessControl(t.uint8_t, enum.Enum):
+    NO_ACCESS = 0b000
+    REPORT = 0b001
+    WRITE = 0b010
+    WRITE_REPORT = 0b011
+    READ = 0b100
+    READ_REPORT = 0b101
+    READ_WRITE = 0b110
+    READ_WRITE_REPORT = 0b111
+
+
+class DiscoverAttributesExtendedResponseRecord(t.Struct):
+    _fields = [
+        ('attrid', t.uint16_t),
+        ('datatype', t.uint8_t),
+        ('acl', AttributeAccessControl),
+    ]
+
+
 COMMANDS = {
     # id: (name, params, is_response)
     0x00: ('Read attributes', (t.List(t.uint16_t), ), False),
@@ -258,8 +277,14 @@ COMMANDS = {
     0x0a: ('Report attributes', (t.List(Attribute), ), False),
     0x0b: ('Default response', (t.uint8_t, Status), True),
     0x0c: ('Discover attributes', (t.uint16_t, t.uint8_t), False),
-    0x0d: ('Discover attributes response', (t.List(DiscoverAttributesResponseRecord), ), True),
+    0x0d: ('Discover attributes response', (t.Bool, t.List(DiscoverAttributesResponseRecord), ), True),
     # 0x0e: ('Read attributes structured', (, ), False),
     # 0x0f: ('Write attributes structured', (, ), False),
     # 0x10: ('Write attributes structured response', (, ), True),
+    0x11: ('Discover commands received', (t.uint8_t, t.uint8_t), False),
+    0x12: ('Discover commands received response', (t.Bool, t.List(t.uint8_t)), True),
+    0x13: ('Discover commands generated', (t.uint8_t, t.uint8_t), False),
+    0x14: ('Discover commands generated response', (t.Bool, t.List(t.uint8_t)), True),
+    0x15: ('Discover attributes extended', (t.uint16_t, t.uint8_t), False),
+    0x16: ('Discover attributes extended response', (t.Bool, t.List(DiscoverAttributesExtendedResponseRecord)), True),
 }


### PR DESCRIPTION
Add support for ZCL discovery commands:
- Discover Attributes
- Discover Attributes extended
- Discover Commands Received
- Discover Commands Generated

