### PR TITLE
Refactor endpoint initialization.

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -213,7 +213,7 @@ async def test_init_endpoint_info_unicode(ep):
     await test_initialize_zha(ep)
 
 
-def _init_endpoint_info(ep, test_manuf=None, test_model=None):
+def _init_endpoint_info(ep, test_manuf=None, test_model=None, profile=260):
     clus = ep.add_input_cluster(0)
     assert 0 in ep.in_clusters
     assert ep.in_clusters[0] is clus
@@ -226,7 +226,7 @@ def _init_endpoint_info(ep, test_manuf=None, test_model=None):
         return [[rar4, rar5]]
     clus.request = mockrequest
 
-    return test_initialize_zha(ep)
+    return _test_initialize(ep, profile)
 
 
 @pytest.mark.asyncio
@@ -257,6 +257,17 @@ async def test_init_endpoint_info_null_padded_manuf_model(ep):
 
     assert ep.manufacturer == 'Mock Manufacturer'
     assert ep.model == 'Mock Model'
+
+
+@pytest.mark.asyncio
+async def test_init_endpoint_info_not_zha_profile(ep):
+    manufacturer = b'Mock Manufacturer'
+    model = b'Mock Model'
+    profile_id = 0xc2df
+    await _init_endpoint_info(ep, manufacturer, model, profile=profile_id)
+
+    assert ep.manufacturer is None
+    assert ep.model is None
 
 
 def _group_add_mock(ep, success=True,

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -141,6 +141,10 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return res[0]
 
     async def initialize_endpoint_info(self):
+        if self.profile_id not in (zigpy.profiles.zha.PROFILE_ID,
+                                   zigpy.profiles.zll.PROFILE_ID, ):
+            return
+
         attributes = {
             'manufacturer': None,
             'model': None,


### PR DESCRIPTION
Skip reading model & manufacturer for non ZHA/ZLL endpoint profiles.
ConBee is having issues reading `model` and `manufacturer` from non ZHA/ZLL endpoints: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/158#issuecomment-502411929 and because of it, device discovery fails https://github.com/zigpy/zigpy-deconz/issues/44 

Since ATM `zigpy` library currently supports only ZHA and ZLL profiles we can skip reading model and manufacturer for those endpoints. The endpoints are still going to be there, so quirk matching would not be affected, as long as `model` and `manufacturer` attributes are not matched for those endpoints.
