### PR TITLE
Increase coverage

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -6,6 +6,7 @@ import pytest
 from zigpy import profiles
 import zigpy.application
 from zigpy.config import CONF_DATABASE, ZIGPY_SCHEMA
+from zigpy.const import SIG_ENDPOINTS, SIG_MANUFACTURER, SIG_MODEL
 from zigpy.device import Device, Status
 import zigpy.ota
 from zigpy.quirks import CustomDevice
@@ -121,6 +122,14 @@ async def test_database(tmpdir):
     clus.listener_event("cluster_command", 0)
     clus.listener_event("general_command")
     dev.relays = relays_1
+    signature = dev.get_signature()
+    assert ep.endpoint_id in signature[SIG_ENDPOINTS]
+    assert SIG_MANUFACTURER not in signature
+    assert SIG_MODEL not in signature
+    dev.manufacturer = "Custom"
+    dev.model = "Model"
+    assert dev.get_signature()[SIG_MANUFACTURER] == "Custom"
+    assert dev.get_signature()[SIG_MODEL] == "Model"
 
     # Test a CustomDevice
     custom_ieee = make_ieee(1)
@@ -133,7 +142,6 @@ async def test_database(tmpdir):
         app.device_initialized(dev)
     assert isinstance(app.get_device(custom_ieee), FakeCustomDevice)
     assert isinstance(app.get_device(custom_ieee), CustomDevice)
-    assert ep.endpoint_id in dev.get_signature()
     app.device_initialized(app.get_device(custom_ieee))
     dev.relays = relays_2
     await app.pre_shutdown()

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -567,3 +567,60 @@ async def test_device_cleanup(tmpdir, caplog):
     assert ieee_1 in app_2.devices
     assert len(app_2.devices) == 1
     await app_2.pre_shutdown()
+
+
+@patch(
+    "zigpy.device.Device.schedule_initialize", new=mock_dev_init(Status.ENDPOINTS_INIT)
+)
+async def test_stopped_appdb_listener(tmpdir):
+    db = os.path.join(str(tmpdir), "test.db")
+    app = await make_app(db)
+    ieee = make_ieee()
+    app.handle_join(99, ieee, 0)
+
+    dev = app.get_device(ieee)
+    ep = dev.add_endpoint(1)
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+    clus = ep.add_input_cluster(0)
+    ep.add_output_cluster(1)
+    app.device_initialized(dev)
+
+    with patch("zigpy.appdb.PersistingListener._save_attribute") as mock_attr_save:
+        clus._update_attribute(0, 99)
+        clus._update_attribute(4, bytes("Custom", "ascii"))
+        clus._update_attribute(5, bytes("Model", "ascii"))
+        await app.pre_shutdown()
+        assert mock_attr_save.call_count == 3
+
+        clus._update_attribute(0, 100)
+        for i in range(100):
+            await asyncio.sleep(0)
+        assert mock_attr_save.call_count == 3
+
+
+@patch(
+    "zigpy.device.Device.schedule_initialize", new=mock_dev_init(Status.ENDPOINTS_INIT)
+)
+async def test_no_ep_device_cleanup(tmpdir):
+    """Test that devices without any endpoints are removed"""
+    db = os.path.join(str(tmpdir), "test.db")
+    app = await make_app(db)
+
+    ieee = make_ieee()
+    app.handle_join(0x0000, ieee, 0)
+    dev = app.get_device(ieee)
+    app.device_initialized(dev)
+
+    ieee_2 = make_ieee(2)
+    app.handle_join(0x0002, ieee_2, 0)
+    dev = app.get_device(ieee_2)
+    app.device_initialized(dev)
+
+    await app.pre_shutdown()
+    del app, dev
+
+    app_2 = await make_app(db)
+    assert ieee in app_2.devices
+    assert ieee_2 not in app_2.devices
+    await app_2.pre_shutdown()

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -2,10 +2,7 @@ import itertools
 
 import pytest
 
