### PR TITLE
RFC Zigpy group management framework.

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -223,7 +223,7 @@ async def test_node_descriptor_updated(tmpdir, monkeypatch):
 async def test_groups(tmpdir, monkeypatch):
     monkeypatch.setattr(Device, '_initialize', _initialize)
 
-    group_id, group_name = 0x1221, "Test Group 0x1221"
+    group_id, group_name = 0x1221, "app db Test Group 0x1221"
 
     async def mock_request(*args, **kwargs):
         return [ZCLStatus.SUCCESS, group_id]
@@ -252,6 +252,11 @@ async def test_groups(tmpdir, monkeypatch):
 
     await dev.add_to_group(group_id, group_name)
     await dev_b.add_to_group(group_id, group_name)
+    assert group_id in app.groups
+    group = app.groups[group_id]
+    assert group.name == group_name
+    assert dev.ieee in group
+    assert group_id in dev.member_of
 
     # Everything should've been saved - check that it re-loads
     app2 = make_app(db)
@@ -259,11 +264,11 @@ async def test_groups(tmpdir, monkeypatch):
     assert group_id in app2.groups
     group = app2.groups[group_id]
     assert group.name == group_name
-    assert dev2.ieee in group.members
+    assert dev2.ieee in group
     assert group_id in dev2.member_of
 
     dev2_b = app2.get_device(ieee_b)
-    assert dev2_b.ieee in group.members
+    assert dev2_b.ieee in group
     assert group_id in dev2_b.member_of
 
     # check member removal
@@ -273,11 +278,11 @@ async def test_groups(tmpdir, monkeypatch):
     assert group_id in app3.groups
     group = app3.groups[group_id]
     assert group.name == group_name
-    assert dev3.ieee in group.members
+    assert dev3.ieee in group
     assert group_id in dev3.member_of
 
     dev3_b = app3.get_device(ieee_b)
-    assert dev3_b.ieee not in group.members
+    assert dev3_b.ieee not in group
     assert group_id not in dev3_b.member_of
 
     # check group removal

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -130,9 +130,9 @@ def test_group_add_member_no_evt(group, device):
     listener = mock.MagicMock()
     group.add_listener(listener)
 
-    assert device.ieee not in group.members
+    assert device.ieee not in group
     group.add_member(device, suppress_event=True)
-    assert device.ieee in group.members
+    assert device.ieee in group
     assert FIXTURE_GRP_ID in device.member_of
     assert listener.member_added.call_count == 0
     assert listener.member_removed.call_count == 0
@@ -149,10 +149,10 @@ def test_group_remove_member(group, device):
 
     group.add_member(device, suppress_event=True)
 
-    assert device.ieee in group.members
+    assert device.ieee in group
     assert FIXTURE_GRP_ID in device.member_of
     group.remove_member(device)
-    assert device.ieee not in group.members
+    assert device.ieee not in group
     assert FIXTURE_GRP_ID not in device.member_of
     assert listener.member_added.call_count == 0
     assert listener.member_removed.call_count == 1

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -6,10 +6,162 @@ import pytest
 import zigpy.types as t
 from zigpy.application import ControllerApplication
 import zigpy.group
+import zigpy.device
+
+
+FIXTURE_GRP_ID = 0x1001
+FIXTURE_GRP_NAME = 'fixture group'
+
+
+@pytest.fixture
+def device():
+    app_mock = mock.MagicMock(spec_set=ControllerApplication)
+    app_mock.remove.side_effect = asyncio.coroutine(mock.MagicMock())
+    app_mock.request.side_effect = asyncio.coroutine(mock.MagicMock())
+    ieee = t.EUI64(map(t.uint8_t, [0, 1, 2, 3, 4, 5, 6, 7]))
+    return zigpy.device.Device(app_mock, ieee, 65535)
 
 
 @pytest.fixture
 def groups():
     app_mock = mock.MagicMock(spec_set=ControllerApplication)
