### PR TITLE
Model & Manufacturer properties for zigpy.device.Device class.

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -153,6 +153,8 @@ def test_appdb_load_null_padded_manuf(tmpdir):
     model = b'Mock Model'
     dev = _test_null_padded(tmpdir, manufacturer, model)
 
+    assert dev.manufacturer == 'Mock Manufacturer'
+    assert dev.model == 'Mock Model'
     assert dev.endpoints[3].manufacturer == 'Mock Manufacturer'
     assert dev.endpoints[3].model == 'Mock Model'
 
@@ -162,6 +164,8 @@ def test_appdb_load_null_padded_model(tmpdir):
     model = b'Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
     dev = _test_null_padded(tmpdir, manufacturer, model)
 
+    assert dev.manufacturer == 'Mock Manufacturer'
+    assert dev.model == 'Mock Model'
     assert dev.endpoints[3].manufacturer == 'Mock Manufacturer'
     assert dev.endpoints[3].model == 'Mock Model'
 
@@ -171,6 +175,8 @@ def test_appdb_load_null_padded_manuf_model(tmpdir):
     model = b'Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
     dev = _test_null_padded(tmpdir, manufacturer, model)
 
+    assert dev.manufacturer == 'Mock Manufacturer'
+    assert dev.model == 'Mock Model'
     assert dev.endpoints[3].manufacturer == 'Mock Manufacturer'
     assert dev.endpoints[3].model == 'Mock Model'
 
@@ -180,6 +186,8 @@ def test_appdb_str_model(tmpdir):
     model = 'Mock Model'
     dev = _test_null_padded(tmpdir, manufacturer, model)
 
+    assert dev.manufacturer == 'Mock Manufacturer'
+    assert dev.model == 'Mock Model'
     assert dev.endpoints[3].manufacturer == 'Mock Manufacturer'
     assert dev.endpoints[3].model == 'Mock Model'
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -400,4 +400,3 @@ def test_ep_model(ep):
 
     ep.model = mock.sentinel.ep_model
     assert ep.model is mock.sentinel.ep_model
-

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -384,3 +384,20 @@ async def test_remove_from_group_fail(ep):
     assert groups.remove_group.call_count == 0
     assert grp_mock.add_member.call_count == 0
     assert grp_mock.remove_member.call_count == 0
+
+
+def test_ep_manufacturer(ep):
+    ep.device.manufacturer = mock.sentinel.device_manufacturer
+    assert ep.manufacturer is mock.sentinel.device_manufacturer
+
+    ep.manufacturer = mock.sentinel.ep_manufacturer
+    assert ep.manufacturer is mock.sentinel.ep_manufacturer
+
+
+def test_ep_model(ep):
+    ep.device.model = mock.sentinel.device_model
+    assert ep.model is mock.sentinel.device_model
+
+    ep.model = mock.sentinel.ep_model
+    assert ep.model is mock.sentinel.ep_model
+

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -30,7 +30,7 @@ def test_registry():
 def test_get_device():
     application = mock.sentinel.application
     ieee = mock.sentinel.ieee
-    nwk = mock.sentinel.nwk
+    nwk = 0x2233
     real_device = zigpy.device.Device(application, ieee, nwk)
 
     real_device.add_endpoint(1)
@@ -139,14 +139,20 @@ def test_custom_device():
                     'output_clusters': [0x0001, MyCluster],
                 },
                 2: (MyEndpoint, mock.sentinel.custom_endpoint_arg),
-            }
+            },
+            'model': 'Mock Model',
+            'manufacturer': 'Mock Manufacturer',
         }
 
     assert 0x8888 not in Cluster._registry
 
     replaces = mock.MagicMock()
     replaces[1].device_type = mock.sentinel.device_type
