### PR TITLE
__repr__ for zcl.foundation.TypeValue.

### DIFF
--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -7,6 +7,10 @@ def test_typevalue():
     tv.type = 0x20
     tv.value = t.uint8_t(99)
     ser = tv.serialize()
+    r = repr(tv)
+    assert r.startswith('<') and r.endswith('>')
+    assert 'type=uint8_t' in r
+    assert 'value=99' in r
 
     tv2, data = foundation.TypeValue.deserialize(ser)
     assert data == b''

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -159,7 +159,8 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
 
         if command_id == 0x0a:  # Report attributes
             valuestr = ", ".join([
-                "%s=%s" % (a.attrid, a.value.value) for a in args[0]
+                "%s=%s" % (self.attributes.get(a.attrid, [a.attrid])[0],
+                           a.value.value) for a in args[0]
             ])
             self.debug("Attribute report received: %s", valuestr)
             for attr in args[0]:

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -66,6 +66,7 @@ class TypeValue:
                                            self.value.__class__.__name__,
                                            self.value)
 
+
 class TypedCollection(TypeValue):
     @classmethod
     def deserialize(cls, data):

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -61,6 +61,10 @@ class TypeValue:
         self.value, data = python_type.deserialize(data)
         return self, data
 
+    def __repr__(self):
+        return "<%s type=%s, value=%s>" % (self.__class__.__name__,
+                                           self.value.__class__.__name__,
+                                           self.value)
 
 class TypedCollection(TypeValue):
     @classmethod


### PR DESCRIPTION
Implement `__repr__` method for `zigpy.zcl.foundation.TypeValue` class.
Friendly print attribute names (if avaialble) when an attribute report is received.

Log debug message like
```
2019-04-28 02:45:49 DEBUG (MainThread) [zigpy.zcl] [0x16a3:1:0x0b04] ZCL request 0x000a: [[<Attribute attrid=1285 value=<TypeValue type=uint16_t, value=124>>, <Attribute attrid=1288 value=<TypeValue type=uint16_t, value=0>>, <Attribute attrid=1361 value=<TypeValue type=uint32_t, value=52691>>]]
2019-04-28 02:45:49 DEBUG (MainThread) [zigpy.zcl] [0x16a3:1:0x0b04] Attribute report received: rms_voltage=124, rms_current=0, 1361=52691
```

instead of
```
2019-04-28 00:45:49 DEBUG (MainThread) [zigpy.zcl] [0x16a3:1:0x0b04] ZCL request 0x000a: [[<Attribute attrid=1285 value=<zigpy.zcl.foundation.TypeValue object at 0x9b6675d0>>, <Attribute attrid=1288 value=<zigpy.zcl.foundation.TypeValue object at 0x9bd7b590>>, <Attribute attrid=1361 value=<zigpy.zcl.foundation.TypeValue object at 0x9bd7b4d0>>]]
2019-04-28 00:45:49 DEBUG (MainThread) [zigpy.zcl] [0x16a3:1:0x0b04] Attribute report received: 1285=123, 1288=0, 1361=52691
```