### PR TITLE
Change IKEA OTA url to use http

### DIFF
--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -139,7 +139,7 @@ class IKEAImage:
 class Trådfri(Basic):
     """IKEA OTA Firmware provider."""
 
-    UPDATE_URL = "https://fw.ota.homesmart.ikea.net/feed/version_info.json"
+    UPDATE_URL = "http://fw.ota.homesmart.ikea.net/feed/version_info.json"
     MANUFACTURER_ID = 4476
     HEADERS = {"accept": "application/json;q=0.9,*/*;q=0.8"}
 


### PR DESCRIPTION
Change protocol for IKEA OTA firmware list URL.