### PR TITLE
Add dst_addressing indicator to incoming message handlers

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -591,3 +591,52 @@ def test_bitmap_instance_types():
     assert issubclass(TestBitmap, t.uint16_t)
     assert isinstance(TestBitmap(0xFF00), t.uint16_t)
     assert isinstance(TestBitmap(0xFF00), TestBitmap)
+
+
+def test_addressing_ieee():
+    """Test addressing mode ieee."""
+
+    data = b"\x03\x08\x07\x06\x05\x04\x03\x02\x01\x20"
+    extra = b"extra data"
+
+    r, rest = t.Addressing.deserialize(data + extra)
+    assert rest == extra
+    assert r.addr_mode == t.AddrMode.IEEE
+    assert r.addr == t.EUI64.convert("01:02:03:04:05:06:07:08")
+    assert r.endpoint == 32
+
+    assert r.serialize() == data
+    dst = t.Addressing.ieee([8, 7, 6, 5, 4, 3, 2, 1], 32)
+    assert dst.serialize() == data
+
+
+def test_addressing_group():
+    """Test addressing mode group."""
+
+    data = b"\x01\x08\x07"
+    extra = b"extra data"
+
+    r, rest = t.Addressing.deserialize(data + extra)
+    assert rest == extra
+    assert r.addr_mode == t.AddrMode.Group
+    assert r.addr == t.Group(0x0708)
+
+    assert r.serialize() == data
+    dst = t.Addressing.group(0x0708)
+    assert dst.serialize() == data
+
+
+def test_addressing_nwk():
+    """Test addressing mode nwk."""
+
+    data = b"\x02\x07\x08\x2A"
+    extra = b"extra data"
+
+    r, rest = t.Addressing.deserialize(data + extra)
+    assert rest == extra
+    assert r.addr_mode == t.AddrMode.NWK
+    assert r.addr == t.NWK(0x0807)
+
+    assert r.serialize() == data
+    dst = t.Addressing.nwk(0x0807, 42)
+    assert dst.serialize() == data

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -640,3 +640,10 @@ def test_addressing_nwk():
     assert r.serialize() == data
     dst = t.Addressing.nwk(0x0807, 42)
     assert dst.serialize() == data
+
+
+def test_invalid_addressing():
+    """Invalid addressing mode."""
+
+    with pytest.raises(ValueError):
+        t.Addressing.deserialize(b"\x05invalid")

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1,7 +1,7 @@
 import abc
 import asyncio
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import zigpy.appdb
 import zigpy.config
@@ -187,6 +187,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         src_ep: int,
         dst_ep: int,
         message: bytes,
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
     ) -> None:
         self.listener_event(
             "handle_message", sender, profile, cluster, src_ep, dst_ep, message
@@ -216,7 +220,14 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 cluster,
             )
             return
-        return sender.handle_message(profile, cluster, src_ep, dst_ep, message)
+        return sender.handle_message(
+            profile,
+            cluster,
+            src_ep,
+            dst_ep,
+            message,
+            dst_addressing=dst_addressing,
+        )
 
     def handle_join(self, nwk, ieee, parent_nwk):
         ieee = t.EUI64(ieee)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -18,7 +18,7 @@ from zigpy.const import (
 import zigpy.endpoint
 import zigpy.exceptions
 import zigpy.neighbor
-from zigpy.types import NWK, BroadcastAddress, Relays
+from zigpy.types import NWK, Addressing, BroadcastAddress, Relays
 import zigpy.util
 import zigpy.zcl.foundation as foundation
 import zigpy.zdo as zdo
@@ -227,7 +227,18 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def deserialize(self, endpoint_id, cluster_id, data):
         return self.endpoints[endpoint_id].deserialize(cluster_id, data)
 
-    def handle_message(self, profile, cluster, src_ep, dst_ep, message):
+    def handle_message(
+        self,
+        profile: int,
+        cluster: int,
+        src_ep: int,
+        dst_ep: int,
+        message: bytes,
+        *,
+        dst_addressing: Optional[
+            Union[Addressing.Group, Addressing.IEEE, Addressing.NWK]
+        ] = None,
+    ):
         self.last_seen = time.time()
         try:
             hdr, args = self.deserialize(src_ep, cluster, message)
@@ -265,7 +276,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 )
                 return
         endpoint = self.endpoints[src_ep]
