### PR TITLE
Don't override endpoint's manufacturer/model from quirks.

### DIFF
--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -76,8 +76,6 @@ class CustomEndpoint(zigpy.endpoint.Endpoint):
 
         set_device_attr('profile_id')
         set_device_attr('device_type')
-        set_device_attr('manufacturer')
-        set_device_attr('model')
         self.status = zigpy.endpoint.Status.ZDO_INIT
 
         for c in replacement_data.get('input_clusters', []):


### PR DESCRIPTION
Don't override endpoint's manufacturer and/or mode from quirks.