### PR TITLE
Add "node descriptor" to zigpy.device.Device class.

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -7,7 +7,7 @@ import zigpy.types as t
 from zigpy.application import ControllerApplication
 from zigpy import profiles
 from zigpy.quirks import CustomDevice
-from zigpy.device import Status
+from zigpy.device import Device, Status
 from zigpy.zdo import types as zdo_t
 
 
@@ -32,7 +32,8 @@ async def _initialize(self):
 
 def fake_get_device(device):
     if device.endpoints.get(1) is not None and device[1].profile_id == 65535:
-        return FakeCustomDevice(device.application, make_ieee(1), 199, {})
+        return FakeCustomDevice(device.application, make_ieee(1), 199,
+                                Device(device.application, make_ieee(1), 199))
     return device
 
 
@@ -170,3 +171,37 @@ def test_appdb_load_null_padded_manuf_model(tmpdir):
 
     assert dev.endpoints[3].manufacturer == 'Mock Manufacturer'
     assert dev.endpoints[3].model == 'Mock Model'
+
+
+@pytest.mark.asyncio
+async def test_node_descriptor_updated(tmpdir):
+    db = os.path.join(str(tmpdir), 'test_nd.db')
+    app = make_app(db)
+    nd_ieee = make_ieee(2)
+    app.handle_join(299, nd_ieee, 0)
+
+    dev = app.get_device(nd_ieee)
+    ep = dev.add_endpoint(1)
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+    ep.add_input_cluster(0)
+    ep.add_output_cluster(1)
+    app.device_initialized(dev)
+
+    node_desc = zdo_t.NodeDescriptor.deserialize(b'abcdefghijklm')[0]
+
+    async def mock_get_node_descriptor():
+        dev.node_desc = node_desc
+        return node_desc
+    dev.get_node_descriptor = mock.MagicMock()
+    dev.get_node_descriptor.side_effect = mock_get_node_descriptor
+    await dev.refresh_node_descriptor()
+
+    assert dev.get_node_descriptor.call_count == 1
+
+    app2 = make_app(db)
+    dev = app2.get_device(nd_ieee)
+    assert dev.node_desc.is_valid
+    assert dev.node_desc.serialize() == b'abcdefghijklm'
+
+    os.unlink(db)

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -8,6 +8,7 @@ from zigpy.application import ControllerApplication
 from zigpy import profiles
 from zigpy.quirks import CustomDevice
 from zigpy.device import Status
+from zigpy.zdo import types as zdo_t
 
 
 def make_app(database_file):
@@ -45,6 +46,7 @@ async def test_database(tmpdir):
     app.handle_join(99, ieee, 0)
 
     dev = app.get_device(ieee)
+    dev.node_desc, _ = zdo_t.NodeDescriptor.deserialize(b'1234567890')
     ep = dev.add_endpoint(1)
     ep.profile_id = 260
     ep.device_type = profiles.zha.DeviceType.PUMP

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -41,10 +41,57 @@ def test_multi_address_invalid():
 
 
 def test_node_descriptor():
-    data = b'\x00\x00\x01\x02\x02\x03\x04\x04\x05\x05\x06\x06\x07\xff'
-    nd, data = types.NodeDescriptor.deserialize(data)
+    data = b'\x00\x01\x02\x03\x03\x04\x05\x05\x06\x06\x07\x07\x08\xff'
+    nd, rest = types.NodeDescriptor.deserialize(data)
 
