### PR TITLE
Refactor enums.

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -344,6 +344,20 @@ def test_enum_undef():
     assert r.serialize() == data
     assert isinstance(r, TestEnum)
 
+    r = TestEnum("85")
+    assert r == 0x55
+    assert r.value == 0x55
+    assert r.name == "undefined_0x55"
+    assert r.serialize() == data
+    assert isinstance(r, TestEnum)
+
+    r = TestEnum("0x55")
+    assert r == 0x55
+    assert r.value == 0x55
+    assert r.name == "undefined_0x55"
+    assert r.serialize() == data
+    assert isinstance(r, TestEnum)
+
 
 def test_enum():
     class TestEnum(t.enum8):
@@ -355,6 +369,20 @@ def test_enum():
 
     r, rest = TestEnum.deserialize(data + extra)
     assert rest == extra
+    assert r == 0x55
+    assert r.value == 0x55
+    assert r.name == "ALL"
+    assert isinstance(r, TestEnum)
+    assert TestEnum.ALL + TestEnum.ERR == 0x56
+
+    r = TestEnum("85")
+    assert r == 0x55
+    assert r.value == 0x55
+    assert r.name == "ALL"
+    assert isinstance(r, TestEnum)
+    assert TestEnum.ALL + TestEnum.ERR == 0x56
+
+    r = TestEnum("0x55")
     assert r == 0x55
     assert r.value == 0x55
     assert r.name == "ALL"

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -88,22 +88,19 @@ class uint64_t(uint_t):  # noqa: N801
     _size = 8
 
 
-class _UndefEnumMeta(enum.EnumMeta):
+class _IntEnumMeta(enum.EnumMeta):
     def __call__(cls, value, names=None, *args, **kwargs):
-        try:
-            return super().__call__(value, names, *args, **kwargs)
-        except ValueError:
-            return cls.undefined(value)
-
-
-class _UndefEnum(enum.Enum, metaclass=_UndefEnumMeta):
-    pass
+        if isinstance(value, str) and value.startswith("0x"):
+            value = int(value, base=16)
+        else:
+            value = int(value)
+        return super().__call__(value, names, *args, **kwargs)
 
 
 def enum_factory(int_type: CALLABLE_T, undefined: str = "undefined",) -> CALLABLE_T:
     """Enum factory."""
 
-    class _NewEnum(enum.IntEnum, _UndefEnum):
+    class _NewEnum(enum.IntEnum, metaclass=_IntEnumMeta):
         def serialize(self):
             """Serialize enum."""
             return int_type(self.value).serialize()
@@ -115,10 +112,12 @@ def enum_factory(int_type: CALLABLE_T, undefined: str = "undefined",) -> CALLABL
             return cls(val), data
 
         @classmethod
-        def undefined(cls, val):
+        def _missing_(cls, value):
+            new = int_type.__new__(cls, value)
             name = f"{undefined}_0x{{:0{int_type._size * 2}x}}"  # pylint: disable=protected-access
-            fake = _UndefEnum(cls.__name__, {name.format(val): val}, type=cls,)
-            return fake(val)
+            new._name_ = name.format(value)
+            new._value_ = value
+            return new
 
     return _NewEnum
 


### PR DESCRIPTION
Allow instantiation using string values, eg `t.enum8("42")` or `t.enum8("0x28")` to maintain backward compatibility from the times when `enum`s where just `int`s.