### PR TITLE
Concrete List/LVList/FixedList types

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -264,25 +264,36 @@ def test_list():
 
 
 def test_list_types():
-    class LVListSubclass(t.LVList, length_type=t.uint8_t, item_type=t.uint16_t):
-        pass
-
     # Brackets create singleton types
-    anon_lst = t.LVList[t.uint8_t, t.uint16_t]
-    assert anon_lst._length_type is t.uint8_t
-    assert anon_lst._item_type is t.uint16_t
-    assert t.LVList[t.uint8_t, t.uint16_t] is t.LVList[t.uint8_t, t.uint16_t]
+    anon_lst1 = t.LVList[t.uint16_t]
+    anon_lst2 = t.LVList[t.uint16_t, t.uint8_t]
+
+    assert anon_lst1._length_type is t.uint8_t
+    assert anon_lst1._item_type is t.uint16_t
+    assert anon_lst2._length_type is t.uint8_t
+    assert anon_lst2._item_type is t.uint16_t
+    assert anon_lst1 is anon_lst2
+    assert issubclass(t.LVList[t.uint8_t, t.uint16_t], t.LVList[t.uint8_t, t.uint16_t])
+    assert not issubclass(
+        t.LVList[t.uint16_t, t.uint8_t], t.LVList[t.uint8_t, t.uint16_t]
+    )
 
     # Bracketed types are compatible with explicit subclasses
-    assert issubclass(t.LVList[t.uint8_t, t.uint16_t], t.LVList[t.uint8_t, t.uint16_t])
-    assert issubclass(LVListSubclass, t.LVList[t.uint8_t, t.uint16_t])
+    class LVListSubclass(t.LVList, item_type=t.uint16_t, length_type=t.uint8_t):
+        pass
+
+    assert issubclass(LVListSubclass, t.LVList[t.uint16_t, t.uint8_t])
+    assert not issubclass(t.LVList[t.uint16_t, t.uint8_t], LVListSubclass)
+    assert not issubclass(LVListSubclass, t.LVList[t.uint8_t, t.uint16_t])
     assert issubclass(LVListSubclass, LVListSubclass)
 
     # Instances are also compatible
     assert isinstance(LVListSubclass(), LVListSubclass)
-    assert isinstance(LVListSubclass(), t.LVList[t.uint8_t, t.uint16_t])
+    assert isinstance(LVListSubclass(), t.LVList[t.uint16_t, t.uint8_t])
+    assert not isinstance(LVListSubclass(), t.LVList[t.uint8_t, t.uint16_t])
+    assert not isinstance(t.LVList[t.uint16_t, t.uint8_t](), LVListSubclass)
     assert isinstance(
-        t.LVList[t.uint8_t, t.uint16_t](), t.LVList[t.uint8_t, t.uint16_t]
+        t.LVList[t.uint16_t, t.uint8_t](), t.LVList[t.uint16_t, t.uint8_t]
     )
 
 
@@ -551,3 +562,5 @@ def test_bitmap_instance_types():
     assert type(TestBitmap.ALL.value) is t.uint16_t
     assert isinstance(TestBitmap.ALL, t.uint16_t)
     assert issubclass(TestBitmap, t.uint16_t)
+    assert isinstance(TestBitmap(0xFF00), t.uint16_t)
+    assert isinstance(TestBitmap(0xFF00), TestBitmap)

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -430,7 +430,7 @@ async def test_write_attributes_cache_default_response(cluster, status):
     ),
 )
 async def test_write_attributes_cache_success(cluster, attributes, result):
-    rsp_type = t.List(foundation.WriteAttributesStatusRecord)
+    rsp_type = t.List[foundation.WriteAttributesStatusRecord]
     write_mock = CoroutineMock(return_value=[rsp_type.deserialize(result)[0]])
     with mock.patch.object(cluster, "_write_attributes", write_mock):
         await cluster.write_attributes(attributes)

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -72,7 +72,7 @@ def test_attribute_reporting_config_1():
 def test_typed_collection():
     tc = foundation.TypedCollection()
     tc.type = 0x20
-    tc.value = t.LVList[t.uint8_t, t.uint8_t]([t.uint8_t(i) for i in range(100)])
+    tc.value = t.LVList[t.uint8_t]([t.uint8_t(i) for i in range(100)])
     ser = tc.serialize()
 
     assert len(ser) == 1 + 1 + 100  # type, length, values

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -72,7 +72,7 @@ def test_attribute_reporting_config_1():
 def test_typed_collection():
     tc = foundation.TypedCollection()
     tc.type = 0x20
-    tc.value = t.LVList(t.uint8_t)([t.uint8_t(i) for i in range(100)])
+    tc.value = t.LVList[t.uint8_t, t.uint8_t]([t.uint8_t(i) for i in range(100)])
     ser = tc.serialize()
 
     assert len(ser) == 1 + 1 + 100  # type, length, values

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -148,8 +148,8 @@ def test_size_prefixed_simple_descriptor():
     sd.profile = t.uint16_t(2)
     sd.device_type = t.uint16_t(3)
     sd.device_version = t.uint8_t(4)
-    sd.input_clusters = t.LVList(t.uint16_t)([t.uint16_t(5), t.uint16_t(6)])
-    sd.output_clusters = t.LVList(t.uint16_t)([t.uint16_t(7), t.uint16_t(8)])
+    sd.input_clusters = t.LVList[t.uint8_t, t.uint16_t]([t.uint16_t(5), t.uint16_t(6)])
+    sd.output_clusters = t.LVList[t.uint8_t, t.uint16_t]([t.uint16_t(7), t.uint16_t(8)])
 
     ser = sd.serialize()
     assert ser[0] == len(ser) - 1

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -148,8 +148,8 @@ def test_size_prefixed_simple_descriptor():
     sd.profile = t.uint16_t(2)
     sd.device_type = t.uint16_t(3)
     sd.device_version = t.uint8_t(4)
-    sd.input_clusters = t.LVList[t.uint8_t, t.uint16_t]([t.uint16_t(5), t.uint16_t(6)])
-    sd.output_clusters = t.LVList[t.uint8_t, t.uint16_t]([t.uint16_t(7), t.uint16_t(8)])
+    sd.input_clusters = t.LVList[t.uint16_t]([t.uint16_t(5), t.uint16_t(6)])
+    sd.output_clusters = t.LVList[t.uint16_t]([t.uint16_t(7), t.uint16_t(8)])
 
     ser = sd.serialize()
     assert ser[0] == len(ser) - 1

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = True
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
 install_command = pip install {opts} {packages}
