### PR TITLE
Add startup on, off, and restore support

### DIFF
--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -255,7 +255,7 @@ class OnOff(Cluster):
         0x4000: ("global_scene_control", t.Bool),
         0x4001: ("on_time", t.uint16_t),
         0x4002: ("off_wait_time", t.uint16_t),
-        0x4003: ("poweron_onoff", t.enum8),
+        0x4003: ("startup_on_off", t.enum8),
     }
     server_commands = {
         0x0000: ("off", (), False),
@@ -300,6 +300,7 @@ class LevelControl(Cluster):
         0x0012: ("on_transition_time", t.uint16_t),
         0x0013: ("off_transition_time", t.uint16_t),
         0x0014: ("default_move_rate", t.uint8_t),
+        0x4000: ("startup_current_level", t.uint8_t),
     }
     server_commands = {
         0x0000: ("move_to_level", (t.uint8_t, t.uint16_t), False),

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -255,6 +255,7 @@ class OnOff(Cluster):
         0x4000: ("global_scene_control", t.Bool),
         0x4001: ("on_time", t.uint16_t),
         0x4002: ("off_wait_time", t.uint16_t),
+        0x4003: ("poweron_onoff", t.enum8),
     }
     server_commands = {
         0x0000: ("off", (), False),

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -66,6 +66,7 @@ class Color(Cluster):
         0x400A: ("color_capabilities", t.bitmap16),
         0x400B: ("color_temp_physical_min", t.uint16_t),
         0x400C: ("color_temp_physical_max", t.uint16_t),
+        0x4010: ("startup_color_temp", t.uint16_t),
     }
     server_commands = {
         0x0000: (


### PR DESCRIPTION
Philips Hue and potentially other bulbs support setting the startup behavior.

**Startup Off**
OnOff (0x0006):
 - Set startup_on_off (0x4003) value to 0

**Startup On**
OnOff (0x0006):
 - Set startup_on_off (0x4003) value to 1

**Startup Restore**:
OnOff (0x0006):
 - Set startup_on_off (0x4003) value to 255

LevelControl (0x0008):
 - Set startup_current_level (0x4000) value to 255

Color (0x0300):
 - Set startup_color_temp (0x4010) value to 65535
 - Set current_x (0x0003) manufacturer code override to 65535
 - Set current_y (0x0004) manufacturer code override to 65535

This has been added to deconz:
https://github.com/dresden-elektronik/deconz-rest-plugin/blob/edfa1e9cd4f8246f82118c428c193c8c343ae912/general.xml#L502

And recently to zigbee2mqtt:
https://www.zigbee2mqtt.io/devices/9290022169.html#power-on-behavior