### PR TITLE
Add flag to device to allow skipping configuration

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -98,6 +98,12 @@ async def test_failed_request(dev):
     assert dev.last_seen is None
 
 
+def test_skip_configuration(dev):
+    assert dev.skip_configuration is False
+    dev.skip_configuration = True
+    assert dev.skip_configuration is True
+
+
 def test_radio_details(dev):
     dev.radio_details(1, 2)
     assert dev.lqi == 1

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -50,6 +50,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._node_handle = None
         self._pending = zigpy.util.Requests()
         self._relays = None
+        self._skip_configuration = False
 
     def schedule_initialize(self):
         if self.initializing:
@@ -283,6 +284,17 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     @property
     def model(self):
         return self._model
+
+    @property
+    def skip_configuration(self):
+        return self._skip_configuration
+
+    @skip_configuration.setter
+    def skip_configuration(self, should_skip_configuration):
+        if isinstance(should_skip_configuration, bool):
+            self._skip_configuration = should_skip_configuration
+        else:
+            self._skip_configuration = False
 
     @model.setter
     def model(self, value):

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -38,6 +38,7 @@ class CustomDevice(zigpy.device.Device, metaclass=Registry):
         set_device_attr("node_desc")
         set_device_attr("manufacturer")
         set_device_attr("model")
+        set_device_attr("skip_configuration")
         for endpoint_id, endpoint in self.replacement.get("endpoints", {}).items():
             self.add_endpoint(endpoint_id, replace_device=replaces)
 


### PR DESCRIPTION
This PR adds a flag to the device object to signify that a device should or should not skip configuration. It defaults to False. This will be used to handle Xiaomi devices cleanly (skipping binding and skipping report configuration) now that the newer devices are Zigbee certified and need to be configured. 