### PR TITLE
Quirks Device match refactoring.

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -55,7 +55,7 @@ def _dev_reg(device):
     return registry
 
 
-def test_get_device(real_device):
+def test_get_device_new_sig(real_device):
     class TestDevice:
         signature = {
         }
@@ -90,16 +90,16 @@ def test_get_device(real_device):
     assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'][1]['output_clusters'] = [6]
-    TestDevice.signature['endpoints'][1]['model'] = 'x'
+    TestDevice.signature['model'] = 'x'
     registry = _dev_reg(TestDevice)
     assert registry.get_device(real_device) is real_device
 
-    TestDevice.signature['endpoints'][1]['model'] = 'model'
-    TestDevice.signature['endpoints'][1]['manufacturer'] = 'x'
+    TestDevice.signature['model'] = 'model'
+    TestDevice.signature['manufacturer'] = 'x'
     registry = _dev_reg(TestDevice)
     assert registry.get_device(real_device) is real_device
 
-    TestDevice.signature['endpoints'][1]['manufacturer'] = 'manufacturer'
+    TestDevice.signature['manufacturer'] = 'manufacturer'
     registry = _dev_reg(TestDevice)
     assert isinstance(registry.get_device(real_device), TestDevice)
 
@@ -144,39 +144,6 @@ def test_get_device_old_signature(real_device):
     assert registry.get_device(real_device) is real_device
 
     TestDevice.signature[1]['manufacturer'] = 'manufacturer'
-    assert isinstance(registry.get_device(real_device), TestDevice)
-
-
-def test_get_device_model_in_sig(real_device):
-    class TestDevice:
-        signature = {}
-
-        def __init__(*args, **kwargs):
-            pass
-
-        def get_signature(self):
-            pass
-
-    registry = DeviceRegistry()
-    registry.add_to_registry(TestDevice)
-
-    assert registry.get_device(real_device) is real_device
-
-    TestDevice.signature['endpoints'] = {1: {
-        'profile_id': 255,
-        'device_type': 255,
-        'input_clusters': [3],
-        'output_clusters': [6],
-    }}
-
-    TestDevice.signature['endpoints'][1]['model'] = 'x'
-    assert registry.get_device(real_device) is real_device
-
-    TestDevice.signature['endpoints'][1]['model'] = 'model'
-    TestDevice.signature['endpoints'][1]['manufacturer'] = 'x'
-    assert registry.get_device(real_device) is real_device
-
-    TestDevice.signature['endpoints'][1]['manufacturer'] = 'manufacturer'
     assert isinstance(registry.get_device(real_device), TestDevice)
 
 

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -28,7 +28,8 @@ def test_registry():
         signature = {}
 
     assert TestDevice in zigpy.quirks._DEVICE_REGISTRY
-    assert zigpy.quirks._DEVICE_REGISTRY.remove_device(TestDevice) == TestDevice  # :-/
+    assert zigpy.quirks._DEVICE_REGISTRY.remove(TestDevice) is None  # :-/
+    assert TestDevice not in zigpy.quirks._DEVICE_REGISTRY
 
 
 @pytest.fixture
@@ -308,7 +309,8 @@ def test_custom_device():
     test_device.add_endpoint(3)
     assert isinstance(test_device[3], zigpy.endpoint.Endpoint)
 
-    assert zigpy.quirks._DEVICE_REGISTRY.remove_device(Device) == Device  # :-/
+    assert zigpy.quirks._DEVICE_REGISTRY.remove(Device) is None  # :-/
+    assert Device not in zigpy.quirks._DEVICE_REGISTRY
 
 
 def test_kof_no_reply():

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -5,6 +5,7 @@ import pytest
 import zigpy.device
 import zigpy.endpoint
 import zigpy.quirks
+from zigpy.quirks.registry import DeviceRegistry
 import zigpy.types as t
 from zigpy.zcl import Cluster
 
@@ -57,37 +58,36 @@ def test_get_device(real_device):
         def get_signature(self):
             pass
 
-    registry = [TestDevice]
+    registry = DeviceRegistry()
+    registry.add_to_registry(TestDevice)
 
