### PR TITLE
Use Accept instead of Content-Type in firmware provider GET requests

### DIFF
--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -137,7 +137,7 @@ class Trådfri(Basic):
 
     UPDATE_URL = "https://fw.ota.homesmart.ikea.net/feed/version_info.json"
     MANUFACTURER_ID = 4476
-    HEADERS = {"content-type": "application/json"}
+    HEADERS = {"accept": "application/json"}
 
     async def initialize_provider(self, ota_dir: str) -> None:
         if ota_dir is None:
@@ -234,7 +234,7 @@ class Ledvance(Basic):
     # documentation: https://portal.update.ledvance.com/docs/services/firmware-rest-api/
 
     UPDATE_URL = "https://api.update.ledvance.com/v1/zigbee/firmwares"
-    HEADERS = {"content-type": "application/json"}
+    HEADERS = {"accept": "application/json"}
 
     async def initialize_provider(self, ota_dir: str) -> None:
         if ota_dir is None:

--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -137,7 +137,7 @@ class Trådfri(Basic):
 
     UPDATE_URL = "https://fw.ota.homesmart.ikea.net/feed/version_info.json"
     MANUFACTURER_ID = 4476
-    HEADERS = {"accept": "application/json"}
+    HEADERS = {"accept": "application/json;q=0.9,*/*;q=0.8"}
 
     async def initialize_provider(self, ota_dir: str) -> None:
         if ota_dir is None:
@@ -155,6 +155,8 @@ class Trådfri(Basic):
         async with self._locks[LOCK_REFRESH]:
             async with aiohttp.ClientSession(headers=self.HEADERS) as req:
                 async with req.get(self.UPDATE_URL) as rsp:
+                    # IKEA does not always respond with an appropriate Content-Type
+                    # but the response is always JSON
                     fw_lst = await rsp.json(content_type=None)
         self.debug("Finished downloading firmware update list")
         self._cache.clear()
@@ -252,7 +254,7 @@ class Ledvance(Basic):
         async with self._locks[LOCK_REFRESH]:
             async with aiohttp.ClientSession(headers=self.HEADERS) as req:
                 async with req.get(self.UPDATE_URL) as rsp:
-                    fw_lst = await rsp.json(content_type=None)
+                    fw_lst = await rsp.json()
         self.debug("Finished downloading firmware update list")
         self._cache.clear()
         for fw in fw_lst["firmwares"]:


### PR DESCRIPTION
The `Content-Type` header introduced in #299 will be ignored by any compliant HTTP server when sent with a GET request. `Accept` is the appropriate header to use here, since we're expecting only JSON responses.

I've also documented the purpose of the `response.json(content_type=None)` line and removed that relaxation for the Ledvance provider, since their responses already have the appropriate `Content-Type`.