### PR TITLE
Deffer attributes updates for uninitialized devices.

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -29,10 +29,16 @@ class FakeCustomDevice(CustomDevice):
         super().__init__(application, ieee, nwk, replaces)
 
 
-async def _initialize(self):
-    self.status = Status.ENDPOINTS_INIT
-    self.initializing = False
-    self._application.device_initialized(self)
+def mock_dev_init(status: Status):
+    """Device schedule_initialize mock factory."""
+
+    def _initialize(self):
+        self.status = Status.ENDPOINTS_INIT
+        self.initializing = False
+        self._application.device_initialized(self)
+        self.node_desc = zdo_t.NodeDescriptor(0, 1, 2, 3, 4, 5, 6, 7, 8)
+
+    return _initialize
 
 
 def fake_get_device(device):
@@ -48,10 +54,11 @@ def fake_get_device(device):
 
 @pytest.mark.asyncio
 async def test_database(tmpdir, monkeypatch):
-    monkeypatch.setattr(Device, "_initialize", _initialize)
+    monkeypatch.setattr(
+        Device, "schedule_initialize", mock_dev_init(Status.ENDPOINTS_INIT)
+    )
     db = os.path.join(str(tmpdir), "test.db")
     app = make_app(db)
-    # TODO: Leaks a task on dev.initialize, I think?
     ieee = make_ieee()
     relays_1 = [t.NWK(0x1234), t.NWK(0x2345)]
     relays_2 = [t.NWK(0x3456), t.NWK(0x4567)]
@@ -59,7 +66,6 @@ async def test_database(tmpdir, monkeypatch):
     app.handle_join(99, ieee, 0)
 
     dev = app.get_device(ieee)
-    dev.node_desc, _ = zdo_t.NodeDescriptor.deserialize(b"1234567890123")
     ep = dev.add_endpoint(1)
     ep.profile_id = 260
     ep.device_type = profiles.zha.DeviceType.PUMP
@@ -138,7 +144,10 @@ def _test_null_padded(tmpdir, test_manufacturer=None, test_model=None):
     app = make_app(db)
     # TODO: Leaks a task on dev.initialize, I think?
     ieee = make_ieee()
-    with mock.patch("zigpy.device.Device.schedule_initialize"):
+    with mock.patch(
+        "zigpy.device.Device.schedule_initialize",
+        new=mock_dev_init(Status.ENDPOINTS_INIT),
+    ):
         app.handle_join(99, ieee, 0)
         app.handle_join(99, ieee, 0)
 
@@ -210,13 +219,17 @@ def test_appdb_str_model(tmpdir):
     assert dev.endpoints[3].model == "Mock Model"
 
 
+@pytest.mark.parametrize(
+    "status, desc_is_valid",
+    ((Status.ENDPOINTS_INIT, True), (Status.ZDO_INIT, False), (Status.NEW, False)),
+)
 @pytest.mark.asyncio
-async def test_node_descriptor_updated(tmpdir, monkeypatch):
-    monkeypatch.setattr(Device, "_initialize", _initialize)
+async def test_node_descriptor_updated(tmpdir, status, desc_is_valid):
     db = os.path.join(str(tmpdir), "test_nd.db")
     app = make_app(db)
     nd_ieee = make_ieee(2)
-    app.handle_join(299, nd_ieee, 0)
+    with mock.patch.object(Device, "schedule_initialize", new=mock_dev_init(status)):
+        app.handle_join(299, nd_ieee, 0)
 
     dev = app.get_device(nd_ieee)
     ep = dev.add_endpoint(1)
@@ -240,15 +253,20 @@ async def test_node_descriptor_updated(tmpdir, monkeypatch):
 
     app2 = make_app(db)
     dev = app2.get_device(nd_ieee)
-    assert dev.node_desc.is_valid
-    assert dev.node_desc.serialize() == b"abcdefghijklm"
+    if desc_is_valid:
+        assert dev.node_desc.is_valid
+        assert dev.node_desc.serialize() == b"abcdefghijklm"
+    else:
+        assert dev.node_desc.is_valid is False
 
     os.unlink(db)
 
 
 @pytest.mark.asyncio
 async def test_groups(tmpdir, monkeypatch):
-    monkeypatch.setattr(Device, "_initialize", _initialize)
+    monkeypatch.setattr(
+        Device, "schedule_initialize", mock_dev_init(Status.ENDPOINTS_INIT)
+    )
 
     group_id, group_name = 0x1221, "app db Test Group 0x1221"
 

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -25,8 +25,7 @@ def make_ieee(init=0):
 
 
 class FakeCustomDevice(CustomDevice):
-    def __init__(self, application, ieee, nwk, replaces):
-        super().__init__(application, ieee, nwk, replaces)
+    pass
 
 
 def mock_dev_init(status: Status):
@@ -43,12 +42,7 @@ def mock_dev_init(status: Status):
 
 def fake_get_device(device):
     if device.endpoints.get(1) is not None and device[1].profile_id == 65535:
-        return FakeCustomDevice(
-            device.application,
-            make_ieee(1),
-            199,
-            Device(device.application, make_ieee(1), 199),
-        )
+        return FakeCustomDevice(device.application, make_ieee(1), 199, device)
     return device
 
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -171,8 +171,8 @@ class PersistingListener:
             "attributes",
             (
                 "(ieee ieee, endpoint_id, cluster, attrid, value, "
-                "FOREIGN KEY(ieee, endpoint_id, cluster) "
-                "REFERENCES clusters(ieee, endpoint_Id, cluster) "
+                "FOREIGN KEY(ieee, endpoint_id) "
+                "REFERENCES endpoints(ieee, endpoint_id) "
                 "ON DELETE CASCADE)"
             ),
         )

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -252,7 +252,10 @@ class PersistingListener:
         self._db.commit()
 
     def _save_node_descriptor(self, device):
-        if not device.node_desc.is_valid:
+        if (
+            device.status != zigpy.device.Status.ENDPOINTS_INIT
+            or not device.node_desc.is_valid
+        ):
             return
         q = "INSERT OR REPLACE INTO node_descriptors VALUES (?, ?)"
         self.execute(q, (device.ieee, device.node_desc.serialize()))

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -6,6 +6,7 @@ import logging
 import zigpy.types as t
 from zigpy import util
 from zigpy.zcl import foundation
+import zigpy.device
 
 
 LOGGER = logging.getLogger(__name__)
@@ -439,6 +440,8 @@ class ClusterPersistingListener:
         self._cluster = cluster
 
     def attribute_updated(self, attrid, value):
+        if self._cluster.endpoint.device.status != zigpy.device.Status.ENDPOINTS_INIT:
+            return
         self._applistener.attribute_updated(self._cluster, attrid, value)
 
     def cluster_command(self, *args, **kwargs):


### PR DESCRIPTION
- Prevent saving of attribute updates and node descriptors to persistent storage if device is not fully initialized
- Don't save uninitialized device into persistent storage
- Don't use cluster_id as a foreign key for attributes

Fixes #289 