### PR TITLE
Update README.md with link to the zigpy-cc module for experimental TI CC chip support with custom Z-Stack firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ zigpy works with separate radio libraries which can each interface with multiple
 - ZiGate based radios (via the [zigpy-zigate](https://github.com/doudz/zigpy-zigate) library for zigpy)
   - [ZiGate open source ZigBee adapter hardware](https://zigate.fr/)
   
+- Texas Instruments CC2531 based radios (via the [zigpy-cc](https://github.com/sanyatuning/zigpy-cc) library for zigpy)
+  - [CC2531 USB stick hardware with custom Z-Stack firmware from the Zigbee2mqtt project](https://www.zigbee2mqtt.io/getting_started/what_do_i_need.html)
+  
 ## Release packages available via PyPI
 
 Packages of tagged versions are also released via PyPI

--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ zigpy works with separate radio libraries which can each interface with multiple
 - ZiGate based radios (via the [zigpy-zigate](https://github.com/doudz/zigpy-zigate) library for zigpy)
   - [ZiGate open source ZigBee adapter hardware](https://zigate.fr/)
   
-- Texas Instruments CC2531 based radios (via the [zigpy-cc](https://github.com/sanyatuning/zigpy-cc) library for zigpy)
-  - [CC2531 USB stick hardware with custom Z-Stack firmware from the Zigbee2mqtt project](https://www.zigbee2mqtt.io/getting_started/what_do_i_need.html)
-  
+- Texas Instruments CC253x, CC26x2R, and CC13x2 based radios (via the [zigpy-cc](https://github.com/sanyatuning/zigpy-cc) library for zigpy)
+  - [CC2531 USB stick hardware flashed with custom Z-Stack coordinator firmware from the Zigbee2mqtt project](https://www.zigbee2mqtt.io/getting_started/what_do_i_need.html)
+  - [CC2530 + CC2591 USB stick hardware flashed with custom Z-Stack coordinator firmware from the Zigbee2mqtt project](https://www.zigbee2mqtt.io/getting_started/what_do_i_need.html)
+  - [CC2530 + CC2592 dev board hardware flashed with custom Z-Stack coordinator firmware from the Zigbee2mqtt project](https://www.zigbee2mqtt.io/getting_started/what_do_i_need.html)
+  - [CC2652R dev board hardware flashed with custom Z-Stack coordinator firmware from the Zigbee2mqtt project](https://www.zigbee2mqtt.io/getting_started/what_do_i_need.html)
+  - [CC1352P-2 dev board hardware flashed with custom Z-Stack coordinator firmware from the Zigbee2mqtt project](https://www.zigbee2mqtt.io/getting_started/what_do_i_need.html)
+  - [CC2538 + CC2592 dev board hardware flashed with custom Z-Stack coordinator firmware from the Zigbee2mqtt project](https://www.zigbee2mqtt.io/getting_started/what_do_i_need.html)  
+
 ## Release packages available via PyPI
 
 Packages of tagged versions are also released via PyPI


### PR DESCRIPTION
Update README.md with link to experimental "zigpy-cc" by @sanyatuning with TI CC chip for Zigpy when using custom Z-Stack firmware from the Zigbee2mqtt project by @Koenkk

https://github.com/sanyatuning/zigpy-cc

Listing all TI CC chips supported by the custom Z-Stack-firmware from the Zigbee2mqtt community

https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator

CC2538 + CC2592 dev boards and USB sticks should also be supported by zigbee-herdsman that this "zigpy-cc" module is based on according to Zigbee2mqtt and ioBroker communities

Koenkk/zigbee2mqtt#2372

https://github.com/ioBroker/ioBroker.zigbee