### PR TITLE
Pass Zigpy configuration using voluptuous schema.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,5 @@
 [run]
 source = zigpy
+
+omit =
+    zigpy/typing.py

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -2,8 +2,10 @@ import os
 from unittest import mock
 
 import pytest
+import voluptuous as vol
 from zigpy import profiles
-from zigpy.application import ControllerApplication
+import zigpy.application
+from zigpy.config import CONF_DATABASE
 from zigpy.device import Device, Status
 import zigpy.ota
 from zigpy.quirks import CustomDevice
@@ -14,8 +16,11 @@ from zigpy.zdo import types as zdo_t
 
 
 def make_app(database_file):
-    with mock.patch("zigpy.ota.OTA", mock.MagicMock(spec_set=zigpy.ota.OTA)):
-        app = ControllerApplication(database_file)
+    p1 = mock.patch("zigpy.ota.OTA", mock.MagicMock(spec_set=zigpy.ota.OTA))
+    schema = vol.Schema({vol.Optional(CONF_DATABASE, default=database_file): str})
+    p2 = mock.patch.object(zigpy.application, "CONFIG_SCHEMA", new=schema)
+    with p1, p2:
+        app = zigpy.application.ControllerApplication()
     return app
 
 

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -2,7 +2,6 @@ import os
 from unittest import mock
 
 import pytest
-import voluptuous as vol
 from zigpy import profiles
 import zigpy.application
 from zigpy.config import CONF_DATABASE
@@ -16,11 +15,8 @@ from zigpy.zdo import types as zdo_t
 
 
 def make_app(database_file):
-    p1 = mock.patch("zigpy.ota.OTA", mock.MagicMock(spec_set=zigpy.ota.OTA))
-    schema = vol.Schema({vol.Optional(CONF_DATABASE, default=database_file): str})
-    p2 = mock.patch.object(zigpy.application, "CONFIG_SCHEMA", new=schema)
-    with p1, p2:
-        app = zigpy.application.ControllerApplication()
+    with mock.patch("zigpy.ota.OTA", mock.MagicMock(spec_set=zigpy.ota.OTA)):
+        app = zigpy.application.ControllerApplication({CONF_DATABASE: database_file})
     return app
 
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -3,8 +3,10 @@ from unittest import mock
 
 import asynctest
 import pytest
+import voluptuous as vol
 from zigpy import device
-from zigpy.application import ControllerApplication
+import zigpy.application
+from zigpy.config import CONF_DATABASE
 from zigpy.exceptions import DeliveryError
 import zigpy.ota
 import zigpy.types as t
@@ -14,7 +16,10 @@ import zigpy.types as t
 @asynctest.patch("zigpy.ota.OTA", asynctest.MagicMock(spec_set=zigpy.ota.OTA))
 @asynctest.patch("zigpy.device.Device._initialize", asynctest.CoroutineMock())
 def app():
-    return ControllerApplication()
+    schema = vol.Schema({vol.Optional(CONF_DATABASE, default=None): None})
+    with mock.patch.object(zigpy.application, "CONFIG_SCHEMA", new=schema):
+        app = zigpy.application.ControllerApplication()
+    return app
 
 
 @pytest.fixture

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import asynctest
 import pytest
-import voluptuous as vol
 from zigpy import device
 import zigpy.application
 from zigpy.config import CONF_DATABASE
@@ -16,10 +15,7 @@ import zigpy.types as t
 @asynctest.patch("zigpy.ota.OTA", asynctest.MagicMock(spec_set=zigpy.ota.OTA))
 @asynctest.patch("zigpy.device.Device._initialize", asynctest.CoroutineMock())
 def app():
-    schema = vol.Schema({vol.Optional(CONF_DATABASE, default=None): None})
-    with mock.patch.object(zigpy.application, "CONFIG_SCHEMA", new=schema):
-        app = zigpy.application.ControllerApplication()
-    return app
+    return zigpy.application.ControllerApplication({CONF_DATABASE: None})
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,10 @@ def test_config_validation_bool(value, result):
     """Test boolean config validation."""
     assert zigpy.config.cv_boolean(value) is result
 
+    schema = vol.Schema({vol.Required("value"): zigpy.config.cv_boolean})
+    validated = schema({"value": value})
+    assert validated["value"] is result
+
 
 @pytest.mark.parametrize("value", ["invalid", "not a bool", "something"])
 def test_config_validation_bool_invalid(value):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,38 @@