-    get_device = zigpy.quirks.get_device
-
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'] = {1: {'profile_id': 1}}
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'][1]['profile_id'] = 255
     TestDevice.signature['endpoints'][1]['device_type'] = 1
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'][1]['device_type'] = 255
     TestDevice.signature['endpoints'][1]['input_clusters'] = [1]
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'][1]['input_clusters'] = [3]
     TestDevice.signature['endpoints'][1]['output_clusters'] = [1]
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'][1]['output_clusters'] = [6]
     TestDevice.signature['endpoints'][1]['model'] = 'x'
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'][1]['model'] = 'model'
     TestDevice.signature['endpoints'][1]['manufacturer'] = 'x'
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'][1]['manufacturer'] = 'manufacturer'
-    assert isinstance(get_device(real_device, registry), TestDevice)
+    assert isinstance(registry.get_device(real_device), TestDevice)
 
 
 def test_get_device_old_signature(real_device):
@@ -101,37 +101,36 @@ def test_get_device_old_signature(real_device):
         def get_signature(self):
             pass
 
-    registry = [TestDevice]
+    registry = DeviceRegistry()
+    registry.add_to_registry(TestDevice)
 
-    get_device = zigpy.quirks.get_device
-
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature[1] = {'profile_id': 1}
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature[1]['profile_id'] = 255
     TestDevice.signature[1]['device_type'] = 1
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature[1]['device_type'] = 255
     TestDevice.signature[1]['input_clusters'] = [1]
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature[1]['input_clusters'] = [3]
     TestDevice.signature[1]['output_clusters'] = [1]
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature[1]['output_clusters'] = [6]
     TestDevice.signature[1]['model'] = 'x'
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature[1]['model'] = 'model'
     TestDevice.signature[1]['manufacturer'] = 'x'
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature[1]['manufacturer'] = 'manufacturer'
-    assert isinstance(get_device(real_device, registry), TestDevice)
+    assert isinstance(registry.get_device(real_device), TestDevice)
 
 
 def test_get_device_model_in_sig(real_device):
@@ -144,11 +143,10 @@ def test_get_device_model_in_sig(real_device):
         def get_signature(self):
             pass
 
-    registry = [TestDevice]
+    registry = DeviceRegistry()
+    registry.add_to_registry(TestDevice)
 
-    get_device = zigpy.quirks.get_device
-
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'] = {1: {
         'profile_id': 255,
@@ -158,14 +156,14 @@ def test_get_device_model_in_sig(real_device):
     }}
 
     TestDevice.signature['endpoints'][1]['model'] = 'x'
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'][1]['model'] = 'model'
     TestDevice.signature['endpoints'][1]['manufacturer'] = 'x'
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'][1]['manufacturer'] = 'manufacturer'
-    assert isinstance(get_device(real_device, registry), TestDevice)
+    assert isinstance(registry.get_device(real_device), TestDevice)
 
 
 def test_model_manuf_device_sig(real_device):
@@ -178,11 +176,10 @@ def test_model_manuf_device_sig(real_device):
         def get_signature(self):
             pass
 
-    registry = [TestDevice]
+    registry = DeviceRegistry()
+    registry.add_to_registry(TestDevice)
 
-    get_device = zigpy.quirks.get_device
-
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['endpoints'] = {1: {
         'profile_id': 255,
@@ -192,14 +189,14 @@ def test_model_manuf_device_sig(real_device):
     }}
 
     TestDevice.signature['model'] = 'x'
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['model'] = 'model'
     TestDevice.signature['manufacturer'] = 'x'
-    assert get_device(real_device, registry) is real_device
+    assert registry.get_device(real_device) is real_device
 
     TestDevice.signature['manufacturer'] = 'manufacturer'
-    assert isinstance(get_device(real_device, registry), TestDevice)
+    assert isinstance(registry.get_device(real_device), TestDevice)
 
 
 def test_custom_devices():

--- a/tests/test_quirks_registry.py
+++ b/tests/test_quirks_registry.py
@@ -28,18 +28,6 @@ def test_reg_get_model():
             2: {},
             3: {'model': mock.sentinel.ep_model}
         },
-    }
-    assert DeviceRegistry.get_model(fake_dev) is mock.sentinel.ep_model
-
-    fake_dev.signature = {
-        1: {},
-        2: {},
-        3: {'model': mock.sentinel.legacy_model},
-        'endpoints': {
-            1: {},
-            2: {},
-            3: {'model': mock.sentinel.ep_model}
-        },
         'model': mock.sentinel.model
     }
     assert DeviceRegistry.get_model(fake_dev) is mock.sentinel.model