-    return device.Device(app_mock, ieee, 65535)
+    groups = zigpy.group.Groups(app_mock)
+    groups.listener_event = mock.MagicMock()
+    groups.add_group(FIXTURE_GRP_ID, FIXTURE_GRP_NAME, suppress_event=True)
+    return groups
 
+
+@pytest.fixture
+def group():
+    groups_mock = mock.MagicMock(spec_set=zigpy.group.Groups)
+    return zigpy.group.Group(FIXTURE_GRP_ID, FIXTURE_GRP_NAME, groups_mock)
+
+
+def test_add_group(groups, monkeypatch):
+    monkeypatch.setattr(zigpy.group, 'Group',
+                        mock.MagicMock(spec_set=zigpy.group.Group,
+                                       return_value=mock.sentinel.group))
+    grp_id, grp_name = 0x1234, "Group Name for 0x1234 group."
+
+    assert grp_id not in groups
+    ret = groups.add_group(grp_id, grp_name)
+    assert groups.listener_event.call_count == 1
+    assert ret is mock.sentinel.group
+
+    groups.listener_event.reset_mock()
+    ret = groups.add_group(grp_id, grp_name)
+    assert groups.listener_event.call_count == 0
+    assert ret is mock.sentinel.group
+
+
+def test_add_group_no_evt(groups, monkeypatch):
+    monkeypatch.setattr(zigpy.group, 'Group',
+                        mock.MagicMock(spec_set=zigpy.group.Group,
+                                       return_value=mock.sentinel.group))
+    grp_id, grp_name = 0x1234, "Group Name for 0x1234 group."
+
+    assert grp_id not in groups
+    ret = groups.add_group(grp_id, grp_name, suppress_event=True)
+    assert groups.listener_event.call_count == 0
+    assert ret is mock.sentinel.group
+
+    groups.listener_event.reset_mock()
+    ret = groups.add_group(grp_id, grp_name)
+    assert groups.listener_event.call_count == 0
+    assert ret is mock.sentinel.group
+
+
+def test_pop_group_id(groups):
+    assert FIXTURE_GRP_ID in groups
+    grp = groups.pop(FIXTURE_GRP_ID)
+
+    assert isinstance(grp, zigpy.group.Group)
+    assert FIXTURE_GRP_ID not in groups
+    assert groups.listener_event.call_count == 1
+
+    with pytest.raises(KeyError):
+        groups.pop(FIXTURE_GRP_ID)
+
+    grp = groups.pop(FIXTURE_GRP_ID, mock.sentinel.default)
+    assert grp is mock.sentinel.default
+
+
+def test_pop_group(groups):
+    assert FIXTURE_GRP_ID in groups
+    group = groups[FIXTURE_GRP_ID]
+
+    grp = groups.pop(group)
+    assert isinstance(grp, zigpy.group.Group)
+    assert FIXTURE_GRP_ID not in groups
+    assert groups.listener_event.call_count == 1
+
+    with pytest.raises(KeyError):
+        groups.pop(grp)
+
+    grp = groups.pop(grp, mock.sentinel.default)
+    assert grp is mock.sentinel.default
+
+
+def test_group_add_member(group, device):
+    listener = mock.MagicMock()
+    group.add_listener(listener)
+
+    assert device.ieee not in group.members
+    assert FIXTURE_GRP_ID not in device.member_of
+    group.add_member(device)
+    assert device.ieee in group.members
+    assert FIXTURE_GRP_ID in device.member_of
+    assert listener.member_added.call_count == 1
+    assert listener.member_removed.call_count == 0
+
+    listener.reset_mock()
+    group.add_member(device)
+    assert listener.member_added.call_count == 0
+    assert listener.member_removed.call_count == 0
+
+    group.__repr__()
+    assert group.name == FIXTURE_GRP_NAME
+
+    with pytest.raises(ValueError):
+        group.add_member(device.ieee)
+
+
+def test_group_add_member_no_evt(group, device):
+    listener = mock.MagicMock()
+    group.add_listener(listener)
+
+    assert device.ieee not in group.members
+    group.add_member(device, suppress_event=True)
+    assert device.ieee in group.members
+    assert FIXTURE_GRP_ID in device.member_of
+    assert listener.member_added.call_count == 0
+    assert listener.member_removed.call_count == 0
+
+
+def test_noname_group():
+    group = zigpy.group.Group(FIXTURE_GRP_ID)
+    assert group.name.startswith("No name group ")
+
+
+def test_group_remove_member(group, device):
+    listener = mock.MagicMock()
+    group.add_listener(listener)
+
+    group.add_member(device, suppress_event=True)
+
+    assert device.ieee in group.members
+    assert FIXTURE_GRP_ID in device.member_of
+    group.remove_member(device)
+    assert device.ieee not in group.members
+    assert FIXTURE_GRP_ID not in device.member_of
+    assert listener.member_added.call_count == 0
+    assert listener.member_removed.call_count == 1
+
+
+def test_group_magic_methods(group, device):
+
+    group.add_member(device, suppress_event=True)
+
+    assert device.ieee in group.members
+    assert device.ieee in group
+    assert group[device.ieee] is device

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,0 +1,15 @@
+import asyncio
+from unittest import mock
+
+import pytest
+
+import zigpy.types as t
+from zigpy.application import ControllerApplication
+import zigpy.group
+
+
+@pytest.fixture
+def groups():
+    app_mock = mock.MagicMock(spec_set=ControllerApplication)
+    return device.Device(app_mock, ieee, 65535)
+

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -25,6 +25,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         if database_file is not None:
             self._dblistener = zigpy.appdb.PersistingListener(database_file, self)
             self.add_listener(self._dblistener)