+"""Test configuration."""
+
+import pytest
+import voluptuous as vol
+import zigpy.config
+
+
+@pytest.mark.parametrize(
+    "value, result",
+    [
+        (False, False),
+        (True, True),
+        ("1", True),
+        ("yes", True),
+        ("YeS", True),
+        ("on", True),
+        ("oN", True),
+        ("enable", True),
+        ("enablE", True),
+        (0, False),
+        ("no", False),
+        ("nO", False),
+        ("off", False),
+        ("ofF", False),
+        ("disable", False),
+        ("disablE", False),
+    ],
+)
+def test_config_validation_bool(value, result):
+    """Test boolean config validation."""
+    assert zigpy.config.cv_boolean(value) is result
+
+
+@pytest.mark.parametrize("value", ["invalid", "not a bool", "something"])
+def test_config_validation_bool_invalid(value):
+    """Test boolean config validation."""
+    with pytest.raises(vol.Invalid):
+        zigpy.config.cv_boolean(value)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional
 
 import voluptuous as vol
 import zigpy.appdb
+import zigpy.config
 import zigpy.device
 import zigpy.group
 import zigpy.ota
@@ -15,18 +16,20 @@ import zigpy.zcl
 import zigpy.zdo
 import zigpy.zdo.types as zdo_types
 
-CONFIG_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = vol.Schema(zigpy.config.SCHEMA, extra=vol.ALLOW_EXTRA)
 DEFAULT_ENDPOINT_ID = 1
 LOGGER = logging.getLogger(__name__)
 OTA_DIR = "zigpy_ota/"
 
 
 class ControllerApplication(zigpy.util.ListenableMixin):
-    def __init__(self, database_file=None, config={}):
+    def __init__(self, config: Optional[vol.Schema] = None):
         self._send_sequence = 0
         self.devices: Dict[t.EUI64, zigpy.device.Device] = {}
         self._groups = zigpy.group.Groups(self)
         self._listeners = {}
+        if config is None:
+            config = {}
         self._config = CONFIG_SCHEMA(config)
         self._channel = None
         self._channels = None
@@ -36,6 +39,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         self._nwk_update_id = None
         self._pan_id = None
 
+        database_file = self._config[zigpy.config.CONF_DATABASE]
         self._ota = zigpy.ota.OTA(self)
         if database_file is None:
             ota_dir = None

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -3,7 +3,6 @@ import logging
 import os.path
 from typing import Dict, Optional
 
-import voluptuous as vol
 import zigpy.appdb
 import zigpy.config
 import zigpy.device
@@ -16,21 +15,18 @@ import zigpy.zcl
 import zigpy.zdo
 import zigpy.zdo.types as zdo_types
 
-CONFIG_SCHEMA = vol.Schema(zigpy.config.SCHEMA, extra=vol.ALLOW_EXTRA)
 DEFAULT_ENDPOINT_ID = 1
 LOGGER = logging.getLogger(__name__)
 OTA_DIR = "zigpy_ota/"
 
 
 class ControllerApplication(zigpy.util.ListenableMixin):
-    def __init__(self, config: Optional[vol.Schema] = None):
+    def __init__(self, config: Dict):
         self._send_sequence = 0
         self.devices: Dict[t.EUI64, zigpy.device.Device] = {}
         self._groups = zigpy.group.Groups(self)
         self._listeners = {}
-        if config is None:
-            config = {}
-        self._config = CONFIG_SCHEMA(config)
+        self._config = config
         self._channel = None
         self._channels = None
         self._ext_pan_id = None
@@ -39,7 +35,7 @@ class ControllerApplication(zigpy.util.ListenableMixin):
         self._nwk_update_id = None
         self._pan_id = None
 
-        database_file = self._config[zigpy.config.CONF_DATABASE]
+        database_file = config[zigpy.config.CONF_DATABASE]
         self._ota = zigpy.ota.OTA(self)
         if database_file is None:
             ota_dir = None

--- a/zigpy/config.py
+++ b/zigpy/config.py
@@ -27,7 +27,9 @@ def cv_boolean(value: Union[bool, int, str]) -> bool:
     raise vol.Invalid("invalid boolean value {}".format(value))
 
 
