### PR TITLE
Prevent slicing and int.from_bytes from allowing invalid deserialization

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -48,7 +48,7 @@ async def test_database(tmpdir, monkeypatch):
     app.handle_join(99, ieee, 0)
 
     dev = app.get_device(ieee)
-    dev.node_desc, _ = zdo_t.NodeDescriptor.deserialize(b'1234567890')
+    dev.node_desc, _ = zdo_t.NodeDescriptor.deserialize(b'1234567890123')
     ep = dev.add_endpoint(1)
     ep.profile_id = 260
     ep.device_type = profiles.zha.DeviceType.PUMP

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -49,6 +49,14 @@ def test_lvbytes_too_long():
 def test_long_octet_string():
     assert t.LongOctetString(b'asdfoo').serialize() == b'\x06\x00asdfoo'
 
+    orig_len = 65532
+    deserialize_extra = b'1234'
+    to_deserialize = orig_len.to_bytes(2, 'little') + b''.join(
+        itertools.repeat(b'b', orig_len)) + deserialize_extra
+    des, rest = t.LongOctetString.deserialize(to_deserialize)
+    assert len(des) == orig_len
+    assert rest == deserialize_extra
+
 
 def test_long_octet_string_too_long():
     to_serialize = b''.join(itertools.repeat(b'\xbe', 65535))
@@ -101,6 +109,20 @@ def test_char_string_too_short():
 
     with pytest.raises(ValueError):
         t.CharacterString.deserialize(b'\x04123')
+
+        
+def test_long_char_string():
+    orig_len = 65532
+    to_serialize = ''.join(itertools.repeat('a', orig_len))
+    ser = t.LongCharacterString(to_serialize).serialize()
+    assert len(ser) == orig_len + len(orig_len.to_bytes(2, 'little'))
+
+    deserialize_extra = b'1234'
+    to_deserialize = orig_len.to_bytes(2, 'little') + b''.join(
+        itertools.repeat(b'b', orig_len)) + deserialize_extra
+    des, rest = t.LongCharacterString.deserialize(to_deserialize)
+    assert len(des) == orig_len
+    assert rest == deserialize_extra
 
 
 def test_long_char_string_too_long():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -110,7 +110,7 @@ def test_char_string_too_short():
     with pytest.raises(ValueError):
         t.CharacterString.deserialize(b'\x04123')
 
-        
+
 def test_long_char_string():
     orig_len = 65532
     to_serialize = ''.join(itertools.repeat('a', orig_len))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -24,10 +24,19 @@ def test_lvbytes():
     assert t.LVBytes.serialize(d) == b'\x041234'
 
 
+def test_lvbytes_too_short():
+    with pytest.raises(ValueError):
+        t.LVBytes.deserialize(b'\x04123')
+
+
 def test_lvbytes_too_long():
     to_serialize = b''.join(itertools.repeat(b'\xbe', 255))
     with pytest.raises(ValueError):
         t.LVBytes(to_serialize).serialize()
+
+
+def test_long_octet_string():
+    assert t.LongOctetString(b'asdfoo').serialize() == b'\x06\x00asdfoo'
 
 
 def test_long_octet_string_too_long():
@@ -75,10 +84,20 @@ def test_char_string_too_long():
         t.CharacterString(to_serialize).serialize()
 
 
+def test_char_string_too_short():
+    with pytest.raises(ValueError):
+        t.CharacterString.deserialize(b'\x04123')
+
+
 def test_long_char_string_too_long():
     to_serialize = ''.join(itertools.repeat('a', 65535))
     with pytest.raises(ValueError):
         t.LongCharacterString(to_serialize).serialize()
+
+
+def test_long_char_string_too_short():
+    with pytest.raises(ValueError):
+        t.LongCharacterString.deserialize(b'\x04\x00123')
 
 
 def test_limited_char_string():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,6 +4,14 @@ import pytest
 import zigpy.types as t
 
 
+def test_int_too_short():
+    with pytest.raises(ValueError):
+        t.uint8_t.deserialize(b'')
+
+    with pytest.raises(ValueError):
+        t.uint16_t.deserialize(b'\x00')
+
+
 def test_single():
     v = t.Single(1.25)
     ser = v.serialize()
@@ -25,6 +33,9 @@ def test_lvbytes():
 
 
 def test_lvbytes_too_short():
+    with pytest.raises(ValueError):
+        t.LVBytes.deserialize(b'')
+
     with pytest.raises(ValueError):
         t.LVBytes.deserialize(b'\x04123')
 
