### PR TITLE
Fix deserialization type bug with `SizePrefixedSimpleDescriptor`

### DIFF
--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -154,14 +154,21 @@ def test_size_prefixed_simple_descriptor():
     ser = sd.serialize()
     assert ser[0] == len(ser) - 1
 
-    sd2, data = types.SizePrefixedSimpleDescriptor.deserialize(ser)
+    sd2, data = types.SizePrefixedSimpleDescriptor.deserialize(ser + b"extra")
     assert sd.input_clusters == sd2.input_clusters
     assert sd.output_clusters == sd2.output_clusters
+    assert isinstance(sd2, types.SizePrefixedSimpleDescriptor)
+    assert data == b"extra"
 
 
 def test_empty_size_prefixed_simple_descriptor():
     r = types.SizePrefixedSimpleDescriptor.deserialize(b"\x00")
     assert r == (None, b"")
+
+
+def test_invalid_size_prefixed_simple_descriptor():
+    with pytest.raises(ValueError):
+        types.SizePrefixedSimpleDescriptor.deserialize(b"\x01")
 
 
 def test_status_undef():

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -30,7 +30,7 @@ class SizePrefixedSimpleDescriptor(SimpleDescriptor):
     def deserialize(cls, data):
         if not data or data[0] == 0:
             return None, data[1:]
-        return SimpleDescriptor.deserialize(data[1:])
+        return super().deserialize(data[1:])
 
 
 class LogicalType(t.enum8):


### PR DESCRIPTION
`SizePrefixedSimpleDescriptor.deserialize` returns an instance of `SimpleDescriptor`, which breaks code that relies on `isinstance(Obj.deserialize(...), Obj)` being true.