-    test_device = Device(None, None, None, replaces)
+    test_device = Device(None, None, 0x4455, replaces)
+
+    assert test_device.manufacturer == 'Mock Manufacturer'
+    assert test_device.model == 'Mock Model'
+
     assert test_device[1].profile_id == mock.sentinel.profile_id
     assert test_device[1].device_type == mock.sentinel.device_type
 

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -90,6 +90,40 @@ def test_get_device(real_device):
     assert isinstance(get_device(real_device, registry), TestDevice)
 
 
+def test_get_device_model_in_sig(real_device):
+    class TestDevice:
+        signature = {}
+
+        def __init__(*args, **kwargs):
+            pass
+
+        def get_signature(self):
+            pass
+
+    registry = [TestDevice]
+
+    get_device = zigpy.quirks.get_device
+
+    assert get_device(real_device, registry) is real_device
+
+    TestDevice.signature[1] = {
+        'profile_id': 255,
+        'device_type': 255,
+        'input_clusters': [3],
+        'output_clusters': [6],
+    }
+
+    TestDevice.signature['model'] = 'x'
+    assert get_device(real_device, registry) is real_device
+
+    TestDevice.signature['model'] = 'model'
+    TestDevice.signature['manufacturer'] = 'x'
+    assert get_device(real_device, registry) is real_device
+
+    TestDevice.signature['manufacturer'] = 'manufacturer'
+    assert isinstance(get_device(real_device, registry), TestDevice)
+
+
 def test_custom_devices():
     def _check_range(cluster):
         for range in Cluster._registry_range.keys():

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -264,15 +264,15 @@ class PersistingListener:
                         if cluster == Basic.cluster_id and attrid == 4:
                             if isinstance(value, bytes):
                                 value = value.split(b'\x00')[0]
-                                ep.manufacturer = value.decode().strip()
+                                dev.manufacturer = value.decode().strip()
                             else:
-                                ep.manufacturer = value
+                                dev.manufacturer = value
                         if cluster == Basic.cluster_id and attrid == 5:
                             if isinstance(value, bytes):
                                 value = value.split(b'\x00')[0]
-                                ep.model = value.decode().strip()
+                                dev.model = value.decode().strip()
                             else:
-                                ep.model = value
+                                dev.model = value
 
         _load_attributes()
 

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -71,8 +71,17 @@ class CustomDevice(zigpy.device.Device, metaclass=Registry):
 
     def __init__(self, application, ieee, nwk, replaces):
         super().__init__(application, ieee, nwk)
-        self.status = zigpy.device.Status.ENDPOINTS_INIT
-        self.node_desc = replaces.node_desc
+
+        def set_device_attr(attr):
+            if attr in self.replacement:
+                setattr(self, attr, self.replacement[attr])
+            else:
+                setattr(self, attr, getattr(replaces, attr))
+
+        set_device_attr('status')
+        set_device_attr('node_desc')
+        set_device_attr('manufacturer')
+        set_device_attr('model')
         for endpoint_id, endpoint in self.replacement.get('endpoints', {}).items():
             self.add_endpoint(endpoint_id, replace_device=replaces)
 

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -18,9 +18,22 @@ def get_device(device, registry=_DEVICE_REGISTRY):
     dev_ep = set(device.endpoints) - set([0])
     for candidate in registry:
         _LOGGER.debug("Considering %s", candidate)
-        sig = candidate.signature
+        sig = {
+            eid: ep for eid, ep in candidate.signature.items() if isinstance(eid, int)
+        }
+        if not device.model == candidate.signature.get('model', device.model):
+            _LOGGER.debug("Fail, because device model mismatch: '%s'",
+                          device.model)
+            continue
+
+        if not (device.manufacturer ==
+                candidate.signature.get('manufacturer', device.manufacturer)):
+            _LOGGER.debug("Fail, because device manufacturer mismatch: '%s'",
+                          device.manufacturer)
+            continue
+
         if not _match(sig, dev_ep):
-            _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig, dev_ep)
+            _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig.keys(), dev_ep)
             continue
 
         if not all([device[eid].profile_id == sig[eid].get('profile_id', device[eid].profile_id) for eid in sig]):

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -15,37 +15,37 @@ def add_to_registry(device):
 
 def get_device(device, registry=_DEVICE_REGISTRY):
     """Get a CustomDevice object, if one is available"""