-    assert data == b'\xff'
+    assert rest == b'\xff'
+
+    new_node_desc = types.NodeDescriptor(nd)
+    assert new_node_desc.byte1 == 0
+    assert new_node_desc.byte2 == 1
+    assert new_node_desc.mac_capability_flags == 0x02
+    assert new_node_desc.manufacturer_code == 0x0303
+    assert new_node_desc.maximum_buffer_size == 0x04
+    assert new_node_desc.maximum_incoming_transfer_size == 0x0505
+    assert new_node_desc.server_mask == 0x0606
+    assert new_node_desc.maximum_outgoing_transfer_size == 0x0707
+    assert new_node_desc.descriptor_capability_field == 0x08
+
+    nd2 = types.NodeDescriptor(
+        0, 1, 2, 0x0303, 0x04, 0x0505, 0x0606, 0x0707, 0x08)
+    assert nd2.serialize() == new_node_desc.serialize()
+
+
+def test_node_descriptor_is_valid():
+    for field in types.NodeDescriptor._fields:
+        nd = types.NodeDescriptor(
+            0, 1, 2, 0x0303, 0x04, 0x0505, 0x0606, 0x0707, 0x08)
+        assert nd.is_valid is True
+        setattr(nd, field[0], None)
+        assert nd.is_valid is False
+
+
+def test_node_descriptor_props():
+    props = (
+        'logical_type', 'complex_descriptor_available',
+        'user_descriptor_available', 'is_alternate_pan_coordinator',
+        'is_full_function_device', 'is_mains_powered',
+        'is_receiver_on_when_idle', 'is_security_capable', 'allocate_address'
+    )
+
+    empty_nd = types.NodeDescriptor()
+    for prop in props:
+        value = getattr(empty_nd, prop)
+        assert value is None
+
+    nd = types.NodeDescriptor(
+        0b11111000, 0xff, 0xff, 0xffff, 0xff, 0xffff, 0xffff, 0xffff, 0xff)
+    assert nd.logical_type is not None
+    for prop in props:
+        if prop == 'logical_type':
+            continue
+        value = getattr(nd, prop)
+        assert value is True
 
 
 def test_size_prefixed_simple_descriptor():

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -94,6 +94,31 @@ def test_node_descriptor_props():
         assert value is True
 
 
+def test_node_descriptor_logical_types():
+    nd = types.NodeDescriptor()
+    assert nd.is_coordinator is None
+    assert nd.is_end_device is None
+    assert nd.is_router is None
+
+    nd = types.NodeDescriptor(
+        0b11111000, 0xff, 0xff, 0xffff, 0xff, 0xffff, 0xffff, 0xffff, 0xff)
+    assert nd.is_coordinator is True
+    assert nd.is_end_device is False
+    assert nd.is_router is False
+
+    nd = types.NodeDescriptor(
+        0b11111001, 0xff, 0xff, 0xffff, 0xff, 0xffff, 0xffff, 0xffff, 0xff)
+    assert nd.is_coordinator is False
+    assert nd.is_end_device is False
+    assert nd.is_router is True
+
+    nd = types.NodeDescriptor(
+        0b11111010, 0xff, 0xff, 0xffff, 0xff, 0xffff, 0xffff, 0xffff, 0xff)
+    assert nd.is_coordinator is False
+    assert nd.is_end_device is True
+    assert nd.is_router is False
+
+
 def test_size_prefixed_simple_descriptor():
     sd = types.SizePrefixedSimpleDescriptor()
     sd.endpoint = t.uint8_t(1)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -71,6 +71,10 @@ class PersistingListener:
             value,
         )
 
+    def node_descriptor_updated(self, device):
+        self._save_node_descriptor(device)
+        self._db.commit()
+
     def _create_table(self, table_name, spec):
         self.execute("CREATE TABLE IF NOT EXISTS %s %s" % (table_name, spec))
         self.execute("PRAGMA user_version = %s" % (DB_VERSION, ))
@@ -139,11 +143,11 @@ class PersistingListener:
     def _save_device(self, device):
         q = "INSERT OR REPLACE INTO devices (ieee, nwk, status) VALUES (?, ?, ?)"
         self.execute(q, (device.ieee, device.nwk, device.status))
+        self._save_node_descriptor(device)
         if isinstance(device, zigpy.quirks.CustomDevice):
             self._db.commit()
             return
         self._save_endpoints(device)
