### PR TITLE
Normalize attribute reports and  Attribute Reads

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -209,19 +209,26 @@ def _get_model_info(ep, test_manuf=None, test_model=None, fail=False, timeout=Fa
                 raise zigpy.exceptions.ZigbeeException
         nonlocal test_manuf, test_model
 
-        if test_manuf is not None:
-            test_manuf = t.uint8_t(len(test_manuf)).serialize() + test_manuf
-            rar4 = _mk_rar(4, t.CharacterString.deserialize(test_manuf)[0])
-        else:
-            rar4 = _mk_rar(4, None)
+        result = []
+        if 4 in args:
+            if test_manuf is not None:
+                test_manuf = t.uint8_t(len(test_manuf)).serialize() + test_manuf
+                rar4 = _mk_rar(4, t.CharacterString.deserialize(test_manuf)[0])
+                result.append(rar4)
+            else:
+                rar4 = _mk_rar(4, None, status=1)
+                result.append(rar4)
 
-        if test_model is not None:
-            test_model = t.uint8_t(len(test_model)).serialize() + test_model
-            rar5 = _mk_rar(5, t.CharacterString.deserialize(test_model)[0])
-        else:
-            rar5 = _mk_rar(5, None)
+        if 5 in args:
+            if test_model is not None:
+                test_model = t.uint8_t(len(test_model)).serialize() + test_model
+                rar5 = _mk_rar(5, t.CharacterString.deserialize(test_model)[0])
+                result.append(rar5)
+            else:
+                rar5 = _mk_rar(5, None, status=1)
+                result.append(rar5)
 
-        return [[rar4, rar5]]
+        return [result]
 
     clus.request = mockrequest
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -198,11 +198,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
             for attr in args[0]:
                 try:
                     value = self.attributes[attr.attrid][1](attr.value.value)
-                except (KeyError, ValueError):
-                    self.exception(
+                except KeyError:
+                    value = attr.value.value
+                except ValueError:
+                    self.debug(
                         "Couldn't normalize %a attribute with %s value",
                         attr.attrid,
                         attr.value.value,
+                        exc_info=True,
                     )
                     value = attr.value.value
                 self._update_attribute(attr.attrid, value)
@@ -258,13 +261,16 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
                 if record.status == foundation.Status.SUCCESS:
                     try:
                         value = self.attributes[record.attrid][1](record.value.value)
-                    except (KeyError, ValueError):
-                        self.exception(
+                    except KeyError:
+                        value = record.value.value
+                    except ValueError:
+                        value = record.value.value
+                        self.debug(
                             "Couldn't normalize %a attribute with %s value",
                             record.attrid,
-                            record.value.value,
+                            value,
+                            exc_info=True,
                         )
-                        value = record.value.value
                     self._update_attribute(record.attrid, value)
                     success[orig_attribute] = value
                 else:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -196,7 +196,16 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
             )
             self.debug("Attribute report received: %s", valuestr)
             for attr in args[0]:
-                self._update_attribute(attr.attrid, attr.value.value)
+                try:
+                    value = self.attributes[attr.attrid][1](attr.value.value)
+                except (KeyError, ValueError):
+                    self.exception(
+                        "Couldn't normalize %a attribute with %s value",
+                        attr.attrid,
+                        attr.value.value,
+                    )
+                    value = attr.value.value
+                self._update_attribute(attr.attrid, value)
 
     def read_attributes_raw(self, attributes, manufacturer=None):
         attributes = [t.uint16_t(a) for a in attributes]


### PR DESCRIPTION
When receiving an attribute report or ReadAttribute command response, restore enum value name.