### PR TITLE
Refactor ControllerApplication.request()

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -244,3 +244,9 @@ async def test_broadcast(app):
 @pytest.mark.asyncio
 async def test_shutdown(app):
     await app.shutdown()
+
+
+def test_get_dst_address(app):
+    r = app.get_dst_address(mock.MagicMock())
+    assert r.addrmode == 3
+    assert r.endpoint == 1

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -203,7 +203,21 @@ def test_deserialize(app, ieee):
 
 def test_handle_message(app, ieee):
     dev = mock.MagicMock()
-    app.handle_message(dev, False, 260, 1, 1, 1, 1, 1, [])
+    app.handle_message(dev, 260, 1, 1, 1, [])
+    assert dev.handle_message.call_count == 1
+
+
+def test_handle_message_uninitialized_dev(app, ieee):
+    dev = device.Device(app, ieee, 0x1234)
+    dev.handle_message = mock.MagicMock()
+    app.handle_message(dev, 260, 1, 1, 1, [])
+    assert dev.handle_message.call_count == 0
+
+    dev.status = device.Status.ZDO_INIT
+    app.handle_message(dev, 260, 1, 1, 1, [])
+    assert dev.handle_message.call_count == 0
+
+    app.handle_message(dev, 260, 0, 1, 1, [])
     assert dev.handle_message.call_count == 1
 
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -115,19 +115,19 @@ def test_multiple_add_output_cluster(ep):
 def test_handle_message(ep):
     c = ep.add_input_cluster(0)
     c.handle_message = mock.MagicMock()
-    ep.handle_message(False, 0, 0, 0, 1, [])
-    c.handle_message.assert_called_once_with(False, 0, 1, [])
+    ep.handle_message(0, 0, 0, 1, [])
+    c.handle_message.assert_called_once_with(0, 1, [])
 
 
 def test_handle_message_output(ep):
     c = ep.add_output_cluster(0)
     c.handle_message = mock.MagicMock()
-    ep.handle_message(False, 0, 0, 0, 1, [])
-    c.handle_message.assert_called_once_with(False, 0, 1, [])
+    ep.handle_message(0, 0, 0, 1, [])
+    c.handle_message.assert_called_once_with(0, 1, [])
 
 
 def test_handle_request_unknown(ep):
-    ep.handle_message(False, 0, 99, 0, 0, [])
+    ep.handle_message(0, 99, 0, 0, [])
 
 
 def test_cluster_attr(ep):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -152,20 +152,20 @@ def test_attribute_report(cluster):
     attr.attrid = 4
     attr.value = zcl.foundation.TypeValue()
     attr.value.value = 1
-    cluster.handle_message(False, 0, 0x0A, [[attr]])
+    cluster.handle_message(0, 0x0A, [[attr]])
     assert cluster._attr_cache[4] == 1
 
 
 def test_handle_request_unknown(cluster):
-    cluster.handle_message(False, 0, 0xFF, [])
+    cluster.handle_message(0, 0xFF, [])
 
 
 def test_handle_cluster_request(cluster):
-    cluster.handle_message(False, 0, 256, [])
+    cluster.handle_message(0, 256, [])
 
 
 def test_handle_unexpected_reply(cluster):
-    cluster.handle_message(True, 0, 0, [])
+    cluster.handle_message(0, 0, [])
 
 
 def _mk_rar(attrid, value, status=0):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -437,5 +437,17 @@ def test_general_command_reply(cluster):
     assert cluster.request.call_count == 0
     assert cluster.reply.call_count == 1
     cluster.reply.assert_called_with(
-        True, cmd_id, mock.ANY, True, [], manufacturer=0x4567
+        True, cmd_id, mock.ANY, True, [], manufacturer=0x4567, tsn=None
+    )
+
+    cluster.request.reset_mock()
+    cluster.reply.reset_mock()
+    cluster.general_command(
+        cmd_id, True, [], manufacturer=0x4567, tsn=mock.sentinel.tsn
+    )
+
+    assert cluster.request.call_count == 0
+    assert cluster.reply.call_count == 1
+    cluster.reply.assert_called_with(
+        True, cmd_id, mock.ANY, True, [], manufacturer=0x4567, tsn=mock.sentinel.tsn
     )

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -204,6 +204,7 @@ def _ota_next_image(cluster, has_image=True, upgradeable=False):
         mock.sentinel.image_type,
         mock.sentinel.current_file_version,
         mock.sentinel.hw_version,