-    dev_ep = set(device.endpoints.keys()) - set([0])
+    dev_ep = set(device.endpoints) - set([0])
     for candidate in registry:
         _LOGGER.debug("Considering %s", candidate)
         sig = candidate.signature
-        if not _match(sig.keys(), dev_ep):
-            _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig.keys(), dev_ep)
+        if not _match(sig, dev_ep):
+            _LOGGER.debug("Fail because endpoint list mismatch: %s %s", sig, dev_ep)
             continue
 
-        if not all([device[eid].profile_id == sig[eid].get('profile_id', device[eid].profile_id) for eid in sig.keys()]):
+        if not all([device[eid].profile_id == sig[eid].get('profile_id', device[eid].profile_id) for eid in sig]):
             _LOGGER.debug("Fail because profile_id mismatch on at least one endpoint")
             continue
 
-        if not all([device[eid].device_type == sig[eid].get('device_type', device[eid].device_type) for eid in sig.keys()]):
+        if not all([device[eid].device_type == sig[eid].get('device_type', device[eid].device_type) for eid in sig]):
             _LOGGER.debug("Fail because device_type mismatch on at least one endpoint")
             continue
 
-        if not all([device[eid].model == sig[eid].get('model', device[eid].model) for eid in sig.keys()]):
+        if not all([device[eid].model == sig[eid].get('model', device[eid].model) for eid in sig]):
             _LOGGER.debug("Fail because model mismatch on at least one endpoint")
             continue
 
-        if not all([device[eid].manufacturer == sig[eid].get('manufacturer', device[eid].manufacturer) for eid in sig.keys()]):
+        if not all([device[eid].manufacturer == sig[eid].get('manufacturer', device[eid].manufacturer) for eid in sig]):
             _LOGGER.debug("Fail because manufacturer mismatch on at least one endpoint")
             continue
 
