### PR TITLE
Cleanup device on restart

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -419,12 +419,14 @@ async def test_neighbors(tmpdir):
 
     dev_1 = app.get_device(ieee_1)
     dev_1.node_desc = zdo_t.NodeDescriptor(2, 64, 128, 4174, 82, 82, 0, 82, 0)
+    dev_1.add_endpoint(1)
     app.device_initialized(dev_1)
 
     # 2nd device
     app.handle_join(nwk_2, ieee_2, 0)
     dev_2 = app.get_device(ieee_2)
     dev_2.node_desc = zdo_t.NodeDescriptor(1, 64, 142, 4476, 82, 82, 0, 82, 0)
+    dev_2.add_endpoint(1)
     app.device_initialized(dev_2)
 
     neighbors = zdo_t.Neighbors(2, 0, [nei_2, nei_3])


### PR DESCRIPTION
Remove devices without any endpoints. This compliments fix in https://github.com/zigpy/zigpy/pull/515 since users still are going to experience the issue, unless they fully remove and re-pair the affected devices. This removes those affected devices on start up so user just have to re-pair the device.