@@ -60,18 +48,6 @@ def test_reg_get_manufacturer():
         3: {'manufacturer': mock.sentinel.legacy_manufacturer},
     }
     assert DeviceRegistry.get_manufacturer(fake_dev) is mock.sentinel.legacy_manufacturer
-
-    fake_dev.signature = {
-        1: {},
-        2: {},
-        3: {'manufacturer': mock.sentinel.legacy_manufacturer},
-        'endpoints': {
-            1: {},
-            2: {},
-            3: {'manufacturer': mock.sentinel.ep_manufacturer}
-        },
-    }
-    assert DeviceRegistry.get_manufacturer(fake_dev) is mock.sentinel.ep_manufacturer
 
     fake_dev.signature = {
         1: {},

--- a/tests/test_quirks_registry.py
+++ b/tests/test_quirks_registry.py
@@ -1,0 +1,87 @@
+from zigpy.quirks.registry import DeviceRegistry
+
+from unittest import mock
+
+
+def test_reg_get_model():
+    class FakeDevice:
+        def __init__(self):
+            self.signature = {}
+
+    fake_dev = FakeDevice()
+
+    assert DeviceRegistry.get_model(fake_dev) is None
+
+    fake_dev.signature = {
+        1: {},
+        2: {},
+        3: {'model': mock.sentinel.legacy_model},
+    }
+    assert DeviceRegistry.get_model(fake_dev) is mock.sentinel.legacy_model
+
+    fake_dev.signature = {
+        1: {},
+        2: {},
+        3: {'model': mock.sentinel.legacy_model},
+        'endpoints': {
+            1: {},
+            2: {},
+            3: {'model': mock.sentinel.ep_model}
+        },
+    }
+    assert DeviceRegistry.get_model(fake_dev) is mock.sentinel.ep_model
+
+    fake_dev.signature = {
+        1: {},
+        2: {},
+        3: {'model': mock.sentinel.legacy_model},
+        'endpoints': {
+            1: {},
+            2: {},
+            3: {'model': mock.sentinel.ep_model}
+        },
+        'model': mock.sentinel.model
+    }
+    assert DeviceRegistry.get_model(fake_dev) is mock.sentinel.model
+
+
+def test_reg_get_manufacturer():
+    class FakeDevice:
+        def __init__(self):
+            self.signature = {}
+
+    fake_dev = FakeDevice()
+
+    assert DeviceRegistry.get_manufacturer(fake_dev) is None
+
+    fake_dev.signature = {
+        1: {},
+        2: {},
+        3: {'manufacturer': mock.sentinel.legacy_manufacturer},
+    }
+    assert DeviceRegistry.get_manufacturer(fake_dev) is mock.sentinel.legacy_manufacturer
+
+    fake_dev.signature = {
+        1: {},
+        2: {},
+        3: {'manufacturer': mock.sentinel.legacy_manufacturer},
+        'endpoints': {
+            1: {},
+            2: {},
+            3: {'manufacturer': mock.sentinel.ep_manufacturer}
+        },
+    }
+    assert DeviceRegistry.get_manufacturer(fake_dev) is mock.sentinel.ep_manufacturer
+
+    fake_dev.signature = {
+        1: {},
+        2: {},
+        3: {'manufacturer': mock.sentinel.legacy_manufacturer},
+        'endpoints': {
+            1: {},
+            2: {},
+            3: {'manufacturer': mock.sentinel.ep_manufacturer}
+        },
+        'manufacturer': mock.sentinel.manufacturer
+    }
+    assert DeviceRegistry.get_manufacturer(fake_dev) is mock.sentinel.manufacturer

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -2,90 +2,24 @@ import logging
 
 import zigpy.device
 import zigpy.endpoint
+from zigpy.quirks.registry import DeviceRegistry
 import zigpy.zcl
 
-_DEVICE_REGISTRY = []
 _LOGGER = logging.getLogger(__name__)
 
-
-def add_to_registry(device):
-    """Add a device to the registry"""
-    _DEVICE_REGISTRY.append(device)
+_DEVICE_REGISTRY = DeviceRegistry()
 
 
 def get_device(device, registry=_DEVICE_REGISTRY):
     """Get a CustomDevice object, if one is available"""
-    dev_ep = set(device.endpoints) - set([0])
-    _LOGGER.debug("Checking quirks for %s %s (%s)",
-                  device.manufacturer, device.model, device.ieee)
-    for candidate in registry:
-        _LOGGER.debug("Considering %s", candidate)
-        sig = candidate.signature.get('endpoints', {})
-        if not sig:
-            _LOGGER.warning(
-                ("%s signature update is required. Support for `signature = {1: { replacement }}`"
-                 " will be removed in the future releases. Use "
-                 "`signature = {'endpoints': {1: { replacement }}}"), candidate
-            )
-            sig = {
-                eid: ep for eid, ep in candidate.signature.items() if isinstance(eid, int)
-            }
-        if not device.model == candidate.signature.get('model', device.model):
-            _LOGGER.debug("Fail, because device model mismatch: '%s'",
-                          device.model)
-            continue
-
-        if not (device.manufacturer ==
-                candidate.signature.get('manufacturer', device.manufacturer)):
-            _LOGGER.debug("Fail, because device manufacturer mismatch: '%s'",
-                          device.manufacturer)
-            continue
-
-        if not _match(sig, dev_ep):
-            _LOGGER.debug("Fail because endpoint list mismatch: %s %s", set(sig.keys()), dev_ep)
-            continue
-
-        if not all([device[eid].profile_id == sig[eid].get('profile_id', device[eid].profile_id) for eid in sig]):
-            _LOGGER.debug("Fail because profile_id mismatch on at least one endpoint")
-            continue
-
-        if not all([device[eid].device_type == sig[eid].get('device_type', device[eid].device_type) for eid in sig]):
-            _LOGGER.debug("Fail because device_type mismatch on at least one endpoint")
-            continue
-
-        if not all([device[eid].model == sig[eid].get('model', device[eid].model) for eid in sig]):
-            _LOGGER.debug("Fail because model mismatch on at least one endpoint")
-            continue
-
-        if not all([device[eid].manufacturer == sig[eid].get('manufacturer', device[eid].manufacturer) for eid in sig]):
-            _LOGGER.debug("Fail because manufacturer mismatch on at least one endpoint")
-            continue
-
-        if not all([_match(device[eid].in_clusters,
-                           ep.get('input_clusters', []))
-                    for eid, ep in sig.items()]):
-            _LOGGER.debug("Fail because input cluster mismatch on at least one endpoint")
-            continue
-
-        if not all([_match(device[eid].out_clusters,
-                           ep.get('output_clusters', []))
-                    for eid, ep in sig.items()]):
-            _LOGGER.debug("Fail because output cluster mismatch on at least one endpoint")
-            continue
-
-        _LOGGER.debug("Found custom device replacement for %s: %s",
-                      device.ieee, candidate)
-        device = candidate(device._application, device.ieee, device.nwk, device)
-        break
-
-    return device
+    return registry.get_device(device)
 
 
 class Registry(type):
     def __init__(cls, name, bases, nmspc):  # noqa: N805
         super(Registry, cls).__init__(name, bases, nmspc)
         if hasattr(cls, 'signature'):
-            add_to_registry(cls)
+            _DEVICE_REGISTRY.append(cls)
 
 
 class CustomDevice(zigpy.device.Device, metaclass=Registry):
@@ -167,10 +101,6 @@ class CustomEndpoint(zigpy.endpoint.Endpoint):
 
 class CustomCluster(zigpy.zcl.Cluster):
     _skip_registry = True
-
-
-def _match(a, b):
-    return set(a) == set(b)
 
 
 from . import xiaomi  # noqa: F401, F402

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -19,7 +19,7 @@ class Registry(type):
     def __init__(cls, name, bases, nmspc):  # noqa: N805
         super(Registry, cls).__init__(name, bases, nmspc)
         if hasattr(cls, 'signature'):
-            _DEVICE_REGISTRY.append(cls)
+            _DEVICE_REGISTRY.add_to_registry(cls)
 
 
 class CustomDevice(zigpy.device.Device, metaclass=Registry):

--- a/zigpy/quirks/ikea/__init__.py
+++ b/zigpy/quirks/ikea/__init__.py
@@ -26,6 +26,7 @@ class TradfriPlug(CustomDevice):
                 'output_clusters': [33],
             },
         },