-        if not all([_match(device[eid].in_clusters.keys(),
+        if not all([_match(device[eid].in_clusters,
                            ep.get('input_clusters', []))
                     for eid, ep in sig.items()]):
             _LOGGER.debug("Fail because input cluster mismatch on at least one endpoint")
             continue
 
-        if not all([_match(device[eid].out_clusters.keys(),
+        if not all([_match(device[eid].out_clusters,
                            ep.get('output_clusters', []))
                     for eid, ep in sig.items()]):
             _LOGGER.debug("Fail because output cluster mismatch on at least one endpoint")

--- a/zigpy/quirks/ikea/__init__.py
+++ b/zigpy/quirks/ikea/__init__.py
@@ -3,26 +3,28 @@ from zigpy.quirks import CustomDevice
 
 class TradfriPlug(CustomDevice):
     signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=266 device_version=0 input_clusters=[0, 3, 4, 5, 6, 8, 64636] output_clusters=[5, 25, 32]>
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x010A,
-            'input_clusters': [0, 3, 4, 5, 6, 8, 64636],
-            'output_clusters': [5, 25, 32],
-        },
-        # <SimpleDescriptor endpoint=2 profile=49246 device_type=16 device_version=0 input_clusters=[4096] output_clusters=[4096]>
-        2: {
-            'profile_id': 0xC05E,
-            'device_type': 0x0010,
-            'input_clusters': [4096],
-            'output_clusters': [4096],
-        },
-        # <SimpleDescriptor endpoint=242 profile=41440 device_type=97 device_version=0 input_clusters=[33] output_clusters=[33]>
-        242: {
-            'profile_id': 0xA1E0,
-            'device_type': 0x0061,
-            'input_clusters': [33],
-            'output_clusters': [33],
+        'endpoints': {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=266 device_version=0 input_clusters=[0, 3, 4, 5, 6, 8, 64636] output_clusters=[5, 25, 32]>
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x010A,
+                'input_clusters': [0, 3, 4, 5, 6, 8, 64636],
+                'output_clusters': [5, 25, 32],
+            },
+            # <SimpleDescriptor endpoint=2 profile=49246 device_type=16 device_version=0 input_clusters=[4096] output_clusters=[4096]>
+            2: {
+                'profile_id': 0xC05E,
+                'device_type': 0x0010,
+                'input_clusters': [4096],
+                'output_clusters': [4096],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97 device_version=0 input_clusters=[33] output_clusters=[33]>
+            242: {
+                'profile_id': 0xA1E0,
+                'device_type': 0x0061,
+                'input_clusters': [33],
+                'output_clusters': [33],
+            },
         },
     }
 

--- a/zigpy/quirks/keen/__init__.py
+++ b/zigpy/quirks/keen/__init__.py
@@ -3,12 +3,14 @@ from zigpy.quirks import CustomDevice
 
 class KeenTemperatureHumiditySensor(CustomDevice):
     signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=770 device_version=1 input_clusters=[0, 3, 1, 32] output_clusters=[0, 4, 3, 5, 25, 1026, 1029, 1027, 32]>
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x0302,
-            'input_clusters': [0, 3, 1, 32],
-            'output_clusters': [0, 4, 3, 5, 25, 1026, 1029, 1027, 32],
+        'endpoints': {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=770 device_version=1 input_clusters=[0, 3, 1, 32] output_clusters=[0, 4, 3, 5, 25, 1026, 1029, 1027, 32]>
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x0302,
+                'input_clusters': [0, 3, 1, 32],
+                'output_clusters': [0, 4, 3, 5, 25, 1026, 1029, 1027, 32],
+            },
         },
     }
 

--- a/zigpy/quirks/kof/__init__.py
+++ b/zigpy/quirks/kof/__init__.py
@@ -61,22 +61,24 @@ class KofLevelControl(NoReplyMixin, CustomCluster, LevelControl):
 
 class CeilingFan(CustomDevice):
     signature = {
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 14,
-            'input_clusters': [
-                Basic.cluster_id,
-                Identify.cluster_id,
-                Groups.cluster_id,
-                Scenes.cluster_id,
-                OnOff.cluster_id,
-                LevelControl.cluster_id,
-                Fan.cluster_id,
-            ],
-            'output_clusters': [
-                Identify.cluster_id,
-                Ota.cluster_id,
-            ],
+        'endpoints': {
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 14,
+                'input_clusters': [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Fan.cluster_id,
+                ],
+                'output_clusters': [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
         },
     }
 

--- a/zigpy/quirks/smartthings/__init__.py
+++ b/zigpy/quirks/smartthings/__init__.py
@@ -16,13 +16,15 @@ class SmartthingsRelativeHumidityCluster(CustomCluster):
 
 class SmartthingsTemperatureHumiditySensor(CustomDevice):
     signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=770 device_version=0 input_clusters=[0, 1, 3, 32, 1026, 2821, 64581] output_clusters=[3, 25]>
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x0302,
-            'input_clusters': [0, 1, 3, 32, 1026, 2821, 64581],
-            'output_clusters': [3, 25],
-        }
+        'endpoints': {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=770 device_version=0 input_clusters=[0, 1, 3, 32, 1026, 2821, 64581] output_clusters=[3, 25]>
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x0302,
+                'input_clusters': [0, 1, 3, 32, 1026, 2821, 64581],
+                'output_clusters': [3, 25],
+            },
+        },
     }
 
     replacement = {
@@ -54,17 +56,19 @@ class SmartThingsAccelCluster(CustomCluster):
 
 class SmartthingsMultiPurposeSensor(CustomDevice):
     signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        # device_version=0 input_clusters=[0, 1, 3, 32, 1026, 1280, 64514]
-        # output_clusters=[3, 25]>
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x0402,
-            'input_clusters': [
-                0, 1, 3, 32, 1026, 1280, SmartThingsAccelCluster.cluster_id
-            ],
-            'output_clusters': [3, 25],
-        }
+        'endpoints': {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+            # device_version=0 input_clusters=[0, 1, 3, 32, 1026, 1280, 64514]
+            # output_clusters=[3, 25]>
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x0402,
+                'input_clusters': [
+                    0, 1, 3, 32, 1026, 1280, SmartThingsAccelCluster.cluster_id
+                ],
+                'output_clusters': [3, 25],
+            },
+        },
     }
 
     replacement = {

--- a/zigpy/quirks/xiaomi/__init__.py
+++ b/zigpy/quirks/xiaomi/__init__.py
@@ -5,28 +5,30 @@ from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, \
 
 class TemperatureHumiditySensor(CustomDevice):
     signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 25, 65535, 18] output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f01,
