### PR TITLE
Relax attributes table schema.

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -11,7 +11,7 @@ from zigpy.zdo import types as zdo_t
 
 LOGGER = logging.getLogger(__name__)
 
-DB_VERSION = 0x0002
+DB_VERSION = 0x0003
 
 
 def _sqlite_adapters():
@@ -173,8 +173,8 @@ class PersistingListener:
             "attributes",
             (
                 "(ieee ieee, endpoint_id, cluster, attrid, value, "
-                "FOREIGN KEY(ieee, endpoint_id) "
-                "REFERENCES endpoints(ieee, endpoint_id) "
+                "FOREIGN KEY(ieee) "
+                "REFERENCES devices(ieee) "
                 "ON DELETE CASCADE)"
             ),
         )


### PR DESCRIPTION
Quirks often update attributes on unexisting clusters and endpoints.