### PR TITLE
Move quirks code out of `appdb.py` and into `application.py` and `device.py`

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -130,10 +130,12 @@ async def test_database(tmpdir, monkeypatch):
     ep.profile_id = 65535
     with patch("zigpy.quirks.get_device", fake_get_device):
         app.device_initialized(dev)
-    assert isinstance(app.get_device(custom_ieee), FakeCustomDevice)
-    assert isinstance(app.get_device(custom_ieee), CustomDevice)
+
+    dev = app.get_device(custom_ieee)
+    assert isinstance(dev, FakeCustomDevice)
+    assert isinstance(dev, CustomDevice)
     assert ep.endpoint_id in dev.get_signature()
-    app.device_initialized(app.get_device(custom_ieee))
+    app.device_initialized(dev)
     dev.relays = relays_2
 
     # Everything should've been saved - check that it re-loads
@@ -157,20 +159,20 @@ async def test_database(tmpdir, monkeypatch):
 
     app.handle_leave(99, ieee)
 
-    app2 = await make_app(db)
-    assert ieee in app2.devices
+    app3 = await make_app(db)
+    dev = app3.get_device(custom_ieee)
+    assert dev.relays is None
+    assert ieee in app3.devices
 
     async def mockleave(*args, **kwargs):
         return [0]
 
-    app2.devices[ieee].zdo.leave = mockleave
-    await app2.remove(ieee)
-    assert ieee not in app2.devices
-
-    app3 = await make_app(db)
+    app3.devices[ieee].zdo.leave = mockleave
+    await app3.remove(ieee)
     assert ieee not in app3.devices
-    dev = app2.get_device(custom_ieee)
-    assert dev.relays is None
+
+    app4 = await make_app(db)
+    assert ieee not in app4.devices
 
     os.unlink(db)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -8,6 +8,7 @@ import zigpy.application
 import zigpy.exceptions
 from zigpy.profiles import zha
 import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zdo import types as zdo_t
 
 from .async_mock import AsyncMock, MagicMock, patch, sentinel
@@ -303,3 +304,16 @@ def test_device_manufacture_id_override(dev):
 
     dev.node_desc = zdo_t.NodeDescriptor()
     assert dev.manufacturer_id == 2345
+
+
+def test_device_model_manufacturer(dev):
+    assert dev.manufacturer is None
+    assert dev.model is None
+
+    ep = dev.add_endpoint(1)
+    cluster = ep.add_input_cluster(Basic.cluster_id)
+    cluster._update_attribute(0x0004, b"Manufacturer\x00\x00")
+    cluster._update_attribute(0x0005, b"Model\x00\x00")
+
+    assert dev.manufacturer == "Manufacturer"
+    assert dev.model == "Model"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -315,5 +315,23 @@ def test_device_model_manufacturer(dev):
     cluster._update_attribute(0x0004, b"Manufacturer\x00\x00")
     cluster._update_attribute(0x0005, b"Model\x00\x00")
 
+    # Nothing is changed until the attributes are reloaded
+    assert dev.manufacturer is None
+    assert dev.model is None
+
+    dev._update_model_manufacturer()
+
     assert dev.manufacturer == "Manufacturer"
     assert dev.model == "Model"
+
+    cluster._update_attribute(0x0004, b"New Manufacturer\x00\x00")
+    cluster._update_attribute(0x0005, b"New Model\x00\x00")
+
+    # Changing the cached attributes will not affect the device's current info
+    assert dev.manufacturer == "Manufacturer"
+    assert dev.model == "Model"
+
+    dev._update_model_manufacturer()
+
+    assert dev.manufacturer == "New Manufacturer"
+    assert dev.model == "New Model"

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -196,9 +196,10 @@ def test_custom_device():
     class Device(zigpy.quirks.CustomDevice):
         signature = {}
 
-        class MyEndpoint:
+        class MyEndpoint(zigpy.endpoint.Endpoint):
             def __init__(self, device, endpoint_id, *args, **kwargs):
                 assert args == (sentinel.custom_endpoint_arg, replaces)
+                super().__init__(device, endpoint_id)
 
         class MyCluster(zigpy.quirks.CustomCluster):
             cluster_id = 0x8888
@@ -219,9 +220,10 @@ def test_custom_device():
     class Device2(zigpy.quirks.CustomDevice):
         signature = {}
 
-        class MyEndpoint:
+        class MyEndpoint(zigpy.endpoint.Endpoint):
             def __init__(self, device, endpoint_id, *args, **kwargs):
                 assert args == (sentinel.custom_endpoint_arg, replaces)
+                super().__init__(device, endpoint_id)
 
         class MyCluster(zigpy.quirks.CustomCluster):
             cluster_id = 0x8888

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -349,10 +349,8 @@ class PersistingListener:
         self.execute("DELETE FROM relays WHERE ieee = ?", (ieee,))
         self._db.commit()
 