-commands = py.test --cov --cov-report=
+commands = py.test --cov --cov-report=html
 deps =
     asynctest
     coveralls

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -436,12 +436,8 @@ class LVList(list, metaclass=KwargTypeMeta):
 
     def serialize(self) -> bytes:
         assert self._item_type is not None
-        return b"".join(
-            [
-                i.serialize()
-                for i in [self._length_type(len(self))]
-                + [self._item_type(i) for i in self]
-            ]
+        return self._length_type(len(self)).serialize() + b"".join(
+            [self._item_type(i).serialize() for i in self]
         )
 
     @classmethod

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -16,7 +16,7 @@ class BroadcastAddress(basic.enum16):
     RESERVED_FFF8 = 0xFFF8
 
 
-class EUI64(basic.fixed_list(8, basic.uint8_t)):
+class EUI64(basic.FixedList, item_type=basic.uint8_t, length=8):
     # EUI 64-bit ID (an IEEE address).
     def __repr__(self):
         return ":".join("%02x" % i for i in self[::-1])
@@ -33,7 +33,7 @@ class EUI64(basic.fixed_list(8, basic.uint8_t)):
         return cls(ieee)
 
 
-class KeyData(basic.fixed_list(16, basic.uint8_t)):
+class KeyData(basic.FixedList, item_type=basic.uint8_t, length=16):
     pass
 
 
@@ -170,7 +170,7 @@ class LocalTime(_Time):
     pass
 
 
-class Relays(basic.LVList(NWK)):
+class Relays(basic.LVList, item_type=NWK, length_type=basic.uint8_t):
     """Relay list for static routing."""
 
     pass

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -323,7 +323,7 @@ class Groups(Cluster):
             (foundation.Status, t.Group, t.CharacterString),
             True,
         ),
-        0x0002: ("get_membership_response", (t.uint8_t, t.LVList[t.Group]), True,),
+        0x0002: ("get_membership_response", (t.uint8_t, t.LVList[t.Group]), True),
         0x0003: ("remove_response", (foundation.Status, t.Group), True),
     }
 
@@ -371,7 +371,7 @@ class Scenes(Cluster):
         0x0004: ("store_response", (t.uint8_t, t.uint16_t, t.uint8_t), True),
         0x0006: (
             "get_scene_membership_response",
-            (t.uint8_t, t.uint8_t, t.uint16_t, t.Optional(t.LVList[t.uint8_t]),),
+            (t.uint8_t, t.uint8_t, t.uint16_t, t.Optional(t.LVList[t.uint8_t])),
             True,
         ),
         0x0040: ("enhanced_add_response", (), True),
@@ -619,7 +619,7 @@ class RSSILocation(Cluster):
         0x0003: ("compact_location_data_notification", (), False),
         0x0004: ("rssi_ping", (t.uint8_t,), False),  # data8
         0x0005: ("rssi_req", (), False),
-        0x0006: ("report_rssi_measurements", (t.EUI64, t.LVList[NeighborInfo]), False,),
+        0x0006: ("report_rssi_measurements", (t.EUI64, t.LVList[NeighborInfo]), False),
         0x0007: ("request_own_location", (t.EUI64,), False),
     }
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -311,7 +311,7 @@ class Groups(Cluster):
     server_commands = {
         0x0000: ("add", (t.Group, t.CharacterString), False),
         0x0001: ("view", (t.Group,), False),
-        0x0002: ("get_membership", (t.LVList[t.uint8_t, t.Group],), False),
+        0x0002: ("get_membership", (t.LVList[t.Group],), False),
         0x0003: ("remove", (t.Group,), False),
         0x0004: ("remove_all", (), False),
         0x0005: ("add_if_identifying", (t.Group, t.CharacterString), False),
@@ -323,11 +323,7 @@ class Groups(Cluster):
             (foundation.Status, t.Group, t.CharacterString),
             True,
         ),
-        0x0002: (
-            "get_membership_response",
-            (t.uint8_t, t.LVList[t.uint8_t, t.Group]),
-            True,
-        ),
+        0x0002: ("get_membership_response", (t.uint8_t, t.LVList[t.Group]), True,),
         0x0003: ("remove_response", (foundation.Status, t.Group), True),
     }
 
@@ -375,12 +371,7 @@ class Scenes(Cluster):
         0x0004: ("store_response", (t.uint8_t, t.uint16_t, t.uint8_t), True),
         0x0006: (
             "get_scene_membership_response",
-            (
-                t.uint8_t,
-                t.uint8_t,
-                t.uint16_t,
-                t.Optional(t.LVList[t.uint8_t, t.uint8_t]),
-            ),
+            (t.uint8_t, t.uint8_t, t.uint16_t, t.Optional(t.LVList[t.uint8_t]),),
             True,
         ),
         0x0040: ("enhanced_add_response", (), True),
@@ -628,11 +619,7 @@ class RSSILocation(Cluster):
         0x0003: ("compact_location_data_notification", (), False),
         0x0004: ("rssi_ping", (t.uint8_t,), False),  # data8
         0x0005: ("rssi_req", (), False),
-        0x0006: (
-            "report_rssi_measurements",
-            (t.EUI64, t.LVList[t.uint8_t, NeighborInfo]),
-            False,
-        ),
+        0x0006: ("report_rssi_measurements", (t.EUI64, t.LVList[NeighborInfo]), False,),
         0x0007: ("request_own_location", (t.EUI64,), False),
     }
 
@@ -1192,12 +1179,12 @@ class PowerProfile(Cluster):
         ),
         0x0004: (
             "energy_phases_schedule_notification",
-            (t.uint8_t, t.LVList[t.uint8_t, ScheduleRecord]),
+            (t.uint8_t, t.LVList[ScheduleRecord]),
             False,
         ),
         0x0005: (
             "energy_phases_schedule_response",
-            (t.uint8_t, t.LVList[t.uint8_t, ScheduleRecord]),
+            (t.uint8_t, t.LVList[ScheduleRecord]),
             True,
         ),
         0x0006: ("power_profile_schedule_constraints_request", (t.uint8_t,), False),
@@ -1211,25 +1198,17 @@ class PowerProfile(Cluster):
     client_commands = {
         0x0000: (
             "power_profile_notification",
-            (t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, PowerProfilePhase]),
+            (t.uint8_t, t.uint8_t, t.LVList[PowerProfilePhase]),
             False,
         ),
         0x0001: (
             "power_profile_response",
-            (t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, PowerProfilePhase]),
+            (t.uint8_t, t.uint8_t, t.LVList[PowerProfilePhase]),
             True,
         ),
-        0x0002: (
-            "power_profile_state_response",
-            (t.LVList[t.uint8_t, PowerProfile],),
-            True,
-        ),
+        0x0002: ("power_profile_state_response", (t.LVList[PowerProfile],), True,),
         0x0003: ("get_power_profile_price", (t.uint8_t,), False),
