### PR TITLE
Fix Identify cluster trigger_effect command arguments

### DIFF
--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -159,7 +159,7 @@ class Identify(Cluster):
         0x0001: ("identify_query", (), False),
         0x0002: ("ezmode_invoke", (t.bitmap8,), False),
         0x0003: ("update_commission_state", (t.bitmap8,), False),
-        0x0040: ("trigger_effect", (), False),
+        0x0040: ("trigger_effect", (t.uint8_t, t.uint8_t), False),
     }
     client_commands = {0x0000: ("identify_query_response", (t.uint16_t,), True)}
 


### PR DESCRIPTION
This change allows to run zha.issue_zigbee_cluster_command from HA without "wrong number of arguments" error

ZigBee Cluster Library Specification:

![image](https://user-images.githubusercontent.com/30175487/75013366-6a0eea00-5484-11ea-8374-c54b03258fa7.png)
