### PR TITLE
Fix ConfigureReportingResponseRecord and WriteAttributeResponseRecord serialization/deserialization.

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -167,6 +167,8 @@ def test_struct():
         _fields = [('a', t.uint8_t), ('b', t.uint8_t)]
 
     ts = TestStruct()
+    assert ts.a is None
+    assert ts.b is None
     ts.a = t.uint8_t(0xaa)
     ts.b = t.uint8_t(0xbb)
     ts2 = TestStruct(ts)
@@ -179,6 +181,24 @@ def test_struct():
 
     s = ts2.serialize()
     assert s == b'\xaa\xbb'
+
+
+def test_struct_init():
+    class TestStruct(t.Struct):
+        _fields = [
+            ('a', t.uint8_t),
+            ('b', t.uint16_t),
+            ('c', t.CharacterString),
+        ]
+
+    ts = TestStruct(1, 0x0100, 'TestStruct')
+    assert repr(ts)
+    assert isinstance(ts.a, t.uint8_t)
+    assert isinstance(ts.b, t.uint16_t)
+    assert isinstance(ts.c, t.CharacterString)
+    assert ts.a == 1
+    assert ts.b == 0x100
+    assert ts.c == 'TestStruct'
 
 
 def test_hex_repr():

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -113,3 +113,40 @@ def test_write_attribute_status_record():
     rec.status = foundation.Status.UNSUPPORTED_ATTRIBUTE
     assert rec.serialize()[0:1] == foundation.Status.UNSUPPORTED_ATTRIBUTE.serialize()
     assert rec.serialize()[1:] == b'\xbb\xaa'
+
+
+def test_configure_reporting_response_serialization():
+    direction_attr_id = b'\x00\x01\x10'
+    extra = b'12da-'
+    res, d = foundation.ConfigureReportingResponseRecord.deserialize(
+        b'\x00' + direction_attr_id + extra)
+    assert res.status == foundation.Status.SUCCESS
+    assert res.direction is None
+    assert res.attrid is None
+    assert d == direction_attr_id + extra
+    r = repr(res)
+    assert r.startswith(
+        '<' + foundation.ConfigureReportingResponseRecord.__name__)
+    assert 'status' in r
+    assert 'direction' not in r
+    assert 'attrid' not in r
+
+    res, d = foundation.ConfigureReportingResponseRecord.deserialize(
+        b'\x8c' + direction_attr_id + extra)
+    assert res.status == foundation.Status.UNREPORTABLE_ATTRIBUTE
+    assert res.direction is not None
+    assert res.attrid == 0x1001
+    assert d == extra
+
+    r = repr(res)
+    assert 'status' in r
+    assert 'direction' in r
+    assert 'attrid' in r
+
+    rec = foundation.ConfigureReportingResponseRecord(
+        foundation.Status.SUCCESS, 0x00, 0xaabb
+    )
+    assert rec.serialize() == b'\x00'
+    rec.status = foundation.Status.UNREPORTABLE_ATTRIBUTE
+    assert rec.serialize()[0:1] == foundation.Status.UNREPORTABLE_ATTRIBUTE.serialize()
+    assert rec.serialize()[1:] == b'\x00\xbb\xaa'

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -80,3 +80,36 @@ def test_typed_collection():
 
     assert tc2.type == 0x20
     assert tc2.value == list(range(100))
