### PR TITLE
Added power on state to general on/off cluster

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -18,5 +18,6 @@
 - [Abílio Costa] (https://github.com/abmantis)
 - [https://github.com/SchaumburgM] (https://github.com/SchaumburgM)
 - [https://github.com/Nemesis24] (https://github.com/Nemesis24)
+- [Kurt Warwick] (https://github.com/kurtwarwick-new)
 - [Hedda] (https://github.com/Hedda)
 - [Andreas Setterlind] (https://github.com/Gamester17)

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -384,6 +384,12 @@ class OnOff(Cluster):
     """Attributes and commands for switching devices between
     ‘On’ and ‘Off’ states. """
 
+    class PowerOnState(t.enum8):
+        """Power on state enum."""
+        Off = 0x00
+        On = 0x01
+        Previous = 0xff
+
     cluster_id = 0x0006
     name = "On/Off"
     ep_attribute = "on_off"
@@ -392,6 +398,7 @@ class OnOff(Cluster):
         0x4000: ("global_scene_control", t.Bool),
         0x4001: ("on_time", t.uint16_t),
         0x4002: ("off_wait_time", t.uint16_t),
+        0x4003: ("power_on_state", PowerOnState),
     }
     server_commands = {
         0x0000: ("off", (), False),


### PR DESCRIPTION
Added an attribute that allows you to change the initial power on state / power cycle state (for Philips Hue bulbs specifically).

**NOTE**: This has only been tested on Philips Hue bulbs. While it can be set for other bulbs, I am not sure if this attribute is used by other bulbs.