### PR TITLE
Added the new ConBee II (ConBee 2) to known working Zigbee radios

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ zigpy works with separate radio libraries which can each interface with multiple
 - XBee Zigbee based radios (via the [zigpy-xbee](https://github.com/zigpy/zigpy-xbee) library for zigpy)
   - Digi XBee Series 2C (S2C) modules
 - deCONZ based radios (via the [zigpy-deconz](https://github.com/zigpy/zigpy-deconz) library for zigpy)
+  - [ConBee II (a.k.a. ConBee 2) USB adapter from Dresden-Elektronik](https://shop.dresden-elektronik.de/conbee-2.html)
   - [ConBee](https://www.dresden-elektronik.de/conbee/) USB adio adapter from [Dresden-Elektronik](https://www.dresden-elektronik.de)
   - [RaspBee](https://www.dresden-elektronik.de/raspbee/) GPIO radio adapter from [Dresden-Elektronik](https://www.dresden-elektronik.de)


### PR DESCRIPTION
"ConBee II" (a.k.a. "ConBee 2") hardware has just now been released and is confirmed by Dresden-Elektronik employee @manup to be backwards compatible with the deCONZ serial protocol that zigpy-deconz radio module for zigpy utilizes. (He, @manup wrote that "the serial protocol is identical and will be maintained for all devices equally").

FYI; Apparently the new "ConBee II" ZigBee USB dongle/stick features is based on a 32-bit ARM-Cortex-M0 SoC microcontroller (Microchip ATSAMR21E18A) instead of an 8-bit AVR based CMOS microcontroller (Atmel ATmega256RFR2) like the previous version of ConBee and the current RaspBee versions.

- https://shop.dresden-elektronik.de/conbee-2.html
- https://www.dresden-elektronik.de/fileadmin/Downloads/Dokumente/Produkte/11_Phoscon_gateway/Phoscon_ConBee-II_10-2018_eng.pdf
- http://www.amazon.de/dp/B01FDWOIHK