### PR TITLE
Handle special identification for some sensors

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -27,6 +27,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     def __init__(self, config: Dict):
         self._send_sequence = 0
         self.devices: Dict[t.EUI64, zigpy.device.Device] = {}
+        self.quirks = zigpy.quirks
         self.topology = None
         self._listeners = {}
         self._channel = None

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -80,6 +80,26 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         self.status = Status.ZDO_INIT
 
+    def initialize_from_quirk(self, endpoint):
+        if self.status == Status.ZDO_INIT:
+            return
+        self.profile_id = endpoint["profile_id"]
+        self.device_type = endpoint["device_type"]
+        if self.profile_id == 260:
+            self.device_type = zigpy.profiles.zha.DeviceType(self.device_type)
+        elif self.profile_id == 49246:
+            self.device_type = zigpy.profiles.zll.DeviceType(self.device_type)
+
+        for cluster in endpoint["input_clusters"]:
+            clus = self.add_input_cluster(cluster)
+            if cluster == 0:
+                clus._attr_cache[4] = self.manufacturer
+                clus._attr_cache[5] = self.model
+        for cluster in endpoint["output_clusters"]:
+            self.add_output_cluster(cluster)
+
+        self.status = Status.ZDO_INIT
+
     def add_input_cluster(self, cluster_id, cluster=None):
         """Adds an endpoint's input cluster
 

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -28,6 +28,11 @@ def get_device(device, registry=_DEVICE_REGISTRY):
     return registry.get_device(device)
 
 
+def get_device_metadata(model, manufacturer=None, registry=_DEVICE_REGISTRY):
+    """Get a CustomDevice object, if one is available"""
+    return registry.get_device_metadata(model, manufacturer)
+
+
 class Registry(type):
     def __init__(cls, name, bases, nmspc):  # noqa: N805
         super(Registry, cls).__init__(name, bases, nmspc)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -209,6 +209,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
                     for a in args[0]
                 ]
             )
+            attributes = {
+                self.attributes.get(a.attrid, [a.attrid])[0]: a.value.value
+                for a in args[0]
+            }
+            self.listener_event("attributes_updated", attributes)
             self.debug("Attribute report received: %s", valuestr)
             for attr in args[0]:
                 try:


### PR DESCRIPTION
This allows sensors like Xiaomi and Terncy ones to be initialized without exchanging interview messages.
Requires the following PR in quirks: https://github.com/zigpy/zha-device-handlers/pull/550

Example of how quick a Xiaomi Motion sensor gets paired (I've pressed the button only once): https://photos.app.goo.gl/GhyLpZEAHQqCgSsm9