### PR TITLE
Reject invalid SiLabs upgrade images

### DIFF
--- a/tests/test_ota_validators.py
+++ b/tests/test_ota_validators.py
@@ -1,0 +1,163 @@
+import pytest
+
+from zigpy.ota import validators
+from zigpy.ota.image import ElementTagId, OTAImage, SubElement
+from zigpy.ota.validators import ValidationResult
+
+VALID_EBL_IMAGE = (
+    b"\x00\x00\x00\x8C" + b"\xAB" * 140 + b"\xFC\x04\x00\x00" + b"\xFF" * 44
+)
+VALID_GBL_IMAGE = b"\xEB\x17\xA6\x03\x00\x00\x00\x00"
+
+
+def create_subelement(tag_id, value):
+    return SubElement.deserialize(
+        tag_id.serialize() + len(value).to_bytes(4, "little") + value
+    )[0]
+
+
+def test_parse_silabs_ebl():
+    img = b"AA" + b"\x00\x04" + b"test" + b"\xFC\x04\x00\x00" + b"\xFF" * 52
+
+    assert list(validators.parse_silabs_ebl(img)) == [
+        (b"AA", b"test"),
+        (b"\xFC\x04", b""),
+    ]
+
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_ebl(b""))
+
+    # Needs to be a multiple of 64 bytes
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_ebl(img[:-1]))
+
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_ebl(img + b"\xFF"))
+
+    # Bad length
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_ebl(b"AA\xFF\xFF" + b"\xFF" * 60))
+
+    img2 = (
+        b"AA"
+        + b"\x00\x05"
+        + b"test1"
+        + b"BB"
+        + b"\x00\x04"
+        + b"test"
+        + b"\xFC\x04\x00\x00"
+        + b"\xFF" * 43
+    )
+
+    assert list(validators.parse_silabs_ebl(img2)) == [
+        (b"AA", b"test1"),
+        (b"BB", b"test"),
+        (b"\xFC\x04", b""),
+    ]
+
+
+def test_parse_silabs_gbl():
+    img = b"AAAA" + b"\x04\x00\x00\x00" + b"test"
+
+    assert list(validators.parse_silabs_gbl(img)) == [(b"AAAA", b"test")]
+
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_gbl(b""))
+
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_gbl(img[:-1]))
+
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_gbl(img + b"\xFF"))
+
+    # Bad length
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_gbl(b"AAAA\xFF\xFF\xFF\xFF"))
+
+    img2 = (
+        b"AAAA"
+        + b"\x05\x00\x00\x00"
+        + b"test1"
+        + b"BBBB"
+        + b"\x04\x00\x00\x00"
+        + b"test"
+    )
+
+    assert list(validators.parse_silabs_gbl(img2)) == [
+        (b"AAAA", b"test1"),
+        (b"BBBB", b"test"),
+    ]
+
+
+def test_validate_firmware():
+    assert validators.validate_firmware(VALID_EBL_IMAGE) == ValidationResult.VALID
+    assert (
+        validators.validate_firmware(VALID_EBL_IMAGE[:-1]) == ValidationResult.INVALID
+    )
+    assert (
+        validators.validate_firmware(VALID_EBL_IMAGE + b"\xFF")
+        == ValidationResult.INVALID
+    )
+
+    assert validators.validate_firmware(VALID_GBL_IMAGE) == ValidationResult.VALID
+    assert (
+        validators.validate_firmware(VALID_GBL_IMAGE[:-1]) == ValidationResult.INVALID
+    )
+
+    assert validators.validate_firmware(b"UNKNOWN") == ValidationResult.UNKNOWN
+
+
+def test_validate_ota_image_simple_valid():
+    image = OTAImage()
+    image.subelements = [
+        create_subelement(ElementTagId.UPGRADE_IMAGE, VALID_EBL_IMAGE),
+    ]
+
+    assert validators.validate_ota_image(image) == ValidationResult.VALID
+
+
+def test_validate_ota_image_complex_valid():
+    image = OTAImage()
+    image.subelements = [
+        create_subelement(ElementTagId.ECDSA_SIGNATURE, b"asd"),
+        create_subelement(ElementTagId.UPGRADE_IMAGE, VALID_EBL_IMAGE),
+        create_subelement(ElementTagId.UPGRADE_IMAGE, VALID_GBL_IMAGE),
+        create_subelement(ElementTagId.ECDSA_SIGNING_CERTIFICATE, b"foo"),
+    ]
+
+    assert validators.validate_ota_image(image) == ValidationResult.VALID
+
+
+def test_validate_ota_image_invalid():
+    image = OTAImage()
+    image.subelements = [
+        create_subelement(ElementTagId.UPGRADE_IMAGE, VALID_EBL_IMAGE[:-1]),
+    ]
+
+    assert validators.validate_ota_image(image) == ValidationResult.INVALID
+
+
+def test_validate_ota_image_mixed_invalid():
+    image = OTAImage()
+    image.subelements = [
+        create_subelement(ElementTagId.UPGRADE_IMAGE, b"unknown"),
+        create_subelement(ElementTagId.UPGRADE_IMAGE, VALID_EBL_IMAGE[:-1]),
+    ]
+
+    assert validators.validate_ota_image(image) == ValidationResult.INVALID
+
+
+def test_validate_ota_image_mixed_valid():
+    image = OTAImage()
+    image.subelements = [
+        create_subelement(ElementTagId.UPGRADE_IMAGE, b"unknown1"),
+        create_subelement(ElementTagId.UPGRADE_IMAGE, VALID_EBL_IMAGE),
+    ]
+
+    assert validators.validate_ota_image(image) == ValidationResult.UNKNOWN
+
+
+def test_validate_ota_image_empty():
+    image = OTAImage()
+
+    assert validators.validate_ota_image(image) == ValidationResult.UNKNOWN

