### PR TITLE
fix binding dst endpoint

### DIFF
--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -90,14 +90,14 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         dstaddr = types.MultiAddress()
         dstaddr.addrmode = 3
         dstaddr.ieee = self._device.application.ieee
-        dstaddr.endpoint = endpoint
+        dstaddr.endpoint = 1
         return self.Bind_req(self._device.ieee, endpoint, cluster, dstaddr)
 
     def unbind(self, endpoint, cluster):
         dstaddr = types.MultiAddress()
         dstaddr.addrmode = 3
         dstaddr.ieee = self._device.application.ieee
-        dstaddr.endpoint = endpoint
+        dstaddr.endpoint = 1
         return self.Unbind_req(self._device.ieee, endpoint, cluster, dstaddr)
 
     def leave(self):


### PR DESCRIPTION
When binding, the destination endpoint (the endpoint on the coordinator stick) should be 1.
This could be improved in the future to receive the dst endpoint as a parameter.