### PR TITLE
Fixe regression introduced in #555

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -132,6 +132,7 @@ def test_get_device_new_sig(real_device):
     TestDevice.signature[SIG_ENDPOINTS][2] = {SIG_EP_PROFILE: 2}
     registry = _dev_reg(TestDevice)
     assert registry.get_device(real_device) is real_device
+    assert zigpy.quirks.get_device(real_device, registry) is real_device
 
 
 def test_model_manuf_device_sig(real_device):

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -36,16 +36,22 @@ _DEVICE_REGISTRY = DeviceRegistry()
 _uninitialized_device_message_handlers = []
 
 
-def get_device(device, registry=_DEVICE_REGISTRY):
+def get_device(device: zigpy.device.Device, registry: Optional[DeviceRegistry] = None):
     """Get a CustomDevice object, if one is available"""
+    if registry is None:
+        return _DEVICE_REGISTRY.get_device(device)
+
     return registry.get_device(device)
 
 
-def get_model_quirks(
-    model: str, registry: DeviceRegistry = _DEVICE_REGISTRY
-) -> List["CustomDevice"]:
-    """Get all quirks for given model."""
-    return registry.model_quirks[model]
+def get_quirk_list(
+    manufacturer: str, model: str, registry: Optional[DeviceRegistry] = None
+):
+    """Get the Quirk list for a given manufacturer and model."""
+    if registry is None:
+        return _DEVICE_REGISTRY.registry[manufacturer][model]
+
+    return registry.registry[manufacturer][model]
 
 
 def register_uninitialized_device_message_handler(handler: Callable) -> None:

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -25,9 +25,8 @@ TYPE_MANUF_QUIRKS_DICT = Dict[str, TYPE_MODEL_QUIRKS_LIST]
 
 class DeviceRegistry:
     def __init__(self, *args, **kwargs):
-        self._model_quirks: TYPE_MODEL_QUIRKS_LIST = collections.defaultdict(list)
         self._registry: TYPE_MANUF_QUIRKS_DICT = collections.defaultdict(
-            lambda: self._model_quirks
+            lambda: collections.defaultdict(list)
         )
 
     def add_to_registry(self, custom_device: CustomDeviceType) -> None:
@@ -156,11 +155,6 @@ class DeviceRegistry:
     @property
     def registry(self):
         return self._registry
-
-    @property
-    def model_quirks(self) -> TYPE_MODEL_QUIRKS_LIST:
-        """Return a list of quirks for a given model."""
-        return self._model_quirks
 
     def __contains__(self, device: CustomDeviceType) -> bool:
         manufacturer, model = device.signature.get(


### PR DESCRIPTION
Fixes https://github.com/zigpy/zigpy/issues/566
Using the same instance of the "model" default dict, causes different manufacturers to share the list for the same "model" name.
