### PR TITLE
Refactor ZCL DataTypes

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1,4 +1,5 @@
-from asynctest import mock
+from unittest import mock
+
 import pytest
 import zigpy.endpoint
 import zigpy.types as t
@@ -364,12 +365,10 @@ def test_read_attributes_resp_str(cluster):
     assert cluster._endpoint.request.call_count == 0
 
 
-def test_read_attributes_resp_exc(cluster, monkeypatch):
-    type_idx = mock.MagicMock()
-    type_idx.__getitem__.side_effect = ValueError()
-    monkeypatch.setattr(foundation, "DATA_TYPE_IDX", type_idx)
-
-    cluster.read_attributes_rsp({"hw_version": 32})
+def test_read_attributes_resp_exc(cluster):
+    with mock.patch.object(foundation.DATA_TYPES, "pytype_to_datatype_id") as mck:
+        mck.side_effect = ValueError
+        cluster.read_attributes_rsp({"hw_version": 32})
     assert cluster._endpoint.reply.call_count == 1
     assert cluster._endpoint.request.call_count == 0
     assert cluster.endpoint.reply.call_args[0][2][-3:] == b"\x03\x00\x86"

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -304,9 +304,9 @@ def test_frame_header_cluster():
 
 def test_data_types():
     """Test data types mappings."""
-    assert len(foundation.DATA_TYPES) == len(foundation.DATA_TYPE_IDX)
+    assert len(foundation.DATA_TYPES) == len(foundation.DATA_TYPES._idx_by_class)
     data_types_set = set([d[1] for d in foundation.DATA_TYPES.values()])
-    dt_2_id_set = set(foundation.DATA_TYPE_IDX.keys())
+    dt_2_id_set = set(foundation.DATA_TYPES._idx_by_class.keys())
     assert data_types_set == dt_2_id_set
 
 
@@ -319,3 +319,56 @@ def test_attribute_report():
     assert a.attrid == b.attrid
     assert a.direction == b.direction
     assert a.timeout == b.timeout
+
+
+def test_pytype_to_datatype_derived_enums():
+    """Test pytype_to_datatype_id lookup for derived enums."""
+
+    class e_1(t.enum8):
+        pass
+
+    class e_2(t.enum8):
+        pass
+
+    class e_3(t.enum16):
+        pass
+
+    enum8_id = foundation.DATA_TYPES.pytype_to_datatype_id(t.enum8)
+    enum16_id = foundation.DATA_TYPES.pytype_to_datatype_id(t.enum16)
+
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(e_1) == enum8_id
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(e_2) == enum8_id
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(e_3) == enum16_id
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(e_2) == enum8_id
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(e_3) == enum16_id
+
+
+def test_pytype_to_datatype_derived_bitmaps():
+    """Test pytype_to_datatype_id lookup for derived enums."""
+
+    class b_1(t.bitmap8):
+        pass
+
+    class b_2(t.bitmap8):
+        pass
+
+    class b_3(t.bitmap16):
+        pass
+
+    bitmap8_id = foundation.DATA_TYPES.pytype_to_datatype_id(t.bitmap8)
+    bitmap16_id = foundation.DATA_TYPES.pytype_to_datatype_id(t.bitmap16)
+
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(b_1) == bitmap8_id
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(b_2) == bitmap8_id
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(b_3) == bitmap16_id
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(b_2) == bitmap8_id
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(b_3) == bitmap16_id
+
+
+def test_ptype_to_datatype_notype():
+    """Test ptype for NoData."""
+
+    class ZigpyUnknown:
+        pass
+
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(ZigpyUnknown) == 0xFF

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -185,13 +185,13 @@ def test_zdo_header_cmd_id():
     unk_cmd = 0x00FF
     assert unk_cmd not in list(types.ZDOCmd)
     hdr = types.ZDOHeader(unk_cmd, 0x55)