+            self.groups.add_listener(self._dblistener)
             self._dblistener.load()
 
     async def shutdown(self):
@@ -161,6 +162,10 @@ class ControllerApplication(zigpy.util.ListenableMixin):
                 return dev
 
         raise KeyError
+
+    @property
+    def groups(self):
+        return self._groups
 
     @property
     def ieee(self):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -3,6 +3,7 @@ import logging
 
 import zigpy.appdb
 import zigpy.device
+import zigpy.group
 import zigpy.quirks
 import zigpy.types as t
 import zigpy.util
@@ -16,6 +17,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
     def __init__(self, database_file=None):
         self._send_sequence = 0
         self.devices = {}
+        self._groups = zigpy.group.Groups(self)
         self._listeners = {}
         self._ieee = None
         self._nwk = None

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -37,6 +37,7 @@ class Device(zigpy.util.LocalLogMixin):
         self.last_seen = None
         self.status = Status.NEW
         self.initializing = False
+        self._member_of = {}
         self.node_desc = zdo.types.NodeDescriptor()
         self._node_handle = None
 
@@ -173,6 +174,10 @@ class Device(zigpy.util.LocalLogMixin):
     @property
     def ieee(self):
         return self._ieee
+
+    @property
+    def member_of(self):
+        return self._member_of
 
     def __getitem__(self, key):
         return self.endpoints[key]

--- a/zigpy/group.py
+++ b/zigpy/group.py
@@ -1,19 +1,112 @@
 import logging
+from typing import Optional
+
+from zigpy import types as t
+from zigpy.device import Device
+from zigpy.util import ListenableMixin
 
 LOGGER = logging.getLogger(__name__)
 
 
-class Group:
-    def add_member(self, device):
-        pass
+class Group(ListenableMixin):
+    def __init__(self, group_id, name=None, groups=None):
+        self._groups = groups
+        self._group_id = t.Group(group_id)
+        self._listeners = {}
+        self._members = {}
+        self._name = name
+        if groups:
+            self.add_listener(groups)
 
+    def add_member(self, device: Device, suppress_event=False):
+        if not isinstance(device, Device):
+            raise ValueError("%s is not %s class" %
+                             (device, Device.__class__.__name__))
+        if device.ieee in self.members:
+            return self.members[device.ieee]
+        self.members[device.ieee] = device
+        device.member_of[self.group_id] = self
+        if not suppress_event:
+            self.listener_event('member_added', self, device)
+        return self
 
