### PR TITLE
Remove unused `Optional` annotations from `Struct` and cache `fields`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ ENV/
 
 # Visual Studio Code
 .vscode
+
+.DS_Store

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -86,7 +86,7 @@ def test_node_descriptor():
 
 
 def test_node_descriptor_is_valid():
-    for field in types.NodeDescriptor.fields():
+    for field in types.NodeDescriptor.fields:
         nd = types.NodeDescriptor(0, 1, 2, 0x0303, 0x04, 0x0505, 0x0606, 0x0707, 0x08)
         assert nd.is_valid is True
         setattr(nd, field.name, None)

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -57,7 +57,7 @@ class NodeDescriptor(t.Struct):
     def is_valid(self):
         """Return True if all fields were initialized."""
         non_empty_fields = [
-            getattr(self, field.name) is not None for field in self.fields()
+            getattr(self, field.name) is not None for field in self.fields
         ]
         return all(non_empty_fields)
 


### PR DESCRIPTION
This is now not supported (and was never actually used in the codebase):

```Python
class TestStruct(t.Struct):
    foo: t.Optional[t.uint8_t]
```

The following is also now invalid due to Python providing no way to get the order of annotated and unannotated attributes:

```Python
class TestStruct(t.Struct):
    foo: t.uint8_t
    bar = t.StructField(type=t.uint8_t)
    baz: t.uint8_t
```

Instead, you have to use `None` as a type annotation (maybe it'd be better to use `t.StructField`??):

```Python
class TestStruct(t.Struct):
    foo: t.uint8_t
    bar: None = t.StructField(type=t.uint8_t)
    baz: t.uint8_t
```
