### PR TITLE
Simplify attribute record types in foundation

### DIFF
--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -136,6 +136,11 @@ def test_configure_reporting_response_serialization():
     assert res.direction is foundation.ReportingDirection.SendReports
     assert res.attrid == 0x1001
     assert d == extra
+    r = repr(res)
+    assert r.startswith(foundation.ConfigureReportingResponseRecord.__name__ + "(")
+    assert "status" in r
+    assert "direction" not in r
+    assert "attrid" not in r
 
     # failure record deserialization
     res, d = foundation.ConfigureReportingResponseRecord.deserialize(
@@ -146,7 +151,12 @@ def test_configure_reporting_response_serialization():
     assert res.attrid == 0x1001
     assert d == extra
 
-    # successful record with direction and attrid
+    r = repr(res)
+    assert "status" in r
+    assert "direction" in r
+    assert "attrid" in r
+
+    # successful record serializes only Status
     rec = foundation.ConfigureReportingResponseRecord(
         foundation.Status.SUCCESS, 0x00, 0xAABB
     )

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -147,7 +147,7 @@ def test_configure_reporting_response_serialization():
     rec = foundation.ConfigureReportingResponseRecord(
         foundation.Status.SUCCESS, 0x00, 0xAABB
     )
-    assert rec.serialize() == b"\x00\x00\xbb\xaa"
+    assert rec.serialize() == b"\x00"
     rec.status = foundation.Status.UNREPORTABLE_ATTRIBUTE
     assert rec.serialize()[0:1] == foundation.Status.UNREPORTABLE_ATTRIBUTE.serialize()
     assert rec.serialize()[1:] == b"\x00\xbb\xaa"
@@ -437,15 +437,6 @@ def test_configure_reporting_response_deserialize():
     assert r[0].direction is None
     assert r[0].attrid is None
     assert rest == b""
-
-    with pytest.raises(ValueError):
-        foundation.ConfigureReportingResponse.deserialize(b"\x00\x00")
-
-    with pytest.raises(ValueError):
-        foundation.ConfigureReportingResponse.deserialize(b"\x00\x00\x00")
-
-    with pytest.raises(ValueError):
-        foundation.ConfigureReportingResponse.deserialize(b"\x00\x00\x00\x00\x00")
 
     data = b"\x00"
     extra = b"\x01\xaa\x55"

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -469,6 +469,14 @@ def test_configure_reporting_response_deserialize():
         foundation.ConfigureReportingResponse.deserialize(data + extra)
 
 
+def test_configure_reporting_response_serialize_empty():
+    r = foundation.ConfigureReportingResponse()
+
+    # An empty configure reporting response doesn't make sense
+    with pytest.raises(ValueError):
+        r.serialize()
+
+
 @pytest.mark.parametrize(
     "attributes, data",
     (

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -55,6 +55,9 @@ def test_attribute_reporting_config_0():
     assert arc2.max_interval == arc.max_interval
     assert arc.reportable_change == arc.reportable_change
 
+    assert repr(arc)
+    assert repr(arc) == repr(arc2)
+
 
 def test_attribute_reporting_config_1():
     arc = foundation.AttributeReportingConfig()

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -30,7 +30,7 @@ def test_read_attribute_record():
 
     r = repr(rar)
     assert len(r) > 5
-    assert r.startswith("<") and r.endswith(">")
+    assert repr(foundation.Status.SUCCESS) in r
 
     ser = rar.serialize()
     assert ser == orig
@@ -93,7 +93,7 @@ def test_write_attribute_status_record():
     assert res.attrid is None
     assert d == attr_id + extra
     r = repr(res)
-    assert r.startswith("<" + foundation.WriteAttributesStatusRecord.__name__)
+    assert r.startswith(foundation.WriteAttributesStatusRecord.__name__)
     assert "status" in r
     assert "attrid" not in r
 

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -10,6 +10,10 @@ def test_multi_address_3():
     ma.endpoint = 1
     ser = ma.serialize()
 
+    assert "ieee" in repr(ma)
+    assert "endpoint" in repr(ma)
+    assert "nwk" not in repr(ma)
+
     ma2, data = types.MultiAddress.deserialize(ser)
     assert data == b""
     assert ma2.addrmode == ma.addrmode
@@ -22,6 +26,10 @@ def test_multi_address_1():
     ma.addrmode = 1
     ma.nwk = 123
     ser = ma.serialize()
+
+    assert "ieee" not in repr(ma)
+    assert "endpoint" not in repr(ma)
+    assert "nwk" in repr(ma)
 
     ma2, data = types.MultiAddress.deserialize(ser)
     assert data == b""

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -351,7 +351,7 @@ class ConfigureReportingResponseRecord(t.Struct):
 
     def __repr__(self):
         r = f"{self.__class__.__name__}(status={self.status}"
-        if self.direction is not None or self.attrid is not None:
+        if self.status != Status.SUCCESS:
             r += f", direction={self.direction}, attrid={self.attrid}"
         r += ")"
         return r

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -302,6 +302,25 @@ class AttributeReportingConfig:
 
         return self, data
 
+    def __repr__(self):
+        r = f"{self.__class__.__name__}("
+        r += f"direction={self.direction}"
+        r += f", attrid={self.attrid}"
+
+        if self.direction == ReportingDirection.ReceiveReports:
+            r += f", timeout={self.timeout}"
+        else:
+            r += f", datatype={self.datatype}"
+            r += f", min_interval={self.min_interval}"
+            r += f", max_interval={self.max_interval}"
+
+            if self.reportable_change is not None:
+                r += f", reportable_change={self.reportable_change}"
+
+        r += ")"
+
+        return r
+
 
 class ConfigureReportingResponseRecord(t.Struct):
     status: Status

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -208,32 +208,7 @@ class ReadAttributeRecord(t.Struct):
 
     attrid: t.uint16_t
     status: Status
-    value: TypeValue
-
-    @classmethod
-    def deserialize(cls, data):
-        r = cls()
-        r.attrid, data = t.uint16_t.deserialize(data)
-        r.status, data = Status.deserialize(data)
-        if r.status == Status.SUCCESS:
-            r.value, data = TypeValue.deserialize(data)
-
-        return r, data
-
-    def serialize(self):
-        r = t.uint16_t(self.attrid).serialize()
-        r += t.uint8_t(self.status).serialize()
-        if self.status == Status.SUCCESS:
-            r += self.value.serialize()
-
-        return r
-
-    def __repr__(self):
-        r = "<ReadAttributeRecord attrid=%s status=%s" % (self.attrid, self.status)
-        if self.status == Status.SUCCESS:
-            r += " value=%s" % (self.value.value,)
-        r += ">"
-        return r
+    value: TypeValue = t.StructField(requires=lambda s: s.status == Status.SUCCESS)
 
 
 class Attribute(t.Struct):
@@ -243,29 +218,7 @@ class Attribute(t.Struct):
 
 class WriteAttributesStatusRecord(t.Struct):
     status: Status
-    attrid: t.uint16_t
-
-    @classmethod
-    def deserialize(cls, data):
-        r = cls()
-        r.status, data = Status.deserialize(data)
-        if r.status != Status.SUCCESS:
-            r.attrid, data = t.uint16_t.deserialize(data)
-
-        return r, data
-
-    def serialize(self):
-        r = Status(self.status).serialize()
-        if self.status != Status.SUCCESS:
-            r += t.uint16_t(self.attrid).serialize()
-        return r
-
-    def __repr__(self):
-        r = "<%s status=%s" % (self.__class__.__name__, self.status)
-        if self.status != Status.SUCCESS:
-            r += " attrid=%s" % (self.attrid,)
-        r += ">"
-        return r
+    attrid: t.uint16_t = t.StructField(requires=lambda s: s.status != Status.SUCCESS)
 
 
 class WriteAttributesResponse(list):


### PR DESCRIPTION
The only one left is `AttributeReportingConfig`, which has a field whose data type is determined by a previous field. This isn't supported by the `struct` module right now without a few changes.

One ambiguous class that I saw is `ConfigureReportingResponseRecord`. The spec (**2.5.10.1**) says that:

> Note that attribute status records **are not included** for successfully configured attributes, in order to save bandwidth. In the case of successful configuration of all attributes, only a single attribute status record SHALL be included in the command, with the status field set to SUCCESS and the direction and attribute identifier fields omitted.

It doesn't say "SHALL not", only "are not". Does this mean that status records for successfully configured attributes can possibly be present? If so, can they have `direction` and `attrid` fields?

I'd like for serialization and deserialization to be inverses, so `T.deserialize(T.serialize()) == (T, b"")` should always be true.

This necessitated the behavior of the class and an associated unit test to be changed by making `ConfigureReportingResponseRecord(Status.SUCCESS, 0x00, 0xAABB).serialize()` be equal to `b"\x00\x00\xbb\xaa"` instead of `b"\x00"`.