### PR TITLE
Refactor node_descriptor request.

### DIFF
--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -69,8 +69,9 @@ class Device(zigpy.util.LocalLogMixin):
 
     async def _initialize(self):
         if self.status == Status.NEW:
-            self._node_handle = asyncio.ensure_future(
-                self.get_node_descriptor())
+            if self._node_handle is None or self._node_handle.done():
+                self._node_handle = asyncio.ensure_future(
+                    self.get_node_descriptor())
             await self._node_handle
             self.info("Discovering endpoints")
             try:


### PR DESCRIPTION
Don't request node_descriptor during device discovery, if the node
descriptor request was already triggered by incoming traffic.