### PR TITLE
ControllerApplication State class and counters

### DIFF
--- a/tests/test_app_state.py
+++ b/tests/test_app_state.py
@@ -1,0 +1,194 @@
+"""Test unit for app status and counters."""
+
+import pytest
+
+import zigpy.application.state as app_state
+
+COUNTER_NAMES = ["counter_1", "counter_2", "some random name"]
+
+
+@pytest.fixture
+def counters():
+    """Counters fixture."""
+    return app_state.Counters("ezsp_counters", COUNTER_NAMES)
+
+
+def test_counter():
+    """Test basic counter."""
+
+    counter = app_state.Counter("mock_counter")
+    assert counter.value == 0
+
+    counter = app_state.Counter("mock_counter", 5)
+    assert counter.value == 5
+    assert counter.reset_count == 0
+
+    counter.update(5)
+    assert counter.value == 5
+    assert counter.reset_count == 0
+
+    counter.update(8)
+    assert counter.value == 8
+    assert counter.reset_count == 0
+
+    counter.update(9)
+    assert counter.value == 9
+    assert counter.reset_count == 0
+
+    counter.reset()
+    assert counter.value == 9
+    assert counter._raw_value == 0
+    assert counter.reset_count == 1
+
+    # new value after a counter was reset/clear
+    counter.update(12)
+    assert counter.value == 21
+    assert counter.reset_count == 1
+
+    counter.update(15)
+    assert counter.value == 24
+    assert counter.reset_count == 1
+
+    # new counter value is less than previously reported.
+    # assume counter was reset
+    counter.update(14)
+    assert counter.value == 24 + 14
+    assert counter.reset_count == 2
+
+    counter.reset_and_update(14)
+    assert counter.value == 38 + 14
+    assert counter.reset_count == 3
+
+
+def test_counter_str():
+    """Test counter str representation."""
+
+    counter = app_state.Counter("some_counter", 8)
+    assert str(counter) == "some_counter = 8"
+
+
+def test_counters_init(counters):
+    """Test counters initialization."""
+
+    assert counters.name == "ezsp_counters"
+    assert counters.list
+    assert len(counters.list) == 3
+
+    cnt_1, cnt_2, cnt_3 = counters.list
+    assert cnt_1.name == "counter_1"
+    assert cnt_2.name == "counter_2"
+    assert cnt_3.name == "some random name"
+
+    assert cnt_1.value == 0
+    assert cnt_2.value == 0
+    assert cnt_3.value == 0
+
+    with pytest.raises(KeyError):
+        counters["no such counter"]
+
+    counters["some random name"] = 2
+    assert cnt_3.value == 2
+    assert counters["some random name"].value == 2
+    assert counters["some random name"] == 2
+    assert counters["some random name"] == cnt_3
+    assert int(cnt_3) == 2
+
+    assert "counter_2" in counters
+    assert [counter.name for counter in counters] == COUNTER_NAMES
+
+    with pytest.raises(KeyError):
+        counters["no such counter"] = 2
+
+    counters.reset()
+    for counter in counters:
+        assert counter.reset_count == 1
+
+    existing = counters.add_counter("some random name")
+    assert existing.value == 2
+    assert len(counters.list) == 3
+
+    new = counters.add_counter("new_counter", 42)
+    assert new.value == 42
+    assert len(counters.list) == 4
+
+
+def test_counters_str_and_repr(counters):
+    """Test counters str and repr."""
+
+    counters["counter_1"] = 22
+    counters["counter_2"] = 33
+
+    assert (
+        str(counters)
+        == "ezsp_counters: [counter_1 = 22, counter_2 = 33, some random name = 0]"
+    )
+
+    assert (
+        repr(counters) == """Counters('ezsp_counters', {Counter('counter_1', 22), """
+        """Counter('counter_2', 33), Counter('some random name', 0)})"""
+    )
+
+
+def test_state():
+    """Test state structure."""
+    state = app_state.State()
+    assert state
+    assert state.counters == {}
+
+    state.initialize_counters("new_collection", ("counter_2", "counter_3"))
+    assert state.counters["new_collection"]["counter_2"] == 0
+    assert state.counters["new_collection"]["counter_2"].reset_count == 0
+    assert state.counters["new_collection"]["counter_3"].reset_count == 0
+    state.counters["new_collection"]["counter_2"] = 2
+
+    state.initialize_counters("new_collection", ("counter_2", "counter_3"))
+    assert state.counters["new_collection"]["counter_2"] == 2
+    assert state.counters["new_collection"]["counter_2"].reset_count == 1
+    assert state.counters["new_collection"]["counter_3"] == 0
+    assert state.counters["new_collection"]["counter_3"].reset_count == 1
+
+
+def test_counters_reset(counters):
+    """Test counter resetting."""
+
+    counter = counters["counter_1"]
+
+    assert counter.reset_count == 0
+    counters["counter_1"] = 22
+    assert counter.value == 22
+    assert counter.reset_count == 0
+
+    counters.reset()
+    assert counter.reset_count == 1
+    counter.update(22)
+    assert counter.value == 44
+    assert counter.reset_count == 1
+
+
+def test_counter_incr():
+    """Test counter incement."""
+
+    counter = app_state.Counter("counter_name", 42)
+    assert counter == 42
+
+    counter.increment()
+    assert counter == 43
+
+    counter.increment(5)
+    assert counter == 48
+    assert counter.value == 48
+
+    with pytest.raises(AssertionError):
+        counter.increment(-1)
+
+
+def test_counters_by_name(counters):
+    """Test accessing individual counters by name."""
+    counters["counter_2"] = 22
+    counter = counters["counter_2"]
+    assert counters.counter_2 is counter
+    assert counter == 22
+    assert counters.counter_2 == 22
+
+    with pytest.raises(AttributeError):
+        counters.no_such_counter