+        tsn=0x21,
     )
 
 
@@ -296,6 +297,7 @@ def _ota_image_block(cluster, has_image=True, correct_version=True, wrong_offset
         mock.sentinel.max_data_size,
         mock.sentinel.addr,
         mock.sentinel.delay,
+        tsn=0x21,
     )
 
 
@@ -381,6 +383,7 @@ async def test_ota_handle_upgrade_end(ota_cluster):
         mock.sentinel.manufacturer_id,
         mock.sentinel.image_type,
         mock.sentinel.image_version,
+        tsn=0x21,
     )
 
     assert ota_cluster.upgrade_end_response.call_count == 1

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -27,6 +27,11 @@ def app():
     app = mock.MagicMock()
     app.ieee = t.EUI64(map(t.uint8_t, [8, 9, 10, 11, 12, 13, 14, 15]))
     app.get_sequence.return_value = DEFAULT_SEQUENCE
+    dst_addr = zdo_types.MultiAddress()
+    dst_addr.addrmode = 3
+    dst_addr.ieee = app.ieee
+    dst_addr.endpoint = 1
+    app.get_dst_address.return_value = dst_addr
     return app
 
 
@@ -62,14 +67,20 @@ async def test_request(zdo_f):
 
 @pytest.mark.asyncio
 async def test_bind(zdo_f):
-    await zdo_f.bind(1, 1026)
+    cluster = mock.MagicMock()
+    cluster.endpoint.endpoint_id = 1
+    cluster.cluster_id = 1026
+    await zdo_f.bind(cluster)
     assert zdo_f.device.request.call_count == 1
     assert zdo_f.device.request.call_args[0][1] == 0x0021
 
 
 @pytest.mark.asyncio
 async def test_unbind(zdo_f):
-    await zdo_f.unbind(1, 1026)
+    cluster = mock.MagicMock()
+    cluster.endpoint.endpoint_id = 1
+    cluster.cluster_id = 1026
+    await zdo_f.unbind(cluster)
     assert zdo_f.device.request.call_count == 1
     assert zdo_f.device.request.call_args[0][1] == 0x0022
 

--- a/zigpy/__init__.py
+++ b/zigpy/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 MAJOR_VERSION = 0
 MINOR_VERSION = 9
-PATCH_VERSION = "0.dev0"
+PATCH_VERSION = "0a1"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)

--- a/zigpy/__init__.py
+++ b/zigpy/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 MAJOR_VERSION = 0
 MINOR_VERSION = 9
-PATCH_VERSION = "0a1"
+PATCH_VERSION = "0a2"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)

--- a/zigpy/__init__.py
+++ b/zigpy/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 MAJOR_VERSION = 0
 MINOR_VERSION = 9
-PATCH_VERSION = "0a2"
+PATCH_VERSION = "0a3"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -11,6 +11,7 @@ import zigpy.types as t
 import zigpy.util
 import zigpy.zcl
 import zigpy.zdo
+import zigpy.zdo.types as zdo_types
 
 LOGGER = logging.getLogger(__name__)
 OTA_DIR = "zigpy_ota/"
@@ -249,6 +250,20 @@ class ControllerApplication(zigpy.util.ListenableMixin):
                 return dev
 
         raise KeyError
