### PR TITLE
Refactor Zigbee enum and bitmap data types

### DIFF
--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -159,7 +159,9 @@ def test_status_undef():
     status, rest = foundation.Status.deserialize(data + extra)
     assert rest == extra
     assert status == 0xAA
-    assert not isinstance(status, foundation.Status)
+    assert status.value == 0xAA
+    assert status.name == "undefined_0xaa"
+    assert isinstance(status, foundation.Status)
 
 
 def test_frame_control():

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -154,7 +154,9 @@ def test_status_undef():
     status, rest = types.Status.deserialize(data + extra)
     assert rest == extra
     assert status == 0xAA
-    assert not isinstance(status, types.Status)
+    assert status.value == 0xAA
+    assert status.name == "undefined_0xaa"
+    assert isinstance(status, types.Status)
 
 
 def test_zdo_header():

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -371,14 +371,10 @@ class PersistingListener:
             dev = self._application.get_device(ieee)
             ep = dev.add_endpoint(epid)
             ep.profile_id = profile_id
-            try:
-                if profile_id == 260:
-                    device_type = zigpy.profiles.zha.DeviceType(device_type)
-                elif profile_id == 49246:
-                    device_type = zigpy.profiles.zll.DeviceType(device_type)
-            except ValueError:
-                pass
-            ep.device_type = device_type
+            if profile_id == 260:
+                ep.device_type = zigpy.profiles.zha.DeviceType(device_type)
+            elif profile_id == 49246:
+                ep.device_type = zigpy.profiles.zll.DeviceType(device_type)
             ep.status = zigpy.endpoint.Status(status)
 
     def _load_clusters(self):

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -66,13 +66,10 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         sd = sdr[2]
         self.profile_id = sd.profile
         self.device_type = sd.device_type
-        try:
-            if self.profile_id == 260:
-                self.device_type = zigpy.profiles.zha.DeviceType(self.device_type)
-            elif self.profile_id == 49246:
-                self.device_type = zigpy.profiles.zll.DeviceType(self.device_type)
-        except ValueError:
-            pass
+        if self.profile_id == 260:
+            self.device_type = zigpy.profiles.zha.DeviceType(self.device_type)
+        elif self.profile_id == 49246:
+            self.device_type = zigpy.profiles.zll.DeviceType(self.device_type)
 
         for cluster in sd.input_clusters:
             self.add_input_cluster(cluster)

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -1,6 +1,4 @@
 """OTA Firmware handling."""
-import enum
-
 import attr
 import zigpy.types as t
 
@@ -114,7 +112,7 @@ class OTAImageHeader(t.Struct):
         return data
 
 
-class ElementTagId(t.uint16_t, enum.Enum):
+class ElementTagId(t.enum16):
     UPGRADE_IMAGE = 0x0000
     ECDSA_SIGNATURE = 0x0001
     ECDSA_SIGNING_CERTIFICATE = 0x0002
@@ -135,11 +133,7 @@ class SubElement(bytes):
         if len(data) < 6:
             raise ValueError("Data is too short for {}".format(cls.__name__))
 
-        try:
-            tag_id, rest = ElementTagId.deserialize(data)
-        except ValueError:
-            tag_id, rest = t.uint16_t.deserialize(data)
-
+        tag_id, rest = ElementTagId.deserialize(data)
         length, rest = t.uint32_t.deserialize(rest)
         if length > len(rest):
             raise ValueError("Data is too short for {}".format(cls.__name__))

--- a/zigpy/profiles/zha.py
+++ b/zigpy/profiles/zha.py
@@ -1,9 +1,9 @@
-import enum
+import zigpy.types as t
 
 PROFILE_ID = 260
 
 
-class DeviceType(enum.IntEnum):
+class DeviceType(t.enum16):
     # Generic
     ON_OFF_SWITCH = 0x0000
     LEVEL_CONTROL_SWITCH = 0x0001

--- a/zigpy/profiles/zll.py
+++ b/zigpy/profiles/zll.py
@@ -1,9 +1,9 @@
-import enum
+import zigpy.types as t
 
 PROFILE_ID = 49246
 
 
-class DeviceType(enum.IntEnum):
+class DeviceType(t.enum16):
     ON_OFF_LIGHT = 0x0000
     ON_OFF_PLUGIN_UNIT = 0x0010
     DIMMABLE_LIGHT = 0x0100

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -4,7 +4,7 @@ from . import basic
 from .struct import Struct
 
 
