### PR TITLE
Fix `isinstance` check for optional `Struct` subclasses

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -215,6 +215,17 @@ def test_struct_init():
     assert ts.c == "TestStruct"
 
 
+def test_struct_optional_init():
+    class TestStruct(t.Struct):
+        _fields = [("a", t.uint8_t), ("b", t.uint16_t), ("c", t.CharacterString)]
+
+    ts = TestStruct(1, 0x0100, "TestStruct")
+    ts_copy = TestStruct(ts)
+    ts_optional = t.Optional(TestStruct)(ts)
+
+    assert ts.serialize() == ts_copy.serialize() == ts_optional.serialize()
+
+
 def test_hex_repr():
     class NwkAsHex(t.HexRepr, t.uint16_t):
         _hex_len = 4

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -1,6 +1,12 @@
 class Struct:
     def __init__(self, *args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], self.__class__):
+        if getattr(self, "optional", False):
+            # the "Optional" subclass is dynamically created
+            cls = next(c for c in self.__class__.__mro__ if c.__name__ != "Optional")
+        else:
+            cls = self.__class__
+
+        if len(args) == 1 and isinstance(args[0], cls):
             # copy constructor
             for field in self._fields:
                 setattr(self, field[0], getattr(args[0], field[0]))


### PR DESCRIPTION
`Struct.__init__` uses `isinstance(other, self.__class__)` for its "copy constructor", which silently fails if a type is declared optional by using `t.Optional(SomeStruct)`. This fix feels a little hacky because of the MRO list traversal and relying on the `Optional` class's name but I can't really see an alternative that doesn't involve redoing a bunch of type stuff elsewhere in the codebase.