### PR TITLE
Fix circular imports and tests task leaking.

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -38,7 +38,8 @@ def fake_get_device(device):
 
 
 @pytest.mark.asyncio
-async def test_database(tmpdir):
+async def test_database(tmpdir, monkeypatch):
+    monkeypatch.setattr(Device, '_initialize', _initialize)
     db = os.path.join(str(tmpdir), 'test.db')
     app = make_app(db)
     # TODO: Leaks a task on dev.initialize, I think?
@@ -73,7 +74,6 @@ async def test_database(tmpdir):
     app.device_initialized(dev)
     ep = dev.add_endpoint(1)
     ep.profile_id = 65535
-    dev._initialize = _initialize
     with mock.patch('zigpy.quirks.get_device', fake_get_device):
         app.device_initialized(dev)
     assert isinstance(app.get_device(custom_ieee), FakeCustomDevice)
@@ -174,7 +174,8 @@ def test_appdb_load_null_padded_manuf_model(tmpdir):
 
 
 @pytest.mark.asyncio
-async def test_node_descriptor_updated(tmpdir):
+async def test_node_descriptor_updated(tmpdir, monkeypatch):
+    monkeypatch.setattr(Device, '_initialize', _initialize)
     db = os.path.join(str(tmpdir), 'test_nd.db')
     app = make_app(db)
     nd_ieee = make_ieee(2)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -272,18 +272,3 @@ class PersistingListener:
             dev = self._application.get_device(ieee)
             ep = dev.endpoints[endpoint_id]
             ep.add_output_cluster(cluster)
-
-
-class ClusterPersistingListener:
-    def __init__(self, applistener, cluster):
-        self._applistener = applistener
-        self._cluster = cluster
-
-    def attribute_updated(self, attrid, value):
-        self._applistener.attribute_updated(self._cluster, attrid, value)
-
-    def cluster_command(self, *args, **kwargs):
-        pass
-
-    def zdo_command(self, *args, **kwargs):
-        pass

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -1,7 +1,6 @@
 import enum
 import logging
 
-import zigpy.appdb
 import zigpy.profiles
 import zigpy.util
 import zigpy.zcl
@@ -89,7 +88,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self._cluster_attr[cluster.ep_attribute] = cluster
 
         if hasattr(self._device.application, '_dblistener'):
-            listener = zigpy.appdb.ClusterPersistingListener(
+            listener = zigpy.zcl.ClusterPersistingListener(
                 self._device.application._dblistener,
                 cluster,
             )

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -354,5 +354,20 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
     discover_commands_generated = functools.partialmethod(_discover, 0x13)
 
 
+class ClusterPersistingListener:
+    def __init__(self, applistener, cluster):
+        self._applistener = applistener
+        self._cluster = cluster
+
+    def attribute_updated(self, attrid, value):
+        self._applistener.attribute_updated(self._cluster, attrid, value)
+
+    def cluster_command(self, *args, **kwargs):
+        pass
+
+    def zdo_command(self, *args, **kwargs):
+        pass
+
+
 # Import to populate the registry
 from . import clusters  # noqa: F401, F402


### PR DESCRIPTION
`zigpy.endpoint` still had circular imports as it tried to import `zigpy.appdb`, `zigpy.appdb` tried to import `zigpy.quirks` and `zigpy.quirks` required `zigpy.endpoint.Endpoint`:
```
Python 3.7.3rc1 (default, Mar 13 2019, 11:01:15) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import zigpy.endpoint
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lex/lex/src/zigpy/zigpy/endpoint.py", line 4, in <module>
    import zigpy.appdb
  File "/home/lex/lex/src/zigpy/zigpy/appdb.py", line 7, in <module>
    import zigpy.quirks
  File "/home/lex/lex/src/zigpy/zigpy/quirks/__init__.py", line 102, in <module>
    class CustomEndpoint(zigpy.endpoint.Endpoint):
AttributeError: module 'zigpy' has no attribute 'endpoint'
>>> 
```

`test_appdb.test_database()` was leaking tasks during `app.handle_join()`. Plug `zigpy.device.Device._initialize()` with a mock.