-        self._save_node_descriptor(device)
         for epid, ep in device.endpoints.items():
             if epid == 0:
                 # ZDO

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -175,7 +175,7 @@ class PersistingListener:
         self._db.commit()
 
     def _save_node_descriptor(self, device):
-        if device.node_desc is None:
+        if not device.node_desc.is_valid:
             return
         q = "INSERT OR REPLACE INTO node_descriptors VALUES (?, ?)"
         self.execute(q, (device.ieee, device.node_desc.serialize()))

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -37,6 +37,7 @@ class Device(zigpy.util.LocalLogMixin):
         self.last_seen = None
         self.status = Status.NEW
         self.initializing = False
+        self.node_desc = None
 
     def schedule_initialize(self):
         if self.initializing:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -37,7 +37,7 @@ class Device(zigpy.util.LocalLogMixin):
         self.last_seen = None
         self.status = Status.NEW
         self.initializing = False
-        self.node_desc = None
+        self.node_desc = zdo.types.NodeDescriptor()
         self._node_handle = None
 
     def schedule_initialize(self):
@@ -61,16 +61,6 @@ class Device(zigpy.util.LocalLogMixin):
                 self.warn("Requesting Node Descriptor failed: %s", status)
         except Exception as exc:
             self.warn("Requesting Node Descriptor failed: %s", exc)
-            self.node_desc = zdo.types.NodeDescriptor()
-            self.node_desc.byte1 = 2
-            self.node_desc.byte2 = 64
-            self.node_desc.mac_capability_flags = 142
-            self.node_desc.manufacturer_code = 0
-            self.node_desc.maximum_buffer_size = 82
-            self.node_desc.maximum_incoming_transfer_size = 82
-            self.node_desc.server_mask = 0
-            self.node_desc.maximum_outgoing_transfer_size = 82
-            self.node_desc.descriptor_capability_field = 0
 
     async def refresh_node_descriptor(self):
         if await self.get_node_descriptor():
@@ -148,7 +138,7 @@ class Device(zigpy.util.LocalLogMixin):
 
     def handle_message(self, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args):
         self.last_seen = time.time()
-        if self.node_desc is None and \
+        if not self.node_desc.is_valid and \
                 (self._node_handle is None or self._node_handle.done()):
             self._node_handle = asyncio.ensure_future(
                 self.refresh_node_descriptor())

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -72,6 +72,7 @@ class CustomDevice(zigpy.device.Device, metaclass=Registry):
     def __init__(self, application, ieee, nwk, replaces):
         super().__init__(application, ieee, nwk)
         self.status = zigpy.device.Status.ENDPOINTS_INIT
+        self.node_desc = replaces.node_desc
         for endpoint_id, endpoint in self.replacement.get('endpoints', {}).items():
             self.add_endpoint(endpoint_id, replace_device=replaces)
 

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -33,6 +33,17 @@ class SizePrefixedSimpleDescriptor(SimpleDescriptor):
         return SimpleDescriptor.deserialize(data[1:])
 
 
+class LogicalType(t.uint8_t, enum.Enum):
+    Coordinator = 0b000
+    Router = 0b001
+    EndDevice = 0b010
+    Reserved3 = 0b011
+    Reserved4 = 0b100
+    Reserved5 = 0b101
+    Reserved6 = 0b110
+    Reserved7 = 0b111
+
+
 class NodeDescriptor(t.Struct):
     _fields = [
         ('byte1', t.uint8_t),
@@ -66,6 +77,61 @@ class NodeDescriptor(t.Struct):
             getattr(self, field[0]) is not None for field in self._fields
         ]
         return all(non_empty_fields)