-    assert isinstance(hdr.command_id, t.uint16_t)
+    assert isinstance(hdr.command_id, types.ZDOCmd)
     assert hdr.command_id == unk_cmd
 
     unk_cmd += 1
     assert unk_cmd not in list(types.ZDOCmd)
     hdr.command_id = unk_cmd
-    assert isinstance(hdr.command_id, t.uint16_t)
+    assert isinstance(hdr.command_id, types.ZDOCmd)
     assert hdr.command_id == unk_cmd
 
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -103,7 +103,17 @@ class _UndefEnum(enum.Enum, metaclass=_UndefEnumMeta):
 def enum_factory(int_type: CALLABLE_T, undefined: str = "undefined",) -> CALLABLE_T:
     """Enum factory."""
 
-    class _NewEnum(int_type, _UndefEnum):
+    class _NewEnum(enum.IntEnum, _UndefEnum):
+        def serialize(self):
+            """Serialize enum."""
+            return int_type(self.value).serialize()
+
+        @classmethod
+        def deserialize(cls, data: bytes) -> (bytes, bytes):
+            """Deserialize data."""
+            val, data = int_type.deserialize(data)
+            return cls(val), data
+
         @classmethod
         def undefined(cls, val):
             name = f"{undefined}_0x{{:0{int_type._size * 2}x}}"  # pylint: disable=protected-access

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -274,7 +274,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
             try:
                 a.status = foundation.Status.SUCCESS
                 python_type = self.attributes[attrid][1]
-                a.value.type = t.uint8_t(foundation.DATA_TYPE_IDX[python_type])
+                a.value.type = foundation.DATA_TYPES.pytype_to_datatype_id(python_type)
                 a.value.value = python_type(value)
             except ValueError as e:
                 a.status = foundation.Status.UNSUPPORTED_ATTRIBUTE
@@ -295,7 +295,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
 
             try:
                 python_type = self.attributes[attrid][1]
-                a.value.type = t.uint8_t(foundation.DATA_TYPE_IDX[python_type])
+                a.value.type = foundation.DATA_TYPES.pytype_to_datatype_id(python_type)
                 a.value.value = python_type(value)
                 args.append(a)
             except ValueError as e:
@@ -328,8 +328,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
         cfg = foundation.AttributeReportingConfig()
         cfg.direction = 0
         cfg.attrid = attrid