+
+    def get_dst_address(self, cluster):
+        """Helper to get a dst address for bind/unbind operations.
+
+        Allows radios to provide correct information especially for radios which listen
+        on specific endpoints only.
+        :param cluster: cluster instance to be bound to coordinator
+        :returns: returns a "destination address"
+        """
+        dstaddr = zdo_types.MultiAddress()
+        dstaddr.addrmode = 3
+        dstaddr.ieee = self.ieee
+        dstaddr.endpoint = 1
+        return dstaddr
 
     @property
     def groups(self):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -142,11 +142,20 @@ class ControllerApplication(zigpy.util.ListenableMixin):
 
     @zigpy.util.retryable_request
     async def request(
-        self, nwk, profile, cluster, src_ep, dst_ep, sequence, data, timeout=10
+        self,
+        device,
+        profile,
+        cluster,
+        src_ep,
+        dst_ep,
+        sequence,
+        data,
+        timeout=30,
+        use_ieee=False,
     ):
         """Submit and send data out as an unicast transmission.
 
-        :param nwk: destination network address
+        :param device: destination device
         :param profile: Zigbee Profile ID to use for outgoing message
         :param cluster: cluster id where the message is being sent
         :param src_ep: source endpoint id
@@ -154,6 +163,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         :param sequence: transaction sequence number of the message
         :param data: zigbee message payload
         :param timeout: how long to wait for transmission ACK
+        :param use_ieee: use EUI64 for destination addressing
         :returns: return a tuple of a status and an error_message. Original requestor
                   has more context to provide a more meaningful error message
         """

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -142,7 +142,16 @@ class ControllerApplication(zigpy.util.ListenableMixin):
 
     @zigpy.util.retryable_request
     async def request(
-        self, device, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee=False
+        self,
+        device,
+        profile,
+        cluster,
+        src_ep,
+        dst_ep,
+        sequence,
+        data,
+        expect_reply=True,
+        use_ieee=False,
     ):
         """Submit and send data out as an unicast transmission.
 
@@ -153,6 +162,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         :param dst_ep: destination endpoint id
         :param sequence: transaction sequence number of the message
         :param data: Zigbee message payload
+        :param expect_reply: True if this is essentially a request
         :param use_ieee: use EUI64 for destination addressing
         :returns: return a tuple of a status and an error_message. Original requestor
                   has more context to provide a more meaningful error message

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -142,16 +142,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
 
     @zigpy.util.retryable_request
     async def request(
-        self,
-        device,
-        profile,
-        cluster,
-        src_ep,
-        dst_ep,
-        sequence,
-        data,
-        timeout=30,
-        use_ieee=False,
+        self, device, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee=False
     ):
         """Submit and send data out as an unicast transmission.
 
@@ -161,8 +152,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         :param src_ep: source endpoint id
         :param dst_ep: destination endpoint id
         :param sequence: transaction sequence number of the message
-        :param data: zigbee message payload
-        :param timeout: how long to wait for transmission ACK
+        :param data: Zigbee message payload
         :param use_ieee: use EUI64 for destination addressing
         :returns: return a tuple of a status and an error_message. Original requestor
                   has more context to provide a more meaningful error message

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -172,7 +172,7 @@ class Device(zigpy.util.LocalLogMixin):
                 self.debug(
                     (
                         "Delivery error for seq # 0x%02x, on endpoint id %s "
-                        "cluster 0x%04x cluster: %s"
+                        "cluster 0x%04x: %s"
                     ),
                     sequence,
                     dst_ep,

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -165,6 +165,7 @@ class Device(zigpy.util.LocalLogMixin):
                 dst_ep,
                 sequence,
                 data,
+                expect_reply=expect_reply,
                 use_ieee=use_ieee,
             )
             if result != foundation.Status.SUCCESS:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -1,14 +1,19 @@
 import asyncio
+import binascii
 import enum
 import logging
 import time
 
 import zigpy.endpoint
+import zigpy.exceptions
 import zigpy.util
 import zigpy.zdo as zdo
+import zigpy.zcl.foundation as foundation
 from zigpy.types import BroadcastAddress, NWK
 
 
+APS_REPLY_TIMEOUT = 5
+APS_REPLY_TIMEOUT_EXTENDED = 28
 LOGGER = logging.getLogger(__name__)
 
 
@@ -42,6 +47,7 @@ class Device(zigpy.util.LocalLogMixin):
         self._model = None
         self.node_desc = zdo.types.NodeDescriptor()
         self._node_handle = None
+        self._pending = zigpy.util.Requests()
 
     def schedule_initialize(self):
         if self.initializing:
@@ -136,47 +142,98 @@ class Device(zigpy.util.LocalLogMixin):
                 await ep.remove_from_group(grp_id)
 
     async def request(
-        self, profile, cluster, src_ep, dst_ep, sequence, data, expect_reply=True
+        self,
+        profile,
+        cluster,
+        src_ep,
+        dst_ep,
+        sequence,
+        data,
+        expect_reply=True,
+        timeout=APS_REPLY_TIMEOUT,
     ):
