### PR TITLE
Remove timeout parameter.

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -142,16 +142,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
 
     @zigpy.util.retryable_request
     async def request(
-        self,
-        device,
-        profile,
-        cluster,
-        src_ep,
-        dst_ep,
-        sequence,
-        data,
-        timeout=30,
-        use_ieee=False,
+        self, device, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee=False
     ):
         """Submit and send data out as an unicast transmission.
 
@@ -161,8 +152,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         :param src_ep: source endpoint id
         :param dst_ep: destination endpoint id
         :param sequence: transaction sequence number of the message
-        :param data: zigbee message payload
-        :param timeout: how long to wait for transmission ACK
+        :param data: Zigbee message payload
         :param use_ieee: use EUI64 for destination addressing
         :returns: return a tuple of a status and an error_message. Original requestor
                   has more context to provide a more meaningful error message

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -158,7 +158,14 @@ class Device(zigpy.util.LocalLogMixin):
             timeout = APS_REPLY_TIMEOUT_EXTENDED
         with self._pending.new(sequence) as req:
             result, msg = await self._application.request(
-                self, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee
+                self,
+                profile,
+                cluster,
+                src_ep,
+                dst_ep,
+                sequence,
+                data,
+                use_ieee=use_ieee,
             )
             if result != foundation.Status.SUCCESS:
                 self.debug(


### PR DESCRIPTION
Remove timeout parameter from ControllerApplication.request() method.
Use keyword only parameters.