### PR TITLE
Add support for model and manufacturer in quirks signatures

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -88,20 +88,20 @@ def test_add_custom_output_cluster(ep):
 
 def test_multiple_add_input_cluster(ep):
     ep.add_input_cluster(0)
-    assert ep.in_clusters[0].cluster_id is 0
+    assert ep.in_clusters[0].cluster_id == 0
     ep.in_clusters[0].cluster_id = 1
-    assert ep.in_clusters[0].cluster_id is 1
+    assert ep.in_clusters[0].cluster_id == 1
     ep.add_input_cluster(0)
-    assert ep.in_clusters[0].cluster_id is 1
+    assert ep.in_clusters[0].cluster_id == 1
 
 
 def test_multiple_add_output_cluster(ep):
     ep.add_output_cluster(0)
-    assert ep.out_clusters[0].cluster_id is 0
+    assert ep.out_clusters[0].cluster_id == 0
     ep.out_clusters[0].cluster_id = 1
-    assert ep.out_clusters[0].cluster_id is 1
+    assert ep.out_clusters[0].cluster_id == 1
     ep.add_output_cluster(0)
-    assert ep.out_clusters[0].cluster_id is 1
+    assert ep.out_clusters[0].cluster_id == 1
 
 
 def test_handle_message(ep):
@@ -152,12 +152,12 @@ def test_reply(ep):
 
 
 def _mk_rar(attrid, value, status=0):
-        r = zcl.foundation.ReadAttributeRecord()
-        r.attrid = attrid
-        r.status = status
-        r.value = zcl.foundation.TypeValue()
-        r.value.value = value
-        return r
+    r = zcl.foundation.ReadAttributeRecord()
+    r.attrid = attrid
+    r.status = status
+    r.value = zcl.foundation.TypeValue()
+    r.value.value = value
+    return r
 
 
 def test_init_endpoint_info(ep):

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -7,15 +7,15 @@ import zigpy.types as t
 from zigpy.zcl import Cluster
 
 ALLOWED_SIGNATURE = set([
+    'profile_id',
     'device_type',
+    'model',
+    'manufacturer',
     'input_clusters',
     'output_clusters',
-    'profile_id',
 ])
 ALLOWED_REPLACEMENT = set([
-    'device_type',
     'endpoints',
-    'profile_id',
 ])
 
 
@@ -36,6 +36,8 @@ def test_get_device():
     real_device.add_endpoint(1)
     real_device[1].profile_id = 255
     real_device[1].device_type = 255
+    real_device[1].model = 'model'
+    real_device[1].manufacturer = 'manufacturer'
     real_device[1].add_input_cluster(3)
     real_device[1].add_output_cluster(6)
 
@@ -63,9 +65,19 @@ def test_get_device():
     assert get_device(real_device, registry) is real_device
 
     TestDevice.signature[1]['device_type'] = 255
+    TestDevice.signature[1]['model'] = 'x'
+    assert get_device(real_device, registry) is real_device
+
+    TestDevice.signature[1]['model'] = 'model'
+    TestDevice.signature[1]['manufacturer'] = 'x'
+    assert get_device(real_device, registry) is real_device
+
+    TestDevice.signature[1]['manufacturer'] = 'manufacturer'
+    TestDevice.signature[1]['input_clusters'] = [1]
     assert get_device(real_device, registry) is real_device
 
     TestDevice.signature[1]['input_clusters'] = [3]
+    TestDevice.signature[1]['output_clusters'] = [1]
     assert get_device(real_device, registry) is real_device
 
     TestDevice.signature[1]['output_clusters'] = [6]

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -138,12 +138,12 @@ def test_handle_unexpected_reply(cluster):
 
 
 def _mk_rar(attrid, value, status=0):
-        r = zcl.foundation.ReadAttributeRecord()
-        r.attrid = attrid
-        r.status = status
-        r.value = zcl.foundation.TypeValue()
-        r.value.value = value
-        return r
+    r = zcl.foundation.ReadAttributeRecord()
+    r.attrid = attrid
+    r.status = status
+    r.value = zcl.foundation.TypeValue()
+    r.value.value = value
+    return r
 
 
 @pytest.mark.asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, lint
+envlist = py35, py36, py37, lint
 skip_missing_interpreters = True
 
 [testenv]

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -209,10 +209,6 @@ class PersistingListener:
             ep = dev.endpoints[endpoint_id]
             ep.add_output_cluster(cluster)
 
-        for device in self._application.devices.values():
-            device = zigpy.quirks.get_device(device)
-            self._application.devices[device.ieee] = device
-
         for (ieee, endpoint_id, cluster, attrid, value) in self._scan("attributes"):
             dev = self._application.get_device(ieee)
             if endpoint_id in dev.endpoints:
@@ -227,6 +223,10 @@ class PersistingListener:
                     if cluster == Basic.cluster_id and attrid == 5:
                         value = value.split(b'\x00')[0]
                         ep.model = value.decode().strip()
+
+        for device in self._application.devices.values():
+            device = zigpy.quirks.get_device(device)
+            self._application.devices[device.ieee] = device
 
 
 class ClusterPersistingListener:

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -31,6 +31,14 @@ def get_device(device, registry=_DEVICE_REGISTRY):
             _LOGGER.debug("Fail because device_type mismatch on at least one endpoint")
             continue
 
+        if not all([device[eid].model == sig[eid].get('model', device[eid].model) for eid in sig.keys()]):
+            _LOGGER.debug("Fail because model mismatch on at least one endpoint")
+            continue
+
+        if not all([device[eid].manufacturer == sig[eid].get('manufacturer', device[eid].manufacturer) for eid in sig.keys()]):
+            _LOGGER.debug("Fail because manufacturer mismatch on at least one endpoint")
+            continue
+
         if not all([_match(device[eid].in_clusters.keys(),
                            ep.get('input_clusters', []))
                     for eid, ep in sig.items()]):

--- a/zigpy/quirks/xiaomi/__init__.py
+++ b/zigpy/quirks/xiaomi/__init__.py
@@ -9,6 +9,8 @@ class TemperatureHumiditySensor(CustomDevice):
         1: {
             'profile_id': 0x0104,
             'device_type': 0x5f01,
+            'model': 'lumi.sensor_ht',
+            'manufacturer': 'LUMI',
             'input_clusters': [0, 3, 25, 65535, 18],
             'output_clusters': [0, 4, 3, 5, 25, 65535, 18],
         },


### PR DESCRIPTION
This PR adds support to match on model and manufacturer in quirks signatures, which is necessary for some devices like the Xiaomi Humidity/Temperature sensor. This supersedes #97 which has not been updated in a while. Thanks @NNMavy for the initial PR!