### PR TITLE
Bump up aiosqlite dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 import zigpy
 
-REQUIRES = ["aiohttp", "aiosqlite", "crccheck", "pycryptodome", "voluptuous"]
+REQUIRES = ["aiohttp", "aiosqlite>=0.16.0", "crccheck", "pycryptodome", "voluptuous"]
 
 setup(
     name="zigpy",


### PR DESCRIPTION
Bump up aiosqlite dependency. Prevents `aiosqlite` from logging as exception on device rejoin.