### PR TITLE
Fix logic bug with cv_key validator

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,6 +69,15 @@ def test_config_validation_key_not_a_byte():
     with pytest.raises(vol.Invalid):
         zigpy.config.validators.cv_key([256 for i in range(16)])
 
+    with pytest.raises(vol.Invalid):
+        zigpy.config.validators.cv_key([0] * 15 + [256])
+
+    with pytest.raises(vol.Invalid):
+        zigpy.config.validators.cv_key([0] * 15 + [-1])
+
+    with pytest.raises(vol.Invalid):
+        zigpy.config.validators.cv_key([0] * 15 + ["x1"])
+
     zigpy.config.validators.cv_key([0xFF for i in range(16)])
 
 

--- a/zigpy/config/validators.py
+++ b/zigpy/config/validators.py
@@ -40,13 +40,13 @@ def cv_hex(value: Union[int, str]) -> int:
 
 def cv_key(key: List[int]) -> t.KeyData:
     """Validate a key."""
-    if not isinstance(key, list):
-        raise vol.Invalid("key is expected to be a list of integers")
+    if not isinstance(key, list) or not all(isinstance(v, int) for v in key):
+        raise vol.Invalid("key must be a list of integers")
 
     if len(key) != 16:
-        raise vol.Invalid("key list length must be 16")
+        raise vol.Invalid("key length must be 16")
 
-    if not any((0 <= e <= 255 for e in key)):
-        raise vol.Invalid("Key element myst be a within (0..255) range")
+    if not all((0 <= e <= 255 for e in key)):
+        raise vol.Invalid("Key bytes must be within (0..255) range")
 
     return t.KeyData(key)


### PR DESCRIPTION
`not any` -> `not all`. Also added check for ensuring each element is of the right type, to avoid raising a `TypeError` when doing `0 <= e <= 255` with a non-integer `e`.