### PR TITLE
Adds Power On State / Power Cycle Behavior attribute to the General On/Off Cluster

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -18,5 +18,6 @@
 - [Abílio Costa] (https://github.com/abmantis)
 - [https://github.com/SchaumburgM] (https://github.com/SchaumburgM)
 - [https://github.com/Nemesis24] (https://github.com/Nemesis24)
+- [Kurt Warwick] (https://github.com/kurtwarwick-new)
 - [Hedda] (https://github.com/Hedda)
 - [Andreas Setterlind] (https://github.com/Gamester17)

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -147,7 +147,6 @@ def test_custom_devices():
 
     # Validate that all CustomDevices look sane
     reg = zigpy.quirks._DEVICE_REGISTRY.registry
-    return
     candidates = list(
         itertools.chain(*itertools.chain(*[m.values() for m in reg.values()]))
     )

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -102,6 +102,10 @@ def test_get_device_new_sig(real_device):
     registry = _dev_reg(TestDevice)
     assert isinstance(registry.get_device(real_device), TestDevice)
 
+    TestDevice.signature["endpoints"][2] = {"profile_id": 2}
+    registry = _dev_reg(TestDevice)
+    assert registry.get_device(real_device) is real_device
+
 
 def test_model_manuf_device_sig(real_device):
     class TestDevice:

--- a/zigpy/__init__.py
+++ b/zigpy/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 MAJOR_VERSION = 0
-MINOR_VERSION = 20
-PATCH_VERSION = "5.dev0"
+MINOR_VERSION = 21
+PATCH_VERSION = "1.dev0"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -227,15 +227,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
         return self._read_attributes(attributes, manufacturer=manufacturer)
 
     async def read_attributes(
-        self,
-        attributes,
-        allow_cache=False,
-        only_cache=False,
-        raw=False,
-        manufacturer=None,
+        self, attributes, allow_cache=False, only_cache=False, manufacturer=None,
     ):
-        if raw:
-            assert len(attributes) == 1
         success, failure = {}, {}
         attribute_ids = []
         orig_attributes = {}
@@ -258,8 +251,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
             to_read = attribute_ids
 
         if not to_read or only_cache:
-            if raw:
-                return success[attributes[0]]
             return success, failure
 
         result = await self.read_attributes_raw(to_read, manufacturer=manufacturer)
@@ -288,9 +279,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
                 else:
                     failure[orig_attribute] = record.status
 
-        if raw:
-            # KeyError is an appropriate exception here, I think.
-            return success[attributes[0]]
         return success, failure
 
     def read_attributes_rsp(self, attributes, manufacturer=None, *, tsn=None):

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -384,6 +384,12 @@ class OnOff(Cluster):
     """Attributes and commands for switching devices between
     ‘On’ and ‘Off’ states. """
 
+    class PowerOnState(t.enum8):
+        """Power on state enum."""
+        Off = 0x00
+        On = 0x01
+        Previous = 0xff
+
     cluster_id = 0x0006
     name = "On/Off"
     ep_attribute = "on_off"
@@ -392,7 +398,7 @@ class OnOff(Cluster):
         0x4000: ("global_scene_control", t.Bool),
         0x4001: ("on_time", t.uint16_t),
         0x4002: ("off_wait_time", t.uint16_t),
-        0x4003: ("power_on__on_off", t.enum8),
+        0x4003: ("power_on_state", PowerOnState),
     }
     server_commands = {
         0x0000: ("off", (), False),

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -392,6 +392,7 @@ class OnOff(Cluster):
         0x4000: ("global_scene_control", t.Bool),
         0x4001: ("on_time", t.uint16_t),
         0x4002: ("off_wait_time", t.uint16_t),
+        0x4003: ("power_on__on_off", t.enum8),
     }
     server_commands = {
         0x0000: ("off", (), False),


### PR DESCRIPTION
Added an attribute that allows you to change the initial power on state / power cycle state (for Philips Hue bulbs specifically).

**NOTE**: This has only been tested on Philips Hue bulbs. I am not sure if this attribute is used by other bulbs.