### PR TITLE
Drop the device from DB if not fully discovered.

### DIFF
--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -12,7 +12,7 @@ class Listenable(util.ListenableMixin):
 
 def test_listenable():
     listen = Listenable()
-    listener = mock.MagicMock()
+    listener = mock.MagicMock(spec_set=['event'])
     listen.add_listener(listener)
     listen.add_listener(listener)
 
@@ -21,6 +21,10 @@ def test_listenable():
     listen.add_listener(broken_listener)
 
     listen.listener_event('event')
+    assert listener.event.call_count == 2
+    assert broken_listener.event.call_count == 1
+
+    listen.listener_event('non_existing_event')
     assert listener.event.call_count == 2
     assert broken_listener.event.call_count == 1
 

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -23,11 +23,13 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def __init__(self, device, endpoint_id):
         self._device = device
         self._endpoint_id = endpoint_id
+        self.device_type = None
         self.in_clusters = {}
         self.out_clusters = {}
         self._cluster_attr = {}
         self.status = Status.NEW
         self._listeners = {}
+        self.profile_id = None
         self.manufacturer = None
         self.model = None
 
@@ -47,7 +49,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             if sdr[0] != 0:
                 raise Exception("Failed to retrieve service descriptor: %s", sdr)
         except Exception as exc:
-            self.warn("Failed ZDO request during device initialization: %s", exc)
+            self.warn("Failed ZDO request during endpoint initialization: %s", exc)
             return
 
         self.info("Discovered endpoint information: %s", sdr[2])

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -21,8 +21,9 @@ class ListenableMixin:
     def listener_event(self, method_name, *args):
         for listener in self._listeners.values():
             try:
-                method = getattr(listener, method_name)
-                method(*args)
+                method = getattr(listener, method_name, None)
+                if method:
+                    method(*args)
             except Exception as e:
                 LOGGER.warning("Error calling listener.%s: %s", method_name, e)
 


### PR DESCRIPTION
Fixes https://github.com/zigpy/zigpy/issues/123
if discovery of any endpoint is not completed, then remove the device and drop it from the db to ensure DB consistency. 
