### PR TITLE
Fix float type (Single/Double) deserialization.

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -13,15 +13,21 @@ def test_int_too_short():
 
 
 def test_single():
-    v = t.Single(1.25)
+    value = 1.25
+    extra = b'ab12!'
+    v = t.Single(value)
     ser = v.serialize()
-    assert t.Single.deserialize(ser) == (1.25, b'')
+    assert t.Single.deserialize(ser) == (value, b'')
+    assert t.Single.deserialize(ser + extra) == (value, extra)
 
 
 def test_double():
-    v = t.Double(1.25)
+    value = 1.25
+    extra = b'ab12!'
+    v = t.Double(value)
     ser = v.serialize()
-    assert t.Double.deserialize(ser) == (1.25, b'')
+    assert t.Double.deserialize(ser) == (value, b'')
+    assert t.Double.deserialize(ser + extra) == (value, extra)
 
 
 def test_lvbytes():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -20,6 +20,9 @@ def test_single():
     assert t.Single.deserialize(ser) == (value, b'')
     assert t.Single.deserialize(ser + extra) == (value, extra)
 
+    with pytest.raises(ValueError):
+        t.Double.deserialize(ser[1:])
+
 
 def test_double():
     value = 1.25
@@ -28,6 +31,9 @@ def test_double():
     ser = v.serialize()
     assert t.Double.deserialize(ser) == (value, b'')
     assert t.Double.deserialize(ser + extra) == (value, extra)
+
+    with pytest.raises(ValueError):
+        t.Double.deserialize(ser[1:])
 
 
 def test_lvbytes():

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -130,7 +130,7 @@ class Single(float):
 
     @classmethod
     def deserialize(cls, data):
-        return struct.unpack('<f', data)[0], data[4:]
+        return struct.unpack('<f', data[0:4])[0], data[4:]
 
 
 class Double(float):
@@ -139,7 +139,7 @@ class Double(float):
 
     @classmethod
     def deserialize(cls, data):
-        return struct.unpack('<d', data)[0], data[8:]
+        return struct.unpack('<d', data[0:8])[0], data[8:]
 
 
 class LVBytes(bytes):

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -125,21 +125,22 @@ class bitmap64(uint64_t):  # noqa: N801
 
 
 class Single(float):
+    _fmt = '<f'
+
     def serialize(self):
-        return struct.pack('<f', self)
+        return struct.pack(self._fmt, self)
 
     @classmethod
     def deserialize(cls, data):
-        return struct.unpack('<f', data[0:4])[0], data[4:]
+        size = struct.calcsize(cls._fmt)
+        if len(data) < size:
+            raise ValueError('Data is too short to contain %s float' % cls.__name__)
+
+        return struct.unpack(cls._fmt, data[0:size])[0], data[size:]
 
 
-class Double(float):
-    def serialize(self):
-        return struct.pack('<d', self)
-
-    @classmethod
-    def deserialize(cls, data):
-        return struct.unpack('<d', data[0:8])[0], data[8:]
+class Double(Single):
+    _fmt = '<d'
 
 
 class LVBytes(bytes):


### PR DESCRIPTION
`struct.unpack('<f', data)` requires buffer size in bytes to match the format string exactly. `zigpy.types.Single.deserialize(b'1234')` would work, but `zigpy.types.Single.deserialize(b'12345')` not.
Deserializing a buffer containing more than just float data fails:

```
2019-05-21 00:00:24 ERROR (MainThread) [bellows.ezsp] Exception running handler
Traceback (most recent call last):
  File "/home/ha/src/bellows/bellows/ezsp.py", line 243, in handle_callback
    handler(*args)
  File "/home/ha/src/bellows/bellows/zigbee/application.py", line 211, in ezsp_callback_handler
    self._handle_frame(*args)
  File "/home/ha/src/bellows/bellows/zigbee/application.py", line 244, in _handle_frame
    tsn, command_id, is_reply, args = self.deserialize(device, aps_frame.sourceEndpoint, aps_frame.clusterId, message)
  File "/home/ha/src/zigpy/zigpy/application.py", line 86, in deserialize
    return sender.deserialize(endpoint_id, cluster_id, data)
  File "/home/ha/src/zigpy/zigpy/device.py", line 148, in deserialize
    return self.endpoints[endpoint_id].deserialize(cluster_id, data)
  File "/home/ha/src/zigpy/zigpy/endpoint.py", line 192, in deserialize
    return cluster.deserialize(tsn, frame_type, is_reply, command_id, data)
  File "/home/ha/src/zigpy/zigpy/zcl/__init__.py", line 95, in deserialize
    value, data = t.deserialize(data, schema)
  File "/home/ha/src/zigpy/zigpy/types/__init__.py", line 9, in deserialize
    value, data = type_.deserialize(data)
  File "/home/ha/src/zigpy/zigpy/types/basic.py", line 184, in deserialize
    item, data = r._itemtype.deserialize(data)
  File "/home/ha/src/zigpy/zigpy/types/struct.py", line 24, in deserialize
    v, data = field_type.deserialize(data)
  File "/home/ha/src/zigpy/zigpy/zcl/foundation.py", line 61, in deserialize
    self.value, data = python_type.deserialize(data)
  File "/home/ha/src/zigpy/zigpy/types/basic.py", line 133, in deserialize
    return struct.unpack('<f', data)[0], data[4:]
struct.error: unpack requires a buffer of 4 bytes
```