-        0x0004: (
-            "power_profile_state_notification",
-            (t.LVList[t.uint8_t, PowerProfile],),
-            False,
-        ),
+        0x0004: ("power_profile_state_notification", (t.LVList[PowerProfile],), False,),
         0x0005: ("get_overall_schedule_price", (), False),
         0x0006: ("energy_phases_schedule_request", (), False),
         0x0007: ("energy_phases_schedule_state_response", (t.uint8_t, t.uint8_t), True),

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -311,7 +311,7 @@ class Groups(Cluster):
     server_commands = {
         0x0000: ("add", (t.Group, t.CharacterString), False),
         0x0001: ("view", (t.Group,), False),
-        0x0002: ("get_membership", (t.LVList(t.Group),), False),
+        0x0002: ("get_membership", (t.LVList[t.uint8_t, t.Group],), False),
         0x0003: ("remove", (t.Group,), False),
         0x0004: ("remove_all", (), False),
         0x0005: ("add_if_identifying", (t.Group, t.CharacterString), False),
@@ -323,7 +323,11 @@ class Groups(Cluster):
             (foundation.Status, t.Group, t.CharacterString),
             True,
         ),
-        0x0002: ("get_membership_response", (t.uint8_t, t.LVList(t.Group)), True),
+        0x0002: (
+            "get_membership_response",
+            (t.uint8_t, t.LVList[t.uint8_t, t.Group]),
+            True,
+        ),
         0x0003: ("remove_response", (foundation.Status, t.Group), True),
     }
 
@@ -371,7 +375,12 @@ class Scenes(Cluster):
         0x0004: ("store_response", (t.uint8_t, t.uint16_t, t.uint8_t), True),
         0x0006: (
             "get_scene_membership_response",
-            (t.uint8_t, t.uint8_t, t.uint16_t, t.Optional(t.LVList(t.uint8_t))),
+            (
+                t.uint8_t,
+                t.uint8_t,
+                t.uint16_t,
+                t.Optional(t.LVList[t.uint8_t, t.uint8_t]),
+            ),
             True,
         ),
         0x0040: ("enhanced_add_response", (), True),
@@ -619,7 +628,11 @@ class RSSILocation(Cluster):
         0x0003: ("compact_location_data_notification", (), False),
         0x0004: ("rssi_ping", (t.uint8_t,), False),  # data8
         0x0005: ("rssi_req", (), False),
-        0x0006: ("report_rssi_measurements", (t.EUI64, t.LVList(NeighborInfo)), False),
+        0x0006: (
+            "report_rssi_measurements",
+            (t.EUI64, t.LVList[t.uint8_t, NeighborInfo]),
+            False,
+        ),
         0x0007: ("request_own_location", (t.EUI64,), False),
     }
 
@@ -752,7 +765,7 @@ class MultistateInput(Cluster):
     cluster_id = 0x0012
     ep_attribute = "multistate_input"
     attributes = {
-        0x000E: ("state_text", t.List(t.CharacterString)),
+        0x000E: ("state_text", t.List[t.CharacterString]),
         0x001C: ("description", t.CharacterString),
         0x004A: ("number_of_states", t.uint16_t),
         0x0051: ("out_of_service", t.Bool),
@@ -771,7 +784,7 @@ class MultistateOutput(Cluster):
     cluster_id = 0x0013
     ep_attribute = "multistate_output"
     attributes = {
-        0x000E: ("state_text", t.List(t.CharacterString)),
+        0x000E: ("state_text", t.List[t.CharacterString]),
         0x001C: ("description", t.CharacterString),
         0x004A: ("number_of_states", t.uint16_t),
         0x0051: ("out_of_service", t.Bool),
@@ -791,7 +804,7 @@ class MultistateValue(Cluster):
     cluster_id = 0x0014
     ep_attribute = "multistate_value"
     attributes = {
-        0x000E: ("state_text", t.List(t.CharacterString)),
+        0x000E: ("state_text", t.List[t.CharacterString]),
         0x001C: ("description", t.CharacterString),
         0x004A: ("number_of_states", t.uint16_t),
         0x0051: ("out_of_service", t.Bool),
@@ -823,10 +836,10 @@ class Commissioning(Cluster):
         0x0005: ("stack_profile", t.uint8_t),
         0x0006: ("startup_control", t.enum8),
         0x0010: ("trust_center_address", t.EUI64),
-        0x0011: ("trust_center_master_key", t.fixed_list(16, t.uint8_t)),
-        0x0012: ("network_key", t.fixed_list(16, t.uint8_t)),
+        0x0011: ("trust_center_master_key", t.FixedList[16, t.uint8_t]),
+        0x0012: ("network_key", t.FixedList[16, t.uint8_t]),
         0x0013: ("use_insecure_join", t.Bool),
-        0x0014: ("preconfigured_link_key", t.fixed_list(16, t.uint8_t)),
+        0x0014: ("preconfigured_link_key", t.FixedList[16, t.uint8_t]),
         0x0015: ("network_key_seq_num", t.uint8_t),
         0x0016: ("network_key_type", t.enum8),
         0x0017: ("network_manager_address", t.uint16_t),
@@ -1179,12 +1192,12 @@ class PowerProfile(Cluster):
         ),
         0x0004: (
             "energy_phases_schedule_notification",
-            (t.uint8_t, t.LVList(ScheduleRecord)),
+            (t.uint8_t, t.LVList[t.uint8_t, ScheduleRecord]),
             False,
         ),
         0x0005: (
             "energy_phases_schedule_response",
-            (t.uint8_t, t.LVList(ScheduleRecord)),
+            (t.uint8_t, t.LVList[t.uint8_t, ScheduleRecord]),
             True,
         ),
         0x0006: ("power_profile_schedule_constraints_request", (t.uint8_t,), False),
@@ -1198,17 +1211,25 @@ class PowerProfile(Cluster):
     client_commands = {
         0x0000: (
             "power_profile_notification",
-            (t.uint8_t, t.uint8_t, t.LVList(PowerProfilePhase)),
+            (t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, PowerProfilePhase]),
             False,
         ),
         0x0001: (
             "power_profile_response",
-            (t.uint8_t, t.uint8_t, t.LVList(PowerProfilePhase)),
+            (t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, PowerProfilePhase]),
             True,
         ),
-        0x0002: ("power_profile_state_response", (t.LVList(PowerProfile),), True),
+        0x0002: (
+            "power_profile_state_response",
+            (t.LVList[t.uint8_t, PowerProfile],),
+            True,
+        ),
         0x0003: ("get_power_profile_price", (t.uint8_t,), False),
-        0x0004: ("power_profile_state_notification", (t.LVList(PowerProfile),), False),
+        0x0004: (
+            "power_profile_state_notification",
+            (t.LVList[t.uint8_t, PowerProfile],),
+            False,
+        ),
         0x0005: ("get_overall_schedule_price", (), False),
         0x0006: ("energy_phases_schedule_request", (), False),
         0x0007: ("energy_phases_schedule_state_response", (t.uint8_t, t.uint8_t), True),

--- a/zigpy/zcl/clusters/hvac.py
+++ b/zigpy/zcl/clusters/hvac.py
@@ -321,7 +321,7 @@ class Thermostat(Cluster):
         0x0000: ("setpoint_raise_lower", (SetpointMode, t.int8s), False),
         0x0001: (
             "set_weekly_schedule",
-            (t.enum8, SeqDayOfWeek, SeqMode, t.List(t.int16s)),
+            (t.enum8, SeqDayOfWeek, SeqMode, t.List[t.int16s]),
             False,
         ),
         0x0002: ("get_weekly_schedule", (SeqDayOfWeek, SeqMode), False),
@@ -331,7 +331,7 @@ class Thermostat(Cluster):
     client_commands = {
         0x0000: (
             "get_weekly_schedule_response",
-            (t.enum8, SeqDayOfWeek, SeqMode, t.List(t.int16s)),
+            (t.enum8, SeqDayOfWeek, SeqMode, t.List[t.int16s]),
             True,
         ),
         0x0001: (

--- a/zigpy/zcl/clusters/lightlink.py
+++ b/zigpy/zcl/clusters/lightlink.py
@@ -107,7 +107,7 @@ class LightLink(Cluster):
         ),
         0x0003: (
             "device_information_rsp",
-            (t.uint32_t, t.uint8_t, t.uint8_t, t.LVList(DeviceInfoRecord)),
+            (t.uint32_t, t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, DeviceInfoRecord]),
             True,
         ),
         0x0011: (
@@ -124,12 +124,12 @@ class LightLink(Cluster):
         ),
         0x0041: (
             "get_group_identifiers_rsp",
-            (t.uint8_t, t.uint8_t, t.LVList(GroupInfoRecord)),
+            (t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, GroupInfoRecord]),
             True,
         ),
         0x0042: (
             "get_endpoint_list_rsp",
-            (t.uint8_t, t.uint8_t, t.LVList(EndpointInfoRecord)),
+            (t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, EndpointInfoRecord]),
             True,
         ),
     }

