### PR TITLE
Allow configuration of IKEA update URL

### DIFF
--- a/zigpy/config/__init__.py
+++ b/zigpy/config/__init__.py
@@ -36,6 +36,7 @@ CONF_NWK_UPDATE_ID = "update_id"
 CONF_OTA = "ota"
 CONF_OTA_DIR = "otau_directory"
 CONF_OTA_IKEA = "ikea_provider"
+CONF_OTA_IKEA_URL = "ikea_update_url"
 CONF_OTA_LEDVANCE = "ledvance_provider"
 CONF_TOPO_SCAN_PERIOD = "topology_scan_period"
 
@@ -72,6 +73,7 @@ SCHEMA_NETWORK = vol.Schema(
 SCHEMA_OTA = {
     vol.Optional(CONF_OTA_DIR, default=CONF_OTA_OTAU_DIR_DEFAULT): vol.Any(None, str),
     vol.Optional(CONF_OTA_IKEA, default=CONF_OTA_IKEA_DEFAULT): cv_boolean,
+    vol.Optional(CONF_OTA_IKEA_URL): vol.Url(),
     vol.Optional(CONF_OTA_LEDVANCE, default=CONF_OTA_LEDVANCE_DEFAULT): cv_boolean,
 }
 


### PR DESCRIPTION
Allow configuration of IKEA update URL via `ikea_update_url` configuration parameter.
For example in Home Assistant core `configuration.yaml` add:

```yaml
zha:
  zigpy_config:
    ota:
      ikea_provider: true
      ikea_update_url: http://fw.test.ota.homesmart.ikea.net/feed/version_info.json
```