--- a/zigpy/application/__init__.py
+++ b/zigpy/application/__init__.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict, Optional
 
 import zigpy.appdb
+import zigpy.application.state
 import zigpy.config
 import zigpy.device
 import zigpy.exceptions
@@ -28,6 +29,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     def __init__(self, config: Dict):
         self._send_sequence = 0
         self.devices: Dict[t.EUI64, zigpy.device.Device] = {}
+        self.state: zigpy.application.state.State = zigpy.application.state.State()
         self.topology = None
         self._listeners = {}
         self._channel = None

--- a/zigpy/application/state.py
+++ b/zigpy/application/state.py
@@ -28,12 +28,17 @@ class NodeInfo:
 class NetworkInformation:
     """Network information."""
 
-    extended_pan_id: Optional[t.ExtendedPanId] = field(default_factory=t.ExtendedPanId)
+    extended_pan_id: Optional[t.ExtendedPanId] = None
     pan_id: Optional[t.PanId] = 0xFFFE
     nwk_update_id: Optional[t.uint8_t] = 0x00
     nwk_manager_id: Optional[t.NWK] = t.NWK(0xFFFE)
     channel: Optional[t.uint8_t] = None
     channel_mask: Optional[t.Channels] = None
+
+    def __post_init__(self) -> None:
+        """Initialize instance."""
+        if self.extended_pan_id is None:
+            self.extended_pan_id = t.EUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff")
 
 
 @dataclass

