### PR TITLE
WIP Implement ZDO commands as enums.

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -65,6 +65,7 @@ async def test_permit(app, ieee):
     await app.permit(node=ncp_ieee)
     assert app.devices[ieee].zdo.permit.call_count == 1
     assert app.permit_ncp.call_count == 1
+    print("{}".format(asyncio.Task.all_tasks()))
 
 
 @pytest.mark.asyncio

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -50,3 +50,11 @@ def test_struct():
 
     s = ts2.serialize()
     assert s == b'\xaa\xbb'
+
+
+def test_hex_repr():
+    class NwkAsHex(t.HexRepr, t.uint16_t):
+        _hex_len = 4
+    nwk = NwkAsHex(0x1234)
+    assert str(nwk) == '0x1234'
+    assert repr(nwk) == '0x1234'

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -12,8 +12,7 @@ def test_commands():
     for cmdid, cmdspec in zdo.types.CLUSTERS.items():
         assert 0 <= cmdid <= 0xffff
         assert isinstance(cmdspec, tuple)
-        assert isinstance(cmdspec[0], str)
-        for paramname, paramtype in zip(cmdspec[1], cmdspec[2]):
+        for paramname, paramtype in zip(cmdspec[0], cmdspec[1]):
             assert isinstance(paramname, str)
             assert hasattr(paramtype, 'serialize')
             assert hasattr(paramtype, 'deserialize')

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -161,3 +161,8 @@ async def test_reply(zdo_f):
     zdo_f.reply(0x0005)
     await asyncio.sleep(0)
     assert call_count == 1
+
+
+def test_get_attr_error(zdo_f):
+    with pytest.raises(AttributeError):
+        zdo_f.no_such_attribute()

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -6,6 +6,7 @@ import time
 import zigpy.endpoint
 import zigpy.util
 import zigpy.zdo as zdo
+from zigpy.zdo.types import ZDOCmd
 from zigpy.types import BroadcastAddress
 
 
@@ -52,7 +53,7 @@ class Device(zigpy.util.LocalLogMixin):
         self.info("Requesting 'Node Descriptor'")
         try:
             status, _, node_desc = await self.zdo.request(
-                0x0002, self.nwk, tries=2, delay=1)
+                ZDOCmd.Node_Desc_req, self.nwk, tries=2, delay=1)
             if status == zdo.types.Status.SUCCESS:
                 self.node_desc = node_desc
                 self.info("Node Descriptor: %s", node_desc)
@@ -73,7 +74,7 @@ class Device(zigpy.util.LocalLogMixin):
             await self._node_handle
             self.info("Discovering endpoints")
             try:
-                epr = await self.zdo.request(0x0005, self.nwk, tries=3, delay=2)
+                epr = await self.zdo.request(ZDOCmd.Active_EP_req, self.nwk, tries=3, delay=2)
                 if epr[0] != 0:
                     raise Exception("Endpoint request failed: %s", epr)
             except Exception as exc:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -6,7 +6,6 @@ import time
 import zigpy.endpoint
 import zigpy.util
 import zigpy.zdo as zdo
-from zigpy.zdo.types import ZDOCmd
 from zigpy.types import BroadcastAddress
 
 
@@ -52,8 +51,9 @@ class Device(zigpy.util.LocalLogMixin):
     async def get_node_descriptor(self):
         self.info("Requesting 'Node Descriptor'")
         try:
-            status, _, node_desc = await self.zdo.request(
-                ZDOCmd.Node_Desc_req, self.nwk, tries=2, delay=1)
+            status, _, node_desc = await self.zdo.Node_Desc_req(self.nwk,
+                                                                tries=2,
+                                                                delay=1)
             if status == zdo.types.Status.SUCCESS:
                 self.node_desc = node_desc
                 self.info("Node Descriptor: %s", node_desc)
@@ -74,7 +74,7 @@ class Device(zigpy.util.LocalLogMixin):
             await self._node_handle
             self.info("Discovering endpoints")
             try:
-                epr = await self.zdo.request(ZDOCmd.Active_EP_req, self.nwk, tries=3, delay=2)
+                epr = await self.zdo.Active_EP_req(self.nwk, tries=3, delay=2)
                 if epr[0] != 0:
                     raise Exception("Endpoint request failed: %s", epr)
             except Exception as exc:

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -5,6 +5,7 @@ import zigpy.profiles
 import zigpy.util
 import zigpy.zcl
 from zigpy.zcl.clusters.general import Basic
