### PR TITLE
WIP handle request/reply interactions in zigpy

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -203,7 +203,21 @@ def test_deserialize(app, ieee):
 
 def test_handle_message(app, ieee):
     dev = mock.MagicMock()
-    app.handle_message(dev, False, 260, 1, 1, 1, 1, 1, [])
+    app.handle_message(dev, 260, 1, 1, 1, [])
+    assert dev.handle_message.call_count == 1
+
+
+def test_handle_message_uninitialized_dev(app, ieee):
+    dev = device.Device(app, ieee, 0x1234)
+    dev.handle_message = mock.MagicMock()
+    app.handle_message(dev, 260, 1, 1, 1, [])
+    assert dev.handle_message.call_count == 0
+
+    dev.status = device.Status.ZDO_INIT
+    app.handle_message(dev, 260, 1, 1, 1, [])
+    assert dev.handle_message.call_count == 0
+
+    app.handle_message(dev, 260, 0, 1, 1, [])
     assert dev.handle_message.call_count == 1
 
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -115,19 +115,19 @@ def test_multiple_add_output_cluster(ep):
 def test_handle_message(ep):
     c = ep.add_input_cluster(0)
     c.handle_message = mock.MagicMock()
-    ep.handle_message(False, 0, 0, 0, 1, [])
-    c.handle_message.assert_called_once_with(False, 0, 1, [])
+    ep.handle_message(0, 0, 0, 1, [])
+    c.handle_message.assert_called_once_with(0, 1, [])
 
 
 def test_handle_message_output(ep):
     c = ep.add_output_cluster(0)
     c.handle_message = mock.MagicMock()
-    ep.handle_message(False, 0, 0, 0, 1, [])
-    c.handle_message.assert_called_once_with(False, 0, 1, [])
+    ep.handle_message(0, 0, 0, 1, [])
+    c.handle_message.assert_called_once_with(0, 1, [])
 
 
 def test_handle_request_unknown(ep):
-    ep.handle_message(False, 0, 99, 0, 0, [])
+    ep.handle_message(0, 99, 0, 0, [])
 
 
 def test_cluster_attr(ep):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -152,20 +152,20 @@ def test_attribute_report(cluster):
     attr.attrid = 4
     attr.value = zcl.foundation.TypeValue()
     attr.value.value = 1
-    cluster.handle_message(False, 0, 0x0A, [[attr]])
+    cluster.handle_message(0, 0x0A, [[attr]])
     assert cluster._attr_cache[4] == 1
 
 
 def test_handle_request_unknown(cluster):
-    cluster.handle_message(False, 0, 0xFF, [])
+    cluster.handle_message(0, 0xFF, [])
 
 
 def test_handle_cluster_request(cluster):
-    cluster.handle_message(False, 0, 256, [])
+    cluster.handle_message(0, 256, [])
 
 
 def test_handle_unexpected_reply(cluster):
-    cluster.handle_message(True, 0, 0, [])
+    cluster.handle_message(0, 0, [])
 
 
 def _mk_rar(attrid, value, status=0):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -144,6 +144,19 @@ class ControllerApplication(zigpy.util.ListenableMixin):
     async def request(
         self, nwk, profile, cluster, src_ep, dst_ep, sequence, data, timeout=10
     ):
+        """Submit and send data out as an unicast transmission.
+
+        :param nwk: destination network address
+        :param profile: Zigbee Profile ID to use for outgoing message
+        :param cluster: cluster id where the message is being sent
+        :param src_ep: source endpoint id
+        :param dst_ep: destination endpoint id
+        :param sequence: transaction sequence number of the message
+        :param data: zigbee message payload
+        :param timeout: how long to wait for transmission ACK
+        :returns: return a tuple of a status and an error_message. Original requestor
+                  has more context to provide a more meaningful error message
+        """
         raise NotImplementedError
 
     async def broadcast(
@@ -158,6 +171,21 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         data,
         broadcast_address,
     ):
