### PR TITLE
Add new Samsung Multipurpose Sensor

### DIFF
--- a/zigpy/quirks/smartthings/__init__.py
+++ b/zigpy/quirks/smartthings/__init__.py
@@ -100,3 +100,46 @@ class SmartthingsMultiPurposeSensor(CustomDevice):
             }
         }
     }
+
+
+class SmartthingsMultiPurposeSensor2019(CustomDevice):
+    signature = {
+        "endpoints": {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+            # device_version=0 input_clusters=[0, 1, 3, 32, 1026, 1280, 2821, 64514]
+            # output_clusters=[3, 25]>
+            1: {
+                "profile_id": 0x0104,
+                "device_type": 0x0402,
+                "input_clusters": [
+                    0,
+                    1,
+                    3,
+                    32,
+                    1026,
+                    1280,
+                    2821,
+                    SmartThingsAccelCluster.cluster_id,
+                ],
+                "output_clusters": [3, 25],
+            }
+        }
+    }
+
+    replacement = {
+        "endpoints": {
+            1: {
+                "input_clusters": [
+                    0x0000,
+                    0x0001,
+                    0x0003,
+                    0x0020,
+                    0x0402,
+                    0x0500,
+                    0x0B05,
+                    SmartThingsAccelCluster,
+                ],
+                "output_clusters": [0x0003, 0x0019],
+            }
+        }
+    }


### PR DESCRIPTION
Hiya!

I just added a few new Samsung multipurpose sensors to ZHA in my HomeAssistant setup. They have a slightly different input cluster signature and thus don't match the quirks for the older unit. This appears to be fully functional within HomeAssistant with acceleration detection, temperature, open/close, as expected.

If there's a better way to do this (integrate it into the existing `SmartthingsMultiPurposeSensor` class?) let me know and I'll adjust my PR.

I didn't see any tests for specific quirks implementations, so didn't add any here.

Cheers!
James