-        result = await self._application.request(
-            self.nwk,
-            profile,
-            cluster,
-            src_ep,
-            dst_ep,
-            sequence,
-            data,
-            expect_reply=expect_reply,
-        )
-        # If application.request raises an exception, we won't get here, so
-        # won't update last_seen, as expected
-        self.last_seen = time.time()
+        if expect_reply and self.node_desc.is_end_device in (True, None):
+            self.debug("Extending timeout for 0x%02x request", sequence)
+            timeout = APS_REPLY_TIMEOUT_EXTENDED
+        with self._pending.new(sequence) as req:
+            result, msg = await self._application.request(
+                self.nwk, profile, cluster, src_ep, dst_ep, sequence, data
+            )
+            if result != foundation.Status.SUCCESS:
+                self.debug(
+                    (
+                        "Delivery error for seq # 0x%02x, on endpoint id %s "
+                        "cluster 0x%04x cluster: %s"
+                    ),
+                    sequence,
+                    dst_ep,
+                    cluster,
+                    msg,
+                )
+                raise zigpy.exceptions.DeliveryError(
+                    "[0x{:04x}:{}:0x{:04x}]: Message send failure".format(
+                        self.nwk, dst_ep, cluster
+                    )
+                )
+            # If application.request raises an exception, we won't get here, so
+            # won't update last_seen, as expected
+            self.last_seen = time.time()
+            if expect_reply:
+                result = await asyncio.wait_for(req.result, timeout)
+
         return result
 
     def deserialize(self, endpoint_id, cluster_id, data):
         return self.endpoints[endpoint_id].deserialize(cluster_id, data)
 
-    def handle_message(
-        self, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args
-    ):
+    def handle_message(self, profile, cluster, src_ep, dst_ep, message):
         self.last_seen = time.time()
         if not self.node_desc.is_valid and (
             self._node_handle is None or self._node_handle.done()
         ):
             self._node_handle = asyncio.ensure_future(self.refresh_node_descriptor())
+
         try:
-            endpoint = self.endpoints[src_ep]
-        except KeyError:
-            self.warn("Message on unknown endpoint %s", src_ep)
+            tsn, command_id, is_reply, args = self.deserialize(src_ep, cluster, message)
+        except ValueError as e:
+            LOGGER.error(
+                "Failed to parse message (%s) on cluster %d, because %s",
+                binascii.hexlify(message),
+                cluster,
+                e,
+            )
+            return
+        except KeyError as e:
+            LOGGER.debug(
+                (
+                    "Ignoring message (%s) on cluster %d: "
+                    "unknown endpoint or cluster id: %s"
+                ),
+                binascii.hexlify(message),
+                cluster,
+                e,
+            )
             return
 
-        return endpoint.handle_message(
-            is_reply, profile, cluster, tsn, command_id, args
-        )
+        if tsn in self._pending and is_reply:
+            try:
+                self._pending[tsn].result.set_result(args)
+                return
+            except asyncio.InvalidStateError:
+                self.debug(
+                    (
+                        "Invalid state on future for 0x%02x seq "
+                        "-- probably duplicate response"
+                    ),
+                    tsn,
+                )
+                return
+        endpoint = self.endpoints[src_ep]
+        return endpoint.handle_message(profile, cluster, tsn, command_id, args)
 
     def reply(self, profile, cluster, src_ep, dst_ep, sequence, data):
