### PR TITLE
Override ZLL profile id for replies.

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -159,6 +159,22 @@ def test_reply(ep):
     assert ep._device.reply.call_count == 1
 
 
+def test_reply_change_profile_id(ep):
+    ep.profile_id = 49246
+    ep.reply(0x1000, 8, b"", 0x3F)
+    assert ep._device.reply.call_count == 1
+    assert ep._device.reply.call_args[0][0] == ep.profile_id
+
+    ep.reply(0x1000, 8, b"", 0x40)
+    assert ep._device.reply.call_count == 2
+    assert ep._device.reply.call_args[0][0] == 0x0104
+
+    ep.profile_id = 0xBEEF
+    ep.reply(0x1000, 8, b"", 0x40)
+    assert ep._device.reply.call_count == 3
+    assert ep._device.reply.call_args[0][0] == ep.profile_id
+
+
 def _mk_rar(attrid, value, status=0):
     r = zcl.foundation.ReadAttributeRecord()
     r.attrid = attrid

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -203,14 +203,17 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             expect_reply=expect_reply,
         )
 
-    def reply(self, cluster, sequence, data):
+    def reply(self, cluster, sequence, data, command_id=0x00):
+        if self.profile_id == zigpy.profiles.zll.PROFILE_ID and not (
+            cluster == zigpy.zcl.clusters.lightlink.LightLink.cluster_id
+            and command_id < 0x40
+        ):
+            profile_id = zigpy.profiles.zha.PROFILE_ID
+        else:
+            profile_id = self.profile_id
+
         return self.device.reply(
-            self.profile_id,
-            cluster,
-            self._endpoint_id,
-            self._endpoint_id,
-            sequence,
-            data,
+            profile_id, cluster, self._endpoint_id, self._endpoint_id, sequence, data
         )
 
     def log(self, lvl, msg, *args):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -160,7 +160,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
         hdr.manufacturer = manufacturer
         data = hdr.serialize() + t.serialize(args, schema)
 
-        return self._endpoint.reply(self.cluster_id, tsn, data)
+        return self._endpoint.reply(self.cluster_id, tsn, data, command_id=command_id)
 
     def handle_message(self, tsn, command_id, args):
         self.debug("ZCL request 0x%04x: %s", command_id, args)


### PR DESCRIPTION
Use ZLL profile id only for `LightLink` cluster specific commands.