-SCHEMA_DEVICE = vol.Schema({vol.Required(CONF_DEVICE_PATH): vol.PathExists()})
+SCHEMA_DEVICE = vol.Schema(
+    {vol.Required(CONF_DEVICE_PATH, default=None): vol.Any(None, vol.PathExists())}
+)
 SCHEMA_OTA = {
     vol.Optional(CONF_OTA_IKEA, default=False): cv_boolean,
     vol.Optional(CONF_OTA_LEDVANCE, default=False): cv_boolean,

--- a/zigpy/config.py
+++ b/zigpy/config.py
@@ -27,19 +27,21 @@ def cv_boolean(value: Union[bool, int, str]) -> bool:
     raise vol.Invalid("invalid boolean value {}".format(value))
 
 
-SCHEMA_DEVICE = vol.Schema(
-    {vol.Required(CONF_DEVICE_PATH, default=None): vol.Any(None, vol.PathExists())}
-)
+SCHEMA_DEVICE = vol.Schema({vol.Required(CONF_DEVICE_PATH): vol.PathExists()})
 SCHEMA_OTA = {
     vol.Optional(CONF_OTA_IKEA, default=False): cv_boolean,
     vol.Optional(CONF_OTA_LEDVANCE, default=False): cv_boolean,
     vol.Optional(CONF_OTA_DIR, default=None): vol.Any(None, vol.IsDir()),
 }
 
-SCHEMA = {
-    vol.Optional(CONF_DATABASE, default=None): vol.Any(None, vol.IsFile()),
-    vol.Optional(CONF_OTA, default={}): SCHEMA_OTA,
-    vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
-}
+ZIGPY_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_DATABASE, default=None): vol.Any(None, vol.IsFile()),
+        vol.Optional(CONF_OTA, default={}): SCHEMA_OTA,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
-CONFIG_SCHEMA = vol.Schema(SCHEMA, extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = ZIGPY_SCHEMA.extend(
+    {vol.Required(CONF_DEVICE): SCHEMA_DEVICE}, extra=vol.ALLOW_EXTRA
+)

--- a/zigpy/config.py
+++ b/zigpy/config.py
@@ -35,7 +35,7 @@ SCHEMA_OTA = {
 }
 
 SCHEMA = {
-    vol.Optional(CONF_DATABASE, default=None): vol.IsFile(),
+    vol.Optional(CONF_DATABASE, default=None): vol.Any(None, vol.IsFile()),
     vol.Optional(CONF_OTA, default={}): SCHEMA_OTA,
     vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
 }

--- a/zigpy/config.py
+++ b/zigpy/config.py
@@ -11,21 +11,6 @@ CONF_OTA_DIR = "otau_directory"
 CONF_OTA_IKEA = "ikea_provider"
 CONF_OTA_LEDVANCE = "ledvance_provider"
 
-SCHEMA_DEVICE = vol.Schema({vol.Required(CONF_DEVICE_PATH): vol.PathExists()})
-SCHEMA_OTA = {
-    vol.Optional(CONF_OTA_IKEA, default=False): vol.Boolean(),
-    vol.Optional(CONF_OTA_LEDVANCE, default=False): vol.Boolean(),
-    vol.Optional(CONF_OTA_DIR, default=None): vol.Any(None, vol.IsDir()),
-}
-
-SCHEMA = {
-    vol.Optional(CONF_DATABASE, default=None): vol.IsFile(),
-    vol.Optional(CONF_OTA, default={}): SCHEMA_OTA,
-    vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
-}
-
-CONFIG_SCHEMA = vol.Schema(SCHEMA, extra=vol.ALLOW_EXTRA)
-
 
 def cv_boolean(value: Union[bool, int, str]) -> bool:
     """Validate and coerce a boolean value."""
@@ -40,3 +25,19 @@ def cv_boolean(value: Union[bool, int, str]) -> bool:
     elif isinstance(value, int):
         return bool(value)
     raise vol.Invalid("invalid boolean value {}".format(value))
+
+
+SCHEMA_DEVICE = vol.Schema({vol.Required(CONF_DEVICE_PATH): vol.PathExists()})
+SCHEMA_OTA = {
+    vol.Optional(CONF_OTA_IKEA, default=False): cv_boolean,
+    vol.Optional(CONF_OTA_LEDVANCE, default=False): cv_boolean,
+    vol.Optional(CONF_OTA_DIR, default=None): vol.Any(None, vol.IsDir()),
+}
+
+SCHEMA = {
+    vol.Optional(CONF_DATABASE, default=None): vol.IsFile(),
+    vol.Optional(CONF_OTA, default={}): SCHEMA_OTA,
+    vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
+}
+
+CONFIG_SCHEMA = vol.Schema(SCHEMA, extra=vol.ALLOW_EXTRA)

--- a/zigpy/config.py
+++ b/zigpy/config.py
@@ -1,0 +1,23 @@
+"""Config schemas and validation."""
+import voluptuous as vol
+
+CONF_DATABASE = "database_path"
+CONF_DEVICE = "device"
+CONF_DEVICE_PATH = "path"
+CONF_OTA = "ota"
+CONF_OTA_DIR = "otau_directory"
+CONF_OTA_IKEA = "ikea_provider"
+CONF_OTA_LEDVANCE = "ledvance_provider"
+
+SCHEMA_DEVICE = vol.Schema({vol.Required(CONF_DEVICE_PATH): vol.PathExists()})
+SCHEMA_OTA = {
+    vol.Optional(CONF_OTA_IKEA, default=False): vol.Boolean(),
+    vol.Optional(CONF_OTA_LEDVANCE, default=False): vol.Boolean(),
+    vol.Optional(CONF_OTA_DIR, default=None): vol.Any(None, vol.IsDir()),
+}
+
+SCHEMA = {
+    vol.Optional(CONF_DATABASE, default=None): vol.IsFile(),
+    vol.Optional(CONF_OTA, default={}): SCHEMA_OTA,
+    vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
+}

--- a/zigpy/config.py
+++ b/zigpy/config.py
@@ -1,4 +1,6 @@
 """Config schemas and validation."""
+from typing import Union
+
 import voluptuous as vol
 
 CONF_DATABASE = "database_path"
@@ -23,3 +25,18 @@ SCHEMA = {
 }
 
 CONFIG_SCHEMA = vol.Schema(SCHEMA, extra=vol.ALLOW_EXTRA)
+
+
+def cv_boolean(value: Union[bool, int, str]) -> bool:
+    """Validate and coerce a boolean value."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        value = value.lower().strip()
+        if value in ("1", "true", "yes", "on", "enable"):
+            return True
+        if value in ("0", "false", "no", "off", "disable"):
+            return False
+    elif isinstance(value, int):
+        return bool(value)
+    raise vol.Invalid("invalid boolean value {}".format(value))

--- a/zigpy/config.py
+++ b/zigpy/config.py
@@ -21,3 +21,5 @@ SCHEMA = {
     vol.Optional(CONF_OTA, default={}): SCHEMA_OTA,
     vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
 }
+
+CONFIG_SCHEMA = vol.Schema(SCHEMA, extra=vol.ALLOW_EXTRA)

--- a/zigpy/typing.py
+++ b/zigpy/typing.py
@@ -1,0 +1,23 @@
+"""Typing helpers for Zigpy."""
+
+from typing import TYPE_CHECKING
+
+import zigpy.application
+import zigpy.device
+import zigpy.endpoint
+import zigpy.zcl
+import zigpy.zdo
+
+# pylint: disable=invalid-name
+ClusterType = "Cluster"
+ControllerApplicationType = "ControllerApplication"
+DeviceType = "Device"
+EndpointType = "Endpoint"
+ZDOType = "ZDO"
+
+if TYPE_CHECKING:
+    ClusterType = zigpy.zcl.Cluster
+    ControllerApplicationType = zigpy.application.ControllerApplication
+    DeviceType = zigpy.device.Device
+    EndpointType = zigpy.endpoint.Endpoint
+    ZDOType = zigpy.zdo.ZDO


### PR DESCRIPTION
Pass configuration to Zigpy using a voluptuous schema. ATM Zigpy supports the following schema:
```yaml
device:
    path: /dev/ttyUSB0

ota:
    ikea_provider: true
    ledvance_provider: true
    otau_directory: /config/ota_updates

database_path: /path/to/zigbee.db
```

Radio modules are allowed to extend schema to include module specific options, eg adding `baudrate` and/or flow control options as well as radio specific configuration options.