-        return self._application.request(
-            self.nwk, profile, cluster, src_ep, dst_ep, sequence, data, False
+        return self.request(
+            profile, cluster, src_ep, dst_ep, sequence, data, expect_reply=False
         )
 
     def radio_details(self, lqi, rssi):

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -158,7 +158,14 @@ class Device(zigpy.util.LocalLogMixin):
             timeout = APS_REPLY_TIMEOUT_EXTENDED
         with self._pending.new(sequence) as req:
             result, msg = await self._application.request(
-                self, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee
+                self,
+                profile,
+                cluster,
+                src_ep,
+                dst_ep,
+                sequence,
+                data,
+                use_ieee=use_ieee,
             )
             if result != foundation.Status.SUCCESS:
                 self.debug(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -151,13 +151,14 @@ class Device(zigpy.util.LocalLogMixin):
         data,
         expect_reply=True,
         timeout=APS_REPLY_TIMEOUT,
+        use_ieee=False,
     ):
         if expect_reply and self.node_desc.is_end_device in (True, None):
             self.debug("Extending timeout for 0x%02x request", sequence)
             timeout = APS_REPLY_TIMEOUT_EXTENDED
         with self._pending.new(sequence) as req:
             result, msg = await self._application.request(
-                self.nwk, profile, cluster, src_ep, dst_ep, sequence, data
+                self, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee
             )
             if result != foundation.Status.SUCCESS:
                 self.debug(
@@ -231,9 +232,16 @@ class Device(zigpy.util.LocalLogMixin):
         endpoint = self.endpoints[src_ep]
         return endpoint.handle_message(profile, cluster, tsn, command_id, args)
 
-    def reply(self, profile, cluster, src_ep, dst_ep, sequence, data):
+    def reply(self, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee=False):
         return self.request(
-            profile, cluster, src_ep, dst_ep, sequence, data, expect_reply=False
+            profile,
+            cluster,
+            src_ep,
+            dst_ep,
+            sequence,
+            data,
+            expect_reply=False,
+            use_ieee=use_ieee,
         )
 
     def radio_details(self, lqi, rssi):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -172,17 +172,17 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         cluster = self.in_clusters.get(cluster_id, self.out_clusters.get(cluster_id))
         return cluster.deserialize(data)
 
-    def handle_message(self, is_reply, profile, cluster, tsn, command_id, args):
+    def handle_message(self, profile, cluster, tsn, command_id, args):
         if cluster in self.in_clusters:
             handler = self.in_clusters[cluster].handle_message
         elif cluster in self.out_clusters:
             handler = self.out_clusters[cluster].handle_message
         else:
             self.debug("Message on unknown cluster 0x%04x", cluster)
-            self.listener_event("unknown_cluster_message", is_reply, command_id, args)
+            self.listener_event("unknown_cluster_message", command_id, args)
             return
 
-        handler(is_reply, tsn, command_id, args)
+        handler(tsn, command_id, args)
 
     def request(self, cluster, sequence, data, expect_reply=True, command_id=0x00):
         if self.profile_id == zigpy.profiles.zll.PROFILE_ID and not (

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -299,14 +299,10 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         return self._write_attributes(args, manufacturer=manufacturer)
 
     def bind(self):
-        return self._endpoint.device.zdo.bind(
-            self._endpoint.endpoint_id, self.cluster_id
-        )
+        return self._endpoint.device.zdo.bind(cluster=self)
 
     def unbind(self):
-        return self._endpoint.device.zdo.unbind(
-            self._endpoint.endpoint_id, self.cluster_id
-        )
+        return self._endpoint.device.zdo.unbind(cluster=self)
 
     def configure_reporting(
         self,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -161,11 +161,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
 
         return self._endpoint.reply(self.cluster_id, sequence, data)
 
-    def handle_message(self, is_reply, tsn, command_id, args):
-        if is_reply:
-            self.debug("Unexpected ZCL reply 0x%04x: %s", command_id, args)
-            return
-
+    def handle_message(self, tsn, command_id, args):
         self.debug("ZCL request 0x%04x: %s", command_id, args)
         if command_id <= 0xFF:
             self.listener_event("zdo_command", tsn, command_id, args)

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -389,7 +389,7 @@ class Time(Cluster):
                     data[attr] = diff.total_seconds()
                 else:
                     data[attr] = None
-            asyncio.ensure_future(self.read_attributes_rsp(data))
+            asyncio.ensure_future(self.read_attributes_rsp(data, tsn=tsn))
 
 
 class RSSILocation(Cluster):
@@ -853,11 +853,11 @@ class Ota(Cluster):
         cmd_name = self.server_commands.get(command_id, [command_id])[0]
 
         if cmd_name == "query_next_image":
-            await self._handle_query_next_image(*args)
+            await self._handle_query_next_image(*args, tsn=tsn)
         elif cmd_name == "image_block":
-            await self._handle_image_block(*args)
+            await self._handle_image_block(*args, tsn=tsn)
         elif cmd_name == "upgrade_end":
-            await self._handle_upgrade_end(*args)
+            await self._handle_upgrade_end(*args, tsn=tsn)
         else:
             self.debug(
                 "no '%s' OTA command handler for '%s %s': %s",
@@ -874,6 +874,8 @@ class Ota(Cluster):
         image_type,
         current_file_version,
         hardware_version,
+        *,
+        tsn
     ):
         self.debug(
             (
@@ -914,11 +916,14 @@ class Ota(Cluster):
                     img.key.image_type,
                     img.version,
                     img.header.image_size,
+                    tsn=tsn,
                 )
                 return
         else:
             self.debug("No OTA image is available")
-        await self.query_next_image_response(foundation.Status.NO_IMAGE_AVAILABLE)
+        await self.query_next_image_response(
+            foundation.Status.NO_IMAGE_AVAILABLE, tsn=tsn
+        )
 
     async def _handle_image_block(
         self,
@@ -930,6 +935,8 @@ class Ota(Cluster):
         max_data_size,
         request_node_addr,
         block_request_delay,
+        *,
+        tsn=None
     ):
         self.debug(
             (
@@ -954,7 +961,7 @@ class Ota(Cluster):
         )
         if img is None or img.version != file_version:
             self.debug("OTA image is not available")
-            await self.image_block_response(foundation.Status.ABORT)
+            await self.image_block_response(foundation.Status.ABORT, tsn=tsn)
             return
         self.debug(
             "OTA upgrade progress: %0.1f", 100.0 * file_offset / img.header.image_size
@@ -967,11 +974,16 @@ class Ota(Cluster):
                 img.version,
                 file_offset,
                 img.get_image_block(file_offset, max_data_size),
+                tsn=tsn,
             )
         except ValueError:
-            await self.image_block_response(foundation.Status.MALFORMED_COMMAND)
+            await self.image_block_response(
+                foundation.Status.MALFORMED_COMMAND, tsn=tsn
+            )
 
-    async def _handle_upgrade_end(self, status, manufacturer_id, image_type, file_ver):
+    async def _handle_upgrade_end(
+        self, status, manufacturer_id, image_type, file_ver, *, tsn
+    ):
         self.debug(
             (
                 "OTA upgrade_end handler for '%s %s': status=%s, "
@@ -985,7 +997,7 @@ class Ota(Cluster):
             file_ver,
         )
         await self.upgrade_end_response(
-            manufacturer_id, image_type, file_ver, 0x00000000, 0x00000000
+            manufacturer_id, image_type, file_ver, 0x00000000, 0x00000000, tsn=tsn
         )
 
 

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -19,11 +19,9 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._listeners = {}
 
     def _serialize(self, command, *args):
-        sequence = self._device.application.get_sequence()
-        data = sequence.to_bytes(1, "little")
         schema = types.CLUSTERS[command][1]
-        data += t.serialize(args, schema)
-        return sequence, data
+        data = t.serialize(args, schema)
+        return data
 
     def deserialize(self, cluster_id, data):
         tsn, data = data[0], data[1:]
@@ -48,26 +46,31 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     @zigpy.util.retryable_request
     def request(self, command, *args):
-        sequence, data = self._serialize(command, *args)
-        return self._device.request(0, command, 0, 0, sequence, data)
+        data = self._serialize(command, *args)
+        tsn = self.device.application.get_sequence()
+        data = t.uint8_t(tsn).serialize() + data
+        return self._device.request(0, command, 0, 0, tsn, data)
 
-    def reply(self, command, *args):
-        sequence, data = self._serialize(command, *args)
+    def reply(self, command, *args, tsn=None):
+        data = self._serialize(command, *args)
+        if tsn is None:
+            tsn = self.device.application.get_sequence()
+        data = t.uint8_t(tsn).serialize() + data
         loop = asyncio.get_event_loop()
-        loop.create_task(self._device.reply(0, command, 0, 0, sequence, data))
+        loop.create_task(self._device.reply(0, command, 0, 0, tsn, data))
 
     def handle_message(self, profile, cluster, tsn, command_id, args):
         self.debug("ZDO request %s: %s", command_id, args)
         app = self._device.application
         if command_id == types.ZDOCmd.NWK_addr_req:
             if app.ieee == args[0]:
-                self.NWK_addr_rsp(0, app.ieee, app.nwk, 0, 0, [])
+                self.NWK_addr_rsp(0, app.ieee, app.nwk, 0, 0, [], tsn=tsn)
         elif command_id == types.ZDOCmd.IEEE_addr_req:
             broadcast = (0xFFFF, 0xFFFD, 0xFFFC)
             if args[0] in broadcast or app.nwk == args[0]:
-                self.IEEE_addr_rsp(0, app.ieee, app.nwk, 0, 0, [])
+                self.IEEE_addr_rsp(0, app.ieee, app.nwk, 0, 0, [], tsn=tsn)
         elif command_id == types.ZDOCmd.Match_Desc_req:
-            self.handle_match_desc(*args)
+            self.handle_match_desc(*args, tsn=tsn)
         elif command_id == types.ZDOCmd.Device_annce:
             self.listener_event("device_announce", self._device)
         elif command_id == types.ZDOCmd.Mgmt_Permit_Joining_req:
@@ -75,12 +78,12 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         else:
             self.warn("Unsupported ZDO request:%s", command_id)
 
-    def handle_match_desc(self, addr, profile, in_clusters, out_clusters):
+    def handle_match_desc(self, addr, profile, in_clusters, out_clusters, *, tsn=None):
         local_addr = self._device.application.nwk
         if profile != 260:
-            return self.Match_Desc_rsp(0, local_addr, [])
+            return self.Match_Desc_rsp(0, local_addr, [], tsn=tsn)
 
-        return self.Match_Desc_rsp(0, local_addr, [t.uint8_t(1)])
+        return self.Match_Desc_rsp(0, local_addr, [t.uint8_t(1)], tsn=tsn)
 
     def bind(self, endpoint, cluster):
         dstaddr = types.MultiAddress()

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -45,19 +45,21 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return tsn, cluster_id, is_reply, args
 
     @zigpy.util.retryable_request
-    def request(self, command, *args):
+    def request(self, command, *args, use_ieee=False):
         data = self._serialize(command, *args)
         tsn = self.device.application.get_sequence()
         data = t.uint8_t(tsn).serialize() + data
-        return self._device.request(0, command, 0, 0, tsn, data)
+        return self._device.request(0, command, 0, 0, tsn, data, use_ieee=use_ieee)
 
-    def reply(self, command, *args, tsn=None):
+    def reply(self, command, *args, tsn=None, use_ieee=False):
         data = self._serialize(command, *args)
         if tsn is None:
             tsn = self.device.application.get_sequence()
         data = t.uint8_t(tsn).serialize() + data
         loop = asyncio.get_event_loop()
-        loop.create_task(self._device.reply(0, command, 0, 0, tsn, data))
+        loop.create_task(
+            self._device.reply(0, command, 0, 0, tsn, data, use_ieee=use_ieee)
+        )
 
     def handle_message(self, profile, cluster, tsn, command_id, args):
         self.debug("ZDO request %s: %s", command_id, args)

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -87,19 +87,21 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         return self.Match_Desc_rsp(0, local_addr, [t.uint8_t(1)], tsn=tsn)
 
-    def bind(self, endpoint, cluster):
-        dstaddr = types.MultiAddress()
-        dstaddr.addrmode = 3
-        dstaddr.ieee = self._device.application.ieee
-        dstaddr.endpoint = endpoint
-        return self.Bind_req(self._device.ieee, endpoint, cluster, dstaddr)
+    def bind(self, cluster):
+        return self.Bind_req(
+            self._device.ieee,
+            cluster.endpoint.endpoint_id,
+            cluster.cluster_id,
+            self.device.application.get_dst_address(cluster),
+        )
 
-    def unbind(self, endpoint, cluster):
-        dstaddr = types.MultiAddress()
-        dstaddr.addrmode = 3
-        dstaddr.ieee = self._device.application.ieee
-        dstaddr.endpoint = endpoint
-        return self.Unbind_req(self._device.ieee, endpoint, cluster, dstaddr)
+    def unbind(self, cluster):
+        return self.Unbind_req(
+            self._device.ieee,
+            cluster.endpoint.endpoint_id,
+            cluster.cluster_id,
+            self.device.application.get_dst_address(cluster),
+        )
 
     def leave(self):
         return self.Mgmt_Leave_req(self._device.ieee, 0x02)

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -56,11 +56,7 @@ class ZDO(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         loop = asyncio.get_event_loop()
         loop.create_task(self._device.reply(0, command, 0, 0, sequence, data))
 
-    def handle_message(self, is_reply, profile, cluster, tsn, command_id, args):
-        if is_reply:
-            self.debug("Unexpected ZDO reply %s: %s", command_id, args)
-            return
-
+    def handle_message(self, profile, cluster, tsn, command_id, args):
         self.debug("ZDO request %s: %s", command_id, args)
         app = self._device.application
         if command_id == types.ZDOCmd.NWK_addr_req:


### PR DESCRIPTION
Keep request/reply tracking in Zigpy. Make radio libraries only responsible for sending and receiving data without any further processing.