-            'model': 'lumi.sensor_ht',
-            'manufacturer': 'LUMI',
-            'input_clusters': [0, 3, 25, 65535, 18],
-            'output_clusters': [0, 4, 3, 5, 25, 65535, 18],
-        },
-        # <SimpleDescriptor endpoint=2 profile=260 device_type=24322 device_version=1 input_clusters=[3, 18] output_clusters=[4, 3, 5, 18]>
-        2: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f02,
-            'input_clusters': [3, 18],
-            'output_clusters': [4, 3, 5, 18],
-        },
-        # <SimpleDescriptor endpoint=3 profile=260 device_type=24323 device_version=1 input_clusters=[3, 12] output_clusters=[4, 3, 5, 12]>
-        3: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f03,
-            'input_clusters': [3, 12],
-            'output_clusters': [4, 3, 5, 12],
+        'endpoints': {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 25, 65535, 18] output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x5f01,
+                'model': 'lumi.sensor_ht',
+                'manufacturer': 'LUMI',
+                'input_clusters': [0, 3, 25, 65535, 18],
+                'output_clusters': [0, 4, 3, 5, 25, 65535, 18],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=24322 device_version=1 input_clusters=[3, 18] output_clusters=[4, 3, 5, 18]>
+            2: {
+                'profile_id': 0x0104,
+                'device_type': 0x5f02,
+                'input_clusters': [3, 18],
+                'output_clusters': [4, 3, 5, 18],
+            },
+            # <SimpleDescriptor endpoint=3 profile=260 device_type=24323 device_version=1 input_clusters=[3, 12] output_clusters=[4, 3, 5, 12]>
+            3: {
+                'profile_id': 0x0104,
+                'device_type': 0x5f03,
+                'input_clusters': [3, 12],
+                'output_clusters': [4, 3, 5, 12],
+            },
         },
     }
 
@@ -41,12 +43,14 @@ class TemperatureHumiditySensor(CustomDevice):
 
 class AqaraTemperatureHumiditySensor(CustomDevice):
     signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 65535, 1026, 1027, 1029] output_clusters=[0, 4, 65535]>
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f01,
-            'input_clusters': [0, 3, 65535, 1026, 1027, 1029],
-            'output_clusters': [0, 4, 65535],
+        'endpoints': {
+            #  <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 65535, 1026, 1027, 1029] output_clusters=[0, 4, 65535]>
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x5f01,
+                'input_clusters': [0, 3, 65535, 1026, 1027, 1029],
+                'output_clusters': [0, 4, 65535],
+            },
         },
     }
 
@@ -61,12 +65,14 @@ class AqaraTemperatureHumiditySensor(CustomDevice):
 
 class AqaraOpenCloseSensor(CustomDevice):
     signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 65535, 6] output_clusters=[0, 4, 65535]>
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f01,
-            'input_clusters': [0, 3, 65535, 6],
-            'output_clusters': [0, 4, 65535],
+        'endpoints': {
+            #  <SimpleDescriptor endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 65535, 6] output_clusters=[0, 4, 65535]>
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x5f01,
+                'input_clusters': [0, 3, 65535, 6],
+                'output_clusters': [0, 4, 65535],
+            },
         },
     }
 