+        """Submit and send data out as an unicast transmission.
+
+        :param profile: Zigbee Profile ID to use for outgoing message
+        :param cluster: cluster id where the message is being sent
+        :param src_ep: source endpoint id
+        :param dst_ep: destination endpoint id
+        :param: grpid: group id to address the broadcast to
+        :param radius: max radius of the broadcast
+        :param sequence: transaction sequence number of the message
+        :param data: zigbee message payload
+        :param timeout: how long to wait for transmission ACK
+        :param broadcast_address: broadcast address.
+        :returns: return a tuple of a status and an error_message. Original requestor
+                  has more context to provide a more meaningful error message
+        """
         raise NotImplementedError
 
     async def permit_ncp(self, time_s=60):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -91,12 +91,8 @@ class ControllerApplication(zigpy.util.ListenableMixin):
     def deserialize(self, sender, endpoint_id, cluster_id, data):
         return sender.deserialize(endpoint_id, cluster_id, data)
 
-    def handle_message(
-        self, sender, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args
-    ):
-        return sender.handle_message(
-            is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args
-        )
+    def handle_message(self, sender, profile, cluster, src_ep, dst_ep, message):
+        return sender.handle_message(profile, cluster, src_ep, dst_ep, message)
 
     def handle_join(self, nwk, ieee, parent_nwk):
         LOGGER.info("Device 0x%04x (%s) joined the network", nwk, ieee)
@@ -124,16 +120,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
 
     @zigpy.util.retryable_request
     async def request(
-        self,
-        nwk,
-        profile,
-        cluster,
-        src_ep,
-        dst_ep,
-        sequence,
-        data,
-        expect_reply=True,
-        timeout=10,
+        self, nwk, profile, cluster, src_ep, dst_ep, sequence, data, timeout=10
     ):
         raise NotImplementedError
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -1,14 +1,19 @@
 import asyncio
+import binascii
 import enum
 import logging
 import time
 
 import zigpy.endpoint
+import zigpy.exceptions
 import zigpy.util
 import zigpy.zdo as zdo
+import zigpy.zcl.foundation as foundation
 from zigpy.types import BroadcastAddress, NWK
 
 
+APS_REPLY_TIMEOUT = 5
+APS_REPLY_TIMEOUT_EXTENDED = 28
 LOGGER = logging.getLogger(__name__)
 
 
@@ -42,6 +47,7 @@ class Device(zigpy.util.LocalLogMixin):
         self._model = None
         self.node_desc = zdo.types.NodeDescriptor()
         self._node_handle = None
+        self._pending = zigpy.util.Requests()
 
     def schedule_initialize(self):
         if self.initializing:
@@ -136,47 +142,98 @@ class Device(zigpy.util.LocalLogMixin):
                 await ep.remove_from_group(grp_id)
 
     async def request(
-        self, profile, cluster, src_ep, dst_ep, sequence, data, expect_reply=True
+        self,
+        profile,
+        cluster,
+        src_ep,
+        dst_ep,
+        sequence,
+        data,
+        expect_reply=True,
+        timeout=APS_REPLY_TIMEOUT,
     ):
-        result = await self._application.request(
-            self.nwk,
-            profile,
-            cluster,
-            src_ep,
-            dst_ep,
-            sequence,
-            data,
-            expect_reply=expect_reply,
-        )
-        # If application.request raises an exception, we won't get here, so
-        # won't update last_seen, as expected
-        self.last_seen = time.time()
+        if expect_reply and self.node_desc.is_end_device in (True, None):
+            self.debug("Extending timeout for 0x%02x request", sequence)
+            timeout = APS_REPLY_TIMEOUT_EXTENDED
+        with self._pending.new(sequence) as req:
+            result, msg = await self._application.request(
+                self.nwk, profile, cluster, src_ep, dst_ep, sequence, data
+            )
+            if result != foundation.Status.SUCCESS:
+                self.debug(
+                    (
+                        "Delivery error for seq # 0x%02x, on endpoint id %s "
+                        "cluster 0x%04x cluster: %s"
+                    ),
+                    sequence,
+                    dst_ep,
+                    cluster,
+                    msg,
+                )
+                raise zigpy.exceptions.DeliveryError(
+                    "[0x{:04x}:{}:0x{:04x}]: Message send failure".format(
+                        self.nwk, dst_ep, cluster
+                    )
+                )
+            # If application.request raises an exception, we won't get here, so
+            # won't update last_seen, as expected
+            self.last_seen = time.time()
+            if expect_reply:
+                result = await asyncio.wait_for(req.result, timeout)
+
         return result
 
     def deserialize(self, endpoint_id, cluster_id, data):
         return self.endpoints[endpoint_id].deserialize(cluster_id, data)
 
-    def handle_message(
-        self, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args
-    ):
+    def handle_message(self, profile, cluster, src_ep, dst_ep, message):
         self.last_seen = time.time()
         if not self.node_desc.is_valid and (
             self._node_handle is None or self._node_handle.done()
         ):
             self._node_handle = asyncio.ensure_future(self.refresh_node_descriptor())
+
         try:
-            endpoint = self.endpoints[src_ep]
-        except KeyError:
-            self.warn("Message on unknown endpoint %s", src_ep)
+            tsn, command_id, is_reply, args = self.deserialize(src_ep, cluster, message)
+        except ValueError as e:
+            LOGGER.error(
+                "Failed to parse message (%s) on cluster %d, because %s",
+                binascii.hexlify(message),
+                cluster,
+                e,
+            )
+            return
+        except KeyError as e:
+            LOGGER.debug(
+                (
+                    "Ignoring message (%s) on cluster %d: "
+                    "unknown endpoint or cluster id: %s"
+                ),
+                binascii.hexlify(message),
+                cluster,
+                e,
+            )
             return
 
-        return endpoint.handle_message(
-            is_reply, profile, cluster, tsn, command_id, args
-        )
+        if tsn in self._pending and is_reply:
+            try:
+                self._pending[tsn].result.set_result(args)
+                return
+            except asyncio.InvalidStateError:
+                self.debug(
+                    (
+                        "Invalid state on future for 0x%02x seq "
+                        "-- probably duplicate response"
+                    ),
+                    tsn,
+                )
+                return
+        endpoint = self.endpoints[src_ep]
+        return endpoint.handle_message(profile, cluster, tsn, command_id, args)
 
     def reply(self, profile, cluster, src_ep, dst_ep, sequence, data):
-        return self._application.request(
-            self.nwk, profile, cluster, src_ep, dst_ep, sequence, data, False
+        return self.request(
+            profile, cluster, src_ep, dst_ep, sequence, data, expect_reply=False
         )
 
     def radio_details(self, lqi, rssi):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -172,17 +172,17 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         cluster = self.in_clusters.get(cluster_id, self.out_clusters.get(cluster_id))
         return cluster.deserialize(data)
 
-    def handle_message(self, is_reply, profile, cluster, tsn, command_id, args):
+    def handle_message(self, profile, cluster, tsn, command_id, args):
         if cluster in self.in_clusters:
             handler = self.in_clusters[cluster].handle_message
         elif cluster in self.out_clusters:
             handler = self.out_clusters[cluster].handle_message
         else:
             self.debug("Message on unknown cluster 0x%04x", cluster)
-            self.listener_event("unknown_cluster_message", is_reply, command_id, args)
+            self.listener_event("unknown_cluster_message", command_id, args)
             return
 
-        handler(is_reply, tsn, command_id, args)
+        handler(tsn, command_id, args)
 
     def request(self, cluster, sequence, data, expect_reply=True, command_id=0x00):
         if self.profile_id == zigpy.profiles.zll.PROFILE_ID and not (

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -161,11 +161,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
 
         return self._endpoint.reply(self.cluster_id, sequence, data)
 
-    def handle_message(self, is_reply, tsn, command_id, args):
-        if is_reply:
-            self.debug("Unexpected ZCL reply 0x%04x: %s", command_id, args)
-            return
-
+    def handle_message(self, tsn, command_id, args):
         self.debug("ZCL request 0x%04x: %s", command_id, args)
         if command_id <= 0xFF:
             self.listener_event("zdo_command", tsn, command_id, args)

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -56,11 +56,7 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         loop = asyncio.get_event_loop()
         loop.create_task(self._device.reply(0, command, 0, 0, sequence, data))
 
-    def handle_message(self, is_reply, profile, cluster, tsn, command_id, args):
-        if is_reply:
-            self.debug("Unexpected ZDO reply %s: %s", command_id, args)
-            return
-
+    def handle_message(self, profile, cluster, tsn, command_id, args):
         self.debug("ZDO request %s: %s", command_id, args)
         app = self._device.application
         if command_id == types.ZDOCmd.NWK_addr_req:


### PR DESCRIPTION
ATM all radios share more or less similar code, where radio has to track request/reply session and handle inbound traffic differently, if it is a part of a reply. This PR moves all this logic into Zigpy, so now radios are just responsible for sending data out and wait for transmission ACK/NAK. All incoming traffic is passed to zigpy as is and zigpy takes care of the reply traffic. 

