### PR TITLE
Framework implementing message handlers from uninitialized devices

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -65,7 +65,6 @@ def mock_dev_init(status: Status):
 
     def _initialize(self):
         self.status = status
-        self.initializing = False
         self.node_desc = zdo_t.NodeDescriptor(0, 1, 2, 3, 4, 5, 6, 7, 8)
 
     return _initialize

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -657,3 +657,28 @@ async def test_configure_reporting_manufacture_specific(
         )
         assert cmd_mock.call_count == 1
         assert cmd_mock.call_args[1]["manufacturer"] is sentinel.another_id
+
+
+def test_get_model_quirks():
+    """Test model quirk list registry."""
+
+    quirk_list = zigpy.quirks.get_model_quirks("some model")
+    assert not quirk_list
+
+    class SomeModel(zigpy.quirks.CustomDevice):
+        signature = {
+            SIG_MODEL: "some model",
+            SIG_MANUFACTURER: "some manufacturer",
+            SIG_ENDPOINTS: {
+                1: {
+                    SIG_EP_PROFILE: 0x0260,
+                    SIG_EP_TYPE: 0x0000,
+                    SIG_EP_INPUT: [0, 1, 3, 4],
+                    SIG_EP_OUTPUT: [0x19],
+                }
+            },
+        }
+
+    quirk_list = zigpy.quirks.get_model_quirks("some model")
+    assert quirk_list
+    assert quirk_list[0] is SomeModel

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -167,6 +167,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 sender.status,
                 dst_ep,
             )
+            zigpy.quirks.handle_message_from_uninitialized_sender(
+                sender, profile, cluster, src_ep, dst_ep, message
+            )
             return
         elif (
             sender.status == zigpy.device.Status.ZDO_INIT

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -158,7 +158,18 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     def deserialize(self, sender, endpoint_id, cluster_id, data):
         return sender.deserialize(endpoint_id, cluster_id, data)
 
-    def handle_message(self, sender, profile, cluster, src_ep, dst_ep, message):
+    def handle_message(
+        self,
+        sender: zigpy.device.Device,
+        profile: int,
+        cluster: int,
+        src_ep: int,
+        dst_ep: int,
+        message: bytes,
+    ) -> None:
+        self.listener_event(
+            "handle_message", sender, profile, cluster, src_ep, dst_ep, message
+        )
         if sender.status == zigpy.device.Status.NEW and dst_ep != 0:
             # only allow ZDO responses while initializing device
             LOGGER.debug(

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -40,6 +40,13 @@ def get_device(device, registry=_DEVICE_REGISTRY):
     return registry.get_device(device)
 
 
+def get_model_quirks(
+    model: str, registry: DeviceRegistry = _DEVICE_REGISTRY
+) -> List["CustomDevice"]:
+    """Get all quirks for given model."""
+    return registry.model_quirks.get(model)
+
+
 class Registry(type):
     def __init__(cls, name, bases, nmspc):  # noqa: N805
         super(Registry, cls).__init__(name, bases, nmspc)

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -33,6 +33,7 @@ import zigpy.zcl.foundation as foundation
 _LOGGER = logging.getLogger(__name__)
 
 _DEVICE_REGISTRY = DeviceRegistry()
+_uninitialized_device_message_handlers = []
 
 
 def get_device(device, registry=_DEVICE_REGISTRY):
@@ -45,6 +46,16 @@ def get_model_quirks(
 ) -> List["CustomDevice"]:
     """Get all quirks for given model."""
     return registry.model_quirks.get(model)
+
+
+def register_uninitialized_device_message_handler(handler: Callable) -> None:
+    """Register an handler for messages received by uninitialized devices.
+
+    each handler is passed same parameters as
+    zigpy.application.ControllerApplication.handle_message
+    """
+    if handler not in _uninitialized_device_message_handlers:
+        _uninitialized_device_message_handlers.append(handler)
 
 
 class Registry(type):
@@ -256,3 +267,17 @@ class CustomCluster(zigpy.zcl.Cluster):
         if manufacturer is None and self._has_manuf_attr([a.attrid for a in args]):
             manufacturer = self.endpoint.manufacturer_id
         return super()._write_attributes_undivided(args, manufacturer=manufacturer)
+
+
+def handle_message_from_uninitialized_sender(
+    sender: zigpy.device.Device,
+    profile: int,
+    cluster: int,
+    src_ep: int,
+    dst_ep: int,
+    message: bytes,
+) -> None:
+    """Processes message from an uninitialized sender."""
+    for handler in _uninitialized_device_message_handlers:
+        if handler(sender, profile, cluster, src_ep, dst_ep, message):
+            break

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -1,7 +1,7 @@
 import collections
 import itertools
 import logging
-from typing import Union
+from typing import Dict, List, Union
 
 import zigpy.quirks
 from zigpy.typing import CustomDeviceType, DeviceType
@@ -19,11 +19,16 @@ SIG_MODELS_INFO = "models_info"
 SIG_NODE_DESC = "node_desc"
 SIG_SKIP_CONFIG = "skip_configuration"
 
+TYPE_MODEL_QUIRKS_LIST = Dict[str, List[zigpy.quirks.CustomDevice]]
+TYPE_MANUF_QUIRKS_DICT = Dict[str, TYPE_MODEL_QUIRKS_LIST]
+
 
 class DeviceRegistry:
     def __init__(self, *args, **kwargs):
-        dd = collections.defaultdict
-        self._registry = dd(lambda: dd(list))
+        self._model_quirks: TYPE_MODEL_QUIRKS_LIST = collections.defaultdict(list)
+        self._registry: TYPE_MANUF_QUIRKS_DICT = collections.defaultdict(
+            lambda: self._model_quirks
+        )
 
     def add_to_registry(self, custom_device: CustomDeviceType) -> None:
         """Add a device to the registry"""
@@ -151,6 +156,11 @@ class DeviceRegistry:
     @property
     def registry(self):
         return self._registry
+
+    @property
+    def model_quirks(self) -> TYPE_MODEL_QUIRKS_LIST:
+        """Return a list of quirks for a given model."""
+        return self._model_quirks
 
     def __contains__(self, device: CustomDeviceType) -> bool:
         manufacturer, model = device.signature.get(

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -19,7 +19,7 @@ SIG_MODELS_INFO = "models_info"
 SIG_NODE_DESC = "node_desc"
 SIG_SKIP_CONFIG = "skip_configuration"
 
-TYPE_MODEL_QUIRKS_LIST = Dict[str, List[zigpy.quirks.CustomDevice]]
+TYPE_MODEL_QUIRKS_LIST = Dict[str, List["zigpy.quirks.CustomDevice"]]
 TYPE_MANUF_QUIRKS_DICT = Dict[str, TYPE_MODEL_QUIRKS_LIST]
 
 


### PR DESCRIPTION
1. Allow registration of `handle_message` handlers for incoming messages from uninitialized devices
2. Add `handle_message` event to remove ZHA hack

This would allow implementation of fast xiaomi initialization in quirks