-class BroadcastAddress(basic.uint16_t, enum.Enum):
+class BroadcastAddress(basic.enum16):
     ALL_DEVICES = 0xFFFF
     RESERVED_FFFE = 0xFFFE
     RX_ON_WHEN_IDLE = 0xFFFD

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -1,7 +1,4 @@
 """Security and Safety Functional Domain"""
-import collections
-import enum
-
 import zigpy.types as t
 from zigpy.zcl import Cluster
 
@@ -10,7 +7,7 @@ class IasZone(Cluster):
     class ZoneStatus(t.Struct):
         _fields = [("zone_id", t.uint8_t), ("zone_status", t.bitmap16)]
 
-    class ZoneType(t.enum16, enum.Enum):
+    class ZoneType(t.enum_factory(t.uint16_t, "manufacturer_specific")):
         """Zone type enum."""
 
         Standard_CIE = 0x0000
@@ -28,15 +25,6 @@ class IasZone(Cluster):
         Glass_Break_Sensor = 0x0226
         Security_Repeater = 0x0229
         Invalid_Zone_Type = 0xFFFF
-
-        @classmethod
-        def deserialize(cls, data):
-            try:
-                return super().deserialize(data)
-            except ValueError:
-                fake = collections.namedtuple(cls.__name__, "name, value")
-                val, data = t.uint16_t.deserialize(data)
-                return fake("manufacturer_specific_0x{:04x}".format(val), val), data
 
     cluster_id = 0x0500
     name = "IAS Zone"
@@ -68,7 +56,7 @@ class IasZone(Cluster):
 
 
 class IasAce(Cluster):
-    class ArmMode(t.enum8, enum.Enum):
+    class ArmMode(t.enum8):
         """IAS ACE arm mode enum."""
 
         Disarm = 0x00
@@ -76,7 +64,7 @@ class IasAce(Cluster):
         Arm_Night_Sleep_Only = 0x02
         Arm_All_Zones = 0x03
 
-    class ArmNotification(t.enum8, enum.Enum):
+    class ArmNotification(t.enum8):
         """IAS ACE arm notification enum."""
 
         All_Zones_Disarmed = 0x00
@@ -87,23 +75,13 @@ class IasAce(Cluster):
         Not_Ready_To_Arm = 0x05
         Already_Disarmed = 0x06
 
-    class AudibleNotification(t.enum8, enum.Enum):
+    class AudibleNotification(t.enum_factory(t.uint8_t, "manufacturer_specific")):
         """IAS ACE audible notification enum."""
 
         Mute = 0x00
         Default_Sound = 0x01
 
-        @classmethod
-        def deserialize(cls, data):
-            """Deserialize the audible notification enum."""
-            try:
-                return super().deserialize(data)
-            except ValueError:
-                fake = collections.namedtuple(cls.__name__, "name, value")
-                val, data = t.uint8_t.deserialize(data)
-                return fake("manufacturer_specific_0x{:02x}".format(val), val), data
-
-    class PanelStatus(t.enum8, enum.Enum):
+    class PanelStatus(t.enum8):
         """IAS ACE panel status enum."""
 
         Panel_Disarmed = 0x00
@@ -118,7 +96,7 @@ class IasAce(Cluster):
         Arming_Night = 0x09
         Arming_Away = 0x0A
 
-    class AlarmStatus(t.enum8, enum.Enum):
+    class AlarmStatus(t.enum8):
         """IAS ACE alarm status enum."""
 
         No_Alarm = 0x00

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1,10 +1,9 @@
-import enum
 from typing import Optional, Union
 
 import zigpy.types as t
 
 
-class Status(t.uint8_t, enum.Enum):
+class Status(t.enum8):
     SUCCESS = 0x00  # Operation was successful.
     FAILURE = 0x01  # Operation was not successful
     NOT_AUTHORIZED = 0x7E  # The sender of the command does not have
@@ -42,13 +41,6 @@ class Status(t.uint8_t, enum.Enum):
     SOFTWARE_FAILURE = 0xC1  # An operation was unsuccessful due to a
     CALIBRATION_ERROR = 0xC2  # An error occurred during calibration
     UNSUPPORTED_CLUSTER = 0xC3  # The cluster is not supported
-
-    @classmethod
-    def deserialize(cls, data):
-        try:
-            return super().deserialize(data)
-        except ValueError:
-            return t.uint8_t.deserialize(data)
 
 
 class Analog:
@@ -317,15 +309,10 @@ class DiscoverAttributesResponseRecord(t.Struct):
     _fields = [("attrid", t.uint16_t), ("datatype", t.uint8_t)]
 
 