-        return endpoint.handle_message(profile, cluster, hdr, args)
+        return endpoint.handle_message(
+            profile, cluster, hdr, args, dst_addressing=dst_addressing
+        )
 
     def reply(self, profile, cluster, src_ep, dst_ep, sequence, data, use_ieee=False):
         return self.request(

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -1,15 +1,16 @@
 import asyncio
 import enum
 import logging
-from typing import Optional
+from typing import List, Optional, Union
 
 import zigpy.exceptions
 import zigpy.profiles
+from zigpy.types import Addressing
 from zigpy.typing import DeviceType
 import zigpy.util
 import zigpy.zcl
 from zigpy.zcl.clusters.general import Basic
-from zigpy.zcl.foundation import Status as ZCLStatus
+from zigpy.zcl.foundation import Status as ZCLStatus, ZCLHeader
 from zigpy.zdo.types import Status as zdo_status
 
 LOGGER = logging.getLogger(__name__)
@@ -193,7 +194,17 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         cluster = self.in_clusters.get(cluster_id, self.out_clusters.get(cluster_id))
         return cluster.deserialize(data)
 
-    def handle_message(self, profile, cluster, hdr, args):
+    def handle_message(
+        self,
+        profile: int,
+        cluster: int,
+        hdr: ZCLHeader,
+        args: List,
+        *,
+        dst_addressing: Optional[
+            Union[Addressing.Group, Addressing.IEEE, Addressing.NWK]
+        ] = None,
+    ) -> None:
         if cluster in self.in_clusters:
             handler = self.in_clusters[cluster].handle_message
         elif cluster in self.out_clusters:

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -511,23 +511,28 @@ class _AddressingNWK(Struct):
 class Addressing:
     """Addr mode, address (group, node id or ieee) and optionally endpoint id."""
 
-    @staticmethod
-    def ieee(ieee: EUI64, endpoint: Union[basic.uint8_t, int]) -> _AddressingIEEE:
+    AddrMode = AddrMode
+    IEEE = _AddressingIEEE
+    Group = _AddressingGroup
+    NWK = _AddressingNWK
+
+    @classmethod
+    def ieee(cls, ieee: EUI64, endpoint: Union[basic.uint8_t, int]) -> _AddressingIEEE:
         """Return IEEE addressing mode."""
 
-        return _AddressingIEEE(AddrMode.IEEE, ieee, endpoint)
+        return cls.IEEE(AddrMode.IEEE, ieee, endpoint)
 
-    @staticmethod
-    def group(group: Group) -> _AddressingGroup:
+    @classmethod
+    def group(cls, group: Group) -> _AddressingGroup:
         """Return Group addressing mode."""
 
-        return _AddressingGroup(AddrMode.Group, group)
+        return cls.Group(AddrMode.Group, group)
 
-    @staticmethod
-    def nwk(nwk: NWK, endpoint: Union[basic.uint8_t, int]) -> _AddressingNWK:
+    @classmethod
+    def nwk(cls, nwk: NWK, endpoint: Union[basic.uint8_t, int]) -> _AddressingNWK:
         """Return NWK addressing mode."""
 
-        return _AddressingNWK(AddrMode.NWK, nwk, endpoint)
+        return cls.NWK(AddrMode.NWK, nwk, endpoint)
 
     @classmethod
     def deserialize(
@@ -536,10 +541,10 @@ class Addressing:
         """Deserialize data."""
 
         if data[0] == AddrMode.IEEE:
-            return _AddressingIEEE.deserialize(data)
+            return cls.IEEE.deserialize(data)
         elif data[0] == AddrMode.Group:
-            return _AddressingGroup.deserialize(data)
+            return cls.Group.deserialize(data)
         elif data[0] == AddrMode.NWK:
-            return _AddressingNWK.deserialize(data)
+            return cls.NWK.deserialize(data)
 
         raise ValueError(f"Invalid '0x{data[0]:02x}' addressing mode")

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-from typing import Coroutine
+from typing import Coroutine, List, Optional, Union
 
 import zigpy.types as t
 import zigpy.util
@@ -51,7 +51,17 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         data = t.uint8_t(tsn).serialize() + data
         return self._device.reply(0, command, 0, 0, tsn, data, use_ieee=use_ieee)
 
-    def handle_message(self, profile, cluster, hdr, args):
+    def handle_message(
+        self,
+        profile: int,
+        cluster: int,
+        hdr: types.ZDOHeader,
+        args: List,
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ) -> None:
         self.debug("ZDO request %s: %s", hdr.command_id, args)
         app = self._device.application
         if hdr.command_id == types.ZDOCmd.NWK_addr_req:
@@ -138,7 +148,7 @@ def broadcast(
     grpid,
     radius,
     *args,
-    broadcast_address=t.BroadcastAddress.RX_ON_WHEN_IDLE
+    broadcast_address=t.BroadcastAddress.RX_ON_WHEN_IDLE,
 ):
     sequence = app.get_sequence()
     data = sequence.to_bytes(1, "little")


### PR DESCRIPTION
Add `dst_addressing_mode indicator` to the message handlers to provide more insight about how the message was received. 
Some received ZDO commands should behave differently, if the incoming message was a broadcast or a unicast. And keep different counters depending on the message type.