--- a/zigpy/zcl/clusters/lightlink.py
+++ b/zigpy/zcl/clusters/lightlink.py
@@ -107,7 +107,7 @@ class LightLink(Cluster):
         ),
         0x0003: (
             "device_information_rsp",
-            (t.uint32_t, t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, DeviceInfoRecord]),
+            (t.uint32_t, t.uint8_t, t.uint8_t, t.LVList[DeviceInfoRecord]),
             True,
         ),
         0x0011: (
@@ -124,12 +124,12 @@ class LightLink(Cluster):
         ),
         0x0041: (
             "get_group_identifiers_rsp",
-            (t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, GroupInfoRecord]),
+            (t.uint8_t, t.uint8_t, t.LVList[GroupInfoRecord]),
             True,
         ),
         0x0042: (
             "get_endpoint_list_rsp",
-            (t.uint8_t, t.uint8_t, t.LVList[t.uint8_t, EndpointInfoRecord]),
+            (t.uint8_t, t.uint8_t, t.LVList[EndpointInfoRecord]),
             True,
         ),
     }

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -38,7 +38,7 @@ class AnalogInputRegular(Cluster):
     attributes = {
         0x0016: ("cov_increment", t.Single),
         0x001F: ("device_type", t.CharacterString),
-        0x004B: ("object_id", t.fixed_list(4, t.uint8_t)),
+        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
         0x004D: ("object_name", t.CharacterString),
         0x004F: ("object_type", t.enum16),
         0x0076: ("update_interval", t.uint8_t),
@@ -80,7 +80,7 @@ class AnalogOutputRegular(Cluster):
     attributes = {
         0x0016: ("cov_increment", t.Single),
         0x001F: ("device_type", t.CharacterString),
-        0x004B: ("object_id", t.fixed_list(4, t.uint8_t)),
+        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
         0x004D: ("object_name", t.CharacterString),
         0x004F: ("object_type", t.enum16),
         0x0076: ("update_interval", t.uint8_t),
@@ -116,7 +116,7 @@ class AnalogValueRegular(Cluster):
     ep_attribute = "bacnet_regular_analog_value"
     attributes = {
         0x0016: ("cov_increment", t.Single),
-        0x004B: ("object_id", t.fixed_list(4, t.uint8_t)),
+        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
         0x004D: ("object_name", t.CharacterString),
         0x004F: ("object_type", t.enum16),
         0x00A8: ("profile_name", t.CharacterString),
@@ -154,7 +154,7 @@ class BinaryInputRegular(Cluster):
         0x0010: ("change_of_state_time", DateTime),
         0x001F: ("device_type", t.CharacterString),
         0x0021: ("elapsed_active_time", t.uint32_t),
-        0x004B: ("object_id", t.fixed_list(4, t.uint8_t)),
+        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
         0x004D: ("object_name", t.CharacterString),
         0x004F: ("object_type", t.enum16),
         0x0072: ("time_of_at_reset", DateTime),
@@ -192,7 +192,7 @@ class BinaryOutputRegular(Cluster):
         0x001F: ("device_type", t.CharacterString),
         0x0021: ("elapsed_active_time", t.uint32_t),
         0x0028: ("feed_back_value", t.enum8),
-        0x004B: ("object_id", t.fixed_list(4, t.uint8_t)),
+        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
         0x004D: ("object_name", t.CharacterString),
         0x004F: ("object_type", t.enum16),
         0x0072: ("time_of_at_reset", DateTime),
@@ -227,7 +227,7 @@ class BinaryValueRegular(Cluster):
         0x000F: ("change_of_state_count", t.uint32_t),
         0x0010: ("change_of_state_time", DateTime),
         0x0021: ("elapsed_active_time", t.uint32_t),
-        0x004B: ("object_id", t.fixed_list(4, t.uint8_t)),
+        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
         0x004D: ("object_name", t.CharacterString),
         0x004F: ("object_type", t.enum16),
         0x0072: ("time_of_at_reset", DateTime),
@@ -261,7 +261,7 @@ class MultistateInputRegular(Cluster):
     ep_attribute = "bacnet_regular_multistate_input"
     attributes = {
         0x001F: ("device_type", t.CharacterString),
-        0x004B: ("object_id", t.fixed_list(4, t.uint8_t)),
+        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
         0x004D: ("object_name", t.CharacterString),
         0x004F: ("object_type", t.enum16),
         0x00A8: ("profile_name", t.CharacterString),
@@ -295,7 +295,7 @@ class MultistateOutputRegular(Cluster):
     attributes = {
         0x001F: ("device_type", t.CharacterString),
         0x0028: ("feed_back_value", t.enum8),
-        0x004B: ("object_id", t.fixed_list(4, t.uint8_t)),
+        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
         0x004D: ("object_name", t.CharacterString),
         0x004F: ("object_type", t.enum16),
         0x00A8: ("profile_name", t.CharacterString),
@@ -325,7 +325,7 @@ class MultistateValueRegular(Cluster):
     cluster_id = 0x0612
     ep_attribute = "bacnet_regular_multistate_value"
     attributes = {
-        0x004B: ("object_id", t.fixed_list(4, t.uint8_t)),
+        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
         0x004D: ("object_name", t.CharacterString),
         0x004F: ("object_type", t.enum16),
         0x00A8: ("profile_name", t.CharacterString),

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -196,7 +196,7 @@ class IasAce(Cluster):
         ),
         0x0006: ("set_bypassed_zone_list", (t.LVList[t.uint8_t],), False),
         0x0007: ("bypass_response", (t.LVList[BypassResponse],), True),
-        0x0008: ("get_zone_status_response", (t.Bool, t.LVList[ZoneStatusRsp]), True,),
+        0x0008: ("get_zone_status_response", (t.Bool, t.LVList[ZoneStatusRsp]), True),
     }
 
 

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -161,7 +161,7 @@ class IasAce(Cluster):
     attributes = {}
     server_commands = {
         0x0000: ("arm", (ArmMode, t.CharacterString, t.uint8_t), False),
-        0x0001: ("bypass", (t.LVList[t.uint8_t, t.uint8_t], t.CharacterString), False),
+        0x0001: ("bypass", (t.LVList[t.uint8_t], t.CharacterString), False),
         0x0002: ("emergency", (), False),
         0x0003: ("fire", (), False),
         0x0004: ("panic", (), False),
@@ -194,13 +194,9 @@ class IasAce(Cluster):
             (PanelStatus, t.uint8_t, AudibleNotification, AlarmStatus),
             True,
         ),
-        0x0006: ("set_bypassed_zone_list", (t.LVList[t.uint8_t, t.uint8_t],), False),
-        0x0007: ("bypass_response", (t.LVList[t.uint8_t, BypassResponse],), True),
-        0x0008: (
-            "get_zone_status_response",
-            (t.Bool, t.LVList[t.uint8_t, ZoneStatusRsp]),
-            True,
-        ),
+        0x0006: ("set_bypassed_zone_list", (t.LVList[t.uint8_t],), False),
+        0x0007: ("bypass_response", (t.LVList[BypassResponse],), True),
+        0x0008: ("get_zone_status_response", (t.Bool, t.LVList[ZoneStatusRsp]), True,),
     }
 
 

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -161,7 +161,7 @@ class IasAce(Cluster):
     attributes = {}
     server_commands = {
         0x0000: ("arm", (ArmMode, t.CharacterString, t.uint8_t), False),
-        0x0001: ("bypass", (t.LVList(t.uint8_t), t.CharacterString), False),
+        0x0001: ("bypass", (t.LVList[t.uint8_t, t.uint8_t], t.CharacterString), False),
         0x0002: ("emergency", (), False),
         0x0003: ("fire", (), False),
         0x0004: ("panic", (), False),
@@ -173,7 +173,7 @@ class IasAce(Cluster):
     }
     client_commands = {
         0x0000: ("arm_response", (ArmNotification,), True),
-        0x0001: ("get_zone_id_map_response", (t.List(t.bitmap16),), True),
+        0x0001: ("get_zone_id_map_response", (t.List[t.bitmap16],), True),
         0x0002: (
             "get_zone_info_response",
             (t.uint8_t, ZoneType, t.EUI64, t.CharacterString),
@@ -194,9 +194,13 @@ class IasAce(Cluster):
             (PanelStatus, t.uint8_t, AudibleNotification, AlarmStatus),
             True,
         ),
-        0x0006: ("set_bypassed_zone_list", (t.LVList(t.uint8_t),), False),
-        0x0007: ("bypass_response", (t.LVList(BypassResponse),), True),
-        0x0008: ("get_zone_status_response", (t.Bool, t.LVList(ZoneStatusRsp)), True),
+        0x0006: ("set_bypassed_zone_list", (t.LVList[t.uint8_t, t.uint8_t],), False),
+        0x0007: ("bypass_response", (t.LVList[t.uint8_t, BypassResponse],), True),
+        0x0008: (
+            "get_zone_status_response",
+            (t.Bool, t.LVList[t.uint8_t, ZoneStatusRsp]),
+            True,
+        ),
     }
 
 

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -104,7 +104,7 @@ class TypedCollection(TypeValue):
         self = cls()
         self.type, data = data[0], data[1:]
         python_item_type = DATA_TYPES[self.type][1]
-        python_type = t.LVList(python_item_type)
+        python_type = t.LVList[t.uint8_t, python_item_type]
         self.value, data = python_type.deserialize(data)
         return self, data
 
@@ -198,7 +198,7 @@ DATA_TYPES = DataTypes(
         0x43: ("Long octet string", t.LongOctetString, Discrete),
         0x44: ("Long character string", t.LongCharacterString, Discrete),
         0x48: ("Array", Array, Discrete),
-        0x4C: ("Structure", t.LVList(TypeValue, 2), Discrete),
+        0x4C: ("Structure", t.LVList[t.uint16_t, TypeValue], Discrete),
         0x50: ("Set", Set, Discrete),
         0x51: ("Bag", Bag, Discrete),
         0xE0: ("Time of day", t.TimeOfDay, Analog),
@@ -396,7 +396,7 @@ class ConfigureReportingResponseRecord(t.Struct):
         return r
 
 
-class ConfigureReportingResponse(t.List(ConfigureReportingResponseRecord)):
+class ConfigureReportingResponse(t.List[ConfigureReportingResponseRecord]):
     def serialize(self):
         failed = [record for record in self if record.status != Status.SUCCESS]
         if failed:
@@ -458,38 +458,38 @@ class Command(t.enum8):
 
 COMMANDS = {
     # id: (params, is_response)
-    Command.Configure_Reporting: ((t.List(AttributeReportingConfig),), False),
+    Command.Configure_Reporting: ((t.List[AttributeReportingConfig],), False),
     Command.Configure_Reporting_rsp: ((ConfigureReportingResponse,), True),
     Command.Default_Response: ((t.uint8_t, Status), True),
     Command.Discover_Attributes: ((t.uint16_t, t.uint8_t), False),
     Command.Discover_Attributes_rsp: (
-        (t.Bool, t.List(DiscoverAttributesResponseRecord)),
+        (t.Bool, t.List[DiscoverAttributesResponseRecord]),
         True,
     ),
     Command.Discover_Attribute_Extended: ((t.uint16_t, t.uint8_t), False),
     Command.Discover_Attribute_Extended_rsp: (
-        (t.Bool, t.List(DiscoverAttributesExtendedResponseRecord)),
+        (t.Bool, t.List[DiscoverAttributesExtendedResponseRecord]),
         True,
     ),
     Command.Discover_Commands_Generated: ((t.uint8_t, t.uint8_t), False),
-    Command.Discover_Commands_Generated_rsp: ((t.Bool, t.List(t.uint8_t)), True),
+    Command.Discover_Commands_Generated_rsp: ((t.Bool, t.List[t.uint8_t]), True),
     Command.Discover_Commands_Received: ((t.uint8_t, t.uint8_t), False),
-    Command.Discover_Commands_Received_rsp: ((t.Bool, t.List(t.uint8_t)), True),
-    Command.Read_Attributes: ((t.List(t.uint16_t),), False),
-    Command.Read_Attributes_rsp: ((t.List(ReadAttributeRecord),), True),
+    Command.Discover_Commands_Received_rsp: ((t.Bool, t.List[t.uint8_t]), True),
+    Command.Read_Attributes: ((t.List[t.uint16_t],), False),
+    Command.Read_Attributes_rsp: ((t.List[ReadAttributeRecord],), True),
     # Command.Read_Attributes_Structured: ((, ), False),
-    Command.Read_Reporting_Configuration: ((t.List(ReadReportingConfigRecord),), False),
+    Command.Read_Reporting_Configuration: ((t.List[ReadReportingConfigRecord],), False),
     Command.Read_Reporting_Configuration_rsp: (
-        (t.List(AttributeReportingConfig),),
+        (t.List[AttributeReportingConfig],),
         True,
     ),
-    Command.Report_Attributes: ((t.List(Attribute),), False),
-    Command.Write_Attributes: ((t.List(Attribute),), False),
-    Command.Write_Attributes_No_Response: ((t.List(Attribute),), False),
+    Command.Report_Attributes: ((t.List[Attribute],), False),
+    Command.Write_Attributes: ((t.List[Attribute],), False),
+    Command.Write_Attributes_No_Response: ((t.List[Attribute],), False),
     Command.Write_Attributes_rsp: ((WriteAttributesResponse,), True),
     # Command.Write_Attributes_Structured: ((, ), False),
     # Command.Write_Attributes_Structured_rsp: ((, ), True),
-    Command.Write_Attributes_Undivided: ((t.List(Attribute),), False),
+    Command.Write_Attributes_Undivided: ((t.List[Attribute],), False),
 }
 
 

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -104,7 +104,7 @@ class TypedCollection(TypeValue):
         self = cls()
         self.type, data = data[0], data[1:]
         python_item_type = DATA_TYPES[self.type][1]
-        python_type = t.LVList[t.uint8_t, python_item_type]
+        python_type = t.LVList[python_item_type]
         self.value, data = python_type.deserialize(data)
         return self, data
 

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -415,7 +415,7 @@ CLUSTERS = {
         ("SimpleDescSizeList", t.LVList[t.uint8_t]),
     ),
     ZDOCmd.Node_Desc_store_req: (NWK, IEEE, ("NodeDescriptor", NodeDescriptor)),
-    ZDOCmd.Active_EP_store_req: (NWK, IEEE, ("ActiveEPList", t.LVList[t.uint8_t]),),
+    ZDOCmd.Active_EP_store_req: (NWK, IEEE, ("ActiveEPList", t.LVList[t.uint8_t])),
     ZDOCmd.Simple_Desc_store_req: (
         NWK,
         IEEE,
@@ -496,8 +496,8 @@ CLUSTERS = {
         NWKI,
         ("SimpleDescriptor", t.Optional(SizePrefixedSimpleDescriptor)),
     ),
-    ZDOCmd.Active_EP_rsp: (STATUS, NWKI, ("ActiveEPList", t.LVList[t.uint8_t]),),
-    ZDOCmd.Match_Desc_rsp: (STATUS, NWKI, ("MatchList", t.LVList[t.uint8_t]),),
+    ZDOCmd.Active_EP_rsp: (STATUS, NWKI, ("ActiveEPList", t.LVList[t.uint8_t])),
+    ZDOCmd.Match_Desc_rsp: (STATUS, NWKI, ("MatchList", t.LVList[t.uint8_t])),
     # ZDO.Complex_Desc_rsp: (
     #     STATUS,
     #     NWKI,

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -15,8 +15,8 @@ class SimpleDescriptor(t.Struct):
     profile: t.uint16_t
     device_type: t.uint16_t
     device_version: t.uint8_t
-    input_clusters: t.LVList[t.uint8_t, t.uint16_t]
-    output_clusters: t.LVList[t.uint8_t, t.uint16_t]
+    input_clusters: t.LVList[t.uint16_t]
+    output_clusters: t.LVList[t.uint16_t]
 
 
 class SizePrefixedSimpleDescriptor(SimpleDescriptor):
@@ -192,7 +192,7 @@ class Neighbors(t.Struct):
 
     Entries: t.uint8_t
     StartIndex: t.uint8_t
-    NeighborTableList: t.LVList[t.uint8_t, Neighbor]
+    NeighborTableList: t.LVList[Neighbor]
 
 
 class Route(t.Struct):
@@ -206,7 +206,7 @@ class Route(t.Struct):
 class Routes(t.Struct):
     Entries: t.uint8_t
     StartIndex: t.uint8_t
-    RoutingTableList: t.LVList[t.uint8_t, Route]
+    RoutingTableList: t.LVList[Route]
 
 
 class NwkUpdate(t.Struct):
@@ -394,8 +394,8 @@ CLUSTERS = {
     ZDOCmd.Match_Desc_req: (
         NWKI,
         ("ProfileID", t.uint16_t),
-        ("InClusterList", t.LVList[t.uint8_t, t.uint16_t]),
-        ("OutClusterList", t.LVList[t.uint8_t, t.uint16_t]),
+        ("InClusterList", t.LVList[t.uint16_t]),
+        ("OutClusterList", t.LVList[t.uint16_t]),
     ),
     # ZDO.Complex_Desc_req: (NWKI, ),
     ZDOCmd.User_Desc_req: (NWKI,),
@@ -412,14 +412,10 @@ CLUSTERS = {
         ("NodeDescSize", t.uint8_t),
         ("PowerDescSize", t.uint8_t),
         ("ActiveEPSize", t.uint8_t),
-        ("SimpleDescSizeList", t.LVList[t.uint8_t, t.uint8_t]),
+        ("SimpleDescSizeList", t.LVList[t.uint8_t]),
     ),
     ZDOCmd.Node_Desc_store_req: (NWK, IEEE, ("NodeDescriptor", NodeDescriptor)),
-    ZDOCmd.Active_EP_store_req: (
-        NWK,
-        IEEE,
-        ("ActiveEPList", t.LVList[t.uint8_t, t.uint8_t]),
-    ),
+    ZDOCmd.Active_EP_store_req: (NWK, IEEE, ("ActiveEPList", t.LVList[t.uint8_t]),),
     ZDOCmd.Simple_Desc_store_req: (
         NWK,
         IEEE,
@@ -433,15 +429,15 @@ CLUSTERS = {
         ("StartIndex", t.uint8_t),
     ),
     ZDOCmd.Extended_Active_EP_req: (NWKI, ("StartIndex", t.uint8_t)),
-    ZDOCmd.Parent_annce: (("Children", t.LVList[t.uint8_t, t.EUI64]),),
+    ZDOCmd.Parent_annce: (("Children", t.LVList[t.EUI64]),),
     #  Bind Management Server Services Responses
     ZDOCmd.End_Device_Bind_req: (
         ("BindingTarget", t.uint16_t),
         ("SrcAddress", t.EUI64),
         ("SrcEndpoint", t.uint8_t),
         ("ProfileID", t.uint8_t),
-        ("InClusterList", t.LVList[t.uint8_t, t.uint8_t]),
-        ("OutClusterList", t.LVList[t.uint8_t, t.uint8_t]),
+        ("InClusterList", t.LVList[t.uint8_t]),
+        ("OutClusterList", t.LVList[t.uint8_t]),
     ),
     ZDOCmd.Bind_req: (
         ("SrcAddress", t.EUI64),
@@ -500,16 +496,8 @@ CLUSTERS = {
         NWKI,
         ("SimpleDescriptor", t.Optional(SizePrefixedSimpleDescriptor)),
     ),
-    ZDOCmd.Active_EP_rsp: (
-        STATUS,
-        NWKI,
-        ("ActiveEPList", t.LVList[t.uint8_t, t.uint8_t]),
-    ),
-    ZDOCmd.Match_Desc_rsp: (
-        STATUS,
-        NWKI,
-        ("MatchList", t.LVList[t.uint8_t, t.uint8_t]),
-    ),
+    ZDOCmd.Active_EP_rsp: (STATUS, NWKI, ("ActiveEPList", t.LVList[t.uint8_t]),),
+    ZDOCmd.Match_Desc_rsp: (STATUS, NWKI, ("MatchList", t.LVList[t.uint8_t]),),
     # ZDO.Complex_Desc_rsp: (
     #     STATUS,
     #     NWKI,
@@ -548,7 +536,7 @@ CLUSTERS = {
         ("StartIndex", t.uint8_t),
         ("ActiveEPList", t.List[t.uint8_t]),
     ),
-    ZDOCmd.Parent_annce_rsp: (STATUS, ("Children", t.LVList[t.uint8_t, t.EUI64])),
+    ZDOCmd.Parent_annce_rsp: (STATUS, ("Children", t.LVList[t.EUI64])),
     #  Bind Management Server Services Responses
     ZDOCmd.End_Device_Bind_rsp: (STATUS,),
     ZDOCmd.Bind_rsp: (STATUS,),
@@ -565,7 +553,7 @@ CLUSTERS = {
         ("ScannedChannels", t.Channels),
         ("TotalTransmissions", t.uint16_t),
         ("TransmissionFailures", t.uint16_t),
-        ("EnergyValues", t.LVList[t.uint8_t, t.uint8_t]),
+        ("EnergyValues", t.LVList[t.uint8_t]),
     )
     # ... TODO optional stuff ...
 }

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -15,8 +15,8 @@ class SimpleDescriptor(t.Struct):
     profile: t.uint16_t
     device_type: t.uint16_t
     device_version: t.uint8_t
-    input_clusters: t.LVList(t.uint16_t)
-    output_clusters: t.LVList(t.uint16_t)
+    input_clusters: t.LVList[t.uint8_t, t.uint16_t]
+    output_clusters: t.LVList[t.uint8_t, t.uint16_t]
 
 
 class SizePrefixedSimpleDescriptor(SimpleDescriptor):
@@ -192,7 +192,7 @@ class Neighbors(t.Struct):
 
     Entries: t.uint8_t
     StartIndex: t.uint8_t
-    NeighborTableList: t.LVList(Neighbor)
+    NeighborTableList: t.LVList[t.uint8_t, Neighbor]
 
 
 class Route(t.Struct):
@@ -206,7 +206,7 @@ class Route(t.Struct):
 class Routes(t.Struct):
     Entries: t.uint8_t
     StartIndex: t.uint8_t
-    RoutingTableList: t.LVList(Route)
+    RoutingTableList: t.LVList[t.uint8_t, Route]
 
 
 class NwkUpdate(t.Struct):
@@ -394,8 +394,8 @@ CLUSTERS = {
     ZDOCmd.Match_Desc_req: (
         NWKI,
         ("ProfileID", t.uint16_t),
-        ("InClusterList", t.LVList(t.uint16_t)),
-        ("OutClusterList", t.LVList(t.uint16_t)),
+        ("InClusterList", t.LVList[t.uint8_t, t.uint16_t]),
+        ("OutClusterList", t.LVList[t.uint8_t, t.uint16_t]),
     ),
     # ZDO.Complex_Desc_req: (NWKI, ),
     ZDOCmd.User_Desc_req: (NWKI,),
@@ -403,7 +403,7 @@ CLUSTERS = {
     ZDOCmd.Device_annce: (NWK, IEEE, ("Capability", t.uint8_t)),
     ZDOCmd.User_Desc_set: (
         NWKI,
-        ("UserDescriptor", t.fixed_list(16, t.uint8_t)),
+        ("UserDescriptor", t.FixedList[16, t.uint8_t]),
     ),  # Really a string
     ZDOCmd.System_Server_Discovery_req: (("ServerMask", t.uint16_t),),
     ZDOCmd.Discovery_store_req: (
@@ -412,10 +412,14 @@ CLUSTERS = {
         ("NodeDescSize", t.uint8_t),
         ("PowerDescSize", t.uint8_t),
         ("ActiveEPSize", t.uint8_t),
-        ("SimpleDescSizeList", t.LVList(t.uint8_t)),
+        ("SimpleDescSizeList", t.LVList[t.uint8_t, t.uint8_t]),
     ),
     ZDOCmd.Node_Desc_store_req: (NWK, IEEE, ("NodeDescriptor", NodeDescriptor)),
-    ZDOCmd.Active_EP_store_req: (NWK, IEEE, ("ActiveEPList", t.LVList(t.uint8_t))),
+    ZDOCmd.Active_EP_store_req: (
+        NWK,
+        IEEE,
+        ("ActiveEPList", t.LVList[t.uint8_t, t.uint8_t]),
+    ),
     ZDOCmd.Simple_Desc_store_req: (
         NWK,
         IEEE,
@@ -429,15 +433,15 @@ CLUSTERS = {
         ("StartIndex", t.uint8_t),
     ),
     ZDOCmd.Extended_Active_EP_req: (NWKI, ("StartIndex", t.uint8_t)),
-    ZDOCmd.Parent_annce: (("Children", t.LVList(t.EUI64)),),
+    ZDOCmd.Parent_annce: (("Children", t.LVList[t.uint8_t, t.EUI64]),),
     #  Bind Management Server Services Responses
     ZDOCmd.End_Device_Bind_req: (
         ("BindingTarget", t.uint16_t),
         ("SrcAddress", t.EUI64),
         ("SrcEndpoint", t.uint8_t),
         ("ProfileID", t.uint8_t),
-        ("InClusterList", t.LVList(t.uint8_t)),
-        ("OutClusterList", t.LVList(t.uint8_t)),
+        ("InClusterList", t.LVList[t.uint8_t, t.uint8_t]),
+        ("OutClusterList", t.LVList[t.uint8_t, t.uint8_t]),
     ),
     ZDOCmd.Bind_req: (
         ("SrcAddress", t.EUI64),
@@ -471,7 +475,7 @@ CLUSTERS = {
         NWK,
         ("NumAssocDev", t.Optional(t.uint8_t)),
         ("StartIndex", t.Optional(t.uint8_t)),
-        ("NWKAddressAssocDevList", t.Optional(t.List(t.NWK))),
+        ("NWKAddressAssocDevList", t.Optional(t.List[t.NWK])),
     ),
     ZDOCmd.IEEE_addr_rsp: (
         STATUS,
@@ -479,7 +483,7 @@ CLUSTERS = {
         NWK,
         ("NumAssocDev", t.Optional(t.uint8_t)),
         ("StartIndex", t.Optional(t.uint8_t)),
-        ("NWKAddrAssocDevList", t.Optional(t.List(t.NWK))),
+        ("NWKAddrAssocDevList", t.Optional(t.List[t.NWK])),
     ),
     ZDOCmd.Node_Desc_rsp: (
         STATUS,
@@ -496,8 +500,16 @@ CLUSTERS = {
         NWKI,
         ("SimpleDescriptor", t.Optional(SizePrefixedSimpleDescriptor)),
     ),
-    ZDOCmd.Active_EP_rsp: (STATUS, NWKI, ("ActiveEPList", t.LVList(t.uint8_t))),
-    ZDOCmd.Match_Desc_rsp: (STATUS, NWKI, ("MatchList", t.LVList(t.uint8_t))),
+    ZDOCmd.Active_EP_rsp: (
+        STATUS,
+        NWKI,
+        ("ActiveEPList", t.LVList[t.uint8_t, t.uint8_t]),
+    ),
+    ZDOCmd.Match_Desc_rsp: (
+        STATUS,
+        NWKI,
+        ("MatchList", t.LVList[t.uint8_t, t.uint8_t]),
+    ),
     # ZDO.Complex_Desc_rsp: (
     #     STATUS,
     #     NWKI,
@@ -508,7 +520,7 @@ CLUSTERS = {
         STATUS,
         NWKI,
         ("Length", t.uint8_t),
-        ("UserDescriptor", t.Optional(t.fixed_list(16, t.uint8_t))),
+        ("UserDescriptor", t.Optional(t.FixedList[16, t.uint8_t])),
     ),
     ZDOCmd.Discovery_Cache_rsp: (STATUS,),
     ZDOCmd.User_Desc_conf: (STATUS, NWKI),
@@ -527,16 +539,16 @@ CLUSTERS = {
         ("AppInputClusterCount", t.uint8_t),
         ("AppOutputClusterCount", t.uint8_t),
         ("StartIndex", t.uint8_t),
-        ("AppClusterList", t.Optional(t.List(t.uint16_t))),
+        ("AppClusterList", t.Optional(t.List[t.uint16_t])),
     ),
     ZDOCmd.Extended_Active_EP_rsp: (
         STATUS,
         NWKI,
         ("ActiveEPCount", t.uint8_t),
         ("StartIndex", t.uint8_t),
-        ("ActiveEPList", t.List(t.uint8_t)),
+        ("ActiveEPList", t.List[t.uint8_t]),
     ),
-    ZDOCmd.Parent_annce_rsp: (STATUS, ("Children", t.LVList(t.EUI64))),
+    ZDOCmd.Parent_annce_rsp: (STATUS, ("Children", t.LVList[t.uint8_t, t.EUI64])),
     #  Bind Management Server Services Responses
     ZDOCmd.End_Device_Bind_rsp: (STATUS,),
     ZDOCmd.Bind_rsp: (STATUS,),
@@ -553,7 +565,7 @@ CLUSTERS = {
         ("ScannedChannels", t.Channels),
         ("TotalTransmissions", t.uint16_t),
         ("TransmissionFailures", t.uint16_t),
-        ("EnergyValues", t.LVList(t.uint8_t)),
+        ("EnergyValues", t.LVList[t.uint8_t, t.uint8_t]),
     )
     # ... TODO optional stuff ...
 }


### PR DESCRIPTION
The main change is overloading subclass and instance checks in the list metaclass so that the classes can be used as types:

```Python
class LVListSubclass(t.LVList, length_type=t.uint8_t, item_type=t.uint16_t):
    pass

assert issubclass(LVListSubclass, t.LVList[t.uint8_t, t.uint16_t])
assert isinstance(LVListSubclass(), LVListSubclass)
assert isinstance(LVListSubclass(), t.LVList[t.uint8_t, t.uint16_t])
```

This still allows for the creation of anonymous `t.LVList`s that work as you'd expect. With #444, most of the weirdness in the type system will be fixed and hacks relying on the names of classes can be removed (e.g. https://github.com/zigpy/zigpy/blob/41986610e84a51cd89ff09701ce1a055d7c9a6a6/zigpy/zcl/foundation.py#L136-L152).