### PR TITLE
Improve logging context by ignoring `LocalLogMixin`'s stack frames in Python 3.8+

### DIFF
--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -77,8 +77,8 @@ class LocalLogMixin:
         if sys.version_info >= (3, 8):
             # We have to exclude log, _log, and info
             return self.log(lvl, msg, *args, stacklevel=4, **kwargs)
-        else:
-            return self.log(lvl, msg, *args, **kwargs)
+
+        return self.log(lvl, msg, *args, **kwargs)
 
     def exception(self, msg, *args, **kwargs):
         return self._log(logging.ERROR, msg, *args, **kwargs)

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -3,6 +3,7 @@ import asyncio
 import functools
 import inspect
 import logging
+import sys
 import traceback
 from typing import Any, Coroutine, Optional, Tuple, Type, Union
 
@@ -72,20 +73,27 @@ class LocalLogMixin:
     def log(self, lvl: int, msg: str, *args, **kwargs):  # pragma: no cover
         pass
 
+    def _log(self, lvl: int, msg: str, *args, **kwargs):
+        if sys.version_info >= (3, 8):
+            # We have to exclude log, _log, and info
+            return self.log(lvl, msg, *args, stacklevel=4, **kwargs)
+        else:
+            return self.log(lvl, msg, *args, **kwargs)
+
     def exception(self, msg, *args, **kwargs):
-        return self.log(logging.ERROR, msg, *args, **kwargs)
+        return self._log(logging.ERROR, msg, *args, **kwargs)
 
     def debug(self, msg, *args, **kwargs):
-        return self.log(logging.DEBUG, msg, *args, **kwargs)
+        return self._log(logging.DEBUG, msg, *args, **kwargs)
 
     def info(self, msg, *args, **kwargs):
-        return self.log(logging.INFO, msg, *args, **kwargs)
+        return self._log(logging.INFO, msg, *args, **kwargs)
 
     def warning(self, msg, *args, **kwargs):
-        return self.log(logging.WARNING, msg, *args, **kwargs)
+        return self._log(logging.WARNING, msg, *args, **kwargs)
 
     def error(self, msg, *args, **kwargs):
-        return self.log(logging.ERROR, msg, *args, **kwargs)
+        return self._log(logging.ERROR, msg, *args, **kwargs)
 
 
 async def retry(func, retry_exceptions, tries=3, delay=0.1):


### PR DESCRIPTION
`LocalLogMixin` introduces a few more stack frames with its helper methods. This removes useful info from logs:

```
[2020-04-14 18:51:07] DEBUG [zigpy.zcl.log:486] [0x8758:1:0x0000] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=GLOBAL_COMMAND manufacturer_specific=True is_reply=True disable_default_response=True> manufacturer=4447 tsn=250 command_id=Command.Report_Attributes>
[2020-04-14 18:51:07] DEBUG [zigpy.zcl.log:486] [0x8758:1:0x0000] ZCL request 0x000a: [[<Attribute attrid=65281 value=<TypeValue type=LVBytes, value=b'\x01!\xd1\x0b\x03(\x15\x04!\xa8\x13\x05!P\x00\x06$\x01\x00\x00\x00\x00\n!\xae^d\x10\x00\x0b!\xc7\x01'>>]]
[2020-04-14 18:51:07] DEBUG [zigpy.zcl.log:486] [0x8758:1:0x0000] Attribute report received: 65281=b'\x01!\xd1\x0b\x03(\x15\x04!\xa8\x13\x05!P\x00\x06$\x01\x00\x00\x00\x00\n!\xae^d\x10\x00\x0b!\xc7\x01'
```

Python 3.8 lets you skip them with `stacklevel`:

```
[2020-04-14 18:57:29] DEBUG [zigpy.zcl.deserialize:84] [0x97a6:1:0x0000] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=GLOBAL_COMMAND manufacturer_specific=True is_reply=True disable_default_response=True> manufacturer=4447 tsn=51 command_id=Command.Report_Attributes>
[2020-04-14 18:57:29] DEBUG [zigpy.zcl.handle_message:177] [0x97a6:1:0x0000] ZCL request 0x000a: [[<Attribute attrid=65281 value=<TypeValue type=LVBytes, value=b'\x01!\xa9\x0b\x03(\x15\x04!\xa8\x13\x05!L\x00\x06$\x01\x00\x00\x00\x00\n!\xa1{d\x10\x00\x0b!]\x00'>>]]
[2020-04-14 18:57:29] DEBUG [zigpy.zcl.handle_cluster_general_request:197] [0x97a6:1:0x0000] Attribute report received: 65281=b'\x01!\xa9\x0b\x03(\x15\x04!\xa8\x13\x05!L\x00\x06$\x01\x00\x00\x00\x00\n!\xa1{d\x10\x00\x0b!]\x00'
```