-class Groups:
-    def __init__(self, app):
-        self._application = app
+    def remove_member(self, device: Device, suppress_event=False):
+        self.members.pop(device.ieee, None)
+        device.member_of.pop(self.group_id, None)
+        if not suppress_event:
+            self.listener_event('member_removed', self, device)
+        return self
 
-    def add_group(self, group_id, name):
-        pass
+    def __contains__(self, item):
+        return item in self._members
 
     def __getitem__(self, item):
-        return Group()
+        return self._members[item]
+
+    def __repr__(self):
+        return "<{} group_id={} name='{}'>".format(
+            self.__class__.__name__, self.group_id, self.name)
+
+    @property
+    def group_id(self):
+        return self._group_id
+
+    @property
+    def members(self):
+        return self._members
+
+    @property
+    def name(self):
+        if self._name is None:
+            return "No name group {}".format(self.group_id)
+        return self._name
+
+
+class Groups(ListenableMixin):
+    def __init__(self, app):
+        self._application = app
+        self._listeners = {}
+        self._groups = {}
+        self._pending = {}
+
+    def add_group(self,
+                  group_id: int,
+                  name: str = None,
+                  suppress_event: bool = False) -> Optional[Group]:
+        if group_id in self.groups:
+            return self.groups[group_id]
+        LOGGER.debug("Adding group: %s, %s", group_id, name)
+        group = Group(group_id, name, self)
+        self.groups[group_id] = group
+        if not suppress_event:
+            self.listener_event('group_added', group)
+        return group
+
+    def member_added(self, group: Group, device: Device):
+        self.listener_event('group_member_added', group, device)
+
+    def member_removed(self, group: Group, device: Device):
+        self.listener_event('group_member_removed', group, device)
+        if not group.members:
+            self.pop(group)
+
+    def pop(self, item, *args) -> Optional[Group]:
+        if isinstance(item, Group):
+            group = self.groups.pop(item.group_id, *args)
+            self.listener_event('group_removed', group)
+            return group
+        group = self.groups.pop(item, *args)
+        self.listener_event('group_removed', group)
+        return group
+
+    remove_group = pop
+
+    def __contains__(self, item):
+        return item in self._groups
+
+    def __getitem__(self, item):
+        return self._groups[item]
+
+    @property
+    def groups(self):
+        return self._groups

--- a/zigpy/group.py
+++ b/zigpy/group.py
@@ -1,0 +1,19 @@
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Group:
+    def add_member(self, device):
+        pass
+
+
+class Groups:
+    def __init__(self, app):
+        self._application = app
+
+    def add_group(self, group_id, name):
+        pass
+
+    def __getitem__(self, item):
+        return Group()

--- a/zigpy/group.py
+++ b/zigpy/group.py
@@ -8,44 +8,39 @@ from zigpy.util import ListenableMixin
 LOGGER = logging.getLogger(__name__)
 
 
-class Group(ListenableMixin):
-    def __init__(self, group_id, name=None, groups=None):
+class Group(ListenableMixin, dict):
+    def __init__(self, group_id, name=None, groups=None, *args, **kwargs):
         self._groups = groups
         self._group_id = t.Group(group_id)
         self._listeners = {}
-        self._members = {}
         self._name = name
         if groups is not None:
             self.add_listener(groups)
+        super().__init__(*args, **kwargs)
 
     def add_member(self, device: Device, suppress_event=False):
         if not isinstance(device, Device):
             raise ValueError("%s is not %s class" %
                              (device, Device.__class__.__name__))
-        if device.ieee in self.members:
-            return self.members[device.ieee]
-        self.members[device.ieee] = device
+        if device.ieee in self:
+            return self[device.ieee]
+        self[device.ieee] = device
         device.member_of[self.group_id] = self
         if not suppress_event:
             self.listener_event('member_added', self, device)
         return self
 
     def remove_member(self, device: Device, suppress_event=False):
