### PR TITLE
Extract IKEA OTA image offset and size directly from the container

### DIFF
--- a/tests/test_ota_provider.py
+++ b/tests/test_ota_provider.py
@@ -154,13 +154,13 @@ async def test_basic_get_image(basic_prov, key):
 def test_basic_enable_provider(key):
     basic_prov = ota_p.Basic()
 
-    assert not basic_prov.is_enabled
+    assert basic_prov.is_enabled is False
 
     basic_prov.enable()
-    assert basic_prov.is_enabled
+    assert basic_prov.is_enabled is True
 
     basic_prov.disable()
-    assert not basic_prov.is_enabled
+    assert basic_prov.is_enabled is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_ota_provider.py
+++ b/tests/test_ota_provider.py
@@ -154,13 +154,13 @@ async def test_basic_get_image(basic_prov, key):
 def test_basic_enable_provider(key):
     basic_prov = ota_p.Basic()
 
-    assert basic_prov.is_enabled is False
+    assert not basic_prov.is_enabled
 
     basic_prov.enable()
-    assert basic_prov.is_enabled is True
+    assert basic_prov.is_enabled
 
     basic_prov.disable()
-    assert basic_prov.is_enabled is False
+    assert not basic_prov.is_enabled
 
 
 @pytest.mark.asyncio
@@ -324,18 +324,23 @@ async def test_ikea_refresh_list_locked(mock_get, ikea_prov, image_with_version)
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession.get")
 async def test_ikea_fetch_image(mock_get, image_with_version):
-    prefix = b"\x00This is extra data\x00\x55\xaa"
-    data = (
+    data = bytes.fromhex(
         "1ef1ee0b0001380000007c11012178563412020054657374204f544120496d61"
         "676500000000000000000000000000000000000042000000"
     )
-    data = binascii.unhexlify(data)
     sub_el = b"\x00\x00\x04\x00\x00\x00abcd"
+
+    container = bytearray(b"\x00This is extra data\x00\x55\xaa" * 100)
+    container[0:4] = b'NGIS'
+    container[16:20] = (512).to_bytes(4, 'little')      # offset
+    container[20:24] = len(data + sub_el).to_bytes(4, 'little')  # size
+    container[512:512 + len(data) + len(sub_el)] = data + sub_el
+
     img = image_with_version(image_type=0x2101)
     img.url = mock.sentinel.url
 
     mock_get.return_value.__aenter__.return_value.read = CoroutineMock(
-        side_effect=[prefix + data + sub_el]
+        side_effect=[container]
     )
 
     r = await img.fetch_image()

--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -82,8 +82,6 @@ class Basic:
 
 @attr.s
 class IKEAImage:
-    OTA_HEADER = 0x0BEEF11E .to_bytes(4, "little")
-
     manufacturer_id = attr.ib()
     image_type = attr.ib()
     version = attr.ib(default=None)
@@ -108,7 +106,15 @@ class IKEAImage:
             LOGGER.debug("Downloading %s for %s", self.url, self.key)
             async with req.get(self.url) as rsp:
                 data = await rsp.read()
-        offset = data.index(self.OTA_HEADER)
+
+        assert len(data) > 24
+        offset = int.from_bytes(data[16:20], 'little')
+        size = int.from_bytes(data[20:24], 'little')
+        assert len(data) > offset + size
+
+        ota_image, _ = OTAImage.deserialize(data[offset:offset + size])
+        assert ota_image.key == self.key
+
         LOGGER.debug(
             "Finished downloading %s bytes from %s for %s ver %s",
             self.image_size,
@@ -116,7 +122,7 @@ class IKEAImage:
             self.key,
             self.version,
         )
-        return OTAImage.deserialize(data[offset:])[0]
+        return ota_image
 
 
 class Trådfri(Basic):


### PR DESCRIPTION
The chances of finding the four byte OTA header erroneously are slim but you can avoid searching by just reading the offset straight from the container file.