### PR TITLE
Don't initialize a device that is already initialized

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -54,7 +54,9 @@ async def test_permit(app, ieee):
     ncp_ieee = t.EUI64(map(t.uint8_t, range(8, 16)))
     app._ieee = ncp_ieee
     app.devices[ieee] = mock.MagicMock()
-    app.devices[ieee].zdo.permit = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    app.devices[ieee].zdo.permit = mock.MagicMock(
+        side_effect=asyncio.coroutine(mock.MagicMock())
+    )
     app.permit_ncp = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
     await app.permit(node=(1, 1, 1, 1, 1, 1, 1, 1))
     assert app.devices[ieee].zdo.permit.call_count == 0
@@ -107,6 +109,9 @@ def test_join_handler_change_id(app, ieee):
     app.handle_join(1, ieee, None)
     app.handle_join(2, ieee, None)
     assert app.devices[ieee].nwk == 2
+    app.devices[ieee].status = device.Status.ENDPOINTS_INIT
+    app.handle_join(3, ieee, None)
+    assert app.devices[ieee].nwk == 3
 
 
 async def _remove(app, ieee, retval, zdo_reply=True, delivery_failure=True):
@@ -195,7 +200,7 @@ def test_nwk(app):
 
 def test_deserialize(app, ieee):
     dev = mock.MagicMock()
-    app.deserialize(dev, 1, 1, b'')
+    app.deserialize(dev, 1, 1, b"")
     assert dev.deserialize.call_count == 1
 
 
@@ -208,12 +213,21 @@ def test_handle_message(app, ieee):
 @pytest.mark.asyncio
 async def test_broadcast(app):
     from zigpy.profiles import zha
+
     with pytest.raises(NotImplementedError):
         (profile, cluster, src_ep, dst_ep, grp, radius, tsn, data) = (
-            zha.PROFILE_ID, 1, 2, 3, 0, 4, 212, b'\x02\x01\x00'
+            zha.PROFILE_ID,
+            1,
+            2,
+            3,
+            0,
+            4,
+            212,
+            b"\x02\x01\x00",
         )
-        await app.broadcast(app, profile, cluster, src_ep, dst_ep,
-                            grp, radius, tsn, data)
+        await app.broadcast(
+            app, profile, cluster, src_ep, dst_ep, grp, radius, tsn, data
+        )
 
 
 @pytest.mark.asyncio

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -91,7 +91,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
             if dev.nwk != nwk:
                 LOGGER.debug("Device %s changed id (0x%04x => 0x%04x)", ieee, dev.nwk, nwk)
                 dev.nwk = nwk
-            elif dev.initializing or dev.status == zigpy.device.Status.ENDPOINTS_INIT:
+            if dev.initializing or dev.status == zigpy.device.Status.ENDPOINTS_INIT:
                 LOGGER.debug("Skip initialization for existing device %s", ieee)
                 return
         else:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -41,11 +41,7 @@ class Device(zigpy.util.LocalLogMixin):
         self._node_handle = None
 
     def schedule_initialize(self):
-        if self.initializing:
-            LOGGER.debug("Canceling old initialize call")
-            self._init_handle.cancel()
-        else:
-            self.initializing = True
+        self.initializing = True
         self._init_handle = asyncio.ensure_future(self._initialize())
 
     async def get_node_descriptor(self):


### PR DESCRIPTION
We already had a check to not initialize devices that were already initialized. There are cases when a device that has already initialized will get issued a new nwk address. We handled those cases correctly but we were also pumping those devices back through the initialization process. With this change we will only send devices through initialization that aren't already initialized or aren't already in the process of initializing even when the nwk address changes. 