--- a/tests/test_ota_validators.py
+++ b/tests/test_ota_validators.py
@@ -75,6 +75,13 @@ def test_parse_silabs_ebl():
     with pytest.raises(AssertionError):
         list(validators.parse_silabs_ebl(image + b"\xFF"))
 
+    # Corrupted images are detected
+    corrupted_image = image.replace(b"foo", b"goo", 1)
+    assert image != corrupted_image
+
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_ebl(corrupted_image))
+
 
 def test_parse_silabs_gbl():
     list(validators.parse_silabs_gbl(VALID_GBL_IMAGE))
@@ -90,6 +97,13 @@ def test_parse_silabs_gbl():
     # No padding is allowed
     with pytest.raises(AssertionError):
         list(validators.parse_silabs_gbl(image + b"\xFF"))
+
+    # Corrupted images are detected
+    corrupted_image = image.replace(b"foo", b"goo", 1)
+    assert image != corrupted_image
+
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_gbl(corrupted_image))
 
 
 def test_validate_firmware():

--- a/tests/test_ota_validators.py
+++ b/tests/test_ota_validators.py
@@ -1,13 +1,53 @@
+import zlib
+
 import pytest
 
 from zigpy.ota import validators
 from zigpy.ota.image import ElementTagId, OTAImage, SubElement
 from zigpy.ota.validators import ValidationResult
 
-VALID_EBL_IMAGE = (
-    b"\x00\x00\x00\x8C" + b"\xAB" * 140 + b"\xFC\x04\x00\x00" + b"\xFF" * 44
-)
-VALID_GBL_IMAGE = b"\xEB\x17\xA6\x03\x00\x00\x00\x00"
+
+def create_ebl_image(tags):
+    # All images start with a 140-byte "0x0000" header
+    tags = [(b"\x00\x00", b"test" * 35)] + tags
+
+    assert all([len(tag) == 2 for tag, value in tags])
+    image = b"".join(tag + len(value).to_bytes(2, "big") + value for tag, value in tags)
+
+    # And end with a checksum
+    image += b"\xFC\x04\x00\x04" + zlib.crc32(image + b"\xFC\x04\x00\x04").to_bytes(
+        4, "little"
+    )
+
+    if len(image) % 64 != 0:
+        image += b"\xFF" * (64 - len(image) % 64)
+
+    return image
+
+
+def create_gbl_image(tags):
+    # All images start with an 8-byte header
+    tags = [(b"\xEB\x17\xA6\x03", b"\x00\x00\x00\x03\x01\x01\x00\x00")] + tags
+
+    assert all([len(tag) == 4 for tag, value in tags])
+    image = b"".join(
+        tag + len(value).to_bytes(4, "little") + value for tag, value in tags
+    )
+
+    # And end with a checksum
+    image += (
+        b"\xFC\x04\x04\xFC"
+        + b"\x04\x00\x00\x00"
+        + zlib.crc32(image + b"\xFC\x04\x04\xFC" + b"\x04\x00\x00\x00").to_bytes(
+            4, "little"
+        )
+    )
+
+    return image
+
+
+VALID_EBL_IMAGE = create_ebl_image([(b"ab", b"foo")])
+VALID_GBL_IMAGE = create_gbl_image([(b"test", b"foo")])
 
 
 def create_subelement(tag_id, value):
@@ -17,76 +57,39 @@ def create_subelement(tag_id, value):
 
 
 def test_parse_silabs_ebl():
-    img = b"AA" + b"\x00\x04" + b"test" + b"\xFC\x04\x00\x00" + b"\xFF" * 52
+    list(validators.parse_silabs_ebl(VALID_EBL_IMAGE))
 
