### PR TITLE
Update CONTRIBUTING.md URL link to isort has changed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ In general when contributing code to this project it is encouraged that you try 
 It is recommended that code is formatted with `black` and sorted with `isort`. The check format script that runs in CI will ensure that code meets this requirement and that it is correctly formatted with black. Instructions for installing black in many editors can be found here: https://github.com/psf/black#editor-integration
 
 - https://github.com/psf/black
-- https://github.com/timothycrosley/isort
+- https://github.com/PyCQA/isort
 
 #### Setup
 


### PR DESCRIPTION
Update CONTRIBUTING.md link to isort has moved from https://github.com/timothycrosley/isort to https://github.com/PyCQA/isort

For rference see https://github.com/zigpy/zigpy/issues/467 & https://github.com/zigpy/zigpy/pull/488 & https://github.com/zigpy/bellows/pull/349