### PR TITLE
Group request method.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(
         'crccheck',
     ],
     tests_require=[
+        'asynctest',
         'pytest',
+        'pytest-asyncio',
     ],
 )

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -264,3 +264,12 @@ def test_props(app):
     assert app.extended_pan_id is None
     assert app.pan_id is None
     assert app.nwk_update_id is None
+
+
+@pytest.mark.asyncio
+async def test_mrequest(app):
+    s = mock.sentinel
+    with pytest.raises(NotImplementedError):
+        await app.mrequest(
+            s.group_id, s.profile_id, s.cluster, s.src_ep, s.sequence, s.data
+        )

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -126,7 +126,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
             )
             return error
 
-        sequence = self._endpoint._device.application.get_sequence()
+        sequence = self._endpoint.device.application.get_sequence()
         if general:
             hdr = foundation.ZCLHeader.general(sequence, command_id, manufacturer)
         else:
@@ -147,7 +147,7 @@ class Cluster(util.ListenableMixin, util.LocalLogMixin, metaclass=Registry):
             self.debug("Schema and args lengths do not match in reply")
 
         if tsn is None:
-            tsn = self._endpoint._device.application.get_sequence()
+            tsn = self._endpoint.device.application.get_sequence()
         if general:
             hdr = foundation.ZCLHeader.general(
                 tsn, command_id, manufacturer, is_reply=True


### PR DESCRIPTION
Implement sending ZCL requests to multicast groups. ATM only ZCL clusters are supported.

### Example
```
group_id = 0x0100
group = application_controller.groups[group_id]
status, msg = await group.on_off.toggle()
status, msg = await group[6].toggle()
```