-    def _scan(self, table, filter=None):
-        if filter is None:
-            return self.execute("SELECT * FROM %s" % (table,))
-        return self.execute("SELECT * FROM %s WHERE %s" % (table, filter))
+    def _scan(self, table):
+        return self.execute("SELECT * FROM %s" % (table,))
 
     async def load(self) -> None:
         LOGGER.debug("Loading application state from %s", self._database_file)
@@ -402,13 +400,7 @@ class PersistingListener:
     async def _load_attributes(self):
         for (ieee, endpoint_id, cluster, attrid, value) in self._scan("attributes"):
             dev = self._application.get_device(ieee)
-            if endpoint_id not in dev.endpoints:
-                continue
-
             ep = dev.endpoints[endpoint_id]
-            if cluster not in ep.in_clusters:
-                continue
-
             clus = ep.in_clusters[cluster]
             clus._attr_cache[attrid] = value
             LOGGER.debug(

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -422,9 +422,9 @@ class PersistingListener:
             ep = dev.add_endpoint(epid)
             ep.profile_id = profile_id
             ep.device_type = device_type
-            if profile_id == 260:
+            if profile_id == zigpy.profiles.zha.PROFILE_ID:
                 ep.device_type = zigpy.profiles.zha.DeviceType(device_type)
-            elif profile_id == 49246:
+            elif profile_id == zigpy.profiles.zll.PROFILE_ID:
                 ep.device_type = zigpy.profiles.zll.DeviceType(device_type)
             ep.status = zigpy.endpoint.Status(status)
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -70,6 +70,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # Replace all of the Device objects with CustomDevice objects, if necessary
         for device in self.devices.values():
             device = self.quirk_device(device)
+            device._update_model_manufacturer()
             device.add_context_listener(self._dblistener)
             device.neighbors.add_context_listener(self._dblistener)
 
@@ -139,6 +140,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Used by a device to signal that it is initialized"""
         self.listener_event("raw_device_initialized", device)
         device = self.quirk_device(device)
+        device._update_model_manufacturer()
         if self._dblistener is not None:
             device.add_context_listener(self._dblistener)
             device.neighbors.add_context_listener(self._dblistener)

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -67,19 +67,19 @@ class CustomDevice(zigpy.device.Device, metaclass=Registry):
 
     def add_endpoint(self, endpoint_id, replace_device=None):
         if endpoint_id not in self.replacement.get("endpoints", {}):
-            ep = super().add_endpoint(endpoint_id)
+            return super().add_endpoint(endpoint_id)
+
+        endpoints = self.replacement["endpoints"]
+
+        if isinstance(endpoints[endpoint_id], tuple):
+            custom_ep_type = endpoints[endpoint_id][0]
+            replacement_data = endpoints[endpoint_id][1]
         else:
-            endpoints = self.replacement["endpoints"]
+            custom_ep_type = CustomEndpoint
+            replacement_data = endpoints[endpoint_id]
 
-            if isinstance(endpoints[endpoint_id], tuple):
-                custom_ep_type = endpoints[endpoint_id][0]
-                replacement_data = endpoints[endpoint_id][1]
-            else:
-                custom_ep_type = CustomEndpoint
-                replacement_data = endpoints[endpoint_id]
-
-            ep = custom_ep_type(self, endpoint_id, replacement_data, replace_device)
-            self.endpoints[endpoint_id] = ep
+        ep = custom_ep_type(self, endpoint_id, replacement_data, replace_device)
+        self.endpoints[endpoint_id] = ep
 
         return ep
 

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -55,13 +55,12 @@ class DeviceRegistry:
         ):
             _LOGGER.debug("Considering %s", candidate)
 
-            if not device.model == candidate.signature.get("model", device.model):
+            if device.model != candidate.signature.get("model", device.model):
                 _LOGGER.debug("Fail, because device model mismatch: '%s'", device.model)
                 continue
 
-            if not (
-                device.manufacturer
-                == candidate.signature.get("manufacturer", device.manufacturer)
+            if device.manufacturer != candidate.signature.get(
+                "manufacturer", device.manufacturer
             ):
                 _LOGGER.debug(
                     "Fail, because device manufacturer mismatch: '%s'",


### PR DESCRIPTION
 - `Device`s are now replaced with `CustomDevice` objects within the `application` module instead of the `appdb` module, inside of `device_initialized` and `_load_db`. This simplifies the creation of other other database providers (e.g. JSON) and removes unrelated functionality from the `appdb` module.
 - `appdb` no longer sets the `manufacturer` and `model` attributes when creating a device. This is done dynamically within the `Device` class by finding the first `Basic` cluster with these cached attributes.
 - listeners on endpoints, clusters, and the device itself are preserved when creating a `CustomDevice`.
