### PR TITLE
Ensure `app.force_remove` throwing an exception does not break removal

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -298,6 +298,19 @@ async def test_remove_with_reply_timeout(app, ieee):
     assert app.force_remove.call_count == 1
 
 
+async def test_force_remove_failure(app, ieee):
+    app.force_remove = AsyncMock(side_effect=RuntimeError("Failure"))
+
+    # The application fails to remove the device
+    with pytest.raises(RuntimeError):
+        await _remove(app, ieee, [1])
+
+    assert app.force_remove.call_count == 1
+
+    # But the device was still removed
+    assert ieee not in app.devices
+
+
 def test_add_device(app, ieee):
     app.add_device(ieee, 8)
     app.add_device(ieee, 9)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -146,11 +146,13 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
             LOGGER.debug("Sending 'zdo_leave_req' failed: %s", ex)
 
-        if not zdo_worked:
-            await self.force_remove(dev)
-        self.devices.pop(ieee, None)
-
-        self.listener_event("device_removed", dev)
+        try:
+            if not zdo_worked:
+                await self.force_remove(dev)
+        finally:
+            # Remove the device from the database even if `force_remove` fails
+            self.devices.pop(ieee, None)
+            self.listener_event("device_removed", dev)
 
     async def force_remove(self, dev):
         raise NotImplementedError


### PR DESCRIPTION
Makes sure that a radio library's `force_remove` throwing an exception does not break removal from the DB (https://github.com/zigpy/zigpy/issues/563).

---

Imagine this scenario:

```
[Coordinator]  <--->  [Router]  <--->  [Router to be removed]
```

If the "router to be removed" is joined through "router" and you shut "router to be removed" off, it will retain the network information and have everything it needs to re-join the network. Calling `app.remove(router_to_be_removed)` will fail, as will the force remove. I believe powering this router back on will cause it to rejoin the network (since it never believes it left) and it will re-announce itself, causing zigpy to think it's a newly-joined device and start reconfiguring it. Is this expected behavior?