### PR TITLE
Move imports to functions to prevent circular processing during testing

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -117,6 +117,7 @@ class PersistingListener:
         self._db.commit()
 
     def _save_device(self, device):
+        import zigpy.quirks
         q = "INSERT OR REPLACE INTO devices (ieee, nwk, status) VALUES (?, ?, ?)"
         self.execute(q, (device.ieee, device.nwk, device.status))
         if isinstance(device, zigpy.quirks.CustomDevice):
@@ -176,6 +177,10 @@ class PersistingListener:
         return self.execute("SELECT * FROM %s" % (table, ))
 
     def load(self):
+        import zigpy.profiles
+        import zigpy.device
+        import zigpy.endpoint
+        import zigpy.quirks
         LOGGER.debug("Loading application state from %s", self._database_file)
         for (ieee, nwk, status) in self._scan("devices"):
             dev = self._application.add_device(ieee, nwk)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -1,10 +1,6 @@
 import logging
 import sqlite3
 
-import zigpy.device
-import zigpy.endpoint
-import zigpy.profiles
-import zigpy.quirks
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic
 


### PR DESCRIPTION
These imports lead to circular imports when attempting to use Zigpy in Homeassistant tests.

```
ImportError while importing test module '/Volumes/development/ha_remote_dev/home-assistant/tests/components/zha/core/test_device.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/components/zha/core/test_device.py:5: in <module>
    import zigpy.device as zigpy_device
.tox/py36/lib/python3.6/site-packages/zigpy/device.py:6: in <module>
    import zigpy.endpoint
.tox/py36/lib/python3.6/site-packages/zigpy/endpoint.py:4: in <module>
    import zigpy.appdb
.tox/py36/lib/python3.6/site-packages/zigpy/appdb.py:7: in <module>
    import zigpy.quirks
.tox/py36/lib/python3.6/site-packages/zigpy/quirks/__init__.py:3: in <module>
    from zigpy.device import Device, Status as DeviceStatus
E   ImportError: cannot import name 'Device'
```

Moving the imports to the functions that need them corrects the issue. 
