### PR TITLE
Make fixed-size integers and Enum subclasses' types behave properly

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -119,7 +119,7 @@ def test_struct_attribute_assignment():
     s1 = TestStruct(a=1)
     s1.a = -1
 
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         s1.serialize()
 
     s1.a = 1

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -205,12 +205,26 @@ def test_list():
 
 
 def test_hex_repr():
-    class NwkAsHex(t.HexRepr, t.uint16_t):
-        _hex_len = 4
+    class NwkAsHex(t.uint16_t, hex_repr=True):
+        pass
 
-    nwk = NwkAsHex(0x1234)
-    assert str(nwk) == "0x1234"
-    assert repr(nwk) == "0x1234"
+    nwk = NwkAsHex(0x123A)
+    assert str(nwk) == "0x123A"
+    assert repr(nwk) == "0x123A"
+
+    assert str([nwk]) == "[0x123A]"
+    assert repr([nwk]) == "[0x123A]"
+
+    # You can turn it off as well
+    class NwkWithoutHex(NwkAsHex, hex_repr=False):
+        pass
+
+    nwk = NwkWithoutHex(1234)
+    assert str(nwk) == "1234"
+    assert repr(nwk) == "1234"
+
+    assert str([nwk]) == "[1234]"
+    assert repr([nwk]) == "[1234]"
 
 
 def test_optional():

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -376,8 +376,18 @@ def test_pytype_to_datatype_derived_bitmaps():
     assert foundation.DATA_TYPES.pytype_to_datatype_id(b_3) == bitmap16_id
 
 
+def test_ptype_to_datatype_lvlist():
+    """Test pytype for Structure."""
+
+    lst1 = t.LVList(foundation.TypeValue, 2)
+    lst2 = t.LVList(t.uint8_t, 2)
+
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(lst1) == 0x4C
+    assert foundation.DATA_TYPES.pytype_to_datatype_id(lst2) == 0xFF
+
+
 def test_ptype_to_datatype_notype():
-    """Test ptype for NoData."""
+    """Test pytype for NoData."""
 
     class ZigpyUnknown:
         pass

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -42,15 +42,7 @@ class Bool(basic.uint8_t, enum.Enum):
     true = 1
 
 
-class HexRepr:
-    def __repr__(self):
-        return ("0x{:0" + str(self._size * 2) + "x}").format(self)
-
-    def __str__(self):
-        return ("0x{:0" + str(self._size * 2) + "x}").format(self)
-
-
-class AttributeId(HexRepr, basic.uint16_t):
+class AttributeId(basic.uint16_t, hex_repr=True):
     pass
 
 
@@ -118,7 +110,7 @@ class Date(Struct):
         self.years_since_1900 = years - 1900
 
 
-class NWK(HexRepr, basic.uint16_t):
+class NWK(basic.uint16_t, hex_repr=True):
     pass
 
 
@@ -130,7 +122,7 @@ class ExtendedPanId(EUI64):
     pass
 
 
-class Group(HexRepr, basic.uint16_t):
+class Group(basic.uint16_t, hex_repr=True):
     pass
 
 

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -246,7 +246,7 @@ class APSStatus(basic.enum8):
     @classmethod
     def _missing_(cls, value):
         chained = NWKStatus(value)
-        status = basic.uint8_t.__new__(cls, chained.value)
+        status = cls._member_type_.__new__(cls, chained.value)
         status._name_ = chained.name
         status._value_ = value
         return status
@@ -479,7 +479,7 @@ class NWKStatus(basic.enum8):
     @classmethod
     def _missing_(cls, value):
         chained = MACStatus(value)
-        status = basic.uint8_t.__new__(cls, chained.value)
+        status = cls._member_type_.__new__(cls, chained.value)
         status._name_ = chained.name
         status._value_ = value
         return status

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -290,7 +290,7 @@ class Status(t.enum8):
     @classmethod
     def _missing_(cls, value):
         chained = t.APSStatus(value)
-        status = t.uint8_t.__new__(cls, chained.value)
+        status = cls._member_type_.__new__(cls, chained.value)
         status._name_ = chained.name
         status._value_ = value
         return status
@@ -302,8 +302,8 @@ IEEE = ("IEEEAddr", t.EUI64)
 STATUS = ("Status", Status)
 
 
-class _CommandID(t.HexRepr, t.uint16_t):
-    _hex_len = 4
+class _CommandID(t.uint16_t, hex_repr=True):
+    pass
 
 
 class ZDOCmd(t.enum_factory(_CommandID)):


### PR DESCRIPTION
The major improvement here is integer `Enum`s' and their members' types now make sense. This simplifies a bit of code.

Before:

```Python
import zigpy.types as t

class TestEnum(t.enum8):
    Member = 0x00

assert isinstance(TestEnum.Member, t.uint8_t) is False  # this is annoying
assert type(TestEnum.Member.value) is int  # this breaks a lot of stuff
TestEnum.Member.serialize()  # works only because TestEnum itself has a serialize method
```

After:

```Python
assert isinstance(TestEnum.Member, t.uint8_t) is True
assert type(TestEnum.Member.value) is t.uint8_t
TestEnum.Member.serialize()  # no special handling needed
```

Other improvements:

 - `t.uint8_t(-1)` and `t.uint8_t(256)` throw a `ValueError`. The former's `OverflowError` is re-raised as a `ValueError`.

Problems:

 - `t.LVList` not being an actual type breaks a few things relying on `isinstance` and `issubclass` to work. While fixing my introduced bug I found a new one with `pytype_to_datatype_id` whose root cause was also `t.LVList`. I fixed this in zigpy-znp [by making `LVList` a real type](https://github.com/zha-ng/zigpy-znp/blob/660423511ac548f45e6a88117937ac92c6ecdafe/zigpy_znp/types/basic.py#L176-L228) but this has the downside (upside?) of requiring every subclass of `t.LVList` to be explicitly named and not constructed anonymously. It would be cool to have `t.LVList[t.uint8_t, ValueType]` be compatible with `class SubType(t.LVList, length_type=t.uint8_t, item_type=ValueType):  pass`