### PR TITLE
Support arbitrary callables as quirk matchers

### DIFF
--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -64,6 +64,18 @@ def register_uninitialized_device_message_handler(handler: Callable) -> None:
         _uninitialized_device_message_handlers.append(handler)
 
 
+def register_quirk_matcher(
+    matcher: Callable, registry: Optional[DeviceRegistry] = _DEVICE_REGISTRY
+) -> None:
+    """Registers a callable quirk matcher that accepts a `Device` object and returns a
+    `CustomDevice` subclass, a `CustomDevice` instance, or `None`.
+
+    Takes precedence over any signature-based matches.
+    """
+
+    registry.add_matcher_to_registry(matcher)
+
+
 class Registry(type):
     def __init__(cls, name, bases, nmspc):  # noqa: N805
         super(Registry, cls).__init__(name, bases, nmspc)


### PR DESCRIPTION
The goal of this change is to support complex quirks that accept a `Device` instance and possibly return a replacement class (or instance). At the moment it's not very useful but there has been interest in supporting quirks kept independently of the `zhaquirks` package, maybe as a config option:

```yaml
zigpy:
  custom_quirks_path: /config/custom_zha_quirks
```

One use case is supporting modified Xiaomi motion sensors, which have a timeout of 5s instead of the usual 120s. They are otherwise indistinguishable from other Xiaomi motion sensors and cannot be matched with a normal quirk:

```Python
# /config/custom_zha_quirks/fast_xiaomi.py
import zigpy.quirks
from zhaquirks.xiaomi.aqara.motion_aq2 import MotionAQ2

FAST_XIAOMI_SENSORS = {"AA:BB:CC:DD:EE:FF", "00:11:22:33:44:55:66"}


@zigpy.quirks.register_quirk_matcher
def fast_xiaomi_motion(device):
    if str(device.ieee).upper() not in FAST_XIAOMI_SENSORS:
        return

    replacement = MotionAQ2(device._application, device.ieee, device.nwk, device)
    replacement.endpoints[1].occupancy.reset_s = 5

    return replacement
```

This approach can also be used to simplify the existing quirks matching code within zigpy and possibly move some of it into zha-device-handlers.