### PR TITLE
Don't fail deserialization of undefined statuses

### DIFF
--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -150,3 +150,13 @@ def test_configure_reporting_response_serialization():
     rec.status = foundation.Status.UNREPORTABLE_ATTRIBUTE
     assert rec.serialize()[0:1] == foundation.Status.UNREPORTABLE_ATTRIBUTE.serialize()
     assert rec.serialize()[1:] == b'\x00\xbb\xaa'
+
+
+def test_status_undef():
+    data = b'\xaa'
+    extra = b'extra'
+
+    status, rest = foundation.Status.deserialize(data + extra)
+    assert rest == extra
+    assert status == 0xaa
+    assert not isinstance(status, foundation.Status)

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -139,3 +139,13 @@ def test_size_prefixed_simple_descriptor():
 def test_empty_size_prefixed_simple_descriptor():
     r = types.SizePrefixedSimpleDescriptor.deserialize(b'\x00')
     assert r == (None, b'')
+
+
+def test_status_undef():
+    data = b'\xaa'
+    extra = b'extra'
+
+    status, rest = types.Status.deserialize(data + extra)
+    assert rest == extra
+    assert status == 0xaa
+    assert not isinstance(status, types.Status)

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -37,8 +37,15 @@ class Status(t.uint8_t, enum.Enum):
     NOTIFICATION_PENDING = 0x9a  # The command has been received and is being processed
     HARDWARE_FAILURE = 0xc0  # An operation was unsuccessful due to a
     SOFTWARE_FAILURE = 0xc1  # An operation was unsuccessful due to a
-    CALIBRATION_ERROR = 0xc2  # An error occurred during calibratio
+    CALIBRATION_ERROR = 0xc2  # An error occurred during calibration
     UNSUPPORTED_CLUSTER = 0xc3  # The cluster is not supported
+
+    @classmethod
+    def deserialize(cls, data):
+        try:
+            return super().deserialize(data)
+        except ValueError:
+            return t.uint8_t.deserialize(data)
 
 
 class Analog:

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -269,6 +269,13 @@ class Status(t.uint8_t, enum.Enum):
     # request is not authorized from this device.
     NOT_AUTHORIZED = 0x8d
 
+    @classmethod
+    def deserialize(cls, data):
+        try:
+            return super().deserialize(data)
+        except ValueError:
+            return t.uint8_t.deserialize(data)
+
 
 NWK = ('NWKAddr', t.NWK)
 NWKI = ('NWKAddrOfInterest', t.NWK)


### PR DESCRIPTION
ZCL and ZDO statuses may contain status values from the lower levels (NWK, MAC). Don't fail deserialization for those.