### PR TITLE
Don't query node descriptor on incoming messages

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -23,7 +23,12 @@ def app():
 def dev(monkeypatch, app):
     monkeypatch.setattr(device, "APS_REPLY_TIMEOUT_EXTENDED", 0.1)
     ieee = t.EUI64(map(t.uint8_t, [0, 1, 2, 3, 4, 5, 6, 7]))
-    return device.Device(app, ieee, 65535)
+    dev = device.Device(app, ieee, 65535)
+    node_desc = zdo_t.NodeDescriptor(1, 2, 3, 4, 5, 6, 7, 8)
+    with patch.object(
+        dev.zdo, "Node_Desc_req", new=AsyncMock(return_value=(0, 0xFFFF, node_desc))
+    ):
+        yield dev
 
 
 async def test_initialize(monkeypatch, dev):
@@ -46,7 +51,7 @@ async def test_initialize(monkeypatch, dev):
 
 async def test_initialize_fail(dev):
     async def mockrequest(nwk, tries=None, delay=None):
-        return [1]
+        return [1, dev.nwk, []]
 
     dev.zdo.Active_EP_req = mockrequest
     await dev._initialize()

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -86,10 +86,6 @@ class PersistingListener:
             value,
         )
 
-    def node_descriptor_updated(self, device):
-        self._save_node_descriptor(device)
-        self._db.commit()
-
     def neighbors_updated(self, neighbors):
         self.execute("DELETE FROM neighbors WHERE device_ieee = ?", (neighbors.ieee,))
         for nei in neighbors.neighbors:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -84,7 +84,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.info("Requesting 'Node Descriptor'")
         try:
             status, _, node_desc = await self.zdo.Node_Desc_req(
-                self.nwk, tries=2, delay=1
+                self.nwk, tries=2, delay=0.1
             )
             if status == zdo.types.Status.SUCCESS:
                 self.node_desc = node_desc
@@ -92,31 +92,29 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 return node_desc
             else:
                 self.warning("Requesting Node Descriptor failed: %s", status)
-        except Exception:
+        except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
             self.warning("Requesting Node Descriptor failed", exc_info=True)
-
-    async def refresh_node_descriptor(self):
-        if await self.get_node_descriptor():
-            self._application.listener_event("node_descriptor_updated", self)
 
     async def _initialize(self):
         if self.status == Status.NEW:
-            if self._node_handle is None or self._node_handle.done():
-                self._node_handle = asyncio.ensure_future(self.get_node_descriptor())
-            await self._node_handle
+            await self.get_node_descriptor()
             self.info("Discovering endpoints")
             try:
-                epr = await self.zdo.Active_EP_req(self.nwk, tries=3, delay=2)
-                if epr[0] != 0:
-                    raise Exception("Endpoint request failed: %s", epr)
-            except Exception:
+                status, _, endpoints = await self.zdo.Active_EP_req(
+                    self.nwk, tries=3, delay=0.5
+                )
+                if status != zdo.types.Status.SUCCESS:
+                    raise zigpy.exceptions.ControllerException(
+                        "Endpoint request failed: %s", status
+                    )
+            except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
                 self.initializing = False
                 self.warning("Failed to discover active endpoints", exc_info=True)
                 return
 
-            self.info("Discovered endpoints: %s", epr[2])
+            self.info("Discovered endpoints: %s", endpoints)
 
-            for endpoint_id in epr[2]:
+            for endpoint_id in endpoints:
                 self.add_endpoint(endpoint_id)
 
             self.status = Status.ZDO_INIT
@@ -218,11 +216,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     def handle_message(self, profile, cluster, src_ep, dst_ep, message):
         self.last_seen = time.time()
-        if not self.node_desc.is_valid and (
-            self._node_handle is None or self._node_handle.done()
-        ):
-            self._node_handle = asyncio.ensure_future(self.refresh_node_descriptor())
-
         try:
             hdr, args = self.deserialize(src_ep, cluster, message)
         except ValueError as e:


### PR DESCRIPTION
This is no longer needed, as it was done to ease the transition for existing setups which did not have node descriptors.