-        cfg.datatype = foundation.DATA_TYPE_IDX.get(
-            self.attributes.get(attrid, (None, None))[1], None
+        cfg.datatype = foundation.DATA_TYPES.pytype_to_datatype_id(
+            self.attributes.get(attrid, (None, foundation.Unknown))[1]
         )
         cfg.min_interval = min_interval
         cfg.max_interval = max_interval

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -55,6 +55,10 @@ class Null:
     pass
 
 
+class Unknown(t.NoData):
+    pass
+
+
 class TypeValue:
     def __init__(self, python_type=None, value=None):
         self.type = python_type
@@ -102,66 +106,97 @@ class Set(TypedCollection):
     pass  # ToDo: Make this a real set?
 
 
-DATA_TYPES = {
-    0x00: ("No data", t.NoData, Null),
-    0x08: ("General", t.data8, Discrete),
-    0x09: ("General", t.data16, Discrete),
-    0x0A: ("General", t.data24, Discrete),
-    0x0B: ("General", t.data32, Discrete),
-    0x0C: ("General", t.data40, Discrete),
-    0x0D: ("General", t.data48, Discrete),
-    0x0E: ("General", t.data56, Discrete),
-    0x0F: ("General", t.data64, Discrete),
-    0x10: ("Boolean", t.Bool, Discrete),
-    0x18: ("Bitmap", t.bitmap8, Discrete),
-    0x19: ("Bitmap", t.bitmap16, Discrete),
-    0x1A: ("Bitmap", t.bitmap24, Discrete),
-    0x1B: ("Bitmap", t.bitmap32, Discrete),
-    0x1C: ("Bitmap", t.bitmap40, Discrete),
-    0x1D: ("Bitmap", t.bitmap48, Discrete),
-    0x1E: ("Bitmap", t.bitmap56, Discrete),
-    0x1F: ("Bitmap", t.bitmap64, Discrete),
-    0x20: ("Unsigned Integer", t.uint8_t, Analog),
-    0x21: ("Unsigned Integer", t.uint16_t, Analog),
-    0x22: ("Unsigned Integer", t.uint24_t, Analog),
-    0x23: ("Unsigned Integer", t.uint32_t, Analog),
-    0x24: ("Unsigned Integer", t.uint40_t, Analog),
-    0x25: ("Unsigned Integer", t.uint48_t, Analog),
-    0x26: ("Unsigned Integer", t.uint56_t, Analog),
-    0x27: ("Unsigned Integer", t.uint64_t, Analog),
-    0x28: ("Signed Integer", t.int8s, Analog),
-    0x29: ("Signed Integer", t.int16s, Analog),
-    0x2A: ("Signed Integer", t.int24s, Analog),
-    0x2B: ("Signed Integer", t.int32s, Analog),
-    0x2C: ("Signed Integer", t.int40s, Analog),
-    0x2D: ("Signed Integer", t.int48s, Analog),
-    0x2E: ("Signed Integer", t.int56s, Analog),
-    0x2F: ("Signed Integer", t.int64s, Analog),
-    0x30: ("Enumeration", t.enum8, Discrete),
-    0x31: ("Enumeration", t.enum16, Discrete),
-    # 0x38: ('Floating point', t.Half, Analog),
-    0x39: ("Floating point", t.Single, Analog),
-    0x3A: ("Floating point", t.Double, Analog),
-    0x41: ("Octet string", t.LVBytes, Discrete),
-    0x42: ("Character string", t.CharacterString, Discrete),
-    0x43: ("Long octet string", t.LongOctetString, Discrete),
-    0x44: ("Long character string", t.LongCharacterString, Discrete),
-    0x48: ("Array", Array, Discrete),
-    0x4C: ("Structure", t.LVList(TypeValue, 2), Discrete),
-    0x50: ("Set", Set, Discrete),
-    0x51: ("Bag", Bag, Discrete),
-    0xE0: ("Time of day", t.TimeOfDay, Analog),
-    0xE1: ("Date", t.Date, Analog),
-    0xE2: ("UTCTime", t.UTCTime, Analog),
-    0xE8: ("Cluster ID", t.ClusterId, Discrete),
-    0xE9: ("Attribute ID", t.AttributeId, Discrete),
-    0xEA: ("BACNet OID", t.BACNetOid, Discrete),
-    0xF0: ("IEEE address", t.EUI64, Discrete),
-    0xF1: ("128-bit security key", t.KeyData, Discrete),
-    0xFF: ("Unknown", None, None),
-}
+class DataTypes(dict):
+    """DataTypes container."""
 
-DATA_TYPE_IDX = {t: tidx for tidx, (tname, t, ad) in DATA_TYPES.items()}
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._idx_by_class = {
+            _type: type_id for type_id, (name, _type, ad) in self.items()
+        }
+        self._idx_by_cls_name = {
+            cls.__name__: type_id for cls, type_id in self._idx_by_class.items()
+        }
+
+    def pytype_to_datatype_id(self, python_type) -> int:
+        """Return Zigbee Datatype ID for a give python type."""
+        data_type_id = self._idx_by_class.get(python_type)
+        if data_type_id is not None:
+            return data_type_id
+
+        # lookup by class name
+        try:
+            return self._idx_by_cls_name[python_type.__name__]
+        except KeyError:
+            pass
+
+        for cls, type_id in self._idx_by_class.items():
+            if issubclass(python_type, cls):
+                self._idx_by_cls_name[python_type.__name__] = type_id
+                return type_id
+        return 0xFF
+
+
+DATA_TYPES = DataTypes(
+    {
+        0x00: ("No data", t.NoData, Null),
+        0x08: ("General", t.data8, Discrete),
+        0x09: ("General", t.data16, Discrete),
+        0x0A: ("General", t.data24, Discrete),
+        0x0B: ("General", t.data32, Discrete),
+        0x0C: ("General", t.data40, Discrete),
+        0x0D: ("General", t.data48, Discrete),
+        0x0E: ("General", t.data56, Discrete),
+        0x0F: ("General", t.data64, Discrete),
+        0x10: ("Boolean", t.Bool, Discrete),
+        0x18: ("Bitmap", t.bitmap8, Discrete),
+        0x19: ("Bitmap", t.bitmap16, Discrete),
+        0x1A: ("Bitmap", t.bitmap24, Discrete),
+        0x1B: ("Bitmap", t.bitmap32, Discrete),
+        0x1C: ("Bitmap", t.bitmap40, Discrete),
+        0x1D: ("Bitmap", t.bitmap48, Discrete),
+        0x1E: ("Bitmap", t.bitmap56, Discrete),
+        0x1F: ("Bitmap", t.bitmap64, Discrete),
+        0x20: ("Unsigned Integer", t.uint8_t, Analog),
+        0x21: ("Unsigned Integer", t.uint16_t, Analog),
+        0x22: ("Unsigned Integer", t.uint24_t, Analog),
+        0x23: ("Unsigned Integer", t.uint32_t, Analog),
+        0x24: ("Unsigned Integer", t.uint40_t, Analog),
+        0x25: ("Unsigned Integer", t.uint48_t, Analog),
+        0x26: ("Unsigned Integer", t.uint56_t, Analog),
+        0x27: ("Unsigned Integer", t.uint64_t, Analog),
+        0x28: ("Signed Integer", t.int8s, Analog),
+        0x29: ("Signed Integer", t.int16s, Analog),
+        0x2A: ("Signed Integer", t.int24s, Analog),
+        0x2B: ("Signed Integer", t.int32s, Analog),
+        0x2C: ("Signed Integer", t.int40s, Analog),
+        0x2D: ("Signed Integer", t.int48s, Analog),
+        0x2E: ("Signed Integer", t.int56s, Analog),
+        0x2F: ("Signed Integer", t.int64s, Analog),
+        0x30: ("Enumeration", t.enum8, Discrete),
+        0x31: ("Enumeration", t.enum16, Discrete),
+        # 0x38: ('Floating point', t.Half, Analog),
+        0x39: ("Floating point", t.Single, Analog),
+        0x3A: ("Floating point", t.Double, Analog),
+        0x41: ("Octet string", t.LVBytes, Discrete),
+        0x42: ("Character string", t.CharacterString, Discrete),
+        0x43: ("Long octet string", t.LongOctetString, Discrete),
+        0x44: ("Long character string", t.LongCharacterString, Discrete),
+        0x48: ("Array", Array, Discrete),
+        0x4C: ("Structure", t.LVList(TypeValue, 2), Discrete),
+        0x50: ("Set", Set, Discrete),
+        0x51: ("Bag", Bag, Discrete),
+        0xE0: ("Time of day", t.TimeOfDay, Analog),
+        0xE1: ("Date", t.Date, Analog),
+        0xE2: ("UTCTime", t.UTCTime, Analog),
+        0xE8: ("Cluster ID", t.ClusterId, Discrete),
+        0xE9: ("Attribute ID", t.AttributeId, Discrete),
+        0xEA: ("BACNet OID", t.BACNetOid, Discrete),
+        0xF0: ("IEEE address", t.EUI64, Discrete),
+        0xF1: ("128-bit security key", t.KeyData, Discrete),
+        0xFF: ("Unknown", Unknown, None),
+    }
+)
 
 
 class ReadAttributeRecord(t.Struct):


### PR DESCRIPTION
Make DataType registry a class with a Python  Type to DataType ID lookup method.
Use new DataType for `TypeValue`  class.