### PR TITLE
Implement Half-precision floating point numbers

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -78,6 +78,17 @@ def test_single_and_double_with_struct(value, only_double):
     assert r2 == b""
 
 
+def test_float_parsing_errors():
+    with pytest.raises(ValueError):
+        t.Double.deserialize(b"\x00\x00\x00\x00\x00\x00\x00")
+
+    with pytest.raises(ValueError):
+        t.Single.deserialize(b"\x00\x00\x00")
+
+    with pytest.raises(ValueError):
+        t.Half.deserialize(b"\x00")
+
+
 def test_lvbytes():
     d, r = t.LVBytes.deserialize(b"\x0412345")
     assert r == b"5"

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -190,7 +190,7 @@ DATA_TYPES = DataTypes(
         0x2F: ("Signed Integer", t.int64s, Analog),
         0x30: ("Enumeration", t.enum8, Discrete),
         0x31: ("Enumeration", t.enum16, Discrete),
-        # 0x38: ('Floating point', t.Half, Analog),
+        0x38: ("Floating point", t.Half, Analog),
         0x39: ("Floating point", t.Single, Analog),
         0x3A: ("Floating point", t.Double, Analog),
         0x41: ("Octet string", t.LVBytes, Discrete),


### PR DESCRIPTION
`struct.pack` and `struct.unpack` are used internally for serialization and deserialization, which ensures `NaN` and the two infinities are handled properly. All that the conversion really does is shrink/expand the size of the exponent and fraction.

Note: this implementation is limited to the precision of the Python runtime (as was the old) so `t.Double` will not be as precise on 32-bit platforms with a Python implementation that doesn't use double-precision floats. This has the side effect of `t.Double(t.Double.deserialize(foo)[0]).serialize() == foo` not necessarily being true (though the two values will be close enough).