### PR TITLE
Don't treat all unsuccessful statuses as hard failures.

### DIFF
--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -120,7 +120,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.debug("Cannot add 0x%04x group, no groups cluster", grp_id)
             return ZCLStatus.FAILURE
 
-        if res[0] != ZCLStatus.SUCCESS:
+        if res[0] not in (ZCLStatus.SUCCESS, ZCLStatus.DUPLICATE_EXISTS):
             self.debug("Couldn't add to 0x%04x group: %s", grp_id, res[0])
             return res[0]
 
@@ -135,7 +135,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.debug("Cannot remove 0x%04x group, no groups cluster", grp_id)
             return ZCLStatus.FAILURE
 
-        if res[0] != ZCLStatus.SUCCESS:
+        if res[0] not in (ZCLStatus.SUCCESS, ZCLStatus.NOT_FOUND):
             self.debug("Couldn't remove to 0x%04x group: %s", grp_id, res[0])
             return res[0]
 


### PR DESCRIPTION
When removing a group which is not there, Status.NOT_FOUND is not a hard failure. Same for Status.DUPLICATE_EXISTS when adding an endpoint to a group.

Fixes #397 