-    assert list(validators.parse_silabs_ebl(img)) == [
-        (b"AA", b"test"),
-        (b"\xFC\x04", b""),
-    ]
+    image = create_ebl_image([(b"AA", b"test"), (b"BB", b"foo" * 20)])
+
+    header, tag1, tag2, checksum = validators.parse_silabs_ebl(image)
+    assert len(image) % 64 == 0
+    assert header[0] == b"\x00\x00" and len(header[1]) == 140
+    assert tag1 == (b"AA", b"test")
+    assert tag2 == (b"BB", b"foo" * 20)
+    assert checksum[0] == b"\xFC\x04" and len(checksum[1]) == 4
+
+    # Padding needs to be a multiple of 64 bytes
+    with pytest.raises(AssertionError):
+        list(validators.parse_silabs_ebl(image[:-1]))
 
     with pytest.raises(AssertionError):
-        list(validators.parse_silabs_ebl(b""))
-
-    # Needs to be a multiple of 64 bytes
-    with pytest.raises(AssertionError):
-        list(validators.parse_silabs_ebl(img[:-1]))
-
-    with pytest.raises(AssertionError):
-        list(validators.parse_silabs_ebl(img + b"\xFF"))
-
-    # Bad length
-    with pytest.raises(AssertionError):
-        list(validators.parse_silabs_ebl(b"AA\xFF\xFF" + b"\xFF" * 60))
-
-    img2 = (
-        b"AA"
-        + b"\x00\x05"
-        + b"test1"
-        + b"BB"
-        + b"\x00\x04"
-        + b"test"
-        + b"\xFC\x04\x00\x00"
-        + b"\xFF" * 43
-    )
-
-    assert list(validators.parse_silabs_ebl(img2)) == [
-        (b"AA", b"test1"),
-        (b"BB", b"test"),
-        (b"\xFC\x04", b""),
-    ]
+        list(validators.parse_silabs_ebl(image + b"\xFF"))
 
 
 def test_parse_silabs_gbl():
-    img = b"AAAA" + b"\x04\x00\x00\x00" + b"test"
+    list(validators.parse_silabs_gbl(VALID_GBL_IMAGE))
 
-    assert list(validators.parse_silabs_gbl(img)) == [(b"AAAA", b"test")]
+    image = create_gbl_image([(b"AAAA", b"test"), (b"BBBB", b"foo" * 20)])
 
+    header, tag1, tag2, checksum = validators.parse_silabs_gbl(image)
+    assert header[0] == b"\xEB\x17\xA6\x03" and len(header[1]) == 8
+    assert tag1 == (b"AAAA", b"test")
+    assert tag2 == (b"BBBB", b"foo" * 20)
+    assert checksum[0] == b"\xFC\x04\x04\xFC" and len(checksum[1]) == 4
+
+    # No padding is allowed
     with pytest.raises(AssertionError):
-        list(validators.parse_silabs_gbl(b""))
-
-    with pytest.raises(AssertionError):
-        list(validators.parse_silabs_gbl(img[:-1]))
-
-    with pytest.raises(AssertionError):
-        list(validators.parse_silabs_gbl(img + b"\xFF"))
-
-    # Bad length
-    with pytest.raises(AssertionError):
-        list(validators.parse_silabs_gbl(b"AAAA\xFF\xFF\xFF\xFF"))
-
-    img2 = (
-        b"AAAA"
-        + b"\x05\x00\x00\x00"
-        + b"test1"
-        + b"BBBB"
-        + b"\x04\x00\x00\x00"
-        + b"test"
-    )
-
-    assert list(validators.parse_silabs_gbl(img2)) == [
-        (b"AAAA", b"test1"),
-        (b"BBBB", b"test"),
-    ]
+        list(validators.parse_silabs_gbl(image + b"\xFF"))
 
 
 def test_validate_firmware():

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -8,6 +8,7 @@ import attr
 from zigpy.config import CONF_OTA, CONF_OTA_DIR, CONF_OTA_IKEA, CONF_OTA_LEDVANCE
 from zigpy.ota.image import ImageKey, OTAImage
 import zigpy.ota.provider
+from zigpy.ota.validators import ValidationResult, validate_ota_image
 from zigpy.typing import ControllerApplicationType
 import zigpy.util
 
@@ -69,11 +70,25 @@ class OTA(zigpy.util.ListenableMixin):
             return self._image_cache[key]
 
         images = await self.async_event("get_image", key)
-        images = [img for img in images if img]
-        if not images:
+        valid_images = []
+
+        for image in images:
+            if image is None:
+                continue
+
+            result = validate_ota_image(image)
+            LOGGER.debug("Validation result for OTA image %s: %s", image, result)
+
+            if result == ValidationResult.INVALID:
+                LOGGER.error("OTA image %s is invalid!", image)
+                continue
+
+            valid_images.append(image)
+
+        if not valid_images:
             return None
 
