### PR TITLE
Implement get() method to access cached ZCL attributes.

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -327,8 +327,17 @@ async def test_item_access_attributes(cluster):
 
     assert cluster["model"] == mock.sentinel.model
     assert cluster[5] == mock.sentinel.model
+    assert cluster.get("model") == mock.sentinel.model
+    assert cluster.get(5) == mock.sentinel.model
+    assert cluster.get("model", mock.sentinel.default) == mock.sentinel.model
+    assert cluster.get(5, mock.sentinel.default) == mock.sentinel.model
     with pytest.raises(KeyError):
         cluster[4]
+    assert cluster.get(4) is None
+    assert cluster.get("manufacturer") is None
+    assert cluster.get(4, mock.sentinel.default) is mock.sentinel.default
+    assert cluster.get("manufacturer", mock.sentinel.default) is mock.sentinel.default
+
     with pytest.raises(KeyError):
         cluster["manufacturer"]
 
@@ -339,6 +348,10 @@ async def test_item_access_attributes(cluster):
     with pytest.raises(ValueError):
         # wrong key type
         cluster[None]
+
+    with pytest.raises(ValueError):
+        # wrong key type
+        cluster.get(None)
 
 
 async def test_item_set_attributes(cluster):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -511,6 +511,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
         else:
             raise AttributeError("No such command name: %s" % (name,))
 
+    def get(self, key: Union[int, str], default: Optional[Any] = None) -> Any:
+        """Get cached attribute."""
+        if isinstance(key, int):
+            return self._attr_cache.get(key, default)
+        elif isinstance(key, str):
+            return self._attr_cache.get(self.attridx[key], default)
+        raise ValueError("attr_name or attr_id are accepted only")
+
     def __getitem__(self, key: Union[int, str]) -> Any:
         """Return cached value of the attr."""
         if isinstance(key, int):


### PR DESCRIPTION
In addition to #421 allow access to cached ZCL attributes via `cluster.get(Union[int, str])` method.