-class AttributeAccessControl(t.uint8_t, enum.Enum):
-    NO_ACCESS = 0b000
-    REPORT = 0b001
-    WRITE = 0b010
-    WRITE_REPORT = 0b011
-    READ = 0b100
-    READ_REPORT = 0b101
-    READ_WRITE = 0b110
-    READ_WRITE_REPORT = 0b111
+class AttributeAccessControl(t.bitmap8):
+    READ = 0x01
+    WRITE = 0x02
+    REPORT = 0x04
 
 
 class DiscoverAttributesExtendedResponseRecord(t.Struct):
@@ -336,7 +323,7 @@ class DiscoverAttributesExtendedResponseRecord(t.Struct):
     ]
 
 
-class Command(t.uint8_t, enum.Enum):
+class Command(t.enum8):
     """ZCL Foundation Global Command IDs."""
 
     Read_Attributes = 0x00
@@ -362,13 +349,6 @@ class Command(t.uint8_t, enum.Enum):
     Discover_Commands_Generated_rsp = 0x14
     Discover_Attribute_Extended = 0x15
     Discover_Attribute_Extended_rsp = 0x16
-
-    @classmethod
-    def deserialize(cls, data):
-        try:
-            return super().deserialize(data)
-        except ValueError:
-            return t.uint8_t.deserialize(data)
 
 
 COMMANDS = {
@@ -411,7 +391,7 @@ COMMANDS = {
 }
 
 
-class FrameType(enum.IntEnum):
+class FrameType(t.enum8):
     """ZCL Frame Type."""
 
     GLOBAL_COMMAND = 0b00

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -545,11 +545,8 @@ class ZCLHeader:
     def command_id(self, value: Command) -> None:
         """Setter for command identifier."""
         if self.frame_control.is_general:
-            try:
-                self._cmd_id = Command(value)
-                return
-            except ValueError:
-                pass
+            self._cmd_id = Command(value)
+            return
         self._cmd_id = t.uint8_t(value)
 
     @property

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -531,10 +531,7 @@ class ZDOHeader:
     """Just a wrapper representing ZDO header, similar to ZCL header."""
 
     def __init__(self, command_id: t.uint16_t = 0x0000, tsn: t.uint8_t = 0) -> None:
-        try:
-            self._command_id = ZDOCmd(command_id)
-        except ValueError:
-            self._command_id = t.uint16_t(command_id)
+        self._command_id = ZDOCmd(command_id)
         self._tsn = t.uint8_t(tsn)
 
     @property
@@ -545,12 +542,7 @@ class ZDOHeader:
     @command_id.setter
     def command_id(self, value: t.uint16_t) -> None:
         """Command ID setter."""
-        try:
-            self._command_id = ZDOCmd(value)
-            return
-        except ValueError:
-            pass
-        self._command_id = t.uint16_t(value)
+        self._command_id = ZDOCmd(value)
 
     @property
     def is_reply(self) -> bool:

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -1,4 +1,3 @@
-import enum
 import typing
 
 import zigpy.types as t
@@ -34,7 +33,7 @@ class SizePrefixedSimpleDescriptor(SimpleDescriptor):
         return SimpleDescriptor.deserialize(data[1:])
 
 
-class LogicalType(t.uint8_t, enum.Enum):
+class LogicalType(t.enum8):
     Coordinator = 0b000
     Router = 0b001
     EndDevice = 0b010
@@ -231,7 +230,7 @@ class Routes(t.Struct):
     ]
 
 
-class Status(t.uint8_t, enum.Enum):
+class Status(t.enum8):
     # The requested operation or transmission was completed successfully.
     SUCCESS = 0x00
     # The supplied request type was invalid.
@@ -267,13 +266,6 @@ class Status(t.uint8_t, enum.Enum):
     # request is not authorized from this device.
     NOT_AUTHORIZED = 0x8D
 
-    @classmethod
-    def deserialize(cls, data):
-        try:
-            return super().deserialize(data)
-        except ValueError:
-            return t.uint8_t.deserialize(data)
-
 
 NWK = ("NWKAddr", t.NWK)
 NWKI = ("NWKAddrOfInterest", t.NWK)
@@ -285,7 +277,7 @@ class _CommandID(t.HexRepr, t.uint16_t):
     _hex_len = 4
 
 
-class ZDOCmd(_CommandID, enum.Enum):
+class ZDOCmd(t.enum_factory(_CommandID)):
     # Device and Service Discovery Server Requests
     NWK_addr_req = 0x0000
     IEEE_addr_req = 0x0001


### PR DESCRIPTION
Refactor enum base class to automatically create an "undefined" member in case the value is not defined for that enum.
Use EnumIntFlags for `bitmaps`