### PR TITLE
Update README.md to mention ITEAD Sonoff ZBBridge with Tasmota

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Radio libraries for zigpy include **[bellows](https://github.com/zigpy/bellows)*
 ### Known working Zigbee radio modules
 
 - **EmberZNet based radios** using the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)
+  - [ITEAD Sonoff ZBBridge](https://www.itead.cc/smart-home/sonoff-zbbridge.html) (Note! This first have to be flashed with [Tasmota firmware and EmberZNet 6.5.x.x](https://www.digiblur.com/2020/07/how-to-use-sonoff-zigbee-bridge-with.html))
   - [Nortek GoControl QuickStick Combo Model HUSBZB-1 (Z-Wave & Zigbee USB Adapter)](https://www.nortekcontrol.com/products/2gig/husbzb-1-gocontrol-quickstick-combo/)
   - [Elelabs Zigbee USB Adapter](https://elelabs.com/products/elelabs_usb_adapter.html)
   - [Elelabs Zigbee Raspberry Pi Shield](https://elelabs.com/products/elelabs_zigbee_shield.html)


### PR DESCRIPTION
Update README.md to mention support for ITEAD Sonoff ZBBridge if flashed with Tasmota and EmberZNet 6.5.x.x

See https://www.digiblur.com/2020/07/how-to-use-sonoff-zigbee-bridge-with.html and https://templates.blakadder.com/sonoff_ZBBridge.html

This solves https://github.com/zigpy/zigpy/issues/385

@Adminiuga Please also see matching PRs https://github.com/zigpy/bellows/pull/285 & https://github.com/home-assistant/home-assistant.io/pull/14124