### PR TITLE
Remove unused `NodeDescriptor.__init__` that breaks `t.Optional` type fix

### DIFF
--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -67,19 +67,6 @@ class NodeDescriptor(t.Struct):
         ("descriptor_capability_field", t.uint8_t),
     ]
 
-    def __init__(self, *args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], self.__class__):
-            # copy constructor
-            for field in self._fields:
-                setattr(self, field[0], getattr(args[0], field[0]))
-            self._valid = True
-        elif len(args) == len(self._fields):
-            for field, val in zip(self._fields, args):
-                setattr(self, field[0], field[1](val))
-        else:
-            for field in self._fields:
-                setattr(self, field[0], None)
-
     @property
     def is_valid(self):
         """Return True if all fields were initialized."""


### PR DESCRIPTION
`NodeDescriptor` is the only `Struct` subclass that has its own initializer. This breaks the typing fix from pull request #416 for this specific class, which appears to be the only unusual `Struct` subclass.

The one difference between `NodeDescriptor.__init__` and the old `Struct.__init__` is the inclusion of a `self._valid` flag. This flag isn't actually used so removing the initializer entirely should be fine.

---

I'm hoping to eventually bring in parts of the typed "structure" system from zigpy-znp back into zigpy, which should eliminate most of these hacks. You can see how optional parameters look [when created](https://github.com/zha-ng/zigpy-znp/blob/c4d955453342b0ad481ab10cde3becaee6db0c7a/zigpy_znp/commands/sys.py#L62-L89) and how they behave in their [unit tests](https://github.com/zha-ng/zigpy-znp/blob/c4d955453342b0ad481ab10cde3becaee6db0c7a/tests/test_commands.py#L241-L322). The parameter `(name, type, description)` objects would make the ZDO definitions a lot easier to parse.