### PR TITLE
Handle TimeoutError during device removal.

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -108,14 +108,16 @@ def test_join_handler_change_id(app, ieee):
     assert app.devices[ieee].nwk == 2
 
 
-async def _remove(app, ieee, retval, zdo_reply=True):
+async def _remove(app, ieee, retval, zdo_reply=True, delivery_failure=True):
     app.devices[ieee] = mock.MagicMock()
 
     async def leave():
         if zdo_reply:
             return retval
-        else:
+        elif delivery_failure:
             raise DeliveryError
+        else:
+            raise asyncio.TimeoutError
 
     app.devices[ieee].zdo.leave.side_effect = leave
     await app.remove(ieee)
@@ -146,6 +148,13 @@ async def test_remove_nonexistent(app, ieee):
 async def test_remove_with_unreachable_device(app, ieee):
     app.force_remove = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
     await _remove(app, ieee, [0], zdo_reply=False)
+    assert app.force_remove.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_remove_with_reply_timeout(app, ieee):
+    app.force_remove = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    await _remove(app, ieee, [0], zdo_reply=False, delivery_failure=False)
     assert app.force_remove.call_count == 1
 
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import zigpy.appdb
@@ -62,7 +63,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         try:
             resp = await dev.zdo.leave()
             zdo_worked = resp[0] == 0
-        except zigpy.exceptions.DeliveryError as ex:
+        except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
             LOGGER.debug("Sending 'zdo_leave_req' failed: %s", ex)
 
         if not zdo_worked:


### PR DESCRIPTION
Currently `ApplicationController.remove()` suppresses only `DeliveryError` exceptions, however some radios (bellows) may raise `asyncio.TimeoutError` exception instead, which would cause the device not to be removed from the database. 