### PR TITLE
Allow inactive endpoints

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -37,7 +37,7 @@ async def _test_initialize(ep, profile):
 
 
 @pytest.mark.asyncio
-async def test_inactive_initialize(ep, profile):
+async def test_inactive_initialize(ep):
     async def mockrequest(nwk, epid, tries=None, delay=None):
         sd = types.SimpleDescriptor()
         sd.endpoint = 2

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -45,7 +45,7 @@ async def test_inactive_initialize(ep):
 
     ep._device.zdo.Simple_Desc_req = mockrequest
     await ep.initialize()
-    assert ep.status > endpoint.Status.ENDPOINT_INACTIVE
+    assert ep.status == endpoint.Status.ENDPOINT_INACTIVE
 
 
 @pytest.mark.asyncio

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -37,6 +37,18 @@ async def _test_initialize(ep, profile):
 
 
 @pytest.mark.asyncio
+async def test_inactive_initialize(ep, profile):
+    async def mockrequest(nwk, epid, tries=None, delay=None):
+        sd = types.SimpleDescriptor()
+        sd.endpoint = 2
+        return [131, None, sd]
+
+    ep._device.zdo.Simple_Desc_req = mockrequest
+    await ep.initialize()
+    assert ep.status > endpoint.Status.ENDPOINT_INACTIVE
+
+
+@pytest.mark.asyncio
 async def test_initialize_zha(ep):
     return await _test_initialize(ep, 260)
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -26,6 +26,8 @@ class Status(enum.IntEnum):
     ZDO_INIT = 1
     # Endpoints initialized
     ENDPOINTS_INIT = 2
+    # Endpoint Inactive
+    ENDPOINT_INACTIVE = 3
 
 
 class Device(zigpy.util.LocalLogMixin):

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -26,8 +26,6 @@ class Status(enum.IntEnum):
     ZDO_INIT = 1
     # Endpoints initialized
     ENDPOINTS_INIT = 2
-    # Endpoint Inactive
-    ENDPOINT_INACTIVE = 3
 
 
 class Device(zigpy.util.LocalLogMixin):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -47,7 +47,11 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             sdr = await self._device.zdo.Simple_Desc_req(
                 self._device.nwk, self._endpoint_id, tries=3, delay=2
             )
-            if sdr[0] != 0:
+            if sdr[0] == 131:
+                # These endpoints are essentially junk but this lets the device join
+                self.status = Status.ENDPOINT_INACTIVE
+                return
+            elif sdr[0] != 0:
                 raise Exception("Failed to retrieve service descriptor: %s", sdr)
         except Exception as exc:
             self.warn("Failed ZDO request during endpoint initialization: %s", exc)

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -19,6 +19,8 @@ class Status(enum.IntEnum):
     NEW = 0
     # Endpoint information (device type, clusters, etc) init done
     ZDO_INIT = 1
+    # Endpoint Inactive
+    ENDPOINT_INACTIVE = 3
 
 
 class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -8,6 +8,7 @@ import zigpy.util
 import zigpy.zcl
 from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import Status as ZCLStatus
+from zigpy.zdo.types import Status as zdo_status
 
 LOGGER = logging.getLogger(__name__)
 
@@ -49,11 +50,11 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             sdr = await self._device.zdo.Simple_Desc_req(
                 self._device.nwk, self._endpoint_id, tries=3, delay=2
             )
-            if sdr[0] == 131:
+            if sdr[0] == zdo_status.NOT_ACTIVE:
                 # These endpoints are essentially junk but this lets the device join
                 self.status = Status.ENDPOINT_INACTIVE
                 return
-            elif sdr[0] != 0:
+            elif sdr[0] != zdo_status.SUCCESS:
                 raise Exception("Failed to retrieve service descriptor: %s", sdr)
         except Exception as exc:
             self.warn("Failed ZDO request during endpoint initialization: %s", exc)


### PR DESCRIPTION
This PR accounts for endpoints that have the status of inactive. This allows devices such as: lumi.remote.b286opcn01, lumi.remote.b486opcn01, lumi.remote.b686opcn01 to join the network as they report 6 endpoints each but 4 of them report inactive status. 