### PR TITLE
Use `ep_attribute` when adding an endpoint to a group.

### DIFF
--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -4,7 +4,7 @@ import logging
 import zigpy.profiles
 import zigpy.util
 import zigpy.zcl
-from zigpy.zcl.clusters.general import Basic, Groups
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import Status as ZCLStatus
 
 LOGGER = logging.getLogger(__name__)
@@ -111,10 +111,12 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return cluster
 
     async def add_to_group(self, grp_id: int, name: str = None):
-        if Groups.cluster_id not in self.in_clusters:
+        try:
+            res = await self.groups.add(grp_id, name)
+        except AttributeError:
             self.debug("Cannot add 0x%04x group, no groups cluster", grp_id)
             return ZCLStatus.FAILURE
-        res = await self.groups.add(grp_id, name)
+
         if res[0] != ZCLStatus.SUCCESS:
             self.debug("Couldn't add to 0x%04x group: %s", grp_id, res[0])
             return res[0]
@@ -124,10 +126,12 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return res[0]
 
     async def remove_from_group(self, grp_id: int):
-        if Groups.cluster_id not in self.in_clusters:
+        try:
+            res = await self.groups.remove(grp_id)
+        except AttributeError:
             self.debug("Cannot remove 0x%04x group, no groups cluster", grp_id)
             return ZCLStatus.FAILURE
-        res = await self.groups.remove(grp_id)
+
         if res[0] != ZCLStatus.SUCCESS:
             self.debug("Couldn't add to 0x%04x group: %s", grp_id, res[0])
             return res[0]

--- a/zigpy/zcl/clusters/lightlink.py
+++ b/zigpy/zcl/clusters/lightlink.py
@@ -1,10 +1,16 @@
 from zigpy import types as t
 from zigpy.zcl import Cluster, foundation
 
-NET_START_JOIN = (
-    t.uint32_t, t.EUI64, t.uint8_t, t.KeyData, t.uint8_t, t.uint16_t,
-    t.uint16_t, t.uint16_t, t.uint16_t, t.uint16_t, t.uint16_t, t.uint16_t,
-    t.uint16_t, t.EUI64, t.uint16_t
+NET_START = (
+    t.uint32_t, t.EUI64, t.uint8_t, t.KeyData, t.uint8_t, t.NWK,
+    t.NWK, t.uint16_t, t.uint16_t, t.uint16_t, t.uint16_t, t.uint16_t,
+    t.uint16_t, t.EUI64, t.NWK
+)
+
+NET_JOIN = (
+    t.uint32_t, t.EUI64, t.uint8_t, t.KeyData, t.uint8_t, t.uint8_t, t.NWK,
+    t.NWK, t.uint16_t, t.uint16_t, t.uint16_t, t.uint16_t, t.uint16_t,
+    t.uint16_t
 )
 
 
@@ -22,7 +28,7 @@ class DeviceInfoRecord(t.Struct):
 
 class EndpointInfoRecord(t.Struct):
     _fields = [
-        ('nwk', t.uint16_t),
+        ('nwk', t.NWK),
         ('endpoint_id', t.uint8_t),
         ('profile_id', t.uint16_t),
         ('device_id', t.uint16_t),
@@ -32,8 +38,8 @@ class EndpointInfoRecord(t.Struct):
 
 class GroupInfoRecord(t.Struct):
     _fields = [
-        ('group_id', t.uint16_t),
-        ('group_type', t.uint16_t),
+        ('group_id', t.Group),
+        ('group_type', t.uint8_t),
     ]
 
 
@@ -42,27 +48,27 @@ class LightLink(Cluster):
     ep_attribute = 'lightlink'
     attributes = {}
     server_commands = {
-        0x0000: ('scan', (t.uint32_t, t.enum8, t.enum8, ), False),
+        0x0000: ('scan', (t.uint32_t, t.bitmap8, t.bitmap8, ), False),
         0x0002: ('device_information', (t.uint32_t, t.uint8_t, ), False),
         0x0006: ('identify', (t.uint32_t, t.uint16_t, ), False),
         0x0007: ('reset_to_factory_new', (t.uint32_t, ), False),
-        0x0010: ('network_start', NET_START_JOIN, False),
-        0x0012: ('network_join_router', NET_START_JOIN, False),
-        0x0014: ('network_join_end_device', NET_START_JOIN, False),
-        0x0016: ('network_update', (t.uint32_t, t.EUI64, t.uint8_t, t.uint8_t, t.uint16_t, t.uint16_t, ), False),
+        0x0010: ('network_start', NET_START, False),
+        0x0012: ('network_join_router', NET_JOIN, False),
+        0x0014: ('network_join_end_device', NET_JOIN, False),
+        0x0016: ('network_update', (t.uint32_t, t.EUI64, t.uint8_t, t.uint8_t, t.NWK, t.NWK, ), False),
         0x0041: ('get_group_identifiers', (t.uint8_t, ), False),
         0x0042: ('get_endpoint_list', (t.uint8_t, ), False),
     }
     client_commands = {
         0x0001: ('scan_rsp', (t.uint32_t, t.uint8_t, t.bitmap8, t.bitmap8, t.bitmap16, t.uint32_t, t.EUI64, t.uint8_t,
-                              t.uint8_t, t.uint16_t, t.uint16_t, t.uint8_t, t.uint8_t, t.Optional(t.uint8_t),
+                              t.uint8_t, t.NWK, t.NWK, t.uint8_t, t.uint8_t, t.Optional(t.uint8_t),
                               t.Optional(t.uint16_t), t.Optional(t.uint16_t), t.Optional(t.uint8_t),
                               t.Optional(t.uint8_t)), True),
         0x0003: ('device_information_rsp', (t.uint32_t, t.uint8_t, t.uint8_t, t.LVList(DeviceInfoRecord), ), True),
         0x0011: ('network_start_rsp', (t.uint32_t, foundation.Status, t.EUI64, t.uint8_t, t.uint8_t, t.uint16_t, ), True),
         0x0013: ('network_join_router_rsp', (t.uint32_t, foundation.Status, ), True),
         0x0015: ('network_join_end_device_rsp', (t.uint32_t, foundation.Status, ), True),
-        0x0040: ('endpoint_information', (t.EUI64, t.uint16_t, t.uint8_t, t.uint16_t, t.uint16_t, t.uint8_t, ), True),
+        0x0040: ('endpoint_information', (t.EUI64, t.NWK, t.uint8_t, t.uint16_t, t.uint16_t, t.uint8_t, ), True),
         0x0041: ('get_group_identifiers_rsp', (t.uint8_t, t.uint8_t, t.LVList(GroupInfoRecord),), True),
         0x0042: ('get_endpoint_list_rsp', (t.uint8_t, t.uint8_t, t.LVList(EndpointInfoRecord)), True),
     }


### PR DESCRIPTION
Use `ep_attribute` for Groups cluster access vs `cluster_id`, as some devices (XBee) use a non standard `cluster_id` for groups cluster.