+        'manufacturer': 'IKEA of Sweden',
     }
 
     replacement = {

--- a/zigpy/quirks/keen/__init__.py
+++ b/zigpy/quirks/keen/__init__.py
@@ -12,6 +12,7 @@ class KeenTemperatureHumiditySensor(CustomDevice):
                 'output_clusters': [0, 4, 3, 5, 25, 1026, 1029, 1027, 32],
             },
         },
+        'manufacturer': 'Keen Home Inc',
     }
 
     replacement = {

--- a/zigpy/quirks/kof/__init__.py
+++ b/zigpy/quirks/kof/__init__.py
@@ -80,6 +80,7 @@ class CeilingFan(CustomDevice):
                 ],
             },
         },
+        'manufacturer': 'King Of Fans,  Inc.',
     }
 
     replacement = {

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -16,10 +16,10 @@ class DeviceRegistry:
         model = self.get_model(device)
         self.registry[manufacturer][model].append(device)
 
-    def remove_device(self, device):
+    def remove(self, device):
         manufacturer = self.get_manufacturer(device)
         model = self.get_model(device)
-        return self.registry[manufacturer][model].pop()
+        return self.registry[manufacturer][model].remove(device)
 
     def get_device(self, device):
         """Get a CustomDevice object, if one is available"""

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -1,0 +1,80 @@
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DeviceRegistry(list):
+    def add_to_registry(self, device):
+        """Add a device to the registry"""
+        self.append(device)
+
+    def get_device(self, device):
+        """Get a CustomDevice object, if one is available"""
+        dev_ep = set(device.endpoints) - set([0])
+        _LOGGER.debug("Checking quirks for %s %s (%s)",
+                      device.manufacturer, device.model, device.ieee)
+        for candidate in self:
+            _LOGGER.debug("Considering %s", candidate)
+            sig = candidate.signature.get('endpoints', {})
+            if not sig:
+                _LOGGER.warning(
+                    ("%s signature update is required. Support for `signature = {1: { replacement }}`"
+                     " will be removed in the future releases. Use "
+                     "`signature = {'endpoints': {1: { replacement }}}"), candidate
+                )
+                sig = {
+                    eid: ep for eid, ep in candidate.signature.items() if isinstance(eid, int)
+                }
+            if not device.model == candidate.signature.get('model', device.model):
+                _LOGGER.debug("Fail, because device model mismatch: '%s'",
+                              device.model)
+                continue
+
+            if not (device.manufacturer ==
+                    candidate.signature.get('manufacturer', device.manufacturer)):
+                _LOGGER.debug("Fail, because device manufacturer mismatch: '%s'",
+                              device.manufacturer)
+                continue
+
+            if not self._match(sig, dev_ep):
+                _LOGGER.debug("Fail because endpoint list mismatch: %s %s", set(sig.keys()), dev_ep)
+                continue
+
+            if not all([device[eid].profile_id == sig[eid].get('profile_id', device[eid].profile_id) for eid in sig]):
+                _LOGGER.debug("Fail because profile_id mismatch on at least one endpoint")
+                continue
+
+            if not all([device[eid].device_type == sig[eid].get('device_type', device[eid].device_type) for eid in sig]):
+                _LOGGER.debug("Fail because device_type mismatch on at least one endpoint")
+                continue
+
+            if not all([device[eid].model == sig[eid].get('model', device[eid].model) for eid in sig]):
+                _LOGGER.debug("Fail because model mismatch on at least one endpoint")
+                continue
+
+            if not all([device[eid].manufacturer == sig[eid].get('manufacturer', device[eid].manufacturer) for eid in sig]):
+                _LOGGER.debug("Fail because manufacturer mismatch on at least one endpoint")
+                continue
+
+            if not all([self._match(device[eid].in_clusters,
+                                    ep.get('input_clusters', []))
+                        for eid, ep in sig.items()]):
+                _LOGGER.debug("Fail because input cluster mismatch on at least one endpoint")
+                continue
+
+            if not all([self._match(device[eid].out_clusters,
+                                    ep.get('output_clusters', []))
+                        for eid, ep in sig.items()]):
+                _LOGGER.debug("Fail because output cluster mismatch on at least one endpoint")
+                continue
+
+            _LOGGER.debug("Found custom device replacement for %s: %s",
+                          device.ieee, candidate)
+            device = candidate(device._application, device.ieee, device.nwk, device)
+            break
+
+        return device
+
+    @staticmethod
+    def _match(a, b):
+        return set(a) == set(b)

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -94,12 +94,10 @@ class DeviceRegistry:
     def get_manufacturer(custom_dev):
         manuf = custom_dev.signature.get('manufacturer')
         if manuf is None:
-            # Get manufacturer from endpoint sig
-            sig = custom_dev.signature.get('endpoints', {})
-            if not sig:
-                sig = {
-                    eid: ep for eid, ep in custom_dev.signature.items() if isinstance(eid, int)
-                }
+            # Get manufacturer from legacy endpoint sig
+            sig = {
+                eid: ep for eid, ep in custom_dev.signature.items() if isinstance(eid, int)
+            }
             manuf = next(
                 (ep['manufacturer'] for ep in sig.values() if 'manufacturer' in ep),
                 None)
@@ -109,12 +107,10 @@ class DeviceRegistry:
     def get_model(custom_dev):
         model = custom_dev.signature.get('model')
         if model is None:
-            # Get model from endpoint sig
-            sig = custom_dev.signature.get('endpoints', {})
-            if not sig:
-                sig = {
-                    eid: ep for eid, ep in custom_dev.signature.items() if isinstance(eid, int)
-                }
+            # Get model from legacy endpoint sig
+            sig = {
+                eid: ep for eid, ep in custom_dev.signature.items() if isinstance(eid, int)
+            }
             model = next(
                 (ep['model'] for ep in sig.values() if 'model' in ep),
                 None)

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -91,12 +91,34 @@ class DeviceRegistry:
         return device
 
     @staticmethod
-    def get_manufacturer(device):
-        return device.signature.get('manufacturer')
+    def get_manufacturer(custom_dev):
+        manuf = custom_dev.signature.get('manufacturer')
+        if manuf is None:
+            # Get manufacturer from endpoint sig
+            sig = custom_dev.signature.get('endpoints', {})
+            if not sig:
+                sig = {
+                    eid: ep for eid, ep in custom_dev.signature.items() if isinstance(eid, int)
+                }
+            manuf = next(
+                (ep['manufacturer'] for ep in sig.values() if 'manufacturer' in ep),
+                None)
+        return manuf
 
     @staticmethod
-    def get_model(device):
-        return device.signature.get('model')
+    def get_model(custom_dev):
+        model = custom_dev.signature.get('model')
+        if model is None:
+            # Get model from endpoint sig
+            sig = custom_dev.signature.get('endpoints', {})
+            if not sig:
+                sig = {
+                    eid: ep for eid, ep in custom_dev.signature.items() if isinstance(eid, int)
+                }
+            model = next(
+                (ep['model'] for ep in sig.values() if 'model' in ep),
+                None)
+        return model
 
     @staticmethod
     def _match(a, b):

--- a/zigpy/quirks/xiaomi/__init__.py
+++ b/zigpy/quirks/xiaomi/__init__.py
@@ -30,6 +30,7 @@ class TemperatureHumiditySensor(CustomDevice):
                 'output_clusters': [4, 3, 5, 12],
             },
         },
