### PR TITLE
`raw` attribute for CharacterString class.

### DIFF
--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -238,8 +238,7 @@ class CharacterString(str):
     def deserialize(cls, data):
         length = int.from_bytes(data[:cls._prefix_length], 'little')
         raw = data[cls._prefix_length:length + 1]
-        raw = raw.split(b'\x00')[0]
-        r = cls(raw.decode('utf8', errors='replace'))
+        r = cls(raw.split(b'\x00')[0].decode('utf8', errors='replace'))
         r.raw = raw
         return r, data[length + 1:]
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -237,9 +237,11 @@ class CharacterString(str):
     @classmethod
     def deserialize(cls, data):
         length = int.from_bytes(data[:cls._prefix_length], 'little')
-        bytes = data[cls._prefix_length:length + 1]
-        bytes = bytes.split(b'\x00')[0]
-        return cls(bytes.decode('utf8', errors='replace')), data[length + 1:]
+        raw = data[cls._prefix_length:length + 1]
+        raw = raw.split(b'\x00')[0]
+        r = cls(raw.decode('utf8', errors='replace'))
+        r.raw = raw
+        return r, data[length + 1:]
 
 
 class LongCharacterString(CharacterString):


### PR DESCRIPTION
Some vendors (I mean Xiaomi) are using `Character String` ZCL data type for sending binary data. Really, Xiaomi? Keep the original bytes data as a `raw` attribute of `CharacterString` class.