### PR TITLE
[DEV] Update README.md to mention experimental ZiGate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ zigpy works with separate radio libraries which can each interface with multiple
   - [ConBee](https://www.dresden-elektronik.de/conbee/) USB radio adapter from [Dresden-Elektronik](https://www.dresden-elektronik.de)
   - [RaspBee](https://www.dresden-elektronik.de/raspbee/) GPIO radio adapter from [Dresden-Elektronik](https://www.dresden-elektronik.de)
   
+**Experimental Zigbee radio modules:**
+- ZiGate based radios (via the [zigpy-zigate](https://github.com/doudz/zigpy-zigate) library for zigpy)
+  - [ZiGate open source ZigBee adapter hardware](https://zigate.fr/)
+  
 **Release packages available via PyPI:**
 Packages of tagged versions are also released via PyPI
 - https://pypi.org/project/zigpy-homeassistant/


### PR DESCRIPTION
Update README.md to mention experimental ZiGate support plus links to code/library and hardware.

@doudz has now publish zigpy-zigate v0.x.0 which has experimental support for ZiGate to Zigpy

https://github.com/doudz/zigpy-zigate

zigpy-zigate 0.1.0 to 0.4.0 versions released so far on PyPI

https://pypi.org/project/zigpy-zigate/#history

Requires ZiGate firmware 3.1a or later firmware version which has added a raw mode

https://zigate.fr/tag/firmware/