### PR TITLE
Refactor EUI64 class.

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -266,3 +266,35 @@ def test_date():
     r.year = 2020
     assert r.serialize()[0] == 2020 - 1900
     assert t.Date().year is None
+
+
+def test_eui64():
+    """Test EUI64."""
+    data = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+    extra = b"\xaa\x55"
+
+    ieee, rest = t.EUI64.deserialize(data + extra)
+    assert ieee[0] == 1
+    assert ieee[1] == 2
+    assert ieee[2] == 3
+    assert ieee[3] == 4
+    assert ieee[4] == 5
+    assert ieee[5] == 6
+    assert ieee[6] == 7
+    assert ieee[7] == 8
+    assert rest == extra
+    assert ieee.serialize() == data
+
+
+def test_eui64_convert():
+    ieee = t.EUI64.convert("08:07:06:05:04:03:02:01")
+    assert ieee[0] == 1
+    assert ieee[1] == 2
+    assert ieee[2] == 3
+    assert ieee[3] == 4
+    assert ieee[4] == 5
+    assert ieee[5] == 6
+    assert ieee[6] == 7
+    assert ieee[7] == 8
+
+    assert t.EUI64.convert(None) is None

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -17,13 +17,12 @@ DB_VERSION = 0x0001
 
 def _sqlite_adapters():
     def adapt_ieee(eui64):
-        return repr(eui64)
+        return str(eui64)
 
     sqlite3.register_adapter(t.EUI64, adapt_ieee)
 
     def convert_ieee(s):
-        ieee = [t.uint8_t(p, base=16) for p in s.split(b":")]
-        return t.EUI64(ieee)
+        return t.EUI64.convert(s.decode())
 
     sqlite3.register_converter("ieee", convert_ieee)
 

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -17,20 +17,19 @@ class BroadcastAddress(basic.uint16_t, enum.Enum):
 
 class EUI64(basic.fixed_list(8, basic.uint8_t)):
     # EUI 64-bit ID (an IEEE address).
-    @classmethod
-    def deserialize(cls, data):
-        r, data = super().deserialize(data)
-        return cls(r[::-1]), data
-
-    def serialize(self):
-        assert self._length == len(self)
-        return b"".join([i.serialize() for i in self[::-1]])
-
     def __repr__(self):
-        return ":".join("%02x" % i for i in self)
+        return ":".join("%02x" % i for i in self[::-1])
 
     def __hash__(self):
         return hash(repr(self))
+
+    @classmethod
+    def convert(cls, ieee: str):
+        if ieee is None:
+            return None
+        ieee = [basic.uint8_t(p, base=16) for p in ieee.split(":")[::-1]]
+        assert len(ieee) == cls._length
+        return cls(ieee)
 
 
 class KeyData(basic.fixed_list(16, basic.uint8_t)):


### PR DESCRIPTION
Since we represent `EUI64` address as a list of 8 bytes, keep LSB portion in the lower indexes of the list and MSB in the higher indexes. This also makes `EUI64` class just a fixed list of 8 `uint8_t` elements.