### PR TITLE
Fix attributes being lost when an existing device is re-added

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -263,7 +263,6 @@ class PersistingListener:
                 device.status,
             )
             return
-
         try:
             q = "INSERT INTO devices (ieee, nwk, status) VALUES (?, ?, ?)"
             self.execute(q, (device.ieee, device.nwk, device.status))
@@ -271,6 +270,7 @@ class PersistingListener:
             LOGGER.debug("Device %s already exists. Updating it.", device.ieee)
             q = "UPDATE devices SET nwk=?, status=? WHERE ieee=?"
             self.execute(q, (device.nwk, device.status, device.ieee))
+
         self._save_node_descriptor(device)
         if isinstance(device, zigpy.quirks.CustomDevice):
             self._db.commit()


### PR DESCRIPTION
INSERT OR REPLACE deletes and inserts when the record already exists.
Since table constraints have ON DELETE CASCADE, the attributes (and probably endpoints and so on) were being deleted when an existing device is saved. 
After rebooting HA, no quirk would match since the device would have not manufacturer attr.

Should we also change the other INSERT OR REPLACE commands?