### PR TITLE
Add Channels.from_channel_list to create masks from numeric lists

### DIFF
--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -39,6 +39,23 @@ def test_multi_address_invalid():
         types.MultiAddress.deserialize(b"\xffnot read")
 
 
+def test_channels():
+    """Test Channels bitmap."""
+
+    assert t.Channels.from_channel_list([]) == t.Channels.NO_CHANNELS
+    assert t.Channels.from_channel_list(range(11, 26 + 1)) == t.Channels.ALL_CHANNELS
+    assert (
+        t.Channels.from_channel_list([11, 21])
+        == t.Channels.CHANNEL_11 | t.Channels.CHANNEL_21
+    )
+
+    with pytest.raises(ValueError):
+        t.Channels.from_channel_list([11, 13, 10])  # 10 is not a valid channel
+
+    with pytest.raises(ValueError):
+        t.Channels.from_channel_list([27, 13, 15, 18])  # 27 is not a valid channel
+
+
 def test_node_descriptor():
     data = b"\x00\x01\x02\x03\x03\x04\x05\x05\x06\x06\x07\x07\x08\xff"
     nd, rest = types.NodeDescriptor.deserialize(data)

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -1,4 +1,5 @@
 import enum
+import typing
 
 from . import basic
 from .struct import Struct
@@ -78,6 +79,20 @@ class Channels(basic.bitmap32):
     CHANNEL_24 = 0x01000000
     CHANNEL_25 = 0x02000000
     CHANNEL_26 = 0x04000000
+
+    @classmethod
+    def from_channel_list(cls, channels: typing.Iterable[int]) -> "Channels":
+        mask = cls.NO_CHANNELS
+
+        for channel in channels:
+            if not 11 <= channel <= 26:
+                raise ValueError(
+                    f"Invalid channel number {channel}. Must be between 11 and 26."
+                )
+
+            mask |= cls[f"CHANNEL_{channel}"]
+
+        return mask
 
 
 class ClusterId(basic.uint16_t):


### PR DESCRIPTION
I'm backporting a few changes from https://github.com/puddly/zigpy-znp.

The rationale for this addition is to potentially replace the single numeric `channel` in `ControllerApplication.form_network` and the channel list in `ControllerApplication.update_network` with a `Channel` bitmask:

https://github.com/zigpy/zigpy/blob/8236bc1a037b4a296cf565de2341471cd5fcecd5/zigpy/application.py#L62

https://github.com/zigpy/zigpy/blob/8236bc1a037b4a296cf565de2341471cd5fcecd5/zigpy/application.py#L74-L82

Thoughts?