### PR TITLE
Update setup.py and tox.ini to fully setup the testing env with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,21 @@
 """Setup module for zigpy"""
 
-from os import path
+import pathlib
 
 from setuptools import find_packages, setup
 import zigpy
-
-this_directory = path.join(path.abspath(path.dirname(__file__)))
-with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
-    long_description = f.read()
 
 setup(
     name="zigpy",
     version=zigpy.__version__,
     description="Library implementing a ZigBee stack",
-    long_description=long_description,
+    long_description=(pathlib.Path(__file__).parent / "README.md").read_text(),
     long_description_content_type="text/markdown",
-    url="http://github.com/zigpy/zigpy",
+    url="https://github.com/zigpy/zigpy",
     author="Russell Cloran",
     author_email="rcloran@gmail.com",
     license="GPL-3.0",
     packages=find_packages(exclude=["*.tests"]),
     install_requires=["aiohttp", "crccheck", "pycryptodome", "voluptuous"],
-    tests_require=["asynctest", "pytest"],
+    extras_require={"testing": ["asynctest", "pytest", "pytest-aiohttp"]},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = True
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
 install_command = pip install {opts} {packages}
-commands = py.test --cov --cov-report=
+commands = py.test --cov --cov-report=html
 deps =
     asynctest
     coveralls


### PR DESCRIPTION
Allows you to do `pip install zigpy[testing]` and then just run `pytest`. 

Also, `setup.py test` is deprecated (https://github.com/pypa/setuptools/issues/1684) and `tests_require` aren't used by `tox`.