@@ -86,6 +97,9 @@ def test_char_string_too_long():
 
 def test_char_string_too_short():
     with pytest.raises(ValueError):
+        t.CharacterString.deserialize(b'')
+
+    with pytest.raises(ValueError):
         t.CharacterString.deserialize(b'\x04123')
 
 
@@ -111,6 +125,14 @@ def test_lvlist():
     assert r == b'5'
     assert d == list(map(ord, '1234'))
     assert t.LVList(t.uint8_t).serialize(d) == b'\x041234'
+
+
+def test_lvlist_too_short():
+    with pytest.raises(ValueError):
+        t.LVList(t.uint8_t).deserialize(b'')
+
+    with pytest.raises(ValueError):
+        t.LVList(t.uint8_t).deserialize(b'\x04123')
 
 
 def test_list():

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -260,7 +260,7 @@ class CharacterString(str):
             raise ValueError('Data is too short')
 
         raw = data[cls._prefix_length:cls._prefix_length + length]
-        raw = bytes.split(b'\x00')[0]
+        raw = raw.split(b'\x00')[0]
 
         r = cls(raw.decode('utf8', errors='replace'))
         r.raw = raw

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -9,6 +9,9 @@ class int_t(int):  # noqa: N801
 
     @classmethod
     def deserialize(cls, data):
+        if len(data) < cls._size:
+            raise ValueError('Data is too short to contain %d bytes' % cls._size)
+
         r = cls.from_bytes(data[:cls._size], 'little', signed=cls._signed)
         return r, data[cls._size:]
 
@@ -150,9 +153,17 @@ class LVBytes(bytes):
 
     @classmethod
     def deserialize(cls, data):
-        bytes = int.from_bytes(data[:cls._prefix_length], 'little')
-        s = data[cls._prefix_length:bytes + 1]
-        return cls(s), data[bytes + 1:]
+        if len(data) < cls._prefix_length:
+            raise ValueError('Data is too short')
+
+        num_bytes = int.from_bytes(data[:cls._prefix_length], 'little')
+
+        if len(data) < cls._prefix_length + num_bytes:
+            raise ValueError('Data is too short')
+
+        s = data[cls._prefix_length:cls._prefix_length + num_bytes]
+
+        return cls(s), data[cls._prefix_length + num_bytes:]
 
 
 class LongOctetString(LVBytes):
@@ -186,6 +197,10 @@ class _LVList(_List):
     @classmethod
     def deserialize(cls, data):
         r = cls()
+
+        if len(data) < cls._prefix_length:
+            raise ValueError('Data is too short')
+
         length = int.from_bytes(data[:cls._prefix_length], 'little')
         data = data[cls._prefix_length:]
         for i in range(length):
@@ -236,11 +251,20 @@ class CharacterString(str):
 
     @classmethod
     def deserialize(cls, data):
+        if len(data) < cls._prefix_length:
+            raise ValueError('Data is too short')
+
         length = int.from_bytes(data[:cls._prefix_length], 'little')
-        raw = data[cls._prefix_length:length + 1]
-        r = cls(raw.split(b'\x00')[0].decode('utf8', errors='replace'))
+
+        if len(data) < cls._prefix_length + length:
+            raise ValueError('Data is too short')
+
+        raw = data[cls._prefix_length:cls._prefix_length + length]
+        raw = bytes.split(b'\x00')[0]
+
+        r = cls(raw.decode('utf8', errors='replace'))
         r.raw = raw
-        return r, data[length + 1:]
+        return r, data[cls._prefix_length + length:]
 
 
 class LongCharacterString(CharacterString):

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -260,9 +260,7 @@ class CharacterString(str):
             raise ValueError('Data is too short')
 
         raw = data[cls._prefix_length:cls._prefix_length + length]
-        raw = raw.split(b'\x00')[0]
-
-        r = cls(raw.decode('utf8', errors='replace'))
+        r = cls(raw.split(b'\x00')[0].decode('utf8', errors='replace'))
         r.raw = raw
         return r, data[cls._prefix_length + length:]
 


### PR DESCRIPTION
Using the pattern `int.from_bytes(s[:n], 'little')` doesn't enforce that `s` is at least `n` bytes long (or that `s` is even non-empty). I've added checks to prevent this from happening for I think all of the affected data types.

It might be better to create some helper functions in the future to deal with this (or switch to using `BytesIO` objects).