### PR TITLE
Refactor ControllerApplication.remove() method

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import pytest
@@ -167,6 +168,8 @@ async def test_database(tmpdir):
 
     app3.devices[ieee].zdo.leave = mockleave
     await app3.remove(ieee)
+    for i in range(1, 20):
+        await asyncio.sleep(0)
     assert ieee not in app3.devices
     await app3.pre_shutdown()
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -506,3 +506,71 @@ def test_uninitialized_message_handlers(app, ieee):
     app.handle_message(device, 0x0260, 0x0000, 1, 1, b"123abcd23")
     assert handler_1.call_count == 2
     assert handler_2.call_count == 1
+
+
+def _devices(index):
+    """Device factory."""
+
+    start_ieee = 0xFEAB000000
+    start_nwk = 0x1000
+
+    dev = MagicMock()
+    dev.ieee = zigpy.types.EUI64(zigpy.types.uint64_t(start_ieee + index).serialize())
+    dev.nwk = zigpy.types.NWK(start_nwk + index)
+    dev.neighbors = []
+    dev.node_desc = zdo_t.NodeDescriptor(1, 64, 142, 4388, 82, 255, 0, 255, 0)
+    dev.zdo = zigpy.zdo.ZDO(dev)
+    return dev
+
+
+async def test_remove_parent_devices(app):
+    """Test removing an end device with parents."""
+
+    end_device = _devices(1)
+    end_device.node_desc.byte1 = 2
+    nei_end_device = MagicMock()
+    nei_end_device.device = end_device
+
+    router_1 = _devices(2)
+    nei_router_1 = MagicMock()
+    nei_router_1.device = router_1
+
+    router_2 = _devices(3)
+    nei_router_2 = MagicMock()
+    nei_router_2.device = router_2
+
+    parent = _devices(4)
+    nei_parent = MagicMock()
+    nei_parent.device = router_1
+
+    router_1.neighbors = [nei_router_2, nei_parent]
+    router_2.neighbors = [nei_parent, nei_router_1]
+    parent.neighbors = [nei_router_2, nei_router_1, nei_end_device]
+
+    app.devices[end_device.ieee] = end_device
+    app.devices[parent.ieee] = parent
+    app.devices[router_1.ieee] = router_1
+    app.devices[router_2.ieee] = router_2
+
+    p1 = patch.object(end_device.zdo, "leave", AsyncMock())
+    p2 = patch.object(end_device.zdo, "request", AsyncMock())
+    p3 = patch.object(parent.zdo, "leave", AsyncMock())
+    p4 = patch.object(parent.zdo, "request", AsyncMock())
+    p5 = patch.object(router_1.zdo, "leave", AsyncMock())
+    p6 = patch.object(router_1.zdo, "request", AsyncMock())
+    p7 = patch.object(router_2.zdo, "leave", AsyncMock())
+    p8 = patch.object(router_2.zdo, "request", AsyncMock())
+
+    with p1, p2, p3, p4, p5, p6, p7, p8:
+        await app.remove(end_device.ieee)
+        for i in range(1, 60):
+            await asyncio.sleep(0)
+
+        assert end_device.zdo.leave.await_count == 1
+        assert end_device.zdo.request.await_count == 0
+        assert router_1.zdo.leave.await_count == 0
+        assert router_1.zdo.request.await_count == 0
+        assert router_2.zdo.leave.await_count == 0
+        assert router_2.zdo.request.await_count == 0
+        assert parent.zdo.leave.await_count == 0
+        assert parent.zdo.request.await_count == 1

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+from typing import Coroutine
 
 import zigpy.types as t
 import zigpy.util
@@ -99,8 +100,14 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
             self.device.application.get_dst_address(cluster),
         )
 
-    def leave(self):
-        return self.Mgmt_Leave_req(self._device.ieee, 0x02)
+    def leave(self, remove_children: bool = True, rejoin: bool = False) -> Coroutine:
+        flags = 0x00
+        if remove_children:
+            flags |= 0x02
+        if rejoin:
+            flags |= 0x01
+
+        return self.Mgmt_Leave_req(self._device.ieee, flags)
 
     def permit(self, duration=60, tc_significance=0):
         return self.Mgmt_Permit_Joining_req(duration, tc_significance)


### PR DESCRIPTION
1. Schedule a ZDO Mgmt_Leave_req to the device being removed
2. If the device being removed is an "End Device", then schedule sending a ZDO Mgmt_Leave_req to each device which has "device being removed" in their neighbor tables

Don't wait for the actual request completion. Remove device from `ControllerApplication.devices` dict on successful reply to ZDO request or on a 30s timeout.

This PR effectively removes requirement to implement `ControllerApplication.force_remove()` method.