### PR TITLE
Run cluster_general_request() response for Time cluster in the loop.

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -253,6 +253,19 @@ def test_write_attributes_wrong_type(cluster):
 def test_write_attributes_report(cluster):
     cluster.write_attributes({0: 5}, is_report=True)
     assert cluster._endpoint.reply.call_count == 1
+    assert cluster._endpoint.request.call_count == 0
+
+
+def test_write_attributes_report_unsupported(cluster):
+    cluster.write_attributes({0: 5}, is_report=True, unsupported_attrs=[])
+    assert cluster._endpoint.reply.call_count == 1
+    assert cluster._endpoint.request.call_count == 0
+    orig_len = len(cluster._endpoint.reply.call_args[0][2])
+
+    cluster.write_attributes({0: 5}, is_report=True, unsupported_attrs=[2])
+    assert cluster._endpoint.reply.call_count == 2
+    assert cluster._endpoint.request.call_count == 0
+    assert len(cluster._endpoint.reply.call_args[0][2]) == orig_len + 3
 
 
 def test_bind(cluster):

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -88,3 +88,16 @@ async def test_time_cluster():
     t.handle_cluster_general_request(tsn, 0, [[7]])
     assert ep.reply.call_count == 5
     assert ep.reply.call_args[0][2][3] == 7
+
+
+@pytest.mark.asyncio
+async def test_time_cluster_unsupported():
+    ep = mock.MagicMock()
+    ep.reply.side_effect = asyncio.coroutine(mock.MagicMock())
+    t = zcl.Cluster._registry[0x000a](ep)
+
+    tsn = 0
+
+    t.handle_cluster_general_request(tsn, 0, [[199, 128]])
+    assert ep.reply.call_count == 1
+    assert ep.reply.call_args[0][2][-6:] == b'\xc7\x00\x86\x80\x00\x86'

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -1,5 +1,7 @@
+import asyncio
 import re
 
+import pytest
 from unittest import mock
 import zigpy.endpoint
 import zigpy.zcl as zcl
@@ -56,8 +58,10 @@ def test_ep_attributes():
         assert not hasattr(ep, cluster.ep_attribute)
 
 
-def test_time_cluster():
+@pytest.mark.asyncio
+async def test_time_cluster():
     ep = mock.MagicMock()
+    ep.reply.side_effect = asyncio.coroutine(mock.MagicMock())
     t = zcl.Cluster._registry[0x000a](ep)
 
     tsn = 0

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -84,3 +84,7 @@ async def test_time_cluster():
     t.handle_cluster_general_request(tsn, 0, [[0, 1, 2]])
     assert ep.reply.call_count == 4
     assert ep.reply.call_args[0][2][3] == 0
+
+    t.handle_cluster_general_request(tsn, 0, [[7]])
+    assert ep.reply.call_count == 5
+    assert ep.reply.call_args[0][2][3] == 7

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -228,7 +228,8 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
             return success[attributes[0]]
         return success, failure
 
-    def write_attributes(self, attributes, is_report=False, manufacturer=None):
+    def write_attributes(self, attributes, is_report=False, manufacturer=None,
+                         unsupported_attrs=[]):
         args = []
         for attrid, value in attributes.items():
             if isinstance(attrid, str):
@@ -253,6 +254,13 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
                 args.append(a)
             except ValueError as e:
                 self.error(str(e))
+
+        if is_report and unsupported_attrs:
+            for attrid in unsupported_attrs:
+                a = foundation.ReadAttributeRecord()
+                a.attrid = attrid
+                a.status = foundation.Status.UNSUPPORTED_ATTRIBUTE
+                args.append(a)
 
         if is_report:
             schema = foundation.COMMANDS[0x01][1]

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -339,8 +339,8 @@ class Time(Cluster):
     def handle_cluster_general_request(self, tsn, command_id, *args):
         if command_id == 0:
             data = {}
+            unsupported = []
             for attr in args[0][0]:
-                # ToDo set status properly for unsupported attributes
                 if attr == 0:
                     epoch = datetime(2000, 1, 1, 0, 0, 0, 0)
                     diff = datetime.utcnow() - epoch
@@ -354,7 +354,11 @@ class Time(Cluster):
                     epoch = datetime(2000, 1, 1, 0, 0, 0, 0)
                     diff = datetime.now() - epoch
                     data[attr] = diff.total_seconds()
-            asyncio.ensure_future(self.write_attributes(data, True))
+                else:
+                    unsupported.append(attr)
+            asyncio.ensure_future(
+                self.write_attributes(data, True,
+                                      unsupported_attrs=unsupported))
 
 
 class RSSILocation(Cluster):

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1,5 +1,6 @@
 """General Functional Domain"""
 
+import asyncio
 from datetime import datetime
 
 import zigpy.types as t
@@ -348,7 +349,7 @@ class Time(Cluster):
                 elif attr == 2:
                     diff = datetime.fromtimestamp(86400) - datetime.utcfromtimestamp(86400)
                     data[attr] = diff.total_seconds()
-            self.write_attributes(data, True)
+            asyncio.ensure_future(self.write_attributes(data, True))
 
 
 class RSSILocation(Cluster):

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -340,6 +340,7 @@ class Time(Cluster):
         if command_id == 0:
             data = {}
             for attr in args[0][0]:
+                # ToDo set status properly for unsupported attributes
                 if attr == 0:
                     epoch = datetime(2000, 1, 1, 0, 0, 0, 0)
                     diff = datetime.utcnow() - epoch
@@ -348,6 +349,10 @@ class Time(Cluster):
                     data[attr] = 7
                 elif attr == 2:
                     diff = datetime.fromtimestamp(86400) - datetime.utcfromtimestamp(86400)
+                    data[attr] = diff.total_seconds()
+                elif attr == 7:
+                    epoch = datetime(2000, 1, 1, 0, 0, 0, 0)
+                    diff = datetime.now() - epoch
                     data[attr] = diff.total_seconds()
             asyncio.ensure_future(self.write_attributes(data, True))
 


### PR DESCRIPTION
If a device tries to read any Time cluster attribute from coordinator, then the response is never awaited. 
eg here's log of a device (GE45857) requesting local time:
```
2019-05-09 12:32:08 DEBUG (MainThread) [zigpy_xbee.api] _handle_explicit_rx: (00:22:a3:00:00:1b:94:bb, 0x43e8, 1, 10, 1, b'0008000700')
2019-05-09 12:32:08 DEBUG (MainThread) [zigpy.zcl] [0x43e8:1:0x000a] ZCL request 0x0000: [[7]]
/home/lex/lex/src/zigpy/zigpy/zcl/clusters/general.py:351: RuntimeWarning: coroutine 'request' was never awaited
  self.write_attributes(data, True)
```

Additionally add support for "local_time" attribute.
Reply with "Status.UNSUPPORTED_ATTRIBUTE" for attributes which we don't support on time cluster.
