### PR TITLE
Differentiate input/output cluster instances.

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -69,6 +69,8 @@ async def test_reinitialize(ep):
 def test_add_input_cluster(ep):
     ep.add_input_cluster(0)
     assert 0 in ep.in_clusters
+    assert ep.in_clusters[0].is_server is True
+    assert ep.in_clusters[0].is_client is False
 
 
 def test_add_custom_input_cluster(ep):
@@ -81,6 +83,8 @@ def test_add_custom_input_cluster(ep):
 def test_add_output_cluster(ep):
     ep.add_output_cluster(0)
     assert 0 in ep.out_clusters
+    assert ep.out_clusters[0].is_server is False
+    assert ep.out_clusters[0].is_client is True
 
 
 def test_add_custom_output_cluster(ep):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -82,7 +82,8 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             return self.in_clusters[cluster_id]
 
         if cluster is None:
-            cluster = zigpy.zcl.Cluster.from_id(self, cluster_id)
+            cluster = zigpy.zcl.Cluster.from_id(self, cluster_id,
+                                                is_server=True)
         self.in_clusters[cluster_id] = cluster
         if hasattr(cluster, 'ep_attribute'):
             self._cluster_attr[cluster.ep_attribute] = cluster
@@ -105,7 +106,8 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             return self.out_clusters[cluster_id]
 
         if cluster is None:
-            cluster = zigpy.zcl.Cluster.from_id(self, cluster_id)
+            cluster = zigpy.zcl.Cluster.from_id(self, cluster_id,
+                                                is_server=False)
         self.out_clusters[cluster_id] = cluster
         return cluster
 

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -83,7 +83,7 @@ class CustomEndpoint(zigpy.endpoint.Endpoint):
                 cluster = None
                 cluster_id = c
             else:
-                cluster = c(self)
+                cluster = c(self, is_server=True)
                 cluster_id = cluster.cluster_id
             self.add_input_cluster(cluster_id, cluster)
 
@@ -92,7 +92,7 @@ class CustomEndpoint(zigpy.endpoint.Endpoint):
                 cluster = None
                 cluster_id = c
             else:
-                cluster = c(self)
+                cluster = c(self, is_server=False)
                 cluster_id = cluster.cluster_id
             self.add_output_cluster(cluster_id, cluster)
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import enum
 import logging
 
 import zigpy.types as t
@@ -38,6 +39,11 @@ class Registry(type):
             cls._registry_range[cls.cluster_id_range] = cls
 
 
+class ClusterType(enum.IntEnum):
+    Server = 0
+    Client = 1
+
+
 class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
     """A cluster on an endpoint"""
     _registry = {}
@@ -45,24 +51,28 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
     _server_command_idx = {}
     _client_command_idx = {}
 
-    def __init__(self, endpoint):
+    def __init__(self, endpoint, is_server=True):
         self._endpoint = endpoint
         self._attr_cache = {}
         self._listeners = {}
+        if is_server:
+            self._type = ClusterType.Server
+        else:
+            self._type = ClusterType.Client
 
     @classmethod
-    def from_id(cls, endpoint, cluster_id):
+    def from_id(cls, endpoint, cluster_id, is_server=True):
         if cluster_id in cls._registry:
-            return cls._registry[cluster_id](endpoint)
+            return cls._registry[cluster_id](endpoint, is_server)
         else:
             for cluster_id_range, cluster in cls._registry_range.items():
                 if cluster_id_range[0] <= cluster_id <= cluster_id_range[1]:
-                    c = cluster(endpoint)
+                    c = cluster(endpoint, is_server)
                     c.cluster_id = cluster_id
                     return c
 
         LOGGER.warning("Unknown cluster %s", cluster_id)
-        c = cls(endpoint)
+        c = cls(endpoint, is_server)
         c.cluster_id = cluster_id
         return c
 
@@ -297,6 +307,16 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
     def client_command(self, command, *args):
         schema = self.client_commands[command][1]
         return self.reply(False, command, schema, *args)
+
+    @property
+    def is_client(self) -> bool:
+        """Return True if this is a client cluster."""
+        return self._type == ClusterType.Client
+
+    @property
+    def is_server(self) -> bool:
+        """Return True if this is a server cluster."""
+        return self._type == ClusterType.Server
 
     @property
     def name(self):


### PR DESCRIPTION
When instantiating clusters, mark clusters as server/client accordingly.