### PR TITLE
0.22.2 Release

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -327,8 +327,17 @@ async def test_item_access_attributes(cluster):
 
     assert cluster["model"] == mock.sentinel.model
     assert cluster[5] == mock.sentinel.model
+    assert cluster.get("model") == mock.sentinel.model
+    assert cluster.get(5) == mock.sentinel.model
+    assert cluster.get("model", mock.sentinel.default) == mock.sentinel.model
+    assert cluster.get(5, mock.sentinel.default) == mock.sentinel.model
     with pytest.raises(KeyError):
         cluster[4]
+    assert cluster.get(4) is None
+    assert cluster.get("manufacturer") is None
+    assert cluster.get(4, mock.sentinel.default) is mock.sentinel.default
+    assert cluster.get("manufacturer", mock.sentinel.default) is mock.sentinel.default
+
     with pytest.raises(KeyError):
         cluster["manufacturer"]
 
@@ -339,6 +348,10 @@ async def test_item_access_attributes(cluster):
     with pytest.raises(ValueError):
         # wrong key type
         cluster[None]
+
+    with pytest.raises(ValueError):
+        # wrong key type
+        cluster.get(None)
 
 
 async def test_item_set_attributes(cluster):

--- a/zigpy/__init__.py
+++ b/zigpy/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 MAJOR_VERSION = 0
-MINOR_VERSION = 23
-PATCH_VERSION = "0.dev0"
+MINOR_VERSION = 22
+PATCH_VERSION = "2"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -331,7 +331,14 @@ class PersistingListener:
                     if cluster in ep.in_clusters:
                         clus = ep.in_clusters[cluster]
                         clus._attr_cache[attrid] = value
-                        LOGGER.debug("Attribute id: %s value: %s", attrid, value)
+                        LOGGER.debug(
+                            "[0x%04x:%s:0x%04x] Attribute id: %s value: %s",
+                            dev.nwk,
+                            endpoint_id,
+                            cluster,
+                            attrid,
+                            value,
+                        )
                         if cluster == Basic.cluster_id and attrid == 4:
                             if isinstance(value, bytes):
                                 value = value.split(b"\x00")[0]

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -511,6 +511,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
         else:
             raise AttributeError("No such command name: %s" % (name,))
 
+    def get(self, key: Union[int, str], default: Optional[Any] = None) -> Any:
+        """Get cached attribute."""
+        if isinstance(key, int):
+            return self._attr_cache.get(key, default)
+        elif isinstance(key, str):
+            return self._attr_cache.get(self.attridx[key], default)
+        raise ValueError("attr_name or attr_id are accepted only")
+
     def __getitem__(self, key: Union[int, str]) -> Any:
         """Return cached value of the attr."""
         if isinstance(key, int):


### PR DESCRIPTION
0.22.2 Release

# Changes
- Implement get() method to access cached ZCL attributes (#441)
- Extra debug log on restoring app state (#442)