@@ -82,12 +88,14 @@ class AqaraOpenCloseSensor(CustomDevice):
 
 class AqaraWaterSensor(CustomDevice):
     signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026 device_version=1 input_clusters=[0, 3, 1] output_clusters=[25]>
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x0402,
-            'input_clusters': [0, 3, 1],
-            'output_clusters': [25],
+        'endpoints': {
+            #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026 device_version=1 input_clusters=[0, 3, 1] output_clusters=[25]>
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x0402,
+                'input_clusters': [0, 3, 1],
+                'output_clusters': [25],
+            },
         },
     }
 
@@ -102,40 +110,42 @@ class AqaraWaterSensor(CustomDevice):
 
 class AqaraMagicCubeSensor(CustomDevice):
     signature = {
-        1: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f01,
-            'input_clusters': [Basic.cluster_id,
-                               Identify.cluster_id,
-                               MultistateInput.cluster_id,
-                               Ota.cluster_id],
-            'output_clusters': [Basic.cluster_id,
-                                Identify.cluster_id,
-                                Groups.cluster_id,
-                                Scenes.cluster_id,
-                                MultistateInput.cluster_id,
-                                Ota.cluster_id],
+        'endpoints': {
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x5f01,
+                'input_clusters': [Basic.cluster_id,
+                                   Identify.cluster_id,
+                                   MultistateInput.cluster_id,
+                                   Ota.cluster_id],
+                'output_clusters': [Basic.cluster_id,
+                                    Identify.cluster_id,
+                                    Groups.cluster_id,
+                                    Scenes.cluster_id,
+                                    MultistateInput.cluster_id,
+                                    Ota.cluster_id],
+            },
+            2: {
+                'profile_id': 0x0104,
+                'device_type': 0x5f02,
+                'input_clusters': [Identify.cluster_id,
+                                   MultistateInput.cluster_id],
+                'output_clusters': [Identify.cluster_id,
+                                    Groups.cluster_id,
+                                    Scenes.cluster_id,
+                                    MultistateInput.cluster_id],
+            },
+            3: {
+                'profile_id': 0x0104,
+                'device_type': 0x5f03,
+                'input_clusters': [Identify.cluster_id,
+                                   AnalogInput.cluster_id],
+                'output_clusters': [Identify.cluster_id,
+                                    Groups.cluster_id,
+                                    Scenes.cluster_id,
+                                    AnalogInput.cluster_id],
+            },
         },
-        2: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f02,
-            'input_clusters': [Identify.cluster_id,
-                               MultistateInput.cluster_id],
-            'output_clusters': [Identify.cluster_id,
-                                Groups.cluster_id,
-                                Scenes.cluster_id,
-                                MultistateInput.cluster_id],
-        },
-        3: {
-            'profile_id': 0x0104,
-            'device_type': 0x5f03,
-            'input_clusters': [Identify.cluster_id,
-                               AnalogInput.cluster_id],
-            'output_clusters': [Identify.cluster_id,
-                                Groups.cluster_id,
-                                Scenes.cluster_id,
-                                AnalogInput.cluster_id],
-        }
 
     }
 


### PR DESCRIPTION
Move Model and Manufacturer attributes to the Zigpy Device class.

### Rationale
In Zigbee, `manufacturer` and `model` values are tied to the `Basic` cluster and therefore to the endpoint. However logically, `Manufacturer` and `Model` notions apply to the entire physical Zigbee device, so it makes sense to implement those as Device class properties and this would clean up some of the Home Assistant ZHA component code.

For compatibility reasons, Endpoint instances still retain model/manufacture attributes, proxying those from the device instance. For now we still allow model/manufacturer overriding from quirks, however this is discouraged and will be removed in the future versions. Do we really need to override model/manufacturer at all?

As a side effect, this allow optimization during device discovery, as we don't have to read `model` and `manufacturer` ZCL attributes for each endpoint. This improves device discovery time, specially for devices with multiple endpoints and fixes (workarounds) https://github.com/zigpy/zigpy-deconz/issues/44