### PR TITLE
Refactor logging during device discovery

### DIFF
--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -111,9 +111,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     raise Exception("Endpoint request failed: %s", epr)
             except Exception:
                 self.initializing = False
-                LOGGER.exception(
-                    "Failed ZDO request during device initialization", exc_info=True
-                )
+                self.warning("Failed to discover active endpoints", exc_info=True)
                 return
 
             self.info("Discovered endpoints: %s", epr[2])
@@ -129,7 +127,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             try:
                 await ep.initialize()
             except Exception as exc:
-                self.debug("Endpoint %s initialization failure: %s", endpoint_id, exc)
+                self.warning("Endpoint %s initialization failure: %s", endpoint_id, exc)
                 break
             if self.manufacturer is None or self.model is None:
                 self.model, self.manufacturer = await ep.get_model_info()

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -60,7 +60,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 raise Exception("Failed to retrieve service descriptor: %s", sdr)
         except Exception:
             self.warning(
-                "Failed ZDO request during endpoint initialization", exc_info=True
+                "Failed to discover endpoint_id %s", self.endpoint_id, exc_info=True
             )
             return
 


### PR DESCRIPTION
log failed discoveries as `warnings`.  Include some additional information like if endpoint discover failed or endpoint id etc.