+
+    @property
+    def logical_type(self):
+        """Return logical type of the device"""
+        if self.byte1 is None:
+            return None
+        return LogicalType(self.byte1 & 0x07)
+
+    @property
+    def complex_descriptor_available(self):
+        if self.byte1 is None:
+            return None
+        return bool(self.byte1 & 0b00001000)
+
+    @property
+    def user_descriptor_available(self):
+        if self.byte1 is None:
+            return None
+        return bool(self.byte1 & 0b00010000)
+
+    @property
+    def is_alternate_pan_coordinator(self):
+        if self.mac_capability_flags is None:
+            return None
+        return bool(self.mac_capability_flags & 0b00000001)
+
+    @property
+    def is_full_function_device(self):
+        if self.mac_capability_flags is None:
+            return None
+        return bool(self.mac_capability_flags & 0b00000010)
+
+    @property
+    def is_mains_powered(self):
+        if self.mac_capability_flags is None:
+            return None
+        return bool(self.mac_capability_flags & 0b00000100)
+
+    @property
+    def is_receiver_on_when_idle(self):
+        if self.mac_capability_flags is None:
+            return None
+        return bool(self.mac_capability_flags & 0b00001000)
+
+    @property
+    def is_security_capable(self):
+        if self.mac_capability_flags is None:
+            return None
+        return bool(self.mac_capability_flags & 0b01000000)
+
+    @property
+    def allocate_address(self):
+        if self.mac_capability_flags is None:
+            return None
+        return bool(self.mac_capability_flags & 0b10000000)
 
 
 class MultiAddress:

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -46,6 +46,27 @@ class NodeDescriptor(t.Struct):
         ('descriptor_capability_field', t.uint8_t),
     ]
 
+    def __init__(self, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], self.__class__):
+            # copy constructor
+            for field in self._fields:
+                setattr(self, field[0], getattr(args[0], field[0]))
+            self._valid = True
+        elif len(args) == len(self._fields):
+            for field, val in zip(self._fields, args):
+                setattr(self, field[0], field[1](val))
+        else:
+            for field in self._fields:
+                setattr(self, field[0], None)
+
+    @property
+    def is_valid(self):
+        """Return True if all fields were initialized."""
+        non_empty_fields = [
+            getattr(self, field[0]) is not None for field in self._fields
+        ]
+        return all(non_empty_fields)
+
 
 class MultiAddress:
     """Used for binds, represents an IEEE+endpoint or NWK address"""

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -86,6 +86,27 @@ class NodeDescriptor(t.Struct):
         return LogicalType(self.byte1 & 0x07)
 
     @property
+    def is_coordinator(self):
+        """Return True whether this is a coordinator."""
+        if self.logical_type is None:
+            return None
+        return self.logical_type == LogicalType.Coordinator
+
+    @property
+    def is_end_device(self):
+        """Return True whether this is an end device."""
+        if self.logical_type is None:
+            return None
+        return self.logical_type == LogicalType.EndDevice
+
+    @property
+    def is_router(self):
+        """Return True whether this is a router."""
+        if self.logical_type is None:
+            return None
+        return self.logical_type == LogicalType.Router
+
+    @property
     def complex_descriptor_available(self):
         if self.byte1 is None:
             return None


### PR DESCRIPTION
This PR adds ZDO Node Descriptor to Zigpy Device and I'm opening this for further discussion and feedback. 
This is in effort to implement `setExtendedTimeout()` in `bellows` to:

> Tell the stack whether or not the normal interval between retransmissions of a retried unicast message should be increased
by EMBER_INDIRECT_TRANSMISSION_TIMEOUT. The interval needs to be increased when sending to a sleepy node so that the message is not retransmitted until the destination has had time to wake up and poll its parent. The stack will automatically extend the timeout: - For our own sleepy children. - When an address response is received from a parent on behalf of its child. - When an indirect transaction expiry route error is received. - When an end device announcement is received from a sleepy node"

To know whether the destination is an end device or router we pull a mandatory ZDO `Node Descriptor` and store it in the database. Normally we're pulling Node Descriptor as part of device discovery, however for the purpose of migration from older versions, we also pulling it whenever we get traffic from a device which doesn't have a node descriptor set. 