### PR TITLE
Simplify some structs by using `t.StructField(requires=...)` instead of custom `serialize`/`deserialize` methods

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -460,3 +460,19 @@ def test_conflicting_types():
 
         class BadStruct(t.Struct):
             foo: t.uint8_t = t.StructField(type=t.uint16_t)
+
+
+def test_requires_uses_instance_of_struct():
+    class TestStruct(t.Struct):
+        foo: t.uint8_t
+
+        # the first parameter is really an instance of TestStruct
+        bar: t.uint8_t = t.StructField(requires=lambda s: s.test)
+
+        @property
+        def test(self):
+            assert isinstance(self, TestStruct)
+            return self.foo == 0x01
+
+    assert TestStruct.deserialize(b"\x00\x00") == (TestStruct(foo=0x00), b"\x00")
+    assert TestStruct.deserialize(b"\x01\x00") == (TestStruct(foo=0x01, bar=0x00), b"")

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -38,6 +38,12 @@ class HeaderString(str):
         return self.encode("utf8").ljust(self._size, b"\x00")
 
 
+class FieldControl(t.bitmap16):
+    SECURITY_CREDENTIAL_VERSION_PRESENT = 0b001
+    DEVICE_SPECIFIC_FILE_PRESENT = 0b010
+    HARDWARE_VERSIONS_PRESENT = 0b100
+
+
 class OTAImageHeader(t.Struct):
     MAGIC_VALUE = 0x0BEEF11E
     OTA_HEADER = MAGIC_VALUE.to_bytes(4, "little")
@@ -45,7 +51,7 @@ class OTAImageHeader(t.Struct):
     upgrade_file_id: t.uint32_t
     header_version: t.uint16_t
     header_length: t.uint16_t
-    field_control: t.uint16_t
+    field_control: FieldControl
     manufacturer_id: t.uint16_t
     image_type: t.uint16_t
     file_version: t.uint32_t
@@ -53,61 +59,48 @@ class OTAImageHeader(t.Struct):
     header_string: HeaderString
     image_size: t.uint32_t
 
+    security_credential_version: t.uint8_t = t.StructField(
+        requires=lambda s: s.security_credential_version_present
+    )
+    upgrade_file_destination: t.EUI64 = t.StructField(
+        requires=lambda s: s.device_specific_file
+    )
+    minimum_hardware_version: HWVersion = t.StructField(
+        requires=lambda s: s.hardware_versions_present
+    )
+    maximum_hardware_version: HWVersion = t.StructField(
+        requires=lambda s: s.hardware_versions_present
+    )
+
     @property
     def security_credential_version_present(self) -> bool:
         if self.field_control is None:
             return None
-        return bool(self.field_control & 0x01)
+        return bool(
+            self.field_control & FieldControl.SECURITY_CREDENTIAL_VERSION_PRESENT
+        )
 
     @property
     def device_specific_file(self) -> bool:
         if self.field_control is None:
             return None
-        return bool(self.field_control & 0x02)
+        return bool(self.field_control & FieldControl.DEVICE_SPECIFIC_FILE_PRESENT)
 
     @property
     def hardware_versions_present(self) -> bool:
         if self.field_control is None:
             return None
-        return bool(self.field_control & 0x04)
+        return bool(self.field_control & FieldControl.HARDWARE_VERSIONS_PRESENT)
 
     @classmethod
     def deserialize(cls, data) -> tuple:
         hdr, data = super().deserialize(data)
         if hdr.upgrade_file_id != cls.MAGIC_VALUE:
             raise ValueError(
-                "Wrong magic number for OTA Image: %s" % (hdr.upgrade_file_id,)
+                f"Wrong magic number for OTA Image: {hdr.upgrade_file_id!r}"
             )
 
-        if hdr.security_credential_version_present:
-            hdr.security_credential_version, data = t.uint8_t.deserialize(data)
-        else:
-            hdr.security_credential_version = None
-
-        if hdr.device_specific_file:
-            hdr.upgrade_file_destination, data = t.EUI64.deserialize(data)
-        else:
-            hdr.upgrade_file_destination = None
-
-        if hdr.hardware_versions_present:
-            hdr.minimum_hardware_version, data = HWVersion.deserialize(data)
-            hdr.maximum_hardware_version, data = HWVersion.deserialize(data)
-        else:
-            hdr.minimum_hardware_version = None
-            hdr.maximum_hardware_version = None
-
         return hdr, data
-
-    def serialize(self) -> bytes:
-        data = super().serialize()
-        if self.security_credential_version_present:
-            data += self.security_credential_version.serialize()
-        if self.device_specific_file:
-            data += self.upgrade_file_destination.serialize()
-        if self.hardware_versions_present:
-            data += self.minimum_hardware_version.serialize()
-            data += self.maximum_hardware_version.serialize()
-        return data
 
 
 class ElementTagId(t.enum16):

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -10,10 +10,6 @@ class ListSubclass(list):
     pass
 
 
-class DotDict(dict):
-    __getattr__ = dict.__getitem__
-
-
 class Struct:
     @classmethod
     def real_cls(cls) -> type:
@@ -194,7 +190,6 @@ class Struct:
         instance = cls()
 
         for field in cls.fields():
-            # XXX: DotDict looks like our struct because it has attributes
             if field.requires is not None and not field.requires(instance):
                 continue
 

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -215,40 +215,14 @@ class NwkUpdate(t.Struct):
 
     ScanChannels: t.Channels
     ScanDuration: t.uint8_t
-    ScanCount: t.uint8_t
-    nwkUpdateId: t.uint8_t
-    nwkManagerAddr: t.NWK
-
-    def serialize(self) -> bytes:
-        """Serialize data."""
-        r = self.ScanChannels.serialize() + self.ScanDuration.serialize()
-        if self.ScanDuration <= 0x05:
-            r += self.ScanCount.serialize()
-        if self.ScanDuration in (
-            self.CHANNEL_CHANGE_REQ,
-            self.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ,
-        ):
-            r += self.nwkUpdateId.serialize()
-        if self.ScanDuration == self.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ:
-            r += self.nwkManagerAddr.serialize()
-        return r
-
-    @classmethod
-    def deserialize(cls, data: bytes) -> typing.Tuple["NwkUpdate", bytes]:
-        """Deserialize data."""
-        r = cls()
-        r.ScanChannels, data = t.Channels.deserialize(data)
-        r.ScanDuration, data = t.uint8_t.deserialize(data)
-        if r.ScanDuration <= 0x05:
-            r.ScanCount, data = t.uint8_t.deserialize(data)
-        if r.ScanDuration in (
-            cls.CHANNEL_CHANGE_REQ,
-            cls.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ,
-        ):
-            r.nwkUpdateId, data = t.uint8_t.deserialize(data)
-        if r.ScanDuration == cls.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ:
-            r.nwkManagerAddr, data = t.NWK.deserialize(data)
-        return r, data
+    ScanCount: t.uint8_t = t.StructField(requires=lambda s: s.ScanDuration <= 0x05)
+    nwkUpdateId: t.uint8_t = t.StructField(
+        requires=lambda s: s.ScanDuration
+        in (s.CHANNEL_CHANGE_REQ, s.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ)
+    )
+    nwkManagerAddr: t.NWK = t.StructField(
+        requires=lambda s: s.ScanDuration == s.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ
+    )
 
 
 class Status(t.enum8):


### PR DESCRIPTION
Use `t.StructField(requires=...)` to replace a couple of custom serialization/deserialization functions. Affected classes are `zigpy.ota.image.OTAImageHeader` and `zigpy.zdo.types.NwkUpdate`.