### PR TITLE
Refactor cluster binding.

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -244,3 +244,9 @@ async def test_broadcast(app):
 @pytest.mark.asyncio
 async def test_shutdown(app):
     await app.shutdown()
+
+
+def test_get_dst_address(app):
+    r = app.get_dst_address(mock.MagicMock())
+    assert r.addrmode == 3
+    assert r.endpoint == 1

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -27,6 +27,11 @@ def app():
     app = mock.MagicMock()
     app.ieee = t.EUI64(map(t.uint8_t, [8, 9, 10, 11, 12, 13, 14, 15]))
     app.get_sequence.return_value = DEFAULT_SEQUENCE
+    dst_addr = zdo_types.MultiAddress()
+    dst_addr.addrmode = 3
+    dst_addr.ieee = app.ieee
+    dst_addr.endpoint = 1
+    app.get_dst_address.return_value = dst_addr
     return app
 
 
@@ -62,14 +67,20 @@ async def test_request(zdo_f):
 
 @pytest.mark.asyncio
 async def test_bind(zdo_f):
-    await zdo_f.bind(1, 1026)
+    cluster = mock.MagicMock()
+    cluster.endpoint.endpoint_id = 1
+    cluster.cluster_id = 1026
+    await zdo_f.bind(cluster)
     assert zdo_f.device.request.call_count == 1
     assert zdo_f.device.request.call_args[0][1] == 0x0021
 
 
 @pytest.mark.asyncio
 async def test_unbind(zdo_f):
-    await zdo_f.unbind(1, 1026)
+    cluster = mock.MagicMock()
+    cluster.endpoint.endpoint_id = 1
+    cluster.cluster_id = 1026
+    await zdo_f.unbind(cluster)
     assert zdo_f.device.request.call_count == 1
     assert zdo_f.device.request.call_args[0][1] == 0x0022
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -11,6 +11,7 @@ import zigpy.types as t
 import zigpy.util
 import zigpy.zcl
 import zigpy.zdo
+import zigpy.zdo.types as zdo_types
 
 LOGGER = logging.getLogger(__name__)
 OTA_DIR = "zigpy_ota/"
@@ -249,6 +250,20 @@ class ControllerApplication(zigpy.util.ListenableMixin):
                 return dev
 
         raise KeyError
+
+    def get_dst_address(self, cluster):
+        """Helper to get a dst address for bind/unbind operations.
+
+        Allows radios to provide correct information especially for radios which listen
+        on specific endpoints only.
+        :param cluster: cluster instance to be bound to coordinator
+        :returns: returns a "destination address"
+        """
+        dstaddr = zdo_types.MultiAddress()
+        dstaddr.addrmode = 3
+        dstaddr.ieee = self.ieee
+        dstaddr.endpoint = 1
+        return dstaddr
 
     @property
     def groups(self):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -299,14 +299,10 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         return self._write_attributes(args, manufacturer=manufacturer)
 
     def bind(self):
-        return self._endpoint.device.zdo.bind(
-            self._endpoint.endpoint_id, self.cluster_id
-        )
+        return self._endpoint.device.zdo.bind(cluster=self)
 
     def unbind(self):
-        return self._endpoint.device.zdo.unbind(
-            self._endpoint.endpoint_id, self.cluster_id
-        )
+        return self._endpoint.device.zdo.unbind(cluster=self)
 
     def configure_reporting(
         self,

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -87,19 +87,21 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         return self.Match_Desc_rsp(0, local_addr, [t.uint8_t(1)], tsn=tsn)
 
-    def bind(self, endpoint, cluster):
-        dstaddr = types.MultiAddress()
-        dstaddr.addrmode = 3
-        dstaddr.ieee = self._device.application.ieee
-        dstaddr.endpoint = endpoint
-        return self.Bind_req(self._device.ieee, endpoint, cluster, dstaddr)
+    def bind(self, cluster):
+        return self.Bind_req(
+            self._device.ieee,
+            cluster.endpoint.endpoint_id,
+            cluster.cluster_id,
+            self.device.application.get_dst_address(cluster),
+        )
 
-    def unbind(self, endpoint, cluster):
-        dstaddr = types.MultiAddress()
-        dstaddr.addrmode = 3
-        dstaddr.ieee = self._device.application.ieee
-        dstaddr.endpoint = endpoint
-        return self.Unbind_req(self._device.ieee, endpoint, cluster, dstaddr)
+    def unbind(self, cluster):
+        return self.Unbind_req(
+            self._device.ieee,
+            cluster.endpoint.endpoint_id,
+            cluster.cluster_id,
+            self.device.application.get_dst_address(cluster),
+        )
 
     def leave(self):
         return self.Mgmt_Leave_req(self._device.ieee, 0x02)


### PR DESCRIPTION
Implement `ControllerApplication.get_dst_address()` helper. This can be overridden in radios so radio lib could provide a correct destination address for `zdo.bind()` & `zdo.unbind()` specifically for radios (ConBee) which receive data only on specific endpoints.