--- a/zigpy/application/state.py
+++ b/zigpy/application/state.py
@@ -1,0 +1,215 @@
+"""Classes to implement status of the application controller."""
+
+from dataclasses import InitVar, dataclass, field
+import functools
+from typing import Any, Dict, Iterable, List, Optional
+
+import zigpy.types as t
+import zigpy.zdo.types as zdo_t
+
+
+@dataclass
+class NodeInfo:
+    """Controller Application network Node information."""
+
+    nwk: t.NWK = t.NWK(0xFFFE)
+    ieee: Optional[t.EUI64] = None
+    logical_type: Optional[zdo_t.LogicalType] = None
+
+    def __post_init__(self) -> None:
+        """Initialize instance."""
+        if self.ieee is None:
+            self.ieee = t.EUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff")
+        if self.logical_type is None:
+            self.logical_type = zdo_t.LogicalType.Reserved7
+
+
+@dataclass
+class NetworkInformation:
+    """Network information."""
+
+    extended_pan_id: Optional[t.ExtendedPanId] = field(default_factory=t.ExtendedPanId)
+    pan_id: Optional[t.PanId] = 0xFFFE
+    nwk_update_id: Optional[t.uint8_t] = 0x00
+    nwk_manager_id: Optional[t.NWK] = t.NWK(0xFFFE)
+    channel: Optional[t.uint8_t] = None
+    channel_mask: Optional[t.Channels] = None
+
+
+@dataclass
+class Counter:
+    """Ever increasing Counter."""
+
+    name: str
+    initial_value: InitVar[int] = 0
+    _raw_value: int = field(init=False, default=0)
+    reset_count: int = field(init=False, default=0)
+    _last_reset_value: int = field(init=False, default=0)
+
+    def __eq__(self, other) -> bool:
+        """Compare two counters."""
+        if isinstance(other, self.__class__):
+            return self.value == other.value
+
+        return self.value == other
+
+    def __int__(self) -> int:
+        """Return int of the current value."""
+        return self.value
+
+    def __post_init__(self, initial_value) -> None:
+        """Initialize instance."""
+        self._raw_value = initial_value
+
+    def __str__(self) -> str:
+        """String representation."""
+        return f"{self.name} = {self.value}"
+
+    @property
+    def value(self) -> int:
+        """Current value of the counter."""
+
+        return self._last_reset_value + self._raw_value
+
+    def update(self, new_value: int) -> None:
+        """Update counter value."""
+
+        if new_value == self._raw_value:
+            return
+
+        diff = new_value - self._raw_value
+        if diff < 0:  # Roll over or reset
+            self.reset_and_update(new_value)
+            return
+
+        self._raw_value = new_value
+
+    def increment(self, increment: int = 1) -> None:
+        """Increment current value by increment."""
+
+        assert increment >= 0
+        self._raw_value += increment
+
+    def reset_and_update(self, value: int) -> None:
+        """Clear (rollover event) and optionally update."""
+
+        self._last_reset_value = self.value
+        self._raw_value = value
+        self.reset_count += 1
+
+    reset = functools.partialmethod(reset_and_update, 0)
+
+
+class Counters:
+    """Named collection of counters."""
+
+    def __init__(
+        self,
+        collection_name: str,
+        names: Optional[Iterable[str]],
+        *,
+        counter_class: Counter = Counter,
+    ) -> None:
+        """Initialize instance."""
+
+        self._name = collection_name
+        self._counters: Dict[Any, Counter] = {
+            name: counter_class(name) for name in names
+        }
+
+    def __contains__(self, item: Any) -> bool:
+        """Is the "counter id/name" in the list."""
+        return item in self._counters
+
+    def __getattr__(self, counter_id: str) -> Counter:
+        """Get specific counter."""
+        try:
+            return self._counters[counter_id]
+        except KeyError as exc:
+            raise AttributeError(f"{counter_id} counter does not exist") from exc
+
+    def __iter__(self) -> Iterable[Counter]:
+        """Return an iterable of the counters"""
+        return (counter for counter in self._counters.values())
+
+    def __str__(self) -> str:
+        """String magic method."""
+        counters = [str(counter) for counter in self]
+        return f"{self.name}: [{', '.join(counters)}]"
+
+    def __repr__(self) -> str:
+        """Representation magic method."""
+        counters = (
+            f"{counter.__class__.__name__}('{counter.name}', {int(counter)})"
+            for counter in self
+        )
+        counters = ", ".join(counters)
+        return f"{self.__class__.__name__}('{self.name}', {{{counters}}})"
+
+    @property
+    def name(self) -> str:
+        """Return counter collection name."""
+        return self._name
+
+    @property
+    def list(self) -> List[Counter]:
+        """Return list of counters."""
+
+        return [counter for counter in self._counters.values()]
+
+    def reset(self) -> None:
+        """Clear and rollover counters."""
+
+        for counter in self._counters.values():
+            counter.reset()
+
+    def __getitem__(self, counter_id: Any) -> Counter:
+        """Get a counter."""
+
+        return self._counters[counter_id]
+
+    def __setitem__(self, counter_id: Any, value: int) -> None:
+        """Update specific counter to new value."""
+
+        self._counters[counter_id].update(value)
+
+    def add_counter(self, name: str, value: int = 0) -> Counter:
+        """Add a new counter."""
+
+        if name in self._counters:
+            return self[name]
+
+        counter = Counter(name, initial_value=value)
+        self._counters[counter.name] = counter
+        return counter
+
+
+@dataclass
+class State:
+    node_information: NodeInfo = field(default_factory=NodeInfo)
+    network_information: NetworkInformation = field(default_factory=NetworkInformation)
+    counters: Optional[Dict[str, Counters]] = None
+
+    def __post_init__(self) -> None:
+        """Initialize default counters."""
+        if self.counters is None:
+            self.counters = {}
+
+    def initialize_counters(
+        self,
+        collection_name: str,
+        names: Iterable[str],
+        *,
+        counter_class: Counter = Counter,
+    ) -> Counters:
+        """Create or Reset counters."""
+
+        try:
+            counters = self.counters[collection_name]
+        except KeyError:
+            counters = Counters(collection_name, names, counter_class=counter_class)
+            self.counters[counters.name] = counters
+        else:
+            counters.reset()
+
+        return counters


### PR DESCRIPTION
A container class to keep minimal network and node information in one place and framework for "Counters".
Instead of keeping attributes like `pan_id`, `extended_pan_id` as the attributes of the `ControllerApplication()` instance, keep those in one class. 
Add a Counter() framework, to keep request/success failure statistics per device. Originally the counters were implemented to deal with EZSP counter overflow, but I've tested an implementation of software counters for request success/failure stats for `bellows` radio module and it worked very well, with stats being very close to the hardware counters. The plan is to keep counter stats on per device level, which should bring a bit more visibility into health of the network. 