### PR TITLE
Add a `context` parameter to `ListenableMixin.add_listener`

### DIFF
--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -23,11 +23,11 @@ def test_listenable():
     listen.add_listener(listener)
 
     context_listener = mock.MagicMock(spec_set=['event'])
-    listen.add_listener(context_listener, context=True)
+    listen.add_context_listener(context_listener)
 
     listen.listener_event('event', 'test1')
     listener.event.assert_has_calls([mock.call('test1'), mock.call('test1')], any_order=True)
-    context_listener.event.assert_has_calls([mock.call('test1', listen)], any_order=True)
+    context_listener.event.assert_has_calls([mock.call(listen, 'test1')], any_order=True)
     broken_listener.event.assert_has_calls([mock.call('test1')], any_order=True)
     assert listener.event.call_count == 2
     assert context_listener.event.call_count == 1
@@ -35,7 +35,7 @@ def test_listenable():
 
     listen.listener_event('non_existing_event', 'test2')
     listener.event.assert_has_calls([mock.call('test1'), mock.call('test1')], any_order=True)
-    context_listener.event.assert_has_calls([mock.call('test1', listen)], any_order=True)
+    context_listener.event.assert_has_calls([mock.call(listen, 'test1')], any_order=True)
     broken_listener.event.assert_has_calls([mock.call('test1')], any_order=True)
     assert listener.event.call_count == 2
     assert context_listener.event.call_count == 1

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -11,23 +11,29 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ListenableMixin:
-    def add_listener(self, listener, context=False):
+    def _add_listener(self, listener, include_context):
         id_ = id(listener)
         while id_ in self._listeners:
             id_ += 1
-        self._listeners[id_] = (listener, context)
+        self._listeners[id_] = (listener, include_context)
         return id_
 
+    def add_listener(self, listener):
+        return self._add_listener(listener, include_context=False)
+
+    def add_context_listener(self, listener):
+        return self._add_listener(listener, include_context=True)
+
     def listener_event(self, method_name, *args):
-        for listener, context in self._listeners.values():
+        for listener, include_context in self._listeners.values():
             method = getattr(listener, method_name, None)
 
             if not method:
                 continue
 
             try:
-                if context:
-                    method(*args, self)
+                if include_context:
+                    method(self, *args)
                 else:
                     method(*args)
             except Exception as e:


### PR DESCRIPTION
This is useful when creating a single listener object that subscribes to events from multiple sources. My use case is a global listener for the OTA cluster for every device that automatically downloads and caches firmware files. It's a little unwieldy to create one-off classes to just pass events along with some context:

```Python

class OTAListener:
    def __init__(self, cluster, global_listener):
        self.cluster = cluster
        self.global_listener = global_listener

    def cluster_command(self, tsn, command_id, args):
        self.global_listener(tsn, command_id, args, self.cluster)

global_listener = MainOTAListener()

for device in devices:
    ota_cluster = device.endpoints[0x001].out_clusters[0x0019]
    ota_cluster.add_listener(OTAListener(ota_cluster, global_listener))
```

Instead, one could do something like this:

```Python

class OTAListener:
    def cluster_command(self, tsn, command_id, args, ota_cluster):
        ...

ota_listener = OTAListener()

for device in devices:
    device.endpoints[0x001].out_clusters[0x0019].add_listener(ota_listener, context=True)
```

It would also be nice to have a catch-all listener (that I currently implement with `__getattr__`) but I will make a second pull request for that.