### PR TITLE
Add ControllerApplication.shutdown() method.

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -204,3 +204,8 @@ async def test_broadcast(app):
         )
         await app.broadcast(app, profile, cluster, src_ep, dst_ep,
                             grp, radius, tsn, data)
+
+
+@pytest.mark.asyncio
+async def test_shutdown(app):
+    await app.shutdown()

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -24,6 +24,10 @@ class ControllerApplication(zigpy.util.ListenableMixin):
             self.add_listener(self._dblistener)
             self._dblistener.load()
 
+    async def shutdown(self):
+        """Perform a complete application shutdown."""
+        pass
+
     async def startup(self, auto_form=False):
         """Perform a complete application startup"""
         raise NotImplementedError


### PR DESCRIPTION
Transition to ControllerApplication shutdown() method. At very least should close the serial port. May perform other "clean up" task depending on radio implementation. 