+        'manufacturer': 'LUMI',
     }
 
     replacement = {
@@ -52,6 +53,7 @@ class AqaraTemperatureHumiditySensor(CustomDevice):
                 'output_clusters': [0, 4, 65535],
             },
         },
+        'manufacturer': 'LUMI',
     }
 
     replacement = {
@@ -74,6 +76,7 @@ class AqaraOpenCloseSensor(CustomDevice):
                 'output_clusters': [0, 4, 65535],
             },
         },
+        'manufacturer': 'LUMI',
     }
 
     replacement = {
@@ -97,6 +100,7 @@ class AqaraWaterSensor(CustomDevice):
                 'output_clusters': [25],
             },
         },
+        'manufacturer': 'LUMI',
     }
 
     replacement = {
@@ -146,7 +150,7 @@ class AqaraMagicCubeSensor(CustomDevice):
                                     AnalogInput.cluster_id],
             },
         },
-
+        'manufacturer': 'LUMI',
     }
 
     replacement = {


### PR DESCRIPTION
With the quirks number growing, keeping all the quirks in a flat list and iterating over the entire list for matching is not optimal anymore. 

Since 90% of the quirks could be tied to a specific model and manufacturer, this PR refactors quirks device registry into multidimensional dict, indexed by `manufacturer` and `model`. This drastically reduces noise in the debug logs (5488 lines vs 1556 lines) and load time, most noticeable on the slower hardware like Raspberry PIs

This could be improved even more, by defining at least the `manufacturer` in the signature for quirks that still miss it. 