-        self.members.pop(device.ieee, None)
+        self.pop(device.ieee, None)
         device.member_of.pop(self.group_id, None)
         if not suppress_event:
             self.listener_event('member_removed', self, device)
         return self
 
-    def __contains__(self, item):
-        return item in self._members
-
-    def __getitem__(self, item):
-        return self._members[item]
-
     def __repr__(self):
-        return "<{} group_id={} name='{}'>".format(
-            self.__class__.__name__, self.group_id, self.name)
+        return "<{} group_id={} name='{}' members={}>".format(
+            self.__class__.__name__, self.group_id, self.name,
+            super().__repr__())
 
     @property
     def group_id(self):
@@ -53,7 +48,7 @@ class Group(ListenableMixin):
 
     @property
     def members(self):
-        return self._members
+        return self
 
     @property
     def name(self):
@@ -86,7 +81,7 @@ class Groups(ListenableMixin, dict):
 
     def member_removed(self, group: Group, device: Device):
         self.listener_event('group_member_removed', group, device)
-        if not group.members:
+        if not group:
             self.pop(group)
 
     def pop(self, item, *args) -> Optional[Group]:

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -53,3 +53,7 @@ class HexRepr:
 
 class NWK(HexRepr, basic.uint16_t):
     _hex_len = 4
+
+
+class Group(HexRepr, basic.uint16_t):
+    _hex_len = 4

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -171,18 +171,18 @@ class Groups(Cluster):
         0x0000: ('name_support', t.bitmap8),
     }
     server_commands = {
-        0x0000: ('add', (t.uint16_t, t.CharacterString), False),
-        0x0001: ('view', (t.uint16_t, ), False),
-        0x0002: ('get_membership', (t.LVList(t.uint16_t), ), False),
-        0x0003: ('remove', (t.uint16_t, ), False),
+        0x0000: ('add', (t.Group, t.CharacterString), False),
+        0x0001: ('view', (t.Group, ), False),
+        0x0002: ('get_membership', (t.LVList(t.Group), ), False),
+        0x0003: ('remove', (t.Group, ), False),
         0x0004: ('remove_all', (), False),
-        0x0005: ('add_if_identifying', (t.uint16_t, t.CharacterString), False),
+        0x0005: ('add_if_identifying', (t.Group, t.CharacterString), False),
     }
     client_commands = {
-        0x0000: ('add_response', (t.uint8_t, t.uint16_t), True),
-        0x0001: ('view_response', (t.uint8_t, t.uint16_t, t.CharacterString), True),
-        0x0002: ('get_membership_response', (t.uint8_t, t.LVList(t.uint16_t)), True),
-        0x0003: ('remove_response', (t.uint8_t, t.uint16_t), True),
+        0x0000: ('add_response', (foundation.Status, t.Group), True),
+        0x0001: ('view_response', (foundation.Status, t.Group, t.CharacterString), True),
+        0x0002: ('get_membership_response', (t.uint8_t, t.LVList(t.Group)), True),
+        0x0003: ('remove_response', (foundation.Status, t.Group), True),
     }
 
 


### PR DESCRIPTION
**Group Management Framework**
* ApplicationController contains `groups` property (`Groups` class) which is a dict of `Group`'s instances
* each `Group` instance is a dict containing member devices (keyed on `IEEE` ) and have the following properties
  * `group_id` -- group ID
  * `name` -- group name
 
A Zigpy Device can be added to a group by calling the async `zigpy.device.Device.add_to_group(group_id, group_name)` method.  A Zigpy Device can be removed from a group by calling the async `zigpy.device.Device.remove_from_group(group_id)` method. Each device has a `member_of` dict, keyed by group_id of which device is member of.

My idea is to add radios as a Zigpy device and each radio could implement its own `add_to_group()`/`remove_from_group()` methods to subscribe/unsubscribe coordinator from receiving traffic for specific groups. 


