### PR TITLE
Use verbose OTA image validation errors

### DIFF
--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -45,7 +45,7 @@ def ota():
     tradfri = MagicMock(spec_set=zigpy.ota.provider.Trådfri)
     validate_ota_image = MagicMock(
         spec_set=zigpy.ota.validators.validate_ota_image,
-        return_value=zigpy.ota.validators.ValidationResult.VALID,
+        return_value=True,
     )
 
     with patch("zigpy.ota.provider.Trådfri", tradfri):
@@ -121,8 +121,8 @@ async def test_get_image_new(ota, image, key, image_with_version, monkeypatch):
 async def test_get_image_invalid(ota, image, image_with_version):
     corrupted = image_with_version(image.version)
 
-    zigpy.ota.validate_ota_image.return_value = (
-        zigpy.ota.validators.ValidationResult.INVALID
+    zigpy.ota.validate_ota_image.side_effect = zigpy.ota.validators.ValidationError(
+        "Bad image"
     )
     ota.async_event = AsyncMock(return_value=[None, corrupted])
 
@@ -144,8 +144,8 @@ async def test_get_image_invalid_then_valid_versions(v1, v2, ota, image_with_ver
 
     ota.async_event = AsyncMock(return_value=[corrupted, image])
     zigpy.ota.validate_ota_image.side_effect = [
-        zigpy.ota.validators.ValidationResult.INVALID,
-        zigpy.ota.validators.ValidationResult.VALID,
+        zigpy.ota.validators.ValidationError("Bad image"),
+        True,
     ]
 
     res = await ota.get_ota_image(MANUFACTURER_ID, IMAGE_TYPE)

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -8,7 +8,7 @@ import attr
 from zigpy.config import CONF_OTA, CONF_OTA_DIR, CONF_OTA_IKEA, CONF_OTA_LEDVANCE
 from zigpy.ota.image import ImageKey, OTAImage
 import zigpy.ota.provider
-from zigpy.ota.validators import ValidationError, validate_ota_image
+from zigpy.ota.validators import check_invalid
 from zigpy.typing import ControllerApplicationType
 import zigpy.util
 
@@ -73,18 +73,10 @@ class OTA(zigpy.util.ListenableMixin):
         valid_images = []
 
         for image in images:
-            if image is None:
+            if image is None or check_invalid(image):
                 continue
 
-            try:
-                if validate_ota_image(image):
-                    LOGGER.debug("OTA image is valid: %s", image.header)
-                else:
-                    LOGGER.debug("OTA image format is unknown: %s", image.header)
-
-                valid_images.append(image)
-            except ValidationError as e:
-                LOGGER.error("OTA image %s is invalid: %s", image.header, e)
+            valid_images.append(image)
 
         if not valid_images:
             return None

--- a/zigpy/ota/validators.py
+++ b/zigpy/ota/validators.py
@@ -1,4 +1,3 @@
-import enum
 import typing
 import zlib
 
@@ -7,10 +6,8 @@ from zigpy.ota.image import ElementTagId, OTAImage
 VALID_SILABS_CRC = 0x2144DF1C  # CRC32(anything | CRC32(anything)) == CRC32(0x00000000)
 
 
-class ValidationResult(enum.Enum):
-    VALID = 0
-    INVALID = 1
-    UNKNOWN = 2
+class ValidationError(Exception):
+    pass
 
 
 def parse_silabs_ebl(data: bytes) -> typing.Iterable[typing.Tuple[bytes, bytes]]:
@@ -18,18 +15,26 @@ def parse_silabs_ebl(data: bytes) -> typing.Iterable[typing.Tuple[bytes, bytes]]
     Parses a Silicon Labs EBL firmware image.
     """
 
-    assert data
-    assert len(data) % 64 == 0
+    if len(data) % 64 != 0:
+        raise ValidationError(
+            f"Image size ({len(data)}) must be a multiple of 64 bytes"
+        )
 
     orig_data = data
 
     while True:
-        assert len(data) >= 4
+        if len(data) < 4:
+            raise ValidationError(
+                "Image is truncated: not long enough to contain a valid tag"
+            )
+
         tag = data[:2]
         length = int.from_bytes(data[2:4], "big")
 
         value = data[4 : 4 + length]
-        assert len(value) == length
+
+        if len(value) < length:
+            raise ValidationError("Image is truncated: tag value is cut off")
 
         data = data[4 + length :]
         yield tag, value
@@ -38,10 +43,17 @@ def parse_silabs_ebl(data: bytes) -> typing.Iterable[typing.Tuple[bytes, bytes]]
             continue
 
         # At this point the EBL should contain nothing but padding
-        assert not data.strip(b"\xFF")
+        if data.strip(b"\xFF"):
+            raise ValidationError("Image padding contains invalid bytes")
 
         unpadded_image = orig_data[: -len(data)] if data else orig_data
-        assert zlib.crc32(unpadded_image) == VALID_SILABS_CRC
+        computed_crc = zlib.crc32(unpadded_image)
+
+        if computed_crc != VALID_SILABS_CRC:
+            raise ValidationError(
+                f"Image CRC-32 is invalid:"
+                f" expected 0x{VALID_SILABS_CRC:08X}, got 0x{computed_crc:08X}"
+            )
 
         break
 
@@ -51,17 +63,27 @@ def parse_silabs_gbl(data: bytes) -> typing.Iterable[typing.Tuple[bytes, bytes]]
     Parses a Silicon Labs GBL firmware image.
     """
 
-    assert data
+    computed_crc = zlib.crc32(data)
 
-    orig_data = data
+    if computed_crc != VALID_SILABS_CRC:
+        raise ValidationError(
+            f"Image CRC-32 is invalid:"
+            f" expected 0x{VALID_SILABS_CRC:08X}, got 0x{computed_crc:08X}"
+        )
 
     while True:
-        assert len(data) >= 8
+        if len(data) < 8:
+            raise ValidationError(
+                "Image is truncated: not long enough to contain a valid tag"
+            )
+
         tag = data[:4]
         length = int.from_bytes(data[4:8], "little")
 
         value = data[8 : 8 + length]
-        assert len(value) == length
+
+        if len(value) < length:
+            raise ValidationError("Image is truncated: tag value is cut off")
 
         data = data[8 + length :]
         yield tag, value
@@ -69,15 +91,13 @@ def parse_silabs_gbl(data: bytes) -> typing.Iterable[typing.Tuple[bytes, bytes]]
         if tag != b"\xFC\x04\x04\xFC":
             continue
 
-        assert not data
+        if data:
+            raise ValidationError("Image contains trailing data")
 
-        # We could replace this entire function with the below line but validating the
-        # image structure along with the checksum is better.
-        assert zlib.crc32(orig_data) == VALID_SILABS_CRC
         break
 
 
-def validate_firmware(data: bytes) -> ValidationResult:
+def validate_firmware(data: bytes) -> bool:
     """
     Validates a firmware image.
     """
@@ -89,16 +109,13 @@ def validate_firmware(data: bytes) -> ValidationResult:
     elif data.startswith(b"\x00\x00\x00\x8C"):
         parser = parse_silabs_ebl
     else:
-        return ValidationResult.UNKNOWN
+        return None
 
-    try:
-        tuple(parser(data))
-        return ValidationResult.VALID
-    except Exception:
-        return ValidationResult.INVALID
+    tuple(parser(data))
+    return True
 
 
-def validate_ota_image(image: OTAImage) -> ValidationResult:
+def validate_ota_image(image: OTAImage) -> bool:
     """
     Validates a Zigbee OTA image's embedded firmwares.
     """
@@ -109,15 +126,7 @@ def validate_ota_image(image: OTAImage) -> ValidationResult:
         if subelement.tag_id == ElementTagId.UPGRADE_IMAGE:
             results.append(validate_firmware(subelement))
 
-    if not results:
-        return ValidationResult.UNKNOWN
+    if not results or any(r is None for r in results):
+        return None
 
-    if ValidationResult.INVALID in results:
-        # If any firmware is invalid, the image is invalid
-        return ValidationResult.INVALID
-    elif ValidationResult.UNKNOWN in results:
-        # If no firmware can be parsed, the image cannot be validated but is not invalid
-        return ValidationResult.UNKNOWN
-    else:
-        # Otherwise, if every subelement can be parsed, the image is valid
-        return ValidationResult.VALID
+    return True

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -129,25 +129,6 @@ class uint64_t(uint_t, size=8):
     pass
 
 
-class EnumIntFlagMixin:
-    """
-    Enum does not allow multiple base classes. We turn enum.IntFlag into a mixin because
-    it doesn't actualy depend on the base class specifically being `int`.
-    """
-
-    # Rebind classmethods to our own class
-    _missing_ = classmethod(enum.IntFlag._missing_.__func__)
-    _create_pseudo_member_ = classmethod(enum.IntFlag._create_pseudo_member_.__func__)
-
-    __or__ = enum.IntFlag.__or__
-    __and__ = enum.IntFlag.__and__
-    __xor__ = enum.IntFlag.__xor__
-    __ror__ = enum.IntFlag.__ror__
-    __rand__ = enum.IntFlag.__rand__
-    __rxor__ = enum.IntFlag.__rxor__
-    __invert__ = enum.IntFlag.__invert__
-
-
 class _IntEnumMeta(enum.EnumMeta):
     def __call__(cls, value, names=None, *args, **kwargs):
         if isinstance(value, str) and value.startswith("0x"):
@@ -155,6 +136,30 @@ class _IntEnumMeta(enum.EnumMeta):
         else:
             value = int(value)
         return super().__call__(value, names, *args, **kwargs)
+
+
+def bitmap_factory(int_type: CALLABLE_T) -> CALLABLE_T:
+    """
+    Mixins are broken by Python 3.8.6 so we must dynamically create the enum with the
+    appropriate methods but with only one non-Enum parent class.
+    """
+
+    class _NewEnum(int_type, enum.Flag):
+        # Rebind classmethods to our own class
+        _missing_ = classmethod(enum.IntFlag._missing_.__func__)
+        _create_pseudo_member_ = classmethod(
+            enum.IntFlag._create_pseudo_member_.__func__
+        )
+
+        __or__ = enum.IntFlag.__or__
+        __and__ = enum.IntFlag.__and__
+        __xor__ = enum.IntFlag.__xor__
+        __ror__ = enum.IntFlag.__ror__
+        __rand__ = enum.IntFlag.__rand__
+        __rxor__ = enum.IntFlag.__rxor__
+        __invert__ = enum.IntFlag.__invert__
+
+    return _NewEnum
 
 
 def enum_factory(int_type: CALLABLE_T, undefined: str = "undefined") -> CALLABLE_T:
@@ -180,35 +185,35 @@ class enum16(enum_factory(uint16_t)):  # noqa: N801
     pass
 
 
-class bitmap8(EnumIntFlagMixin, uint8_t, enum.Flag):
+class bitmap8(bitmap_factory(uint8_t)):
     pass
 
 
-class bitmap16(EnumIntFlagMixin, uint16_t, enum.Flag):
+class bitmap16(bitmap_factory(uint16_t)):
     pass
 
 
-class bitmap24(EnumIntFlagMixin, uint24_t, enum.Flag):
+class bitmap24(bitmap_factory(uint24_t)):
     pass
 
 
-class bitmap32(EnumIntFlagMixin, uint32_t, enum.Flag):
+class bitmap32(bitmap_factory(uint32_t)):
     pass
 
 
-class bitmap40(EnumIntFlagMixin, uint40_t, enum.Flag):
+class bitmap40(bitmap_factory(uint40_t)):
     pass
 
 
-class bitmap48(EnumIntFlagMixin, uint48_t, enum.Flag):
+class bitmap48(bitmap_factory(uint48_t)):
     pass
 
 
-class bitmap56(EnumIntFlagMixin, uint56_t, enum.Flag):
+class bitmap56(bitmap_factory(uint56_t)):
     pass
 
 
-class bitmap64(EnumIntFlagMixin, uint64_t, enum.Flag):
+class bitmap64(bitmap_factory(uint64_t)):
     pass
 
 


### PR DESCRIPTION
<sup>(#504 was auto closed when I force-pushed to my `dev` branch)</sup>

https://github.com/zigpy/zigpy/pull/500 logs `OTAImage` validation statuses with the `DEBUG` log level and invalid images with the `ERROR` log level. The inclusion of `OTAImage` objects in these log message will cause them to be logged in their entirety, which will include over 200kb of image data into logs during normal use when invalid images are encountered.

This change adds verbose validation error messages and replaces the `image` object with `image.header` within the log messages.

Future revisions to the OTA system could include a way to track an image's origin so `image.header` could be replaced with that instead.