+
+
+def test_write_attribute_status_record():
+    attr_id = b'\x01\x00'
+    extra = b'12da-'
+    res, d = foundation.WriteAttributesStatusRecord.deserialize(
+        b'\x00' + attr_id + extra)
+    assert res.status == foundation.Status.SUCCESS
+    assert res.attrid is None
+    assert d == attr_id + extra
+    r = repr(res)
+    assert r.startswith(
+        '<' + foundation.WriteAttributesStatusRecord.__name__)
+    assert 'status' in r
+    assert 'attrid' not in r
+
+    res, d = foundation.WriteAttributesStatusRecord.deserialize(
+        b'\x87' + attr_id + extra)
+    assert res.status == foundation.Status.INVALID_VALUE
+    assert res.attrid == 0x0001
+    assert d == extra
+
+    r = repr(res)
+    assert 'status' in r
+    assert 'attrid' in r
+
+    rec = foundation.WriteAttributesStatusRecord(
+        foundation.Status.SUCCESS, 0xaabb
+    )
+    assert rec.serialize() == b'\x00'
+    rec.status = foundation.Status.UNSUPPORTED_ATTRIBUTE
+    assert rec.serialize()[0:1] == foundation.Status.UNSUPPORTED_ATTRIBUTE.serialize()
+    assert rec.serialize()[1:] == b'\xbb\xaa'

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -4,6 +4,12 @@ class Struct:
             # copy constructor
             for field in self._fields:
                 setattr(self, field[0], getattr(args[0], field[0]))
+        elif len(args) == len(self._fields):
+            for field, value in zip(self._fields, args):
+                setattr(self, field[0], field[1](value))
+        elif not args:
+            for field in self._fields:
+                setattr(self, field[0], None)
 
     def serialize(self):
         r = b''

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -187,6 +187,28 @@ class WriteAttributesStatusRecord(t.Struct):
         ('attrid', t.uint16_t),
     ]
 
+    @classmethod
+    def deserialize(cls, data):
+        r = cls()
+        r.status, data = Status.deserialize(data)
+        if r.status != Status.SUCCESS:
+            r.attrid, data = t.uint16_t.deserialize(data)
+
+        return r, data
+
+    def serialize(self):
+        r = Status(self.status).serialize()
+        if self.status != Status.SUCCESS:
+            r += t.uint16_t(self.attrid).serialize()
+        return r
+
+    def __repr__(self):
+        r = '<%s status=%s' % (self.__class__.__name__, self.status, )
+        if self.status != Status.SUCCESS:
+            r += ' attrid=%s' % (self.attrid, )
+        r += '>'
+        return r
+
 
 class AttributeReportingConfig:
     def serialize(self):

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -250,10 +250,34 @@ class AttributeReportingConfig:
 
 class ConfigureReportingResponseRecord(t.Struct):
     _fields = [
-        ('status', t.uint8_t),
+        ('status', Status),
         ('direction', t.uint8_t),
         ('attrid', t.uint16_t),
     ]
+
+    @classmethod
+    def deserialize(cls, data):
+        r = cls()
+        r.status, data = Status.deserialize(data)
+        if r.status != Status.SUCCESS:
+            r.direction, data = t.uint8_t.deserialize(data)
+            r.attrid, data = t.uint16_t.deserialize(data)
+
+        return r, data
+
+    def serialize(self):
+        r = Status(self.status).serialize()
+        if self.status != Status.SUCCESS:
+            r += t.uint8_t(self.direction).serialize()
+            r += t.uint16_t(self.attrid).serialize()
+        return r
+
+    def __repr__(self):
+        r = '<%s status=%s' % (self.__class__.__name__, self.status, )
+        if self.status != Status.SUCCESS:
+            r += ' direction=%s attrid=%s' % (self.direction, self.attrid, )
+        r += '>'
+        return r
 
 
 class ReadReportingConfigRecord(t.Struct):


### PR DESCRIPTION
PR #155 exposed a few areas, where Zigpy was incorrectly deserializing input data, particularly  handling of ConfigureReportingResponseRecord and WriteAttributeResponseRecord deserialization. Per ZCL specs, in case of success, only Status.Success field is sent back, with "attribute id"/"direction" fields ommited in order to save the bandwidth.

ZCL Specs sections `2.5.5.1.2` and `2.5.8.1.3`

![image](https://user-images.githubusercontent.com/5826160/58038268-8482f400-7afd-11e9-99b4-d17e0f21d448.png)

![image](https://user-images.githubusercontent.com/5826160/58038295-98c6f100-7afd-11e9-8ec1-ceb85f45538a.png)
