### PR TITLE
Migrate from asynctest to stdlib AsyncMock for py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: bionic
 matrix:
   fast_finish: true
   include:
@@ -6,7 +7,6 @@ matrix:
       env: TOXENV=lint
     - python: "3.7"
       env: TOXENV=py37
-      dist: xenial
       sudo: true
     - python: "3.8"
       env: TOXENV=py38

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests modules."""

--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -1,0 +1,9 @@
+"""Mock utilities that are async aware."""
+import sys
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest.mock import *  # noqa
+
+    AsyncMock = CoroutineMock  # noqa: F405
+else:
+    from unittest.mock import *  # noqa

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -120,7 +120,7 @@ async def test_new_exception(ota_mock):
     p1 = patch.object(App, "_load_db", AsyncMock())
     p2 = patch.object(App, "startup", AsyncMock())
     p3 = patch.object(App, "shutdown", AsyncMock())
-    ota_mock.return_value.initialize.side_effect = AsyncMock()
+    ota_mock.return_value.initialize = AsyncMock()
 
     with p1 as db_mck, p2 as start_mck, p3 as shut_mck:
         await App.new(ZIGPY_SCHEMA({CONF_DATABASE: "/dev/null"}))
@@ -132,8 +132,8 @@ async def test_new_exception(ota_mock):
     assert shut_mck.call_count == 0
     assert shut_mck.await_count == 0
 
-    start_mck.side_effect = asyncio.TimeoutError
     with p1 as db_mck, p2 as start_mck, p3 as shut_mck:
+        start_mck.side_effect = asyncio.TimeoutError()
         with pytest.raises(asyncio.TimeoutError):
             await App.new(ZIGPY_SCHEMA({CONF_DATABASE: "/dev/null"}))
     assert db_mck.call_count == 2

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,7 +1,5 @@
 import asyncio
 
-import asynctest
-from asynctest import CoroutineMock, mock
 import pytest
 import voluptuous as vol
 
@@ -19,10 +17,12 @@ from zigpy.exceptions import DeliveryError
 import zigpy.ota
 import zigpy.types as t
 
+from .async_mock import AsyncMock, MagicMock, patch, sentinel
+
 
 @pytest.fixture
-@asynctest.patch("zigpy.ota.OTA", asynctest.MagicMock(spec_set=zigpy.ota.OTA))
-@asynctest.patch("zigpy.device.Device._initialize", asynctest.CoroutineMock())
+@patch("zigpy.ota.OTA", MagicMock(spec_set=zigpy.ota.OTA))
+@patch("zigpy.device.Device._initialize", AsyncMock())
 def app():
     class App(zigpy.application.ControllerApplication):
         async def shutdown(self):
@@ -88,7 +88,7 @@ async def test_startup():
         await App({}).startup()
 
 
-@mock.patch("zigpy.ota.OTA", spec_set=zigpy.ota.OTA)
+@patch("zigpy.ota.OTA", spec_set=zigpy.ota.OTA)
 async def test_new_exception(ota_mock):
     class App(zigpy.application.ControllerApplication):
         async def shutdown(self):
@@ -117,10 +117,10 @@ async def test_new_exception(ota_mock):
         async def probe(self, config):
             return True
 
-    p1 = mock.patch.object(App, "_load_db", CoroutineMock())
-    p2 = mock.patch.object(App, "startup", CoroutineMock())
-    p3 = mock.patch.object(App, "shutdown", CoroutineMock())
-    ota_mock.return_value.initialize.side_effect = CoroutineMock()
+    p1 = patch.object(App, "_load_db", AsyncMock())
+    p2 = patch.object(App, "startup", AsyncMock())
+    p3 = patch.object(App, "shutdown", AsyncMock())
+    ota_mock.return_value.initialize.side_effect = AsyncMock()
 
     with p1 as db_mck, p2 as start_mck, p3 as shut_mck:
         await App.new(ZIGPY_SCHEMA({CONF_DATABASE: "/dev/null"}))
@@ -199,11 +199,9 @@ async def test_permit_ncp():
 async def test_permit(app, ieee):
     ncp_ieee = t.EUI64(map(t.uint8_t, range(8, 16)))
     app._ieee = ncp_ieee
-    app.devices[ieee] = mock.MagicMock()
-    app.devices[ieee].zdo.permit = mock.MagicMock(
-        side_effect=asyncio.coroutine(mock.MagicMock())
-    )
-    app.permit_ncp = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    app.devices[ieee] = MagicMock()
+    app.devices[ieee].zdo.permit = MagicMock(side_effect=asyncio.coroutine(MagicMock()))
+    app.permit_ncp = AsyncMock()
     await app.permit(node=(1, 1, 1, 1, 1, 1, 1, 1))
     assert app.devices[ieee].zdo.permit.call_count == 0
     assert app.permit_ncp.call_count == 0
@@ -221,16 +219,16 @@ async def test_permit_delivery_failure(app, ieee):
     def zdo_permit(*args, **kwargs):
         raise DeliveryError
 
-    app.devices[ieee] = mock.MagicMock()
+    app.devices[ieee] = MagicMock()
     app.devices[ieee].zdo.permit = zdo_permit
-    app.permit_ncp = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    app.permit_ncp = AsyncMock()
     await app.permit(node=ieee)
     assert app.permit_ncp.call_count == 0
 
 
 async def test_permit_broadcast(app):
-    app.broadcast = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
-    app.permit_ncp = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    app.broadcast = AsyncMock()
+    app.permit_ncp = AsyncMock()
     await app.permit(time_s=30)
     assert app.broadcast.call_count == 1
     assert app.permit_ncp.call_count == 1
@@ -255,7 +253,7 @@ async def test_join_handler_change_id(app, ieee):
 
 
 async def _remove(app, ieee, retval, zdo_reply=True, delivery_failure=True):
-    app.devices[ieee] = asynctest.MagicMock()
+    app.devices[ieee] = MagicMock()
 
     async def leave():
         if zdo_reply:
@@ -271,13 +269,13 @@ async def _remove(app, ieee, retval, zdo_reply=True, delivery_failure=True):
 
 
 async def test_remove(app, ieee):
-    app.force_remove = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    app.force_remove = AsyncMock()
     await _remove(app, ieee, [0])
     assert app.force_remove.call_count == 0
 
 
 async def test_remove_with_failed_zdo(app, ieee):
-    app.force_remove = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    app.force_remove = AsyncMock()
     await _remove(app, ieee, [1])
     assert app.force_remove.call_count == 1
 
@@ -288,13 +286,13 @@ async def test_remove_nonexistent(app, ieee):
 
 
 async def test_remove_with_unreachable_device(app, ieee):
-    app.force_remove = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    app.force_remove = AsyncMock()
     await _remove(app, ieee, [0], zdo_reply=False)
     assert app.force_remove.call_count == 1
 
 
 async def test_remove_with_reply_timeout(app, ieee):
-    app.force_remove = mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock()))
+    app.force_remove = AsyncMock()
     await _remove(app, ieee, [0], zdo_reply=False, delivery_failure=False)
     assert app.force_remove.call_count == 1
 
@@ -338,20 +336,20 @@ def test_config(app):
 
 
 def test_deserialize(app, ieee):
-    dev = mock.MagicMock()
+    dev = MagicMock()
     app.deserialize(dev, 1, 1, b"")
     assert dev.deserialize.call_count == 1
 
 
 def test_handle_message(app, ieee):
-    dev = mock.MagicMock()
+    dev = MagicMock()
     app.handle_message(dev, 260, 1, 1, 1, [])
     assert dev.handle_message.call_count == 1
 
 
 def test_handle_message_uninitialized_dev(app, ieee):
     dev = device.Device(app, ieee, 0x1234)
-    dev.handle_message = mock.MagicMock()
+    dev.handle_message = MagicMock()
     app.handle_message(dev, 260, 1, 1, 1, [])
     assert dev.handle_message.call_count == 0
 
@@ -409,7 +407,7 @@ async def test_shutdown():
 
 
 def test_get_dst_address(app):
-    r = app.get_dst_address(mock.MagicMock())
+    r = app.get_dst_address(MagicMock())
     assert r.addrmode == 3
     assert r.endpoint == 1
 
@@ -428,7 +426,7 @@ def test_props(app):
 
 
 async def test_mrequest(app):
-    s = mock.sentinel
+    s = sentinel
     with pytest.raises(NotImplementedError):
         await app.mrequest(
             s.group_id, s.profile_id, s.cluster, s.src_ep, s.sequence, s.data

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 
-from asynctest import CoroutineMock, mock
 import pytest
 
 from zigpy import device, endpoint
@@ -11,11 +10,13 @@ from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zdo import types as zdo_t
 
+from .async_mock import AsyncMock, MagicMock, patch, sentinel
+
 
 @pytest.fixture
 def app():
     """Controller Application mock."""
-    return mock.MagicMock(spec_set=zigpy.application.ControllerApplication)
+    return MagicMock(spec_set=zigpy.application.ControllerApplication)
 
 
 @pytest.fixture
@@ -53,7 +54,7 @@ async def test_initialize_fail(dev):
     assert dev.status == device.Status.NEW
 
 
-@mock.patch("zigpy.device.Device.get_node_descriptor", mock.CoroutineMock())
+@patch("zigpy.device.Device.get_node_descriptor", AsyncMock())
 async def test_initialize_ep_failed(monkeypatch, dev):
     async def mockrequest(req, nwk, tries=None, delay=None):
         return [0, None, [1, 2]]
@@ -73,23 +74,23 @@ async def test_initialize_ep_failed(monkeypatch, dev):
 
 
 async def test_request(dev):
-    seq = mock.sentinel.tsn
+    seq = sentinel.tsn
 
     async def mock_req(*args, **kwargs):
-        dev._pending[seq].result.set_result(mock.sentinel.result)
+        dev._pending[seq].result.set_result(sentinel.result)
         return 0, ""
 
     dev.application.request.side_effect = mock_req
     assert dev.last_seen is None
     r = await dev.request(1, 2, 3, 3, seq, b"")
-    assert r is mock.sentinel.result
+    assert r is sentinel.result
     assert dev._application.request.call_count == 1
     assert dev.last_seen is not None
 
 
 async def test_failed_request(dev):
     assert dev.last_seen is None
-    dev._application.request = CoroutineMock(return_value=(1, "error"))
+    dev._application.request = AsyncMock(return_value=(1, "error"))
     with pytest.raises(zigpy.exceptions.DeliveryError):
         await dev.request(1, 2, 3, 4, 5, b"")
     assert dev.last_seen is None
@@ -109,7 +110,7 @@ def test_radio_details(dev):
 
 def test_deserialize(dev):
     ep = dev.add_endpoint(3)
-    ep.deserialize = mock.MagicMock()
+    ep.deserialize = MagicMock()
     dev.deserialize(3, 1, b"")
     assert ep.deserialize.call_count == 1
 
@@ -120,45 +121,45 @@ async def test_handle_message_no_endpoint(dev):
 
 async def test_handle_message(dev):
     ep = dev.add_endpoint(3)
-    hdr = mock.MagicMock()
-    hdr.tsn = mock.sentinel.tsn
-    hdr.is_reply = mock.sentinel.is_reply
-    dev.deserialize = mock.MagicMock(return_value=[hdr, mock.sentinel.args])
-    ep.handle_message = mock.MagicMock()
+    hdr = MagicMock()
+    hdr.tsn = sentinel.tsn
+    hdr.is_reply = sentinel.is_reply
+    dev.deserialize = MagicMock(return_value=[hdr, sentinel.args])
+    ep.handle_message = MagicMock()
     dev.handle_message(99, 98, 3, 3, b"abcd")
     assert ep.handle_message.call_count == 1
 
 
 async def test_handle_message_reply(dev):
     ep = dev.add_endpoint(3)
-    ep.handle_message = mock.MagicMock()
-    tsn = mock.sentinel.tsn
-    req_mock = mock.MagicMock()
+    ep.handle_message = MagicMock()
+    tsn = sentinel.tsn
+    req_mock = MagicMock()
     dev._pending[tsn] = req_mock
-    hdr_1 = mock.MagicMock()
+    hdr_1 = MagicMock()
     hdr_1.tsn = tsn
-    hdr_1.command_id = mock.sentinel.command_id
+    hdr_1.command_id = sentinel.command_id
     hdr_1.is_reply = True
-    hdr_2 = mock.MagicMock()
-    hdr_2.tsn = mock.sentinel.another_tsn
-    hdr_2.command_id = mock.sentinel.command_id
+    hdr_2 = MagicMock()
+    hdr_2.tsn = sentinel.another_tsn
+    hdr_2.command_id = sentinel.command_id
     hdr_2.is_reply = True
-    dev.deserialize = mock.MagicMock(
+    dev.deserialize = MagicMock(
         side_effect=(
-            (hdr_1, mock.sentinel.args),
-            (hdr_2, mock.sentinel.args),
-            (hdr_1, mock.sentinel.args),
+            (hdr_1, sentinel.args),
+            (hdr_2, sentinel.args),
+            (hdr_1, sentinel.args),
         )
     )
     dev.handle_message(99, 98, 3, 3, b"abcd")
     assert ep.handle_message.call_count == 0
     assert req_mock.result.set_result.call_count == 1
-    assert req_mock.result.set_result.call_args[0][0] is mock.sentinel.args
+    assert req_mock.result.set_result.call_args[0][0] is sentinel.args
 
     req_mock.reset_mock()
     dev.handle_message(99, 98, 3, 3, b"abcd")
     assert ep.handle_message.call_count == 1
-    assert ep.handle_message.call_args[0][-1] is mock.sentinel.args
+    assert ep.handle_message.call_args[0][-1] is sentinel.args
     assert req_mock.result.set_result.call_count == 0
 
     req_mock.reset_mock()
@@ -171,8 +172,8 @@ async def test_handle_message_reply(dev):
 
 async def test_handle_message_deserialize_error(dev):
     ep = dev.add_endpoint(3)
-    dev.deserialize = mock.MagicMock(side_effect=ValueError)
-    ep.handle_message = mock.MagicMock()
+    dev.deserialize = MagicMock(side_effect=ValueError)
+    ep.handle_message = MagicMock()
     dev.handle_message(99, 98, 3, 3, b"abcd")
     assert ep.handle_message.call_count == 0
 
@@ -213,7 +214,7 @@ async def _get_node_descriptor(dev, zdo_success=True, request_success=True):
         status = 0 if zdo_success else 1
         return [status, nwk, zdo_t.NodeDescriptor.deserialize(b"abcdefghijklm")[0]]
 
-    dev.zdo.Node_Desc_req = mock.MagicMock(side_effect=mockrequest)
+    dev.zdo.Node_Desc_req = MagicMock(side_effect=mockrequest)
     return await dev.get_node_descriptor()
 
 
@@ -241,9 +242,9 @@ async def test_get_node_descriptor_fail(dev):
 
 async def test_add_to_group(dev, monkeypatch):
     grp_id, grp_name = 0x1234, "test group 0x1234"
-    epmock = mock.MagicMock(spec_set=endpoint.Endpoint)
-    monkeypatch.setattr(endpoint, "Endpoint", mock.MagicMock(return_value=epmock))
-    epmock.add_to_group.side_effect = asyncio.coroutine(mock.MagicMock())
+    epmock = MagicMock(spec_set=endpoint.Endpoint)
+    monkeypatch.setattr(endpoint, "Endpoint", MagicMock(return_value=epmock))
+    epmock.add_to_group.side_effect = asyncio.coroutine(MagicMock())
 
     dev.add_endpoint(3)
     dev.add_endpoint(4)
@@ -256,9 +257,9 @@ async def test_add_to_group(dev, monkeypatch):
 
 async def test_remove_from_group(dev, monkeypatch):
     grp_id = 0x1234
-    epmock = mock.MagicMock(spec_set=endpoint.Endpoint)
-    monkeypatch.setattr(endpoint, "Endpoint", mock.MagicMock(return_value=epmock))
-    epmock.remove_from_group.side_effect = asyncio.coroutine(mock.MagicMock())
+    epmock = MagicMock(spec_set=endpoint.Endpoint)
+    monkeypatch.setattr(endpoint, "Endpoint", MagicMock(return_value=epmock))
+    epmock.remove_from_group = AsyncMock()
 
     dev.add_endpoint(3)
     dev.add_endpoint(4)
@@ -271,7 +272,7 @@ async def test_remove_from_group(dev, monkeypatch):
 async def test_schedule_group_membership(dev, caplog):
     """Test preempting group membership scan."""
 
-    p1 = mock.patch.object(dev, "group_membership_scan", new=CoroutineMock())
+    p1 = patch.object(dev, "group_membership_scan", new=AsyncMock())
     caplog.set_level(logging.DEBUG)
     with p1 as scan_mock:
         dev.schedule_group_membership_scan()

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -148,20 +148,22 @@ def test_cluster_attr(ep):
     ep.basic
 
 
-def test_request(ep):
+async def test_request(ep):
     ep.profile_id = 260
-    ep.request(7, 8, b"")
+    await ep.request(7, 8, b"")
     assert ep._device.request.call_count == 1
+    assert ep._device.request.await_count == 1
 
 
-def test_request_change_profileid(ep):
+async def test_request_change_profileid(ep):
     ep.profile_id = 49246
-    ep.request(7, 9, b"")
+    await ep.request(7, 9, b"")
     ep.profile_id = 49246
-    ep.request(0x1000, 10, b"")
+    await ep.request(0x1000, 10, b"")
     ep.profile_id = 260
-    ep.request(0x1000, 11, b"")
+    await ep.request(0x1000, 11, b"")
     assert ep._device.request.call_count == 3
+    assert ep._device.request.await_count == 3
 
 
 def test_reply(ep):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,6 +1,5 @@
 import asyncio
 
-from asynctest import CoroutineMock, mock
 import pytest
 
 from zigpy import endpoint, group
@@ -11,11 +10,13 @@ import zigpy.zcl as zcl
 from zigpy.zcl.foundation import Status as ZCLStatus
 from zigpy.zdo import types
 
+from .async_mock import AsyncMock, MagicMock, sentinel
+
 
 @pytest.fixture
 def ep():
-    dev = mock.MagicMock()
-    dev.request = CoroutineMock()
+    dev = MagicMock()
+    dev.request = AsyncMock()
     return endpoint.Endpoint(dev, 1)
 
 
@@ -82,7 +83,7 @@ def test_add_input_cluster(ep):
 
 
 def test_add_custom_input_cluster(ep):
-    mock_cluster = mock.MagicMock()
+    mock_cluster = MagicMock()
     ep.add_input_cluster(0, mock_cluster)
     assert 0 in ep.in_clusters
     assert ep.in_clusters[0] is mock_cluster
@@ -96,7 +97,7 @@ def test_add_output_cluster(ep):
 
 
 def test_add_custom_output_cluster(ep):
-    mock_cluster = mock.MagicMock()
+    mock_cluster = MagicMock()
     ep.add_output_cluster(0, mock_cluster)
     assert 0 in ep.out_clusters
     assert ep.out_clusters[0] is mock_cluster
@@ -122,22 +123,22 @@ def test_multiple_add_output_cluster(ep):
 
 def test_handle_message(ep):
     c = ep.add_input_cluster(0)
-    c.handle_message = mock.MagicMock()
-    ep.handle_message(mock.sentinel.profile, 0, mock.sentinel.hdr, mock.sentinel.data)
-    c.handle_message.assert_called_once_with(mock.sentinel.hdr, mock.sentinel.data)
+    c.handle_message = MagicMock()
+    ep.handle_message(sentinel.profile, 0, sentinel.hdr, sentinel.data)
+    c.handle_message.assert_called_once_with(sentinel.hdr, sentinel.data)
 
 
 def test_handle_message_output(ep):
     c = ep.add_output_cluster(0)
-    c.handle_message = mock.MagicMock()
-    ep.handle_message(mock.sentinel.profile, 0, mock.sentinel.hdr, mock.sentinel.data)
-    c.handle_message.assert_called_once_with(mock.sentinel.hdr, mock.sentinel.data)
+    c.handle_message = MagicMock()
+    ep.handle_message(sentinel.profile, 0, sentinel.hdr, sentinel.data)
+    c.handle_message.assert_called_once_with(sentinel.hdr, sentinel.data)
 
 
 def test_handle_request_unknown(ep):
-    hdr = mock.MagicMock()
-    hdr.command_id = mock.sentinel.command_id
-    ep.handle_message(mock.sentinel.profile, 99, hdr, mock.sentinel.args)
+    hdr = MagicMock()
+    hdr.command_id = sentinel.command_id
+    ep.handle_message(sentinel.profile, 99, hdr, sentinel.args)
 
 
 def test_cluster_attr(ep):
@@ -301,13 +302,13 @@ async def test_get_model_info_timeout(ep):
 
 def _group_add_mock(ep, status=ZCLStatus.SUCCESS, no_groups_cluster=False):
     async def mock_req(*args, **kwargs):
-        return [status, mock.sentinel.group_id]
+        return [status, sentinel.group_id]
 
     if not no_groups_cluster:
         ep.add_input_cluster(4)
-    ep.request = mock.MagicMock(side_effect=mock_req)
+    ep.request = MagicMock(side_effect=mock_req)
 
-    ep.device.application.groups = mock.MagicMock(spec_set=group.Groups)
+    ep.device.application.groups = MagicMock(spec_set=group.Groups)
     return ep
 
 
@@ -357,15 +358,15 @@ async def test_add_to_group_fail(ep, status):
 def _group_remove_mock(ep, success=True, no_groups_cluster=False, not_member=False):
     async def mock_req(*args, **kwargs):
         if success:
-            return [ZCLStatus.SUCCESS, mock.sentinel.group_id]
-        return [ZCLStatus.DUPLICATE_EXISTS, mock.sentinel.group_id]
+            return [ZCLStatus.SUCCESS, sentinel.group_id]
+        return [ZCLStatus.DUPLICATE_EXISTS, sentinel.group_id]
 
     if not no_groups_cluster:
         ep.add_input_cluster(4)
-    ep.request = mock.MagicMock(side_effect=mock_req)
+    ep.request = MagicMock(side_effect=mock_req)
 
-    ep.device.application.groups = mock.MagicMock(spec_set=group.Groups)
-    grp = mock.MagicMock(spec_set=group.Group)
+    ep.device.application.groups = MagicMock(spec_set=group.Groups)
+    grp = MagicMock(spec_set=group.Group)
     ep.device.application.groups.__contains__.return_value = not not_member
     ep.device.application.groups.__getitem__.return_value = grp
     return ep, grp
@@ -413,25 +414,25 @@ async def test_remove_from_group_fail(ep):
 
 
 def test_ep_manufacturer(ep):
-    ep.device.manufacturer = mock.sentinel.device_manufacturer
-    assert ep.manufacturer is mock.sentinel.device_manufacturer
+    ep.device.manufacturer = sentinel.device_manufacturer
+    assert ep.manufacturer is sentinel.device_manufacturer
 
-    ep.manufacturer = mock.sentinel.ep_manufacturer
-    assert ep.manufacturer is mock.sentinel.ep_manufacturer
+    ep.manufacturer = sentinel.ep_manufacturer
+    assert ep.manufacturer is sentinel.ep_manufacturer
 
 
 def test_ep_model(ep):
-    ep.device.model = mock.sentinel.device_model
-    assert ep.model is mock.sentinel.device_model
+    ep.device.model = sentinel.device_model
+    assert ep.model is sentinel.device_model
 
-    ep.model = mock.sentinel.ep_model
-    assert ep.model is mock.sentinel.ep_model
+    ep.model = sentinel.ep_model
+    assert ep.model is sentinel.ep_model
 
 
 async def test_group_membership_scan(ep):
     """Test group membership scan."""
 
-    ep.device.application.groups.update_group_membership = mock.MagicMock()
+    ep.device.application.groups.update_group_membership = MagicMock()
     await ep.group_membership_scan()
     assert ep.device.application.groups.update_group_membership.call_count == 0
     assert ep.device.request.call_count == 0
@@ -451,7 +452,7 @@ async def test_group_membership_scan(ep):
 async def test_group_membership_scan_fail(ep):
     """Test group membership scan failure."""
 
-    ep.device.application.groups.update_group_membership = mock.MagicMock()
+    ep.device.application.groups.update_group_membership = MagicMock()
     ep.add_input_cluster(4)
     ep.device.request.side_effect = asyncio.TimeoutError
     await ep.group_membership_scan()
@@ -461,5 +462,5 @@ async def test_group_membership_scan_fail(ep):
 
 def test_endpoint_manufacturer_id(ep):
     """Test manufacturer id."""
-    ep.device.manufacturer_id = mock.sentinel.manufacturer_id
-    assert ep.manufacturer_id is mock.sentinel.manufacturer_id
+    ep.device.manufacturer_id = sentinel.manufacturer_id
+    assert ep.manufacturer_id is sentinel.manufacturer_id

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -215,9 +215,9 @@ def test_group_cluster_from_cluster_name():
         zigpy.group.GroupCluster.from_attr(MagicMock(), "no_such_cluster")
 
 
-def test_group_ep_request(group_endpoint):
+async def test_group_ep_request(group_endpoint):
     assert group_endpoint.device is not None
-    group_endpoint.request(
+    await group_endpoint.request(
         sentinel.cluster,
         sentinel.seq,
         sentinel.data,
@@ -225,6 +225,7 @@ def test_group_ep_request(group_endpoint):
         extra_kwarg=sentinel.extra_kwarg,
     )
     assert group_endpoint.device.request.call_count == 1
+    assert group_endpoint.device.request.await_count == 1
     assert group_endpoint.device.request.call_args[0][1] is sentinel.cluster
     assert group_endpoint.device.request.call_args[0][2] is sentinel.seq
     assert group_endpoint.device.request.call_args[0][3] is sentinel.data

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -1,7 +1,6 @@
 """Test Units for neighbors."""
 import asyncio
 
-from asynctest import CoroutineMock, mock
 import pytest
 
 import zigpy.device
@@ -10,15 +9,17 @@ import zigpy.neighbor
 import zigpy.types as t
 import zigpy.zdo.types as zdo_t
 
+from .async_mock import AsyncMock, MagicMock, patch, sentinel
+
 
 @pytest.fixture
 def device():
     """Device fixture."""
 
     ieee = t.EUI64.convert("01:02:03:04:05:06:07:08")
-    dev = zigpy.device.Device(mock.MagicMock(), ieee, 0x1234)
-    p2 = mock.patch("zigpy.neighbor.REQUEST_DELAY", new=(0, 0))
-    with mock.patch.object(dev.zdo, "request", new=CoroutineMock()), p2:
+    dev = zigpy.device.Device(MagicMock(), ieee, 0x1234)
+    p2 = patch("zigpy.neighbor.REQUEST_DELAY", new=(0, 0))
+    with patch.object(dev.zdo, "request", new=AsyncMock()), p2:
         yield dev
 
 
@@ -51,7 +52,7 @@ async def test_neighbors_scan(neighbours_f, device):
         b'\x00\x10\x0f\x01h\xf1W\xde\xcb\xaf4"\x93\x13\x05\x00\x00\xb8\xd1\xf0\n\xf2%'
         b"\x02\x0f\xfc",
     )
-    listener = mock.MagicMock()
+    listener = MagicMock()
     neighbours_f.add_listener(listener)
     schema = zdo_t.CLUSTERS[zdo_t.ZDOCmd.Mgmt_Lqi_rsp][1]
     device.zdo.request.side_effect = (t.deserialize(d, schema)[0] for d in data_in)
@@ -70,7 +71,7 @@ async def test_neighbors_scan_fail(neighbours_f, device, side_effect):
     """Test scan fail."""
 
     assert neighbours_f.ieee == device.ieee
-    listener = mock.MagicMock()
+    listener = MagicMock()
     neighbours_f.add_listener(listener)
     device.zdo.request.side_effect = side_effect
 
@@ -84,7 +85,7 @@ async def test_neighbors_scan_fail(neighbours_f, device, side_effect):
 async def test_neighbors_unsupported(neighbours_f, device):
     """Test scanning."""
 
-    listener = mock.MagicMock()
+    listener = MagicMock()
     neighbours_f.add_listener(listener)
     device.zdo.request.return_value = (zdo_t.Status.NOT_SUPPORTED, [])
 
@@ -106,7 +107,7 @@ async def test_neighbors_invalid_ieee(neighbours_f, device):
         b"%\x02\x0f\xfe",
     )
 
-    listener = mock.MagicMock()
+    listener = MagicMock()
     neighbours_f.add_listener(listener)
     schema = zdo_t.CLUSTERS[zdo_t.ZDOCmd.Mgmt_Lqi_rsp][1]
     device.zdo.request.side_effect = (t.deserialize(d, schema)[0] for d in data_in)
@@ -131,7 +132,7 @@ def test_neighbor(device):
 def test_neihgbors_magic_methods(neighbours_f):
     """Test neighbors methods."""
 
-    neighbours_f.append(mock.sentinel.other)
-    neighbours_f[0] = mock.sentinel.nei
-    assert neighbours_f[0] is mock.sentinel.nei
-    assert [n for n in neighbours_f] == [mock.sentinel.nei]
+    neighbours_f.append(sentinel.other)
+    neighbours_f[0] = sentinel.nei
+    assert neighbours_f[0] is sentinel.nei
+    assert [n for n in neighbours_f] == [sentinel.nei]

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -1,6 +1,5 @@
 import datetime
 
-from asynctest import CoroutineMock, mock
 import pytest
 
 import zigpy.application
@@ -8,8 +7,10 @@ import zigpy.ota
 import zigpy.ota.image
 import zigpy.ota.provider
 
-MANUFACTURER_ID = mock.sentinel.manufacturer_id
-IMAGE_TYPE = mock.sentinel.image_type
+from .async_mock import AsyncMock, MagicMock, patch, sentinel
+
+MANUFACTURER_ID = sentinel.manufacturer_id
+IMAGE_TYPE = sentinel.image_type
 
 
 @pytest.fixture
@@ -39,14 +40,14 @@ def key():
 
 @pytest.fixture
 def ota():
-    app = mock.MagicMock(spec_set=zigpy.application.ControllerApplication)
-    tradfri = mock.MagicMock(spec_set=zigpy.ota.provider.Trådfri)
-    with mock.patch("zigpy.ota.provider.Trådfri", tradfri):
+    app = MagicMock(spec_set=zigpy.application.ControllerApplication)
+    tradfri = MagicMock(spec_set=zigpy.ota.provider.Trådfri)
+    with patch("zigpy.ota.provider.Trådfri", tradfri):
         return zigpy.ota.OTA(app)
 
 
 async def test_ota_initialize(ota):
-    ota.async_event = CoroutineMock()
+    ota.async_event = AsyncMock()
     await ota.initialize()
 
     assert ota.async_event.call_count == 1
@@ -55,7 +56,7 @@ async def test_ota_initialize(ota):
 
 
 async def test_get_image_empty(ota, image, key):
-    ota.async_event = CoroutineMock(return_value=[None, None])
+    ota.async_event = AsyncMock(return_value=[None, None])
 
     assert len(ota._image_cache) == 0
     res = await ota.get_ota_image(MANUFACTURER_ID, IMAGE_TYPE)
@@ -70,7 +71,7 @@ async def test_get_image_empty(ota, image, key):
 async def test_get_image_new(ota, image, key, image_with_version, monkeypatch):
     newer = image_with_version(image.version + 1)
 
-    ota.async_event = CoroutineMock(return_value=[None, image, newer])
+    ota.async_event = AsyncMock(return_value=[None, image, newer])
 
     assert len(ota._image_cache) == 0
     res = await ota.get_ota_image(MANUFACTURER_ID, IMAGE_TYPE)

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -1,6 +1,5 @@
 import itertools
 
-from asynctest import CoroutineMock, mock
 import pytest
 
 import zigpy.device
@@ -9,6 +8,8 @@ import zigpy.quirks
 from zigpy.quirks.registry import DeviceRegistry
 import zigpy.types as t
 import zigpy.zcl as zcl
+
+from .async_mock import AsyncMock, MagicMock, patch, sentinel
 
 ALLOWED_SIGNATURE = set(
     [
@@ -34,8 +35,8 @@ def test_registry():
 
 @pytest.fixture
 def real_device():
-    application = mock.sentinel.application
-    ieee = mock.sentinel.ieee
+    application = sentinel.application
+    ieee = sentinel.ieee
     nwk = 0x2233
     real_device = zigpy.device.Device(application, ieee, nwk)
 
@@ -197,7 +198,7 @@ def test_custom_device():
 
         class MyEndpoint:
             def __init__(self, device, endpoint_id, *args, **kwargs):
-                assert args == (mock.sentinel.custom_endpoint_arg, replaces)
+                assert args == (sentinel.custom_endpoint_arg, replaces)
 
         class MyCluster(zigpy.quirks.CustomCluster):
             cluster_id = 0x8888
@@ -205,11 +206,11 @@ def test_custom_device():
         replacement = {
             "endpoints": {
                 1: {
-                    "profile_id": mock.sentinel.profile_id,
+                    "profile_id": sentinel.profile_id,
                     "input_clusters": [0x0000, MyCluster],
                     "output_clusters": [0x0001, MyCluster],
                 },
-                2: (MyEndpoint, mock.sentinel.custom_endpoint_arg),
+                2: (MyEndpoint, sentinel.custom_endpoint_arg),
             },
             "model": "Mock Model",
             "manufacturer": "Mock Manufacturer",
@@ -220,7 +221,7 @@ def test_custom_device():
 
         class MyEndpoint:
             def __init__(self, device, endpoint_id, *args, **kwargs):
-                assert args == (mock.sentinel.custom_endpoint_arg, replaces)
+                assert args == (sentinel.custom_endpoint_arg, replaces)
 
         class MyCluster(zigpy.quirks.CustomCluster):
             cluster_id = 0x8888
@@ -228,11 +229,11 @@ def test_custom_device():
         replacement = {
             "endpoints": {
                 1: {
-                    "profile_id": mock.sentinel.profile_id,
+                    "profile_id": sentinel.profile_id,
                     "input_clusters": [0x0000, MyCluster],
                     "output_clusters": [0x0001, MyCluster],
                 },
-                2: (MyEndpoint, mock.sentinel.custom_endpoint_arg),
+                2: (MyEndpoint, sentinel.custom_endpoint_arg),
             },
             "model": "Mock Model",
             "manufacturer": "Mock Manufacturer",
@@ -241,8 +242,8 @@ def test_custom_device():
 
     assert 0x8888 not in zcl.Cluster._registry
 
-    replaces = mock.MagicMock()
-    replaces[1].device_type = mock.sentinel.device_type
+    replaces = MagicMock()
+    replaces[1].device_type = sentinel.device_type
     test_device = Device(None, None, 0x4455, replaces)
     test_device2 = Device2(None, None, 0x4455, replaces)
 
@@ -252,8 +253,8 @@ def test_custom_device():
     assert test_device.model == "Mock Model"
     assert test_device.skip_configuration is False
 
-    assert test_device[1].profile_id == mock.sentinel.profile_id
-    assert test_device[1].device_type == mock.sentinel.device_type
+    assert test_device[1].profile_id == sentinel.profile_id
+    assert test_device[1].device_type == sentinel.device_type
 
     assert 0x0000 in test_device[1].in_clusters
     assert 0x8888 in test_device[1].in_clusters
@@ -332,7 +333,7 @@ async def test_read_attributes_uncached():
         server_commands = {}
         client_commands = {}
 
-    epmock = mock.MagicMock()
+    epmock = MagicMock()
     epmock._device.application.get_sequence.return_value = 123
     epmock.device.application.get_sequence.return_value = 123
     cluster = TestCluster(epmock, True)
@@ -393,7 +394,7 @@ async def test_read_attributes_default_response():
             0x01: ("client_cmd_1", (t.uint8_t,), True),
         }
 
-    epmock = mock.MagicMock()
+    epmock = MagicMock()
     epmock._device.application.get_sequence.return_value = 123
     epmock.device.application.get_sequence.return_value = 123
     cluster = TestCluster(epmock, True)
@@ -436,8 +437,8 @@ class ManufacturerSpecificCluster(zigpy.quirks.CustomCluster):
 def manuf_cluster():
     """Return a manufacturer specific cluster fixture."""
 
-    ep = mock.MagicMock()
-    ep.manufacturer_id = mock.sentinel.manufacturer_id
+    ep = MagicMock()
+    ep.manufacturer_id = sentinel.manufacturer_id
     return ManufacturerSpecificCluster.from_id(ep, 0x2222)
 
 
@@ -449,8 +450,8 @@ def manuf_cluster2():
         ep_attribute = "just_a_manufacturer_specific_cluster"
         cluster_id = 0xFC00
 
-    ep = mock.MagicMock()
-    ep.manufacturer_id = mock.sentinel.manufacturer_id2
+    ep = MagicMock()
+    ep.manufacturer_id = sentinel.manufacturer_id2
     cluster = ManufCluster2(ep)
     cluster.cluster_id = 0xFC00
     return cluster
@@ -460,174 +461,164 @@ def manuf_cluster2():
     "cmd_name, manufacturer",
     (
         ("client_cmd0", None),
-        ("client_cmd1", mock.sentinel.manufacturer_id),
+        ("client_cmd1", sentinel.manufacturer_id),
     ),
 )
 def test_client_cmd_vendor_specific_by_name(
     manuf_cluster, manuf_cluster2, cmd_name, manufacturer
 ):
     """Test manufacturer specific client commands."""
-    with mock.patch.object(manuf_cluster, "reply") as cmd_mock:
+    with patch.object(manuf_cluster, "reply") as cmd_mock:
         getattr(manuf_cluster, cmd_name)()
         assert cmd_mock.call_count == 1
         assert cmd_mock.call_args[1]["manufacturer"] is manufacturer
 
-    with mock.patch.object(manuf_cluster2, "reply") as cmd_mock:
+    with patch.object(manuf_cluster2, "reply") as cmd_mock:
         getattr(manuf_cluster2, cmd_name)()
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.manufacturer_id2
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.manufacturer_id2
 
 
 @pytest.mark.parametrize(
     "cmd_name, manufacturer",
     (
         ("server_cmd0", None),
-        ("server_cmd1", mock.sentinel.manufacturer_id),
+        ("server_cmd1", sentinel.manufacturer_id),
     ),
 )
 def test_srv_cmd_vendor_specific_by_name(
     manuf_cluster, manuf_cluster2, cmd_name, manufacturer
 ):
     """Test manufacturer specific server commands."""
-    with mock.patch.object(manuf_cluster, "request") as cmd_mock:
+    with patch.object(manuf_cluster, "request") as cmd_mock:
         getattr(manuf_cluster, cmd_name)()
         assert cmd_mock.call_count == 1
         assert cmd_mock.call_args[1]["manufacturer"] is manufacturer
 
-    with mock.patch.object(manuf_cluster2, "request") as cmd_mock:
+    with patch.object(manuf_cluster2, "request") as cmd_mock:
         getattr(manuf_cluster2, cmd_name)()
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.manufacturer_id2
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.manufacturer_id2
 
 
 @pytest.mark.parametrize(
     "attr_name, manufacturer",
     (
         ("attr0", None),
-        ("attr1", mock.sentinel.manufacturer_id),
+        ("attr1", sentinel.manufacturer_id),
     ),
 )
 async def test_read_attr_manufacture_specific(
     manuf_cluster, manuf_cluster2, attr_name, manufacturer
 ):
     """Test manufacturer specific read_attributes command."""
-    with mock.patch.object(
-        zcl.Cluster, "_read_attributes", CoroutineMock()
-    ) as cmd_mock:
+    with patch.object(zcl.Cluster, "_read_attributes", AsyncMock()) as cmd_mock:
         await manuf_cluster.read_attributes([attr_name])
         assert cmd_mock.call_count == 1
         assert cmd_mock.call_args[1]["manufacturer"] is manufacturer
         cmd_mock.reset_mock()
         await manuf_cluster.read_attributes(
-            [attr_name], manufacturer=mock.sentinel.another_id
+            [attr_name], manufacturer=sentinel.another_id
         )
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.another_id
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.another_id
 
-    with mock.patch.object(
-        zcl.Cluster, "_read_attributes", CoroutineMock()
-    ) as cmd_mock:
+    with patch.object(zcl.Cluster, "_read_attributes", AsyncMock()) as cmd_mock:
         await manuf_cluster2.read_attributes([attr_name])
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.manufacturer_id2
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.manufacturer_id2
         cmd_mock.reset_mock()
         await manuf_cluster2.read_attributes(
-            [attr_name], manufacturer=mock.sentinel.another_id
+            [attr_name], manufacturer=sentinel.another_id
         )
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.another_id
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.another_id
 
 
 @pytest.mark.parametrize(
     "attr_name, manufacturer",
     (
         ("attr0", None),
-        ("attr1", mock.sentinel.manufacturer_id),
+        ("attr1", sentinel.manufacturer_id),
     ),
 )
 async def test_write_attr_manufacture_specific(
     manuf_cluster, manuf_cluster2, attr_name, manufacturer
 ):
     """Test manufacturer specific write_attributes command."""
-    with mock.patch.object(
-        zcl.Cluster, "_write_attributes", CoroutineMock()
-    ) as cmd_mock:
+    with patch.object(zcl.Cluster, "_write_attributes", AsyncMock()) as cmd_mock:
         await manuf_cluster.write_attributes({attr_name: 0x12})
         assert cmd_mock.call_count == 1
         assert cmd_mock.call_args[1]["manufacturer"] is manufacturer
         cmd_mock.reset_mock()
         await manuf_cluster.write_attributes(
-            {attr_name: 0x12}, manufacturer=mock.sentinel.another_id
+            {attr_name: 0x12}, manufacturer=sentinel.another_id
         )
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.another_id
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.another_id
 
-    with mock.patch.object(
-        zcl.Cluster, "_write_attributes", CoroutineMock()
-    ) as cmd_mock:
+    with patch.object(zcl.Cluster, "_write_attributes", AsyncMock()) as cmd_mock:
         await manuf_cluster2.write_attributes({attr_name: 0x12})
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.manufacturer_id2
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.manufacturer_id2
         cmd_mock.reset_mock()
         await manuf_cluster2.write_attributes(
-            {attr_name: 0x12}, manufacturer=mock.sentinel.another_id
+            {attr_name: 0x12}, manufacturer=sentinel.another_id
         )
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.another_id
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.another_id
 
 
 @pytest.mark.parametrize(
     "attr_name, manufacturer",
     (
         ("attr0", None),
-        ("attr1", mock.sentinel.manufacturer_id),
+        ("attr1", sentinel.manufacturer_id),
     ),
 )
 async def test_write_attr_undivided_manufacture_specific(
     manuf_cluster, manuf_cluster2, attr_name, manufacturer
 ):
     """Test manufacturer specific write_attributes_undivided command."""
-    with mock.patch.object(
-        zcl.Cluster, "_write_attributes_undivided", CoroutineMock()
+    with patch.object(
+        zcl.Cluster, "_write_attributes_undivided", AsyncMock()
     ) as cmd_mock:
         await manuf_cluster.write_attributes_undivided({attr_name: 0x12})
         assert cmd_mock.call_count == 1
         assert cmd_mock.call_args[1]["manufacturer"] is manufacturer
         cmd_mock.reset_mock()
         await manuf_cluster.write_attributes_undivided(
-            {attr_name: 0x12}, manufacturer=mock.sentinel.another_id
+            {attr_name: 0x12}, manufacturer=sentinel.another_id
         )
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.another_id
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.another_id
 
-    with mock.patch.object(
-        zcl.Cluster, "_write_attributes_undivided", CoroutineMock()
+    with patch.object(
+        zcl.Cluster, "_write_attributes_undivided", AsyncMock()
     ) as cmd_mock:
         await manuf_cluster2.write_attributes_undivided({attr_name: 0x12})
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.manufacturer_id2
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.manufacturer_id2
         cmd_mock.reset_mock()
         await manuf_cluster2.write_attributes_undivided(
-            {attr_name: 0x12}, manufacturer=mock.sentinel.another_id
+            {attr_name: 0x12}, manufacturer=sentinel.another_id
         )
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.another_id
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.another_id
 
 
 @pytest.mark.parametrize(
     "attr_name, manufacturer",
     (
         ("attr0", None),
-        ("attr1", mock.sentinel.manufacturer_id),
+        ("attr1", sentinel.manufacturer_id),
     ),
 )
 async def test_configure_reporting_manufacture_specific(
     manuf_cluster, manuf_cluster2, attr_name, manufacturer
 ):
     """Test manufacturer specific configure_reporting command."""
-    with mock.patch.object(
-        zcl.Cluster, "_configure_reporting", CoroutineMock()
-    ) as cmd_mock:
+    with patch.object(zcl.Cluster, "_configure_reporting", AsyncMock()) as cmd_mock:
         await manuf_cluster.configure_reporting(
             attr_name, min_interval=1, max_interval=1, reportable_change=1
         )
@@ -639,26 +630,24 @@ async def test_configure_reporting_manufacture_specific(
             min_interval=1,
             max_interval=1,
             reportable_change=1,
-            manufacturer=mock.sentinel.another_id,
+            manufacturer=sentinel.another_id,
         )
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.another_id
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.another_id
 
-    with mock.patch.object(
-        zcl.Cluster, "_configure_reporting", CoroutineMock()
-    ) as cmd_mock:
+    with patch.object(zcl.Cluster, "_configure_reporting", AsyncMock()) as cmd_mock:
         await manuf_cluster2.configure_reporting(
             attr_name, min_interval=1, max_interval=1, reportable_change=1
         )
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.manufacturer_id2
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.manufacturer_id2
         cmd_mock.reset_mock()
         await manuf_cluster2.configure_reporting(
             attr_name,
             min_interval=1,
             max_interval=1,
             reportable_change=1,
-            manufacturer=mock.sentinel.another_id,
+            manufacturer=sentinel.another_id,
         )
         assert cmd_mock.call_count == 1
-        assert cmd_mock.call_args[1]["manufacturer"] is mock.sentinel.another_id
+        assert cmd_mock.call_args[1]["manufacturer"] is sentinel.another_id

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -4,48 +4,49 @@ import asyncio
 import logging
 import time
 
-from asynctest import CoroutineMock, mock
 import pytest
 
 import zigpy.config
 import zigpy.neighbor
 import zigpy.topology
 
+from .async_mock import AsyncMock, MagicMock, patch, sentinel
+
 
 @pytest.fixture
 def device_1():
-    dev = mock.MagicMock()
-    dev.ieee = mock.sentinel.ieee_1
+    dev = MagicMock()
+    dev.ieee = sentinel.ieee_1
     dev.node_desc.is_end_device = False
     dev.nwk = 0x1111
-    dev.neighbors.scan = CoroutineMock()
+    dev.neighbors.scan = AsyncMock()
     return dev
 
 
 @pytest.fixture
 def device_2():
-    dev = mock.MagicMock()
-    dev.ieee = mock.sentinel.ieee_2
+    dev = MagicMock()
+    dev.ieee = sentinel.ieee_2
     dev.node_desc.is_end_device = False
     dev.nwk = 0x2222
-    dev.neighbors.scan = CoroutineMock()
+    dev.neighbors.scan = AsyncMock()
     return dev
 
 
 @pytest.fixture
 def device_3():
-    dev = mock.MagicMock()
-    dev.ieee = mock.sentinel.ieee_3
+    dev = MagicMock()
+    dev.ieee = sentinel.ieee_3
     dev.node_desc.is_end_device = False
     dev.nwk = 0x3333
-    dev.neighbors.scan = CoroutineMock()
+    dev.neighbors.scan = AsyncMock()
     dev.neighbors.supported = False
     return dev
 
 
 @pytest.fixture
 def topology_f(device_1, device_2, device_3):
-    app = mock.MagicMock()
+    app = MagicMock()
     app.devices = {
         device_1.ieee: device_1,
         device_2.ieee: device_2,
@@ -53,16 +54,16 @@ def topology_f(device_1, device_2, device_3):
     }
     app.config = {zigpy.config.CONF_TOPO_SCAN_PERIOD: 0}
 
-    with mock.patch("zigpy.topology.DELAY_INTER_DEVICE", 0):
+    with patch("zigpy.topology.DELAY_INTER_DEVICE", 0):
         yield zigpy.topology.Topology(app)
 
 
 async def test_new():
     """Test creating new instance."""
 
-    app = mock.MagicMock()
+    app = MagicMock()
     app.config = {zigpy.config.CONF_TOPO_SCAN_PERIOD: 0}
-    with mock.patch("zigpy.topology.Topology.scan", new=CoroutineMock()) as scan:
+    with patch("zigpy.topology.Topology.scan", new=AsyncMock()) as scan:
         zigpy.topology.Topology.new(app)
         await asyncio.sleep(0)
         await asyncio.sleep(0)

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -1,7 +1,6 @@
 import asyncio
 import re
 
-from asynctest import mock
 import pytest
 
 import zigpy.endpoint
@@ -9,6 +8,8 @@ import zigpy.ota as ota
 import zigpy.types as types
 import zigpy.zcl as zcl
 import zigpy.zcl.clusters.security as sec
+
+from .async_mock import AsyncMock, MagicMock, sentinel
 
 IMAGE_SIZE = 0x2345
 IMAGE_OFFSET = 0x2000
@@ -66,8 +67,8 @@ def test_ep_attributes():
 
 
 async def test_time_cluster():
-    ep = mock.MagicMock()
-    ep.reply = mock.CoroutineMock()
+    ep = MagicMock()
+    ep.reply = AsyncMock()
     t = zcl.Cluster._registry[0x000A](ep)
 
     hdr_general = zcl.foundation.ZCLHeader.general
@@ -98,8 +99,8 @@ async def test_time_cluster():
 
 
 async def test_time_cluster_unsupported():
-    ep = mock.MagicMock()
-    ep.reply.side_effect = asyncio.coroutine(mock.MagicMock())
+    ep = MagicMock()
+    ep.reply.side_effect = asyncio.coroutine(MagicMock())
     t = zcl.Cluster._registry[0x000A](ep)
 
     hdr_general = zcl.foundation.ZCLHeader.general
@@ -112,61 +113,51 @@ async def test_time_cluster_unsupported():
 
 @pytest.fixture
 def ota_cluster():
-    ep = mock.MagicMock()
-    ep.device.application.ota = mock.MagicMock(spec_set=ota.OTA)
+    ep = MagicMock()
+    ep.device.application.ota = MagicMock(spec_set=ota.OTA)
     return zcl.Cluster._registry[0x0019](ep)
 
 
 async def test_ota_handle_cluster_req(ota_cluster):
-    ota_cluster._handle_cluster_request = mock.CoroutineMock()
+    ota_cluster._handle_cluster_request = AsyncMock()
 
-    ota_cluster.handle_cluster_request(
-        mock.sentinel.tsn, mock.sentinel.cmd, mock.sentinel.args
-    )
+    ota_cluster.handle_cluster_request(sentinel.tsn, sentinel.cmd, sentinel.args)
     assert ota_cluster._handle_cluster_request.call_count == 1
 
 
 async def test_ota_handle_cluster_req_wrapper(ota_cluster):
-    ota_cluster._handle_query_next_image = mock.CoroutineMock()
-    ota_cluster._handle_image_block = mock.CoroutineMock()
-    ota_cluster._handle_upgrade_end = mock.CoroutineMock()
+    ota_cluster._handle_query_next_image = AsyncMock()
+    ota_cluster._handle_image_block = AsyncMock()
+    ota_cluster._handle_upgrade_end = AsyncMock()
 
-    await ota_cluster._handle_cluster_request(
-        mock.sentinel.tsn, 0x01, [mock.sentinel.args]
-    )
+    await ota_cluster._handle_cluster_request(sentinel.tsn, 0x01, [sentinel.args])
     assert ota_cluster._handle_query_next_image.call_count == 1
-    assert ota_cluster._handle_query_next_image.call_args[0][0] == mock.sentinel.args
+    assert ota_cluster._handle_query_next_image.call_args[0][0] == sentinel.args
     assert ota_cluster._handle_image_block.call_count == 0
     assert ota_cluster._handle_upgrade_end.call_count == 0
     ota_cluster._handle_query_next_image.reset_mock()
     ota_cluster._handle_image_block.reset_mock()
     ota_cluster._handle_upgrade_end.reset_mock()
 
-    await ota_cluster._handle_cluster_request(
-        mock.sentinel.tsn, 0x03, [mock.sentinel.block_args]
-    )
+    await ota_cluster._handle_cluster_request(sentinel.tsn, 0x03, [sentinel.block_args])
     assert ota_cluster._handle_query_next_image.call_count == 0
     assert ota_cluster._handle_image_block.call_count == 1
-    assert ota_cluster._handle_image_block.call_args[0][0] == mock.sentinel.block_args
+    assert ota_cluster._handle_image_block.call_args[0][0] == sentinel.block_args
     assert ota_cluster._handle_upgrade_end.call_count == 0
     ota_cluster._handle_query_next_image.reset_mock()
     ota_cluster._handle_image_block.reset_mock()
     ota_cluster._handle_upgrade_end.reset_mock()
 
-    await ota_cluster._handle_cluster_request(
-        mock.sentinel.tsn, 0x06, [mock.sentinel.end_args]
-    )
+    await ota_cluster._handle_cluster_request(sentinel.tsn, 0x06, [sentinel.end_args])
     assert ota_cluster._handle_query_next_image.call_count == 0
     assert ota_cluster._handle_image_block.call_count == 0
     assert ota_cluster._handle_upgrade_end.call_count == 1
-    assert ota_cluster._handle_upgrade_end.call_args[0][0] == mock.sentinel.end_args
+    assert ota_cluster._handle_upgrade_end.call_args[0][0] == sentinel.end_args
     ota_cluster._handle_query_next_image.reset_mock()
     ota_cluster._handle_image_block.reset_mock()
     ota_cluster._handle_upgrade_end.reset_mock()
 
-    await ota_cluster._handle_cluster_request(
-        mock.sentinel.tsn, 0x78, [mock.sentinel.just_args]
-    )
+    await ota_cluster._handle_cluster_request(sentinel.tsn, 0x78, [sentinel.just_args])
     assert ota_cluster._handle_query_next_image.call_count == 0
     assert ota_cluster._handle_image_block.call_count == 0
     assert ota_cluster._handle_upgrade_end.call_count == 0
@@ -175,14 +166,14 @@ async def test_ota_handle_cluster_req_wrapper(ota_cluster):
 def _ota_next_image(cluster, has_image=True, upgradeable=False):
     async def get_ota_mock(*args):
         if upgradeable:
-            img = mock.MagicMock()
+            img = MagicMock()
             img.should_update.return_value = True
-            img.key.manufacturer_id = mock.sentinel.manufacturer_id
-            img.key.image_type = mock.sentinel.image_type
-            img.version = mock.sentinel.image_version
-            img.header.image_size = mock.sentinel.image_size
+            img.key.manufacturer_id = sentinel.manufacturer_id
+            img.key.image_type = sentinel.image_type
+            img.version = sentinel.image_version
+            img.header.image_size = sentinel.image_size
         elif has_image:
-            img = mock.MagicMock()
+            img = MagicMock()
             img.should_update.return_value = False
         else:
             img = None
@@ -190,17 +181,17 @@ def _ota_next_image(cluster, has_image=True, upgradeable=False):
 
     cluster.endpoint.device.application.ota.get_ota_image.side_effect = get_ota_mock
     return cluster._handle_query_next_image(
-        mock.sentinel.field_ctrl,
-        mock.sentinel.manufacturer_id,
-        mock.sentinel.image_type,
-        mock.sentinel.current_file_version,
-        mock.sentinel.hw_version,
+        sentinel.field_ctrl,
+        sentinel.manufacturer_id,
+        sentinel.image_type,
+        sentinel.current_file_version,
+        sentinel.hw_version,
         tsn=0x21,
     )
 
 
 async def test_ota_handle_query_next_image_no_img(ota_cluster):
-    ota_cluster.query_next_image_response = mock.CoroutineMock()
+    ota_cluster.query_next_image_response = AsyncMock()
 
     await _ota_next_image(ota_cluster, has_image=False, upgradeable=False)
     assert ota_cluster.query_next_image_response.call_count == 1
@@ -212,7 +203,7 @@ async def test_ota_handle_query_next_image_no_img(ota_cluster):
 
 
 async def test_ota_handle_query_next_image_not_upgradeable(ota_cluster):
-    ota_cluster.query_next_image_response = mock.CoroutineMock()
+    ota_cluster.query_next_image_response = AsyncMock()
 
     await _ota_next_image(ota_cluster, has_image=True, upgradeable=False)
     assert ota_cluster.query_next_image_response.call_count == 1
@@ -224,7 +215,7 @@ async def test_ota_handle_query_next_image_not_upgradeable(ota_cluster):
 
 
 async def test_ota_handle_query_next_image_upgradeable(ota_cluster):
-    ota_cluster.query_next_image_response = mock.CoroutineMock()
+    ota_cluster.query_next_image_response = AsyncMock()
 
     await _ota_next_image(ota_cluster, has_image=True, upgradeable=True)
     assert ota_cluster.query_next_image_response.call_count == 1
@@ -234,57 +225,50 @@ async def test_ota_handle_query_next_image_upgradeable(ota_cluster):
     )
     assert (
         ota_cluster.query_next_image_response.call_args[0][1]
-        == mock.sentinel.manufacturer_id
+        == sentinel.manufacturer_id
     )
+    assert ota_cluster.query_next_image_response.call_args[0][2] == sentinel.image_type
     assert (
-        ota_cluster.query_next_image_response.call_args[0][2]
-        == mock.sentinel.image_type
+        ota_cluster.query_next_image_response.call_args[0][3] == sentinel.image_version
     )
-    assert (
-        ota_cluster.query_next_image_response.call_args[0][3]
-        == mock.sentinel.image_version
-    )
-    assert (
-        ota_cluster.query_next_image_response.call_args[0][4]
-        == mock.sentinel.image_size
-    )
+    assert ota_cluster.query_next_image_response.call_args[0][4] == sentinel.image_size
 
 
 def _ota_image_block(cluster, has_image=True, correct_version=True, wrong_offset=False):
     async def get_ota_mock(*args):
         if has_image:
-            img = mock.MagicMock()
+            img = MagicMock()
             img.should_update.return_value = True
-            img.key.manufacturer_id = mock.sentinel.manufacturer_id
-            img.key.image_type = mock.sentinel.image_type
-            img.version = mock.sentinel.image_version
+            img.key.manufacturer_id = sentinel.manufacturer_id
+            img.key.image_type = sentinel.image_type
+            img.version = sentinel.image_version
             img.header.image_size = IMAGE_SIZE
             if wrong_offset:
                 img.get_image_block.side_effect = ValueError()
             else:
-                img.get_image_block.return_value = mock.sentinel.data
+                img.get_image_block.return_value = sentinel.data
             if not correct_version:
-                img.version = mock.sentinel.wrong_image_version
+                img.version = sentinel.wrong_image_version
         else:
             img = None
         return img
 
     cluster.endpoint.device.application.ota.get_ota_image.side_effect = get_ota_mock
     return cluster._handle_image_block(
-        mock.sentinel.field_ctrl,
-        mock.sentinel.manufacturer_id,
-        mock.sentinel.image_type,
-        mock.sentinel.image_version,
+        sentinel.field_ctrl,
+        sentinel.manufacturer_id,
+        sentinel.image_type,
+        sentinel.image_version,
         IMAGE_OFFSET,
-        mock.sentinel.max_data_size,
-        mock.sentinel.addr,
-        mock.sentinel.delay,
+        sentinel.max_data_size,
+        sentinel.addr,
+        sentinel.delay,
         tsn=0x21,
     )
 
 
 async def test_ota_handle_image_block_no_img(ota_cluster):
-    ota_cluster.image_block_response = mock.CoroutineMock()
+    ota_cluster.image_block_response = AsyncMock()
 
     await _ota_image_block(ota_cluster, has_image=False, correct_version=True)
     assert ota_cluster.image_block_response.call_count == 1
@@ -303,7 +287,7 @@ async def test_ota_handle_image_block_no_img(ota_cluster):
 
 
 async def test_ota_handle_image_block(ota_cluster):
-    ota_cluster.image_block_response = mock.CoroutineMock()
+    ota_cluster.image_block_response = AsyncMock()
 
     await _ota_image_block(ota_cluster, has_image=True, correct_version=True)
     assert ota_cluster.image_block_response.call_count == 1
@@ -311,16 +295,11 @@ async def test_ota_handle_image_block(ota_cluster):
         ota_cluster.image_block_response.call_args[0][0]
         == zcl.foundation.Status.SUCCESS
     )
-    assert (
-        ota_cluster.image_block_response.call_args[0][1]
-        == mock.sentinel.manufacturer_id
-    )
-    assert ota_cluster.image_block_response.call_args[0][2] == mock.sentinel.image_type
-    assert (
-        ota_cluster.image_block_response.call_args[0][3] == mock.sentinel.image_version
-    )
+    assert ota_cluster.image_block_response.call_args[0][1] == sentinel.manufacturer_id
+    assert ota_cluster.image_block_response.call_args[0][2] == sentinel.image_type
+    assert ota_cluster.image_block_response.call_args[0][3] == sentinel.image_version
     assert ota_cluster.image_block_response.call_args[0][4] == IMAGE_OFFSET
-    assert ota_cluster.image_block_response.call_args[0][5] == mock.sentinel.data
+    assert ota_cluster.image_block_response.call_args[0][5] == sentinel.data
     ota_cluster.image_block_response.reset_mock()
 
     await _ota_image_block(ota_cluster, has_image=True, correct_version=False)
@@ -332,7 +311,7 @@ async def test_ota_handle_image_block(ota_cluster):
 
 
 async def test_ota_handle_image_block_wrong_offset(ota_cluster):
-    ota_cluster.image_block_response = mock.CoroutineMock()
+    ota_cluster.image_block_response = AsyncMock()
 
     await _ota_image_block(
         ota_cluster, has_image=True, correct_version=True, wrong_offset=True
@@ -346,25 +325,20 @@ async def test_ota_handle_image_block_wrong_offset(ota_cluster):
 
 
 async def test_ota_handle_upgrade_end(ota_cluster):
-    ota_cluster.upgrade_end_response = mock.CoroutineMock()
+    ota_cluster.upgrade_end_response = AsyncMock()
 
     await ota_cluster._handle_upgrade_end(
-        mock.sentinel.status,
-        mock.sentinel.manufacturer_id,
-        mock.sentinel.image_type,
-        mock.sentinel.image_version,
+        sentinel.status,
+        sentinel.manufacturer_id,
+        sentinel.image_type,
+        sentinel.image_version,
         tsn=0x21,
     )
 
     assert ota_cluster.upgrade_end_response.call_count == 1
-    assert (
-        ota_cluster.upgrade_end_response.call_args[0][0]
-        == mock.sentinel.manufacturer_id
-    )
-    assert ota_cluster.upgrade_end_response.call_args[0][1] == mock.sentinel.image_type
-    assert (
-        ota_cluster.upgrade_end_response.call_args[0][2] == mock.sentinel.image_version
-    )
+    assert ota_cluster.upgrade_end_response.call_args[0][0] == sentinel.manufacturer_id
+    assert ota_cluster.upgrade_end_response.call_args[0][1] == sentinel.image_type
+    assert ota_cluster.upgrade_end_response.call_args[0][2] == sentinel.image_version
     assert ota_cluster.upgrade_end_response.call_args[0][3] == 0x0000
     assert ota_cluster.upgrade_end_response.call_args[0][4] == 0x0000
 

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -198,7 +198,7 @@ async def test_reply_tsn_override(zdo_f, monkeypatch):
     mock_ser = MagicMock()
     mock_ser.return_value = b"\xaa\x55"
     monkeypatch.setattr(t, "serialize", mock_ser)
-    zdo_f.reply(sentinel.cmd, sentinel.arg1, sentinel.arg2)
+    await zdo_f.reply(sentinel.cmd, sentinel.arg1, sentinel.arg2)
     seq = zdo_f.device.request.call_args[0][4]
     data = zdo_f.device.request.call_args[0][5]
     assert seq == DEFAULT_SEQUENCE
@@ -207,7 +207,7 @@ async def test_reply_tsn_override(zdo_f, monkeypatch):
 
     # override tsn
     tsn = 0x23
-    zdo_f.reply(sentinel.cmd, sentinel.arg1, sentinel.arg2, tsn=tsn)
+    await zdo_f.reply(sentinel.cmd, sentinel.arg1, sentinel.arg2, tsn=tsn)
     seq = zdo_f.device.request.call_args[0][4]
     data = zdo_f.device.request.call_args[0][5]
     assert seq == tsn

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -2,11 +2,12 @@ import asyncio
 import logging
 import sys
 
-from asynctest import CoroutineMock, mock
 import pytest
 
 from zigpy import util
 from zigpy.exceptions import ControllerException
+
+from .async_mock import AsyncMock, MagicMock, call, patch, sentinel
 
 
 class Listenable(util.ListenableMixin):
@@ -19,44 +20,36 @@ def test_listenable():
 
     # Python 3.7 guarantees dict ordering so this will be called first to test error
     # handling
-    broken_listener = mock.MagicMock()
+    broken_listener = MagicMock()
     broken_listener.event.side_effect = Exception()
     listen.add_listener(broken_listener)
 
-    listener = mock.MagicMock(spec_set=["event"])
+    listener = MagicMock(spec_set=["event"])
     listen.add_listener(listener)
     listen.add_listener(listener)
 
-    context_listener = mock.MagicMock(spec_set=["event"])
+    context_listener = MagicMock(spec_set=["event"])
     listen.add_context_listener(context_listener)
 
     listen.listener_event("event", "test1")
-    listener.event.assert_has_calls(
-        [mock.call("test1"), mock.call("test1")], any_order=True
-    )
-    context_listener.event.assert_has_calls(
-        [mock.call(listen, "test1")], any_order=True
-    )
-    broken_listener.event.assert_has_calls([mock.call("test1")], any_order=True)
+    listener.event.assert_has_calls([call("test1"), call("test1")], any_order=True)
+    context_listener.event.assert_has_calls([call(listen, "test1")], any_order=True)
+    broken_listener.event.assert_has_calls([call("test1")], any_order=True)
     assert listener.event.call_count == 2
     assert context_listener.event.call_count == 1
     assert broken_listener.event.call_count == 1
 
     listen.listener_event("non_existing_event", "test2")
-    listener.event.assert_has_calls(
-        [mock.call("test1"), mock.call("test1")], any_order=True
-    )
-    context_listener.event.assert_has_calls(
-        [mock.call(listen, "test1")], any_order=True
-    )
-    broken_listener.event.assert_has_calls([mock.call("test1")], any_order=True)
+    listener.event.assert_has_calls([call("test1"), call("test1")], any_order=True)
+    context_listener.event.assert_has_calls([call(listen, "test1")], any_order=True)
+    broken_listener.event.assert_has_calls([call("test1")], any_order=True)
     assert listener.event.call_count == 2
     assert context_listener.event.call_count == 1
     assert broken_listener.event.call_count == 1
 
 
 class Logger(util.LocalLogMixin):
-    log = mock.MagicMock()
+    log = MagicMock()
 
 
 def test_log():
@@ -73,7 +66,7 @@ def test_log():
 )
 def test_log_stacklevel():
     class MockHandler(logging.Handler):
-        emit = mock.Mock()
+        emit = MagicMock()
 
     handler = MockHandler()
 
@@ -370,51 +363,45 @@ def test_fail_convert_install_code():
 async def test_async_listener():
     listenable = Listenable()
 
-    listener_1 = mock.MagicMock(spec=["async_event"])
-    listener_1.async_event.side_effect = CoroutineMock(
-        return_value=mock.sentinel.result_1
-    )
+    listener_1 = MagicMock(spec=["async_event"])
+    listener_1.async_event.side_effect = AsyncMock(return_value=sentinel.result_1)
 
-    listener_2 = mock.MagicMock(spec=["async_event"])
-    listener_2.async_event.side_effect = CoroutineMock(
-        return_value=mock.sentinel.result_2
-    )
+    listener_2 = MagicMock(spec=["async_event"])
+    listener_2.async_event.side_effect = AsyncMock(return_value=sentinel.result_2)
 
-    failed = mock.MagicMock(spec=["async_event"])
-    failed.async_event = CoroutineMock(
-        side_effect=RuntimeError("async listener exception")
-    )
+    failed = MagicMock(spec=["async_event"])
+    failed.async_event = AsyncMock(side_effect=RuntimeError("async listener exception"))
 
     listenable.add_listener(listener_1)
     listenable.add_context_listener(listener_2)
     listenable.add_listener(failed)
 
-    r = await listenable.async_event("async_event", mock.sentinel.data)
+    r = await listenable.async_event("async_event", sentinel.data)
     assert len(r) == 2
-    assert mock.sentinel.result_1 in r
-    assert mock.sentinel.result_2 in r
+    assert sentinel.result_1 in r
+    assert sentinel.result_2 in r
 
     assert listener_1.async_event.call_count == 1
-    assert listener_1.async_event.call_args[0][0] is mock.sentinel.data
+    assert listener_1.async_event.call_args[0][0] is sentinel.data
 
     # context listener
     assert listener_2.async_event.call_count == 1
     assert listener_2.async_event.call_args[0][0] is listenable
-    assert listener_2.async_event.call_args[0][1] is mock.sentinel.data
+    assert listener_2.async_event.call_args[0][1] is sentinel.data
 
     # failed listener
     assert failed.async_event.call_count == 1
-    assert failed.async_event.call_args[0][0] is mock.sentinel.data
+    assert failed.async_event.call_args[0][0] is sentinel.data
 
-    r = await listenable.async_event("no_such_event", mock.sentinel.no_data)
+    r = await listenable.async_event("no_such_event", sentinel.no_data)
     assert r == []
 
 
 def test_requests(monkeypatch):
-    req_mock = mock.MagicMock()
+    req_mock = MagicMock()
     monkeypatch.setattr(util, "Request", req_mock)
     r = util.Requests()
-    r.new(mock.sentinel.seq)
+    r.new(sentinel.seq)
     assert req_mock.call_count == 1
 
 
@@ -433,7 +420,7 @@ async def test_request():
     assert req.result.cancelled() is True
     assert seq not in pending
 
-    seq = mock.sentinel.seq
+    seq = sentinel.seq
     req = pending.new(seq)
     assert seq not in pending
     assert req.result.done() is False
@@ -477,11 +464,11 @@ class _ClusterMock(util.CatchingTaskMixin):
         raise exception()
 
 
-@mock.patch("zigpy.util.CatchingTaskMixin.catching_coro")
+@patch("zigpy.util.CatchingTaskMixin.catching_coro")
 async def test_create_catching_task(catching_coro_mock):
     """Test catching task."""
     mock_cluster = _ClusterMock(logging.getLogger(__name__))
-    coro = CoroutineMock()
+    coro = AsyncMock()
     mock_cluster.create_catching_task(coro)
     assert catching_coro_mock.call_count == 1
     assert catching_coro_mock.call_args[0][0] is coro

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = True
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
 install_command = pip install {opts} {packages}
-commands = py.test --cov --cov-report=html
+commands = py.test --cov --cov-report=
 deps =
     asynctest
     coveralls


### PR DESCRIPTION
Migrate from asynctest to stdlib AsyncMock for py38.
Fixes https://github.com/zigpy/zigpy/issues/475