### PR TITLE
Handle cluster.get("no_such_attr") correctly

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -356,6 +356,9 @@ async def test_item_access_attributes(cluster):
         # wrong key type
         cluster.get(None)
 
+    # Test access to cached attribute via wrong attr name
+    assert cluster.get("no_such_attribute", mock.sentinel.attr) is mock.sentinel.attr
+
 
 async def test_item_set_attributes(cluster):
     with patch.object(cluster, "write_attributes") as write_mock:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -522,7 +522,12 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
         if isinstance(key, int):
             return self._attr_cache.get(key, default)
         elif isinstance(key, str):
-            return self._attr_cache.get(self.attridx[key], default)
+            try:
+                attr_id = self.attridx[key]
+            except KeyError:
+                return default
+            return self._attr_cache.get(attr_id, default)
+
         raise ValueError("attr_name or attr_id are accepted only")
 
     def __getitem__(self, key: Union[int, str]) -> Any:


### PR DESCRIPTION
Return the default value, instead of throwing a KeyError when doing something like `cluster.get("no_such_attribute")`