### PR TITLE
Fix tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skip_missing_interpreters = True
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
-install_command = pip install --process-dependency-links {opts} {packages}
+install_command = pip install {opts} {packages}
 commands = py.test --cov --cov-report=
 deps =
     coveralls


### PR DESCRIPTION
Remove deprecated `--process-dependency-links` option from tox.ini .