### PR TITLE
Add "write_attributes_undivided()" command

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -680,3 +680,10 @@ def test_handle_cluster_general_request(cluster):
     cluster.handle_cluster_general_request(
         mock.sentinel.tsn, mock.sentinel.command_id, mock.sentinel.args
     )
+
+
+async def test_write_attributes_undivided(cluster):
+    with mock.patch.object(cluster, "request", new=CoroutineMock()):
+        i = cluster.write_attributes_undivided({0: 5, "app_version": 4})
+        await i
+        assert cluster.request.call_count == 1

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -348,6 +348,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
 
         return result
 
+    def write_attributes_undivided(
+        self, attributes: Dict[Union[str, int], Any], manufacturer: Optional[int] = None
+    ) -> List:
+        """Either all or none of the attributes are written by the device."""
+        args = self._write_attr_records(attributes)
+        return self._write_attributes_undivided(args, manufacturer=manufacturer)
+
     def bind(self):
         return self._endpoint.device.zdo.bind(cluster=self)
 
@@ -495,6 +502,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
     )
     _write_attributes = functools.partialmethod(
         general_command, foundation.Command.Write_Attributes
+    )
+    _write_attributes_undivided = functools.partialmethod(
+        general_command, foundation.Command.Write_Attributes_Undivided
     )
     discover_attributes = functools.partialmethod(
         general_command, foundation.Command.Discover_Attributes


### PR DESCRIPTION
Implement `write_attributes_undivided()` ZCL command.

The Write Attributes Undivided command is generated when a device wishes to change the values of one or more attributes located on another device, in such a way that if any attribute cannot be written (e.g., if an attribute is not implemented on the device, or a value to be written is outside its valid range), no attribute values are changed.
In all other respects, including generation of a Write Attributes Response command, the format and operation of the command is the same as that of the Write Attributes command