-        cached = CachedImage.new(max(images, key=lambda img: img.version))
+        cached = CachedImage.new(max(valid_images, key=lambda img: img.version))
         self._image_cache[key] = cached
         return cached
 

--- a/zigpy/ota/validators.py
+++ b/zigpy/ota/validators.py
@@ -1,0 +1,97 @@
+import enum
+import typing
+
+from zigpy.ota.image import ElementTagId, OTAImage
+
+
+class ValidationResult(enum.Enum):
+    VALID = 0
+    INVALID = 1
+    UNKNOWN = 2
+
+
+def parse_silabs_ebl(data: bytes) -> typing.Iterable[typing.Tuple[bytes, bytes]]:
+    """
+    Parses a Silicon Labs EBL firmware image.
+    """
+
+    assert data
+    assert len(data) % 64 == 0
+
+    while data:
+        assert len(data) >= 4
+        tag = data[:2]
+        length = int.from_bytes(data[2:4], "big")
+
+        value = data[4 : 4 + length]
+        assert len(value) == length
+
+        data = data[4 + length :]
+        yield tag, value
+
+        if tag == b"\xFC\x04":
+            assert not data.strip(b"\xFF")
+            break
+
+
+def parse_silabs_gbl(data: bytes) -> typing.Iterable[typing.Tuple[bytes, bytes]]:
+    """
+    Parses a Silicon Labs GBL firmware image.
+    """
+
+    assert data
+
+    while data:
+        assert len(data) >= 8
+        tag = data[:4]
+        length = int.from_bytes(data[4:8], "little")
+
+        value = data[8 : 8 + length]
+        assert len(value) == length
+
+        data = data[8 + length :]
+        yield tag, value
+
+
+def validate_firmware(data: bytes) -> ValidationResult:
+    """
+    Validates a firmware image.
+    """
+
+    if data.startswith(b"\xEB\x17\xA6\x03"):
+        parsed = parse_silabs_gbl(data)
+    elif data.startswith(b"\x00\x00\x00\x8C"):
+        parsed = parse_silabs_ebl(data)
+    else:
+        return ValidationResult.UNKNOWN
+
+    try:
+        list(parsed)
+        return ValidationResult.VALID
+    except Exception:
+        return ValidationResult.INVALID
+
+
+def validate_ota_image(image: OTAImage) -> ValidationResult:
+    """
+    Validates a Zigbee OTA image's embedded firmwares.
+    """
+
+    results = []
+
+    for subelement in image.subelements:
+        if subelement.tag_id == ElementTagId.UPGRADE_IMAGE:
+            results.append(validate_firmware(subelement))
+
+    if not results:
+        return ValidationResult.UNKNOWN
+
+    if ValidationResult.INVALID in results:
+        # If any firmware is invalid, the image is invalid
+        return ValidationResult.INVALID
+    elif ValidationResult.UNKNOWN in results:
+        # If no firmware can be parsed, the image cannot be validated but is not invalid
+        return ValidationResult.UNKNOWN
+    else:
+        # Otherwise, if every subelement can be parsed, the image is valid
+        return ValidationResult.VALID


### PR DESCRIPTION
Another fix for #497. This prevents zigpy from even considering the corrupted IKEA OTA files. Only known OTA containers from Silicon Labs with an invalid structure are rejected so this will not affect other firmwares.

I'm hesitant to include a ton of OTA files into the zigpy `tests/` directory so I've run it locally on every single IKEA OTA file downloaded from the current stable and test feeds, along with every OTA file from an older stable feed, and then every file in https://github.com/Koenkk/zigbee-OTA. All OTA images are marked either as "UNKNOWN" or "VALID", with eight images from the currently buggy IKEA feed being marked as "INVALID" (confirmed by testing with Silicon Labs' own firmware tool).

If you have other images you can test every file in a folder recursively:

```Python
import pathlib

from zigpy.ota import OTAImage
from zigpy.ota.validators import validate_ota_image

for f in pathlib.Path("~/Projects/zigpy/ikea-firmwares").expanduser().glob('**/*'):
    if not f.is_file():
        continue

    if f.suffix == '.signed':
        ikea_container = f.read_bytes()

        ota_offset = int.from_bytes(ikea_container[16:20], "little")
        ota_size = int.from_bytes(ikea_container[20:24], "little")

        data = ikea_container[ota_offset:ota_offset + ota_size]
    else:
        data = f.read_bytes()

    try:
        image, _ = OTAImage.deserialize(data)
    except Exception:
        print(f'Not an OTA image: {f}')
        continue

    result = validate_ota_image(image)
    print(f'{result}: {f}')
```