+from zigpy.zdo.types import ZDOCmd
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.info("Discovering endpoint information")
         try:
             sdr = await self._device.zdo.request(
-                0x0004,
+                ZDOCmd.Simple_Desc_req,
                 self._device.nwk,
                 self._endpoint_id,
                 tries=3,

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -5,7 +5,6 @@ import zigpy.profiles
 import zigpy.util
 import zigpy.zcl
 from zigpy.zcl.clusters.general import Basic
-from zigpy.zdo.types import ZDOCmd
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,8 +38,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         self.info("Discovering endpoint information")
         try:
-            sdr = await self._device.zdo.request(
-                ZDOCmd.Simple_Desc_req,
+            sdr = await self._device.zdo.Simple_Desc_req(
                 self._device.nwk,
                 self._endpoint_id,
                 tries=3,

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -39,3 +39,17 @@ class KeyData(basic.fixed_list(16, basic.uint8_t)):
 class Bool(basic.uint8_t, enum.Enum):
     false = 0
     true = 1
+
+
+class HexRepr:
+    _hex_len = 2
+
+    def __repr__(self):
+        return ('0x{:0' + str(self._hex_len) + 'x}').format(self)
+
+    def __str__(self):
+        return ('0x{:0' + str(self._hex_len) + 'x}').format(self)
+
+
+class NWK(HexRepr, basic.uint16_t):
+    _hex_len = 4

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -64,13 +64,11 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         app = self._device.application
         if command_id == types.ZDOCmd.NWK_addr_req:
             if app.ieee == args[0]:
-                self.reply(types.ZDOCmd.NWK_addr_rsp,
-                           0, app.ieee, app.nwk, 0, 0, [])
+                self.NWK_addr_rsp(0, app.ieee, app.nwk, 0, 0, [])
         elif command_id == types.ZDOCmd.IEEE_addr_req:
             broadcast = (0xffff, 0xfffd, 0xfffc)
             if args[0] in broadcast or app.nwk == args[0]:
-                self.reply(types.ZDOCmd.IEEE_addr_rsp,
-                           0, app.ieee, app.nwk, 0, 0, [])
+                self.IEEE_addr_rsp(0, app.ieee, app.nwk, 0, 0, [])
         elif command_id == types.ZDOCmd.Match_Desc_req:
             self.handle_match_desc(*args)
         elif command_id == types.ZDOCmd.Device_annce:
@@ -82,35 +80,30 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     def handle_match_desc(self, addr, profile, in_clusters, out_clusters):
         local_addr = self._device.application.nwk
-        if profile == 260:
-            response = (types.ZDOCmd.Match_Desc_rsp, 0, local_addr, [t.uint8_t(1)])
-        else:
-            response = (types.ZDOCmd.Match_Desc_rsp, 0, local_addr, [])
+        if profile != 260:
+            return self.Match_Desc_rsp(0, local_addr, [])
 
-        self.reply(*response)
+        return self.Match_Desc_rsp(0, local_addr, [t.uint8_t(1)])
 
     def bind(self, endpoint, cluster):
         dstaddr = types.MultiAddress()
         dstaddr.addrmode = 3
         dstaddr.ieee = self._device.application.ieee
         dstaddr.endpoint = endpoint
-        return self.request(types.ZDOCmd.Bind_req,
-                            self._device.ieee, endpoint, cluster, dstaddr)
+        return self.Bind_req(self._device.ieee, endpoint, cluster, dstaddr)
 
     def unbind(self, endpoint, cluster):
         dstaddr = types.MultiAddress()
         dstaddr.addrmode = 3
         dstaddr.ieee = self._device.application.ieee
         dstaddr.endpoint = endpoint
-        return self.request(types.ZDOCmd.Unbind_req,
-                            self._device.ieee, endpoint, cluster, dstaddr)
+        return self.Unbind_req(self._device.ieee, endpoint, cluster, dstaddr)
 
     def leave(self):
-        return self.request(types.ZDOCmd.Mgmt_Leave_req, self._device.ieee, 0x02)
+        return self.Mgmt_Leave_req(self._device.ieee, 0x02)
 
     def permit(self, duration=60, tc_significance=0):
-        return self.request(types.ZDOCmd.Mgmt_Permit_Joining_req,
-                            duration, tc_significance)
+        return self.Mgmt_Permit_Joining_req(duration, tc_significance)
 
     def log(self, lvl, msg, *args):
         msg = '[0x%04x:zdo] ' + msg

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -19,7 +19,7 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def _serialize(self, command, *args):
         sequence = self._device.application.get_sequence()
         data = sequence.to_bytes(1, 'little')
-        schema = types.CLUSTERS[command][2]
+        schema = types.CLUSTERS[command][1]
         data += t.serialize(args, schema)
         return sequence, data
 
@@ -28,15 +28,19 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         is_reply = bool(cluster_id & 0x8000)
         try:
+            cluster_id = types.ZDOCmd(cluster_id)
+        except ValueError:
+            self.warn("Unsupported ZDO cluster id 0x%04x", cluster_id)
+        try:
             cluster_details = types.CLUSTERS[cluster_id]
         except KeyError:
-            LOGGER.warning("Unknown ZDO cluster 0x%02x", cluster_id)
+            self.warn("Unknown ZDO cluster 0x%04x", cluster_id)
             return tsn, cluster_id, is_reply, data
 
-        args, data = t.deserialize(data, cluster_details[2])
+        args, data = t.deserialize(data, cluster_details[1])
         if data != b'':
             # TODO: Seems sane to check, but what should we do?
-            LOGGER.warning("Data remains after deserializing ZDO frame")
+            self.warn("Data remains after deserializing ZDO frame")
 
         return tsn, cluster_id, is_reply, args
 
@@ -52,33 +56,35 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     def handle_message(self, is_reply, profile, cluster, tsn, command_id, args):
         if is_reply:
-            self.debug("Unexpected ZDO reply 0x%04x: %s", command_id, args)
+            self.debug("Unexpected ZDO reply %s: %s", command_id, args)
             return
 
-        self.debug("ZDO request 0x%04x: %s", command_id, args)
+        self.debug("ZDO request %s: %s", command_id, args)
         app = self._device.application
-        if command_id == 0x0000:  # NWK_addr_req
+        if command_id == types.ZDOCmd.NWK_addr_req:
             if app.ieee == args[0]:
-                self.reply(0x8000, 0, app.ieee, app.nwk, 0, 0, [])
-        elif command_id == 0x0001:  # IEEE_addr_req
+                self.reply(types.ZDOCmd.NWK_addr_rsp,
+                           0, app.ieee, app.nwk, 0, 0, [])
+        elif command_id == types.ZDOCmd.IEEE_addr_req:
             broadcast = (0xffff, 0xfffd, 0xfffc)
             if args[0] in broadcast or app.nwk == args[0]:
-                self.reply(0x8001, 0, app.ieee, app.nwk, 0, 0, [])
-        elif command_id == 0x0006:  # Match_Desc_req
+                self.reply(types.ZDOCmd.IEEE_addr_rsp,
+                           0, app.ieee, app.nwk, 0, 0, [])
+        elif command_id == types.ZDOCmd.Match_Desc_req:
             self.handle_match_desc(*args)
-        elif command_id == 0x0013:  # Device_annce
+        elif command_id == types.ZDOCmd.Device_annce:
             self.listener_event('device_announce', self._device)
-        elif command_id == 0x0036:  # Mgmt_Permit_Joining_req
+        elif command_id == types.ZDOCmd.Mgmt_Permit_Joining_req:
             self.listener_event('permit_duration', args[0])
         else:
-            self.warn("Unsupported ZDO request 0x%04x", command_id)
+            self.warn("Unsupported ZDO request:%s", command_id)
 
     def handle_match_desc(self, addr, profile, in_clusters, out_clusters):
         local_addr = self._device.application.nwk
         if profile == 260:
-            response = (0x8006, 0, local_addr, [t.uint8_t(1)])
+            response = (types.ZDOCmd.Match_Desc_rsp, 0, local_addr, [t.uint8_t(1)])
         else:
-            response = (0x8006, 0, local_addr, [])
+            response = (types.ZDOCmd.Match_Desc_rsp, 0, local_addr, [])
 
         self.reply(*response)
 
@@ -87,20 +93,23 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         dstaddr.addrmode = 3
         dstaddr.ieee = self._device.application.ieee
         dstaddr.endpoint = endpoint
-        return self.request(0x0021, self._device.ieee, endpoint, cluster, dstaddr)
+        return self.request(types.ZDOCmd.Bind_req,
+                            self._device.ieee, endpoint, cluster, dstaddr)
 
     def unbind(self, endpoint, cluster):
         dstaddr = types.MultiAddress()
         dstaddr.addrmode = 3
         dstaddr.ieee = self._device.application.ieee
         dstaddr.endpoint = endpoint
-        return self.request(0x0022, self._device.ieee, endpoint, cluster, dstaddr)
+        return self.request(types.ZDOCmd.Unbind_req,
+                            self._device.ieee, endpoint, cluster, dstaddr)
 
     def leave(self):
-        return self.request(0x0034, self._device.ieee, 0x02)
+        return self.request(types.ZDOCmd.Mgmt_Leave_req, self._device.ieee, 0x02)
 
     def permit(self, duration=60, tc_significance=0):
-        return self.request(0x0036, duration, tc_significance)
+        return self.request(types.ZDOCmd.Mgmt_Permit_Joining_req,
+                            duration, tc_significance)
 
     def log(self, lvl, msg, *args):
         msg = '[0x%04x:zdo] ' + msg
@@ -118,7 +127,7 @@ def broadcast(app, command, grpid, radius, *args,
               broadcast_address=t.BroadcastAddress.RX_ON_WHEN_IDLE):
     sequence = app.get_sequence()
     data = sequence.to_bytes(1, 'little')
-    schema = types.CLUSTERS[command][2]
+    schema = types.CLUSTERS[command][1]
     data += t.serialize(args, schema)
     return zigpy.device.broadcast(
         app, 0, command, 0, 0, grpid, radius, sequence, data,

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import logging
 
 import zigpy.types as t
@@ -121,6 +122,16 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     @property
     def device(self):
         return self._device
+
+    def __getattr__(self, name):
+        try:
+            command = types.ZDOCmd[name]
+        except KeyError:
+            raise AttributeError("No such '%s' ZDO command" % (name, ))
+
+        if command & 0x8000:
+            return functools.partial(self.reply, command)
+        return functools.partial(self.request, command)
 
 
 def broadcast(app, command, grpid, radius, *args,

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -276,82 +276,159 @@ IEEE = ('IEEEAddr', t.EUI64)
 STATUS = ('Status', Status)
 
 
-CLUSTERS = {
+class _CommandID(t.HexRepr, t.uint16_t):
+    _hex_len = 4
+
+
+class ZDOCmd(_CommandID, enum.Enum):
     # Device and Service Discovery Server Requests
-    0x0000: ('NWK_addr_req', (IEEE, ('RequestType', t.uint8_t), ('StartIndex', t.uint8_t))),
-    0x0001: ('IEEE_addr_req', (NWKI, ('RequestType', t.uint8_t), ('StartIndex', t.uint8_t))),
-    0x0002: ('Node_Desc_req', (NWKI, )),
-    0x0003: ('Power_Desc_req', (NWKI, )),
-    0x0004: ('Simple_Desc_req', (NWKI, ('EndPoint', t.uint8_t))),
-    0x0005: ('Active_EP_req', (NWKI, )),
-    0x0006: ('Match_Desc_req', (NWKI, ('ProfileID', t.uint16_t), ('InClusterList', t.LVList(t.uint16_t)), ('OutClusterList', t.LVList(t.uint16_t)))),
-    # 0x0010: ('Complex_Desc_req', (NWKI, )),
-    0x0011: ('User_Desc_req', (NWKI, )),
-    0x0012: ('Discovery_Cache_req', (NWK, IEEE)),
-    0x0013: ('Device_annce', (NWK, IEEE, ('Capability', t.uint8_t))),
-    0x0014: ('User_Desc_set', (NWKI, ('UserDescriptor', t.fixed_list(16, t.uint8_t)))),  # Really a string
-    0x0015: ('System_Server_Discovery_req', (('ServerMask', t.uint16_t), )),
-    0x0016: ('Discovery_store_req', (NWK, IEEE, ('NodeDescSize', t.uint8_t), ('PowerDescSize', t.uint8_t), ('ActiveEPSize', t.uint8_t), ('SimpleDescSizeList', t.LVList(t.uint8_t)))),
-    0x0017: ('Node_Desc_store_req', (NWK, IEEE, ('NodeDescriptor', NodeDescriptor))),
-    0x0019: ('Active_EP_store_req', (NWK, IEEE, ('ActiveEPList', t.LVList(t.uint8_t)))),
-    0x001a: ('Simple_Desc_store_req', (NWK, IEEE, ('SimpleDescriptor', SizePrefixedSimpleDescriptor))),
-    0x001b: ('Remove_node_cache_req', (NWK, IEEE)),
-    0x001c: ('Find_node_cache_req', (NWK, IEEE)),
-    0x001d: ('Extended_Simple_Desc_req', (NWKI, ('EndPoint', t.uint8_t), ('StartIndex', t.uint8_t))),
-    0x001e: ('Extended_Active_EP_req', (NWKI, ('StartIndex', t.uint8_t))),
+    NWK_addr_req = 0x0000
+    IEEE_addr_req = 0x0001
+    Node_Desc_req = 0x0002
+    Power_Desc_req = 0x0003
+    Simple_Desc_req = 0x0004
+    Active_EP_req = 0x0005
+    Match_Desc_req = 0x0006
+    Complex_Desc_req = 0x0010
+    User_Desc_req = 0x0011
+    Discovery_Cache_req = 0x0012
+    Device_annce = 0x0013
+    User_Desc_set = 0x0014
+    System_Server_Discovery_req = 0x0015
+    Discovery_store_req = 0x0016
+    Node_Desc_store_req = 0x0017
+    Active_EP_store_req = 0x0019
+    Simple_Desc_store_req = 0x001a
+    Remove_node_cache_req = 0x001b
+    Find_node_cache_req = 0x001c
+    Extended_Simple_Desc_req = 0x001d
+    Extended_Active_EP_req = 0x001e
     #  Bind Management Server Services Responses
-    0x0020: ('End_Device_Bind_req', (('BindingTarget', t.uint16_t), ('SrcAddress', t.EUI64), ('SrcEndpoint', t.uint8_t), ('ProfileID', t.uint8_t), ('InClusterList', t.LVList(t.uint8_t)), ('OutClusterList', t.LVList(t.uint8_t)))),
-    0x0021: ('Bind_req', (('SrcAddress', t.EUI64), ('SrcEndpoint', t.uint8_t), ('ClusterID', t.uint16_t), ('DstAddress', MultiAddress))),
-    0x0022: ('Unind_req', (('SrcAddress', t.EUI64), ('SrcEndpoint', t.uint8_t), ('ClusterID', t.uint16_t), ('DstAddress', MultiAddress))),
+    End_Device_Bind_req = 0x0020
+    Bind_req = 0x0021
+    Unbind_req = 0x0022
     # Network Management Server Services Requests
     # ... TODO optional stuff ...
-    0x0031: ('Mgmt_Lqi_req', (('StartIndex', t.uint8_t), )),
-    0x0032: ('Mgmt_Rtg_req', (('StartIndex', t.uint8_t), )),
+    Mgmt_Lqi_req = 0x0031
+    Mgmt_Rtg_req = 0x0032
     # ... TODO optional stuff ...
-    0x0034: ('Mgmt_Leave_req', (('DeviceAddress', t.EUI64), ('Options', t.bitmap8))),
-    0x0036: ('Mgmt_Permit_Joining_req', (('PermitDuration', t.uint8_t), ('TC_Significant', t.Bool))),
+    Mgmt_Leave_req = 0x0034
+    Mgmt_Permit_Joining_req = 0x0036
     # ... TODO optional stuff ...
 
     # Responses
     # Device and Service Discovery Server Responses
-    0x8000: ('NWK_addr_rsp', (STATUS, IEEE, NWK, ('NumAssocDev', t.uint8_t), ('StartIndex', t.uint8_t), ('NWKAddressAssocDevList', t.List(t.uint16_t)))),
-    0x8001: ('IEEE_addr_rsp', (STATUS, IEEE, NWK, ('NumAssocDev', t.uint8_t), ('StartIndex', t.uint8_t), ('NWKAddrAssocDevList', t.List(t.uint16_t)))),
-    0x8002: ('Node_Desc_rsp', (STATUS, NWKI, ('NodeDescriptor', NodeDescriptor))),
-    0x8003: ('Power_Desc_rsp', (STATUS, NWKI, ('PowerDescriptor', PowerDescriptor))),
-    0x8004: ('Simple_Desc_rsp', (STATUS, NWKI, ('SimpleDescriptor', SizePrefixedSimpleDescriptor))),
-    0x8005: ('Active_EP_rsp', (STATUS, NWKI, ('ActiveEPList', t.LVList(t.uint8_t)))),
-    0x8006: ('Match_Desc_rsp', (STATUS, NWKI, ('MatchList', t.LVList(t.uint8_t)))),
-    # 0x8010: ('Complex_Desc_rsp', (STATUS, NWKI, ('Length', t.uint8_t), ('ComplexDescriptor', ComplexDescriptor))),
-    0x8011: ('User_Desc_rsp', (STATUS, NWKI, ('Length', t.uint8_t), ('UserDescriptor', t.fixed_list(16, t.uint8_t)))),
-    0x8012: ('Discovery_Cache_rsp', (STATUS, )),
-    0x8014: ('User_Desc_conf', (STATUS, NWKI)),
-    0x8015: ('System_Server_Discovery_rsp', (STATUS, ('ServerMask', t.uint16_t))),
-    0x8016: ('Discovery_Store_rsp', (STATUS, )),
-    0x8017: ('Node_Desc_store_rsp', (STATUS, )),
-    0x8018: ('Power_Desc_store_rsp', (STATUS, IEEE, ('PowerDescriptor', PowerDescriptor))),
-    0x8019: ('Active_EP_store_rsp', (STATUS, )),
-    0x801a: ('Simple_Desc_store_rsp', (STATUS, )),
-    0x801b: ('Remove_node_cache_rsp', (STATUS, )),
-    0x801c: ('Find_node_cache_rsp', (('CacheNWKAddr', t.EUI64), NWK, IEEE)),
-    0x801d: ('Extended_Simple_Desc_rsp', (STATUS, NWK, ('Endpoint', t.uint8_t), ('AppInputClusterCount', t.uint8_t), ('AppOutputClusterCount', t.uint8_t), ('StartIndex', t.uint8_t), ('AppClusterList', t.List(t.uint16_t)))),
-    0x801e: ('Extended_Active_EP_rsp', (STATUS, NWKI, ('ActiveEPCount', t.uint8_t), ('StartIndex', t.uint8_t), ('ActiveEPList', t.List(t.uint8_t)))),
+    NWK_addr_rsp = 0x8000
+    IEEE_addr_rsp = 0x8001
+    Node_Desc_rsp = 0x8002
+    Power_Desc_rsp = 0x8003
+    Simple_Desc_rsp = 0x8004
+    Active_EP_rsp = 0x8005
+    Match_Desc_rsp = 0x8006
+    Complex_Desc_rsp = 0x8010
+    User_Desc_rsp = 0x8011
+    Discovery_Cache_rsp = 0x8012
+    User_Desc_conf = 0x8014
+    System_Server_Discovery_rsp = 0x8015
+    Discovery_Store_rsp = 0x8016
+    Node_Desc_store_rsp = 0x8017
+    Power_Desc_store_rsp = 0x8018
+    Active_EP_store_rsp = 0x8019
+    Simple_Desc_store_rsp = 0x801a
+    Remove_node_cache_rsp = 0x801b
+    Find_node_cache_rsp = 0x801c
+    Extended_Simple_Desc_rsp = 0x801d
+    Extended_Active_EP_rsp = 0x801e
     #  Bind Management Server Services Responses
-    0x8020: ('End_Device_Bind_rsp', (STATUS, )),
-    0x8021: ('Bind_rsp', (STATUS, )),
-    0x8022: ('Unbind_rsp', (STATUS, )),
+    End_Device_Bind_rsp = 0x8020
+    Bind_rsp = 0x8021
+    Unbind_rsp = 0x8022
     # ... TODO optional stuff ...
     # Network Management Server Services Responses
-    0x8031: ('Mgmt_Lqi_rsp', (STATUS, ('Neighbors', Neighbors))),
-    0x8032: ('Mgmt_Rtg_rsp', (STATUS, ('Routes', Routes))),
+    Mgmt_Lqi_rsp = 0x8031
+    Mgmt_Rtg_rsp = 0x8032
     # ... TODO optional stuff ...
-    0x8034: ('Mgmt_Leave_rsp', (STATUS, )),
-    0x8036: ('Mgmt_Permit_Joining_rsp', (STATUS, )),
+    Mgmt_Leave_rsp = 0x8034
+    Mgmt_Permit_Joining_rsp = 0x8036
+    # ... TODO optional stuff ...
+
+
+CLUSTERS = {
+    # Device and Service Discovery Server Requests
+    ZDOCmd.NWK_addr_req: (IEEE, ('RequestType', t.uint8_t), ('StartIndex', t.uint8_t)),
+    ZDOCmd.IEEE_addr_req: (NWKI, ('RequestType', t.uint8_t), ('StartIndex', t.uint8_t)),
+    ZDOCmd.Node_Desc_req: (NWKI,),
+    ZDOCmd.Power_Desc_req: (NWKI,),
+    ZDOCmd.Simple_Desc_req: (NWKI, ('EndPoint', t.uint8_t)),
+    ZDOCmd.Active_EP_req: (NWKI,),
+    ZDOCmd.Match_Desc_req: (NWKI, ('ProfileID', t.uint16_t), ('InClusterList', t.LVList(t.uint16_t)), ('OutClusterList', t.LVList(t.uint16_t))),
+    # ZDO.Complex_Desc_req: (NWKI, ),
+    ZDOCmd.User_Desc_req: (NWKI,),
+    ZDOCmd.Discovery_Cache_req: (NWK, IEEE),
+    ZDOCmd.Device_annce: (NWK, IEEE, ('Capability', t.uint8_t)),
+    ZDOCmd.User_Desc_set: (NWKI, ('UserDescriptor', t.fixed_list(16, t.uint8_t))),  # Really a string
+    ZDOCmd.System_Server_Discovery_req: (('ServerMask', t.uint16_t),),
+    ZDOCmd.Discovery_store_req: (NWK, IEEE, ('NodeDescSize', t.uint8_t), ('PowerDescSize', t.uint8_t), ('ActiveEPSize', t.uint8_t), ('SimpleDescSizeList', t.LVList(t.uint8_t))),
+    ZDOCmd.Node_Desc_store_req: (NWK, IEEE, ('NodeDescriptor', NodeDescriptor)),
+    ZDOCmd.Active_EP_store_req: (NWK, IEEE, ('ActiveEPList', t.LVList(t.uint8_t))),
+    ZDOCmd.Simple_Desc_store_req: (NWK, IEEE, ('SimpleDescriptor', SizePrefixedSimpleDescriptor)),
+    ZDOCmd.Remove_node_cache_req: (NWK, IEEE),
+    ZDOCmd.Find_node_cache_req: (NWK, IEEE),
+    ZDOCmd.Extended_Simple_Desc_req: (NWKI, ('EndPoint', t.uint8_t), ('StartIndex', t.uint8_t)),
+    ZDOCmd.Extended_Active_EP_req: (NWKI, ('StartIndex', t.uint8_t)),
+    #  Bind Management Server Services Responses
+    ZDOCmd.End_Device_Bind_req: (('BindingTarget', t.uint16_t), ('SrcAddress', t.EUI64), ('SrcEndpoint', t.uint8_t), ('ProfileID', t.uint8_t), ('InClusterList', t.LVList(t.uint8_t)), ('OutClusterList', t.LVList(t.uint8_t))),
+    ZDOCmd.Bind_req: (('SrcAddress', t.EUI64), ('SrcEndpoint', t.uint8_t), ('ClusterID', t.uint16_t), ('DstAddress', MultiAddress)),
+    ZDOCmd.Unbind_req: (('SrcAddress', t.EUI64), ('SrcEndpoint', t.uint8_t), ('ClusterID', t.uint16_t), ('DstAddress', MultiAddress)),
+    # Network Management Server Services Requests
+    # ... TODO optional stuff ...
+    ZDOCmd.Mgmt_Lqi_req: (('StartIndex', t.uint8_t),),
+    ZDOCmd.Mgmt_Rtg_req: (('StartIndex', t.uint8_t),),
+    # ... TODO optional stuff ...
+    ZDOCmd.Mgmt_Leave_req: (('DeviceAddress', t.EUI64), ('Options', t.bitmap8)),
+    ZDOCmd.Mgmt_Permit_Joining_req: (('PermitDuration', t.uint8_t), ('TC_Significant', t.Bool)),
+    # ... TODO optional stuff ...
+
+    # Responses
+    # Device and Service Discovery Server Responses
+    ZDOCmd.NWK_addr_rsp: (STATUS, IEEE, NWK, ('NumAssocDev', t.uint8_t), ('StartIndex', t.uint8_t), ('NWKAddressAssocDevList', t.List(t.uint16_t))),
+    ZDOCmd.IEEE_addr_rsp: (STATUS, IEEE, NWK, ('NumAssocDev', t.uint8_t), ('StartIndex', t.uint8_t), ('NWKAddrAssocDevList', t.List(t.uint16_t))),
+    ZDOCmd.Node_Desc_rsp: (STATUS, NWKI, ('NodeDescriptor', NodeDescriptor)),
+    ZDOCmd.Power_Desc_rsp: (STATUS, NWKI, ('PowerDescriptor', PowerDescriptor)),
+    ZDOCmd.Simple_Desc_rsp: (STATUS, NWKI, ('SimpleDescriptor', SizePrefixedSimpleDescriptor)),
+    ZDOCmd.Active_EP_rsp: (STATUS, NWKI, ('ActiveEPList', t.LVList(t.uint8_t))),
+    ZDOCmd.Match_Desc_rsp: (STATUS, NWKI, ('MatchList', t.LVList(t.uint8_t))),
+    # ZDO.Complex_Desc_rsp: (STATUS, NWKI, ('Length', t.uint8_t), ('ComplexDescriptor', ComplexDescriptor)),
+    ZDOCmd.User_Desc_rsp: (STATUS, NWKI, ('Length', t.uint8_t), ('UserDescriptor', t.fixed_list(16, t.uint8_t))),
+    ZDOCmd.Discovery_Cache_rsp: (STATUS,),
+    ZDOCmd.User_Desc_conf: (STATUS, NWKI),
+    ZDOCmd.System_Server_Discovery_rsp: (STATUS, ('ServerMask', t.uint16_t)),
+    ZDOCmd.Discovery_Store_rsp: (STATUS,),
+    ZDOCmd.Node_Desc_store_rsp: (STATUS,),
+    ZDOCmd.Power_Desc_store_rsp: (STATUS, IEEE, ('PowerDescriptor', PowerDescriptor)),
+    ZDOCmd.Active_EP_store_rsp: (STATUS,),
+    ZDOCmd.Simple_Desc_store_rsp: (STATUS,),
+    ZDOCmd.Remove_node_cache_rsp: (STATUS,),
+    ZDOCmd.Find_node_cache_rsp: (('CacheNWKAddr', t.EUI64), NWK, IEEE),
+    ZDOCmd.Extended_Simple_Desc_rsp: (STATUS, NWK, ('Endpoint', t.uint8_t), ('AppInputClusterCount', t.uint8_t), ('AppOutputClusterCount', t.uint8_t), ('StartIndex', t.uint8_t), ('AppClusterList', t.List(t.uint16_t))),
+    ZDOCmd.Extended_Active_EP_rsp: (STATUS, NWKI, ('ActiveEPCount', t.uint8_t), ('StartIndex', t.uint8_t), ('ActiveEPList', t.List(t.uint8_t))),
+    #  Bind Management Server Services Responses
+    ZDOCmd.End_Device_Bind_rsp: (STATUS,),
+    ZDOCmd.Bind_rsp: (STATUS,),
+    ZDOCmd.Unbind_rsp: (STATUS,),
+    # ... TODO optional stuff ...
+    # Network Management Server Services Responses
+    ZDOCmd.Mgmt_Lqi_rsp: (STATUS, ('Neighbors', Neighbors)),
+    ZDOCmd.Mgmt_Rtg_rsp: (STATUS, ('Routes', Routes)),
+    # ... TODO optional stuff ...
+    ZDOCmd.Mgmt_Leave_rsp: (STATUS,),
+    ZDOCmd.Mgmt_Permit_Joining_rsp: (STATUS,),
     # ... TODO optional stuff ...
 }
 
 
 # Rewrite to (name, param_names, param_types)
-for command_id, c in CLUSTERS.items():
-    param_names = [p[0] for p in c[1]]
-    param_types = [p[1] for p in c[1]]
-    CLUSTERS[command_id] = (c[0], param_names, param_types)
+for command_id, schema in CLUSTERS.items():
+    param_names = [p[0] for p in schema]
+    param_types = [p[1] for p in schema]
+    CLUSTERS[command_id] = (param_names, param_types)

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -270,8 +270,8 @@ class Status(t.uint8_t, enum.Enum):
     NOT_AUTHORIZED = 0x8d
 
 
-NWK = ('NWKAddr', t.uint16_t)
-NWKI = ('NWKAddrOfInterest', t.uint16_t)
+NWK = ('NWKAddr', t.NWK)
+NWKI = ('NWKAddrOfInterest', t.NWK)
 IEEE = ('IEEEAddr', t.EUI64)
 STATUS = ('Status', Status)
 


### PR DESCRIPTION
Implement ZDO commands as enums.
Allow ZDO command invoking by their name.

Improves code readability and gets rid of "magic" numbers in the code.