### PR TITLE
Pass device itself for ControllerApplication.request() addressing.

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -142,11 +142,20 @@ class ControllerApplication(zigpy.util.ListenableMixin):
 
     @zigpy.util.retryable_request
     async def request(
-        self, nwk, profile, cluster, src_ep, dst_ep, sequence, data, timeout=10
+        self,
+        device,
+        profile,
+        cluster,
+        src_ep,
+        dst_ep,
+        sequence,
+        data,
+        timeout=30,
+        use_ieee=False,
     ):
         """Submit and send data out as an unicast transmission.
 
-        :param nwk: destination network address
+        :param device: destination device
         :param profile: Zigbee Profile ID to use for outgoing message
         :param cluster: cluster id where the message is being sent
         :param src_ep: source endpoint id
@@ -154,6 +163,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         :param sequence: transaction sequence number of the message
         :param data: zigbee message payload
         :param timeout: how long to wait for transmission ACK
+        :param use_ieee: use EUI64 for destination addressing
         :returns: return a tuple of a status and an error_message. Original requestor
                   has more context to provide a more meaningful error message
         """

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -151,13 +151,14 @@ class Device(zigpy.util.LocalLogMixin):
         data,
         expect_reply=True,
         timeout=APS_REPLY_TIMEOUT,
+        use_ieee=False,
     ):
         if expect_reply and self.node_desc.is_end_device in (True, None):
             self.debug("Extending timeout for 0x%02x request", sequence)
             timeout = APS_REPLY_TIMEOUT_EXTENDED
         with self._pending.new(sequence) as req:
             result, msg = await self._application.request(
-                self.nwk, profile, cluster, src_ep, dst_ep, sequence, data
+                self, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee
             )
             if result != foundation.Status.SUCCESS:
                 self.debug(
@@ -231,9 +232,16 @@ class Device(zigpy.util.LocalLogMixin):
         endpoint = self.endpoints[src_ep]
         return endpoint.handle_message(profile, cluster, tsn, command_id, args)
 
-    def reply(self, profile, cluster, src_ep, dst_ep, sequence, data):
+    def reply(self, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee=False):
         return self.request(
-            profile, cluster, src_ep, dst_ep, sequence, data, expect_reply=False
+            profile,
+            cluster,
+            src_ep,
+            dst_ep,
+            sequence,
+            data,
+            expect_reply=False,
+            use_ieee=use_ieee,
         )
 
     def radio_details(self, lqi, rssi):

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -45,19 +45,21 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return tsn, cluster_id, is_reply, args
 
     @zigpy.util.retryable_request
-    def request(self, command, *args):
+    def request(self, command, *args, use_ieee=False):
         data = self._serialize(command, *args)
         tsn = self.device.application.get_sequence()
         data = t.uint8_t(tsn).serialize() + data
-        return self._device.request(0, command, 0, 0, tsn, data)
+        return self._device.request(0, command, 0, 0, tsn, data, use_ieee=use_ieee)
 
-    def reply(self, command, *args, tsn=None):
+    def reply(self, command, *args, tsn=None, use_ieee=False):
         data = self._serialize(command, *args)
         if tsn is None:
             tsn = self.device.application.get_sequence()
         data = t.uint8_t(tsn).serialize() + data
         loop = asyncio.get_event_loop()
-        loop.create_task(self._device.reply(0, command, 0, 0, tsn, data))
+        loop.create_task(
+            self._device.reply(0, command, 0, 0, tsn, data, use_ieee=use_ieee)
+        )
 
     def handle_message(self, profile, cluster, tsn, command_id, args):
         self.debug("ZDO request %s: %s", command_id, args)


### PR DESCRIPTION
Use device for destination addressing, so the radio lib could make an informed decision what timeout to use depending on destination device type. This is for EZSP and XBee based radios, to indicate the underlying radio interface whether to use an extended timeout or not.