-import zigpy.device
-import zigpy.endpoint
-import zigpy.quirks
-from zigpy.quirks.registry import (
+from zigpy.const import (
     SIG_ENDPOINTS,
     SIG_EP_INPUT,
     SIG_EP_OUTPUT,
@@ -15,8 +12,11 @@ from zigpy.quirks.registry import (
     SIG_MODEL,
     SIG_MODELS_INFO,
     SIG_SKIP_CONFIG,
-    DeviceRegistry,
 )
+import zigpy.device
+import zigpy.endpoint
+import zigpy.quirks
+from zigpy.quirks.registry import DeviceRegistry
 import zigpy.types as t
 import zigpy.zcl as zcl
 

--- a/tests/test_quirks_registry.py
+++ b/tests/test_quirks_registry.py
@@ -2,7 +2,8 @@ from unittest import mock
 
 import pytest
 
-from zigpy.quirks.registry import SIG_MODELS_INFO, DeviceRegistry
+from zigpy.const import SIG_MODELS_INFO
+from zigpy.quirks.registry import DeviceRegistry
 
 
 class FakeDevice:

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -19,6 +19,10 @@ def test_typevalue():
     assert tv2.type == tv.type
     assert tv2.value == tv.value
 
+    tv3 = foundation.TypeValue(tv2)
+    assert tv3.type == tv.type
+    assert tv3.value == tv.value
+
 
 def test_read_attribute_record():
     orig = b"\x00\x00\x00\x20\x99"
@@ -71,6 +75,7 @@ def test_attribute_reporting_config_1():
     assert data == b""
     assert arc2.direction == arc.direction
     assert arc2.timeout == arc.timeout
+    assert repr(arc)
 
 
 def test_typed_collection():

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -403,11 +403,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._db.executemany(q, endpoints)
 
     async def _save_node_descriptor(self, device: zigpy.typing.DeviceType) -> None:
-        if (
-            device.status != zigpy.device.Status.ENDPOINTS_INIT
-            or not device.node_desc.is_valid
-        ):
-            return
         q = "INSERT OR REPLACE INTO node_descriptors VALUES (?, ?)"
         await self.execute(q, (device.ieee, device.node_desc.serialize()))
 

--- a/zigpy/const.py
+++ b/zigpy/const.py
@@ -1,0 +1,12 @@
+"""Zigpy Constants."""
+
+SIG_ENDPOINTS = "endpoints"
+SIG_EP_INPUT = "input_clusters"
+SIG_EP_OUTPUT = "output_clusters"
+SIG_EP_PROFILE = "profile_id"
+SIG_EP_TYPE = "device_type"
+SIG_MANUFACTURER = "manufacturer"
+SIG_MODEL = "model"
+SIG_MODELS_INFO = "models_info"
+SIG_NODE_DESC = "node_desc"
+SIG_SKIP_CONFIG = "skip_configuration"

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -5,6 +5,16 @@ import logging
 import time
 from typing import Dict, Optional, Union
 
+from zigpy.const import (
+    SIG_ENDPOINTS,
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    SIG_MANUFACTURER,
+    SIG_MODEL,
+    SIG_NODE_DESC,
+)
 import zigpy.endpoint
 import zigpy.exceptions
 import zigpy.neighbor
@@ -341,22 +351,23 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         #        - Profile Id, Device Id, Cluster Out, Cluster In
         signature = {}
         if self._manufacturer is not None:
-            signature["manufacturer_name"] = self.manufacturer
+            signature[SIG_MANUFACTURER] = self.manufacturer
         if self._model is not None:
-            signature["model"] = self._model
+            signature[SIG_MODEL] = self._model
         if self.node_desc.is_valid:
-            signature["node_descriptor"] = self.node_desc.as_dict()
+            signature[SIG_NODE_DESC] = self.node_desc.as_dict()
 
         for endpoint_id, endpoint in self.endpoints.items():
             if endpoint_id == 0:  # ZDO
                 continue
+            signature.setdefault(SIG_ENDPOINTS, {})
             in_clusters = [c for c in endpoint.in_clusters]
             out_clusters = [c for c in endpoint.out_clusters]
-            signature[endpoint_id] = {
-                "profileid": endpoint.profile_id,
-                "deviceid": endpoint.device_type,
-                "in_clusters": in_clusters,
-                "out_clusters": out_clusters,
+            signature[SIG_ENDPOINTS][endpoint_id] = {
+                SIG_EP_PROFILE: endpoint.profile_id,
+                SIG_EP_TYPE: endpoint.device_type,
+                SIG_EP_INPUT: in_clusters,
+                SIG_EP_OUTPUT: out_clusters,
             }
         return signature
 

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -11,9 +11,7 @@ from typing import (
     Union,
 )
 
-import zigpy.device
-import zigpy.endpoint
-from zigpy.quirks.registry import (  # noqa: F401
+from zigpy.const import (  # noqa: F401
     SIG_ENDPOINTS,
     SIG_EP_INPUT,
     SIG_EP_OUTPUT,
@@ -24,8 +22,10 @@ from zigpy.quirks.registry import (  # noqa: F401
     SIG_MODELS_INFO,
     SIG_NODE_DESC,
     SIG_SKIP_CONFIG,
-    DeviceRegistry,
 )
+import zigpy.device
+import zigpy.endpoint
+from zigpy.quirks.registry import DeviceRegistry  # noqa: F401
 import zigpy.types as t
 import zigpy.zcl
 import zigpy.zcl.foundation as foundation

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -3,21 +3,20 @@ import itertools
 import logging
 from typing import Dict, List, Union
 
+from zigpy.const import (
+    SIG_ENDPOINTS,
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    SIG_MANUFACTURER,
+    SIG_MODEL,
+    SIG_MODELS_INFO,
+)
 import zigpy.quirks
 from zigpy.typing import CustomDeviceType, DeviceType
 
 _LOGGER = logging.getLogger(__name__)
-
-SIG_ENDPOINTS = "endpoints"
-SIG_EP_INPUT = "input_clusters"
-SIG_EP_OUTPUT = "output_clusters"
-SIG_EP_PROFILE = "profile_id"
-SIG_EP_TYPE = "device_type"
-SIG_MANUFACTURER = "manufacturer"
-SIG_MODEL = "model"
-SIG_MODELS_INFO = "models_info"
-SIG_NODE_DESC = "node_desc"
-SIG_SKIP_CONFIG = "skip_configuration"
 
 TYPE_MODEL_QUIRKS_LIST = Dict[str, List["zigpy.quirks.CustomDevice"]]
 TYPE_MANUF_QUIRKS_DICT = Dict[str, TYPE_MODEL_QUIRKS_LIST]


### PR DESCRIPTION
- Increase coverage
- Refactor `zigpy.device.Device.get_signature()` to use same constants as quirks. This is a breaking change.