### PR TITLE
Single function for OTA image parsing, CachedImage simplification, and Hue SBL images

### DIFF
--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -197,3 +197,18 @@ def test_cached_image_expiration_delay():
     cached.expires_on = new_expiration
     cached.get_image_block(0, 40)
     assert cached.expires_on > new_expiration
+
+
+def test_cached_image_serialization_cache(image):
+    image = MagicMock(image)
+    image.serialize.side_effect = [b"data"]
+
+    cached = zigpy.ota.CachedImage.new(image)
+    assert cached.cached_data is None
+    assert image.serialize.call_count == 0
+
+    assert cached.get_image_block(0, 1) == b"d"
+    assert cached.get_image_block(1, 1) == b"a"
+    assert cached.get_image_block(2, 1) == b"t"
+
+    assert image.serialize.call_count == 1

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -18,12 +18,13 @@ IMAGE_TYPE = sentinel.image_type
 def image_with_version():
     def img(version=100):
         img = zigpy.ota.image.OTAImage()
+        img.header = zigpy.ota.image.OTAImageHeader()
         img.header.manufacturer_id = MANUFACTURER_ID
         img.header.image_type = IMAGE_TYPE
         img.header.file_version = version
-        img.subelements.append(
+        img.subelements = [
             zigpy.ota.image.SubElement.deserialize(b"\x00\x00\x04\x00\x00\x00abcdef")[0]
-        )
+        ]
         return img
 
     return img
@@ -76,7 +77,7 @@ async def test_get_image_empty(ota, image, key):
 
 
 async def test_get_image_new(ota, image, key, image_with_version, monkeypatch):
-    newer = image_with_version(image.version + 1)
+    newer = image_with_version(image.header.file_version + 1)
 
     ota.async_event = AsyncMock(return_value=[None, image, newer])
 
@@ -85,8 +86,8 @@ async def test_get_image_new(ota, image, key, image_with_version, monkeypatch):
 
     # got new image in the cache
     assert len(ota._image_cache) == 1
-    assert res.header == newer.header
-    assert res.subelements == newer.subelements
+    assert res.image.header == newer.header
+    assert res.image.subelements == newer.subelements
     assert ota.async_event.call_count == 1
     assert ota.async_event.call_args[0][0] == "get_image"
     assert ota.async_event.call_args[0][1] == key
@@ -97,8 +98,8 @@ async def test_get_image_new(ota, image, key, image_with_version, monkeypatch):
 
     # should get just the cached image
     assert len(ota._image_cache) == 1
-    assert res.header == newer.header
-    assert res.subelements == newer.subelements
+    assert res.image.header == newer.header
+    assert res.image.subelements == newer.subelements
     assert ota.async_event.call_count == 0
 
     # on cache expiration, ping listeners
@@ -113,13 +114,13 @@ async def test_get_image_new(ota, image, key, image_with_version, monkeypatch):
     res = await ota.get_ota_image(MANUFACTURER_ID, IMAGE_TYPE)
 
     assert len(ota._image_cache) == 1
-    assert res.header == newer.header
-    assert res.subelements == newer.subelements
+    assert res.image.header == newer.header
+    assert res.image.subelements == newer.subelements
     assert ota.async_event.call_count == 1
 
 
 async def test_get_image_invalid(ota, image, image_with_version):
-    corrupted = image_with_version(image.version)
+    corrupted = image_with_version(image.header.file_version)
 
     zigpy.ota.check_invalid.side_effect = [True]
     ota.async_event = AsyncMock(return_value=[None, corrupted])
@@ -146,7 +147,7 @@ async def test_get_image_invalid_then_valid_versions(v1, v2, ota, image_with_ver
     res = await ota.get_ota_image(MANUFACTURER_ID, IMAGE_TYPE)
 
     # The valid image is always picked, even if the versions match
-    assert res.header.header_string == image.header.header_string
+    assert res.image.header.header_string == image.header.header_string
 
 
 def test_cached_image_expiration(image, monkeypatch):

--- a/tests/test_ota_image.py
+++ b/tests/test_ota_image.py
@@ -385,3 +385,8 @@ def test_parse_ota_hue_invalid():
     with pytest.raises(ValueError):
         # Only Hue is known to use these images
         firmware.parse_ota_image(header.replace(manufacturer_id=12).serialize() + rest)
+
+
+def test_cached_image_wrapping(image):
+    cached_img = CachedImage(image)
+    assert cached_img.header is image.header

--- a/tests/test_ota_image.py
+++ b/tests/test_ota_image.py
@@ -359,13 +359,13 @@ def create_hue_ota(data):
 
 
 def test_parse_ota_hue():
-    data = create_hue_ota(b"test")
+    data = create_hue_ota(b"test") + b"rest"
     img, rest = firmware.parse_ota_image(data)
 
     assert isinstance(img, firmware.HueSBLOTAImage)
-    assert not rest
+    assert rest == b"rest"
     assert img.data == b"\x2A\x00\x01" + b"test"
-    assert img.serialize() == data
+    assert img.serialize() + b"rest" == data
 
 
 def test_parse_ota_hue_invalid():

--- a/tests/test_ota_image.py
+++ b/tests/test_ota_image.py
@@ -332,6 +332,19 @@ def test_parse_ota_ikea(image):
     assert firmware.parse_ota_image(data) == (image, b"")
 
 
+def test_parse_ota_ikea_trailing(image):
+    data = wrap_ikea(image.serialize() + b"trailing")
+
+    parsed, remaining = firmware.parse_ota_image(data)
+    assert not remaining
+
+    assert parsed.header.image_size == len(image.serialize() + b"trailing")
+    assert parsed.subelements[0].data == b"data" + b"trailing"
+
+    parsed2, remaining2 = firmware.OTAImage.deserialize(parsed.serialize())
+    assert not remaining2
+
+
 @pytest.mark.parametrize(
     "data",
     [

--- a/tests/test_ota_provider.py
+++ b/tests/test_ota_provider.py
@@ -1,4 +1,3 @@
-import binascii
 import os.path
 from unittest import mock
 import uuid
@@ -11,25 +10,18 @@ import zigpy.ota.image
 import zigpy.ota.provider as ota_p
 
 from .async_mock import AsyncMock, patch
+from .test_ota_image import image  # noqa: F401
 
 MANUFACTURER_ID = 4476
 IMAGE_TYPE = mock.sentinel.image_type
 
 
 @pytest.fixture
-def file_image_name(tmpdir):
+def file_image_name(tmpdir, image):  # noqa: F811
     def ota_img_filename(name="ota-image"):
-        prefix = b"\x00This is extra data\x00\x55\xaa"
-        data = (
-            "1ef1ee0b0001380000007c11012178563412020054657374204f54412049"
-            "6d61676500000000000000000000000000000000000042000000"
-        )
-        data = binascii.unhexlify(data)
-        sub_el = b"\x00\x00\x04\x00\x00\x00abcd"
-
         file_name = os.path.join(str(tmpdir), name + "-" + str(uuid.uuid4()))
         with open(os.path.join(file_name), mode="bw+") as file:
-            file.write(prefix + data + sub_el)
+            file.write(image.serialize())
         return file_name
 
     return ota_img_filename
@@ -116,7 +108,7 @@ async def test_initialize_provider(basic_prov):
 
 
 async def test_basic_get_image(basic_prov, key):
-    image = mock.MagicMock()
+    image = mock.MagicMock()  # noqa: F811
     image.fetch_image = AsyncMock(return_value=mock.sentinel.image)
     basic_prov._cache = mock.MagicMock()
     basic_prov._cache.__getitem__.return_value = image
@@ -162,7 +154,7 @@ def test_basic_enable_provider(key, basic_prov):
 
 
 async def test_basic_get_image_filtered(basic_prov, key):
-    image = mock.MagicMock()
+    image = mock.MagicMock()  # noqa: F811
     image.fetch_image = AsyncMock(return_value=mock.sentinel.image)
     basic_prov._cache = mock.MagicMock()
     basic_prov._cache.__getitem__.return_value = image

--- a/tests/test_ota_validators.py
+++ b/tests/test_ota_validators.py
@@ -224,6 +224,7 @@ def test_validate_ota_image_mixed_valid():
 
 def test_validate_ota_image_empty():
     image = OTAImage()
+    image.subelements = []
 
     assert validators.validate_ota_image(image) == ValidationResult.UNKNOWN
 

--- a/tests/test_ota_validators.py
+++ b/tests/test_ota_validators.py
@@ -230,7 +230,7 @@ def test_validate_ota_image_empty():
 
 
 def test_check_invalid():
-    image = mock.Mock()
+    image = OTAImage()
 
     with mock.patch("zigpy.ota.validators.validate_ota_image") as m:
         m.side_effect = [ValidationResult.VALID]
@@ -243,3 +243,12 @@ def test_check_invalid():
     with mock.patch("zigpy.ota.validators.validate_ota_image") as m:
         m.side_effect = [ValidationError("error")]
         assert validators.check_invalid(image)
+
+
+def test_check_invalid_special():
+    image = mock.Mock()
+
+    # Unknown OTA image containers are not checked
+    with mock.patch("zigpy.ota.validators.validate_ota_image") as m:
+        assert not validators.check_invalid(image)
+        assert m.call_count == 0

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -237,7 +237,7 @@ async def test_ota_handle_query_next_image_upgradeable(ota_cluster):
 def _ota_image_block(cluster, has_image=True, correct_version=True, wrong_offset=False):
     async def get_ota_mock(*args):
         if has_image:
-            img = MagicMock()
+            img = MagicMock(spec_set=ota.CachedImage)
             img.should_update.return_value = True
             img.key.manufacturer_id = sentinel.manufacturer_id
             img.key.image_type = sentinel.image_type

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -26,6 +26,7 @@ class CachedImage:
 
     image = attr.ib(default=None)
     expires_on = attr.ib(default=None)
+    cached_data = attr.ib(default=None)
 
     @classmethod
     def new(cls, img):
@@ -75,13 +76,13 @@ class CachedImage:
         ):
             self.expires_on += DELAY_EXPIRATION
 
-        # XXX: this should be cached
-        data = self.image.serialize()
+        if self.cached_data is None:
+            self.cached_data = self.image.serialize()
 
-        if offset > len(data):
+        if offset > len(self.cached_data):
             raise ValueError("Offset exceeds image size")
 
-        return data[offset : offset + min(self.MAXIMUM_DATA_SIZE, size)]
+        return self.cached_data[offset : offset + min(self.MAXIMUM_DATA_SIZE, size)]
 
 
 class OTA(zigpy.util.ListenableMixin):

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -6,28 +6,31 @@ from typing import Optional
 import attr
 
 from zigpy.config import CONF_OTA, CONF_OTA_DIR, CONF_OTA_IKEA, CONF_OTA_LEDVANCE
-from zigpy.ota.image import ImageKey, OTAImage
+from zigpy.ota.image import ImageKey
 import zigpy.ota.provider
 from zigpy.ota.validators import check_invalid
+import zigpy.types as t
 from zigpy.typing import ControllerApplicationType
 import zigpy.util
 
 LOGGER = logging.getLogger(__name__)
 
-DELAY_EXPIRATION = datetime.timedelta(hours=2)
 TIMEDELTA_0 = datetime.timedelta()
+DELAY_EXPIRATION = datetime.timedelta(hours=2)
 
 
 @attr.s
-class CachedImage(OTAImage):
+class CachedImage:
+    MAXIMUM_DATA_SIZE = 40
     DEFAULT_EXPIRATION = datetime.timedelta(hours=18)
 
+    image = attr.ib(default=None)
     expires_on = attr.ib(default=None)
 
     @classmethod
-    def new(cls, img: OTAImage):
+    def new(cls, img):
         expiration = datetime.datetime.now() + cls.DEFAULT_EXPIRATION
-        return cls(img.header, img.subelements, expiration)
+        return cls(img, expiration)
 
     @property
     def expired(self) -> bool:
@@ -35,13 +38,50 @@ class CachedImage(OTAImage):
             return False
         return self.expires_on - datetime.datetime.now() < TIMEDELTA_0
 
-    def get_image_block(self, *args, **kwargs) -> bytes:
+    @property
+    def key(self) -> ImageKey:
+        return self.image.header.key
+
+    @property
+    def version(self) -> int:
+        return self.image.header.file_version
+
+    def should_update(self, manufacturer_id, img_type, ver, hw_ver=None) -> bool:
+        """Check if it should upgrade"""
+
+        if self.key != ImageKey(manufacturer_id, img_type):
+            return False
+
+        if ver >= self.version:
+            return False
+
+        if (
+            hw_ver is not None
+            and self.image.header.hardware_versions_present
+            and not (
+                self.image.header.minimum_hardware_version
+                <= hw_ver
+                <= self.image.header.maximum_hardware_version
+            )
+        ):
+            return False
+
+        return True
+
+    def get_image_block(self, offset: t.uint32_t, size: t.uint8_t) -> bytes:
         if (
             self.expires_on is not None
             and self.expires_on - datetime.datetime.now() < DELAY_EXPIRATION
         ):
             self.expires_on += DELAY_EXPIRATION
-        return super().get_image_block(*args, **kwargs)
+
+        # XXX: this should be cached
+        data = self.image.serialize()
+
+        if offset > len(data):
+            raise ValueError("Offset exceeds image size")
+
+        return data[offset : offset + min(self.MAXIMUM_DATA_SIZE, size)]
 
 
 class OTA(zigpy.util.ListenableMixin):
@@ -64,7 +104,7 @@ class OTA(zigpy.util.ListenableMixin):
         await self.async_event("initialize_provider", self._app.config[CONF_OTA])
         self._not_initialized = False
 
-    async def get_ota_image(self, manufacturer_id, image_type) -> Optional[OTAImage]:
+    async def get_ota_image(self, manufacturer_id, image_type) -> Optional[CachedImage]:
         key = ImageKey(manufacturer_id, image_type)
         if key in self._image_cache and not self._image_cache[key].expired:
             return self._image_cache[key]
@@ -81,7 +121,9 @@ class OTA(zigpy.util.ListenableMixin):
         if not valid_images:
             return None
 
-        cached = CachedImage.new(max(valid_images, key=lambda img: img.version))
+        cached = CachedImage.new(
+            max(valid_images, key=lambda img: img.header.file_version)
+        )
         self._image_cache[key] = cached
         return cached
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -6,7 +6,7 @@ from typing import Optional
 import attr
 
 from zigpy.config import CONF_OTA, CONF_OTA_DIR, CONF_OTA_IKEA, CONF_OTA_LEDVANCE
-from zigpy.ota.image import ImageKey, OTAImageHeader
+from zigpy.ota.image import BaseOTAImage, ImageKey, OTAImageHeader
 import zigpy.ota.provider
 from zigpy.ota.validators import check_invalid
 import zigpy.types as t
@@ -29,7 +29,7 @@ class CachedImage:
     cached_data = attr.ib(default=None)
 
     @classmethod
-    def new(cls, img):
+    def new(cls, img: BaseOTAImage) -> "CachedImage":
         expiration = datetime.datetime.now() + cls.DEFAULT_EXPIRATION
         return cls(img, expiration)
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -6,7 +6,7 @@ from typing import Optional
 import attr
 
 from zigpy.config import CONF_OTA, CONF_OTA_DIR, CONF_OTA_IKEA, CONF_OTA_LEDVANCE
-from zigpy.ota.image import ImageKey
+from zigpy.ota.image import ImageKey, OTAImageHeader
 import zigpy.ota.provider
 from zigpy.ota.validators import check_invalid
 import zigpy.types as t
@@ -42,6 +42,10 @@ class CachedImage:
     @property
     def key(self) -> ImageKey:
         return self.image.header.key
+
+    @property
+    def header(self) -> OTAImageHeader:
+        return self.image.header
 
     @property
     def version(self) -> int:

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -240,7 +240,6 @@ def parse_ota_image(data: bytes) -> typing.Tuple[BaseOTAImage, bytes]:
         if rest:
             LOGGER.warning(
                 "Fixing IKEA OTA image with trailing data (%s bytes)",
-                image.header.image_size,
                 size - image.header.image_size,
             )
             image.header.image_size += len(rest)

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -193,7 +193,7 @@ class HueSBLOTAImage(BaseOTAImage):
     @classmethod
     def deserialize(cls, data) -> typing.Tuple["HueSBLOTAImage", bytes]:
         header, remaining_data = OTAImageHeader.deserialize(data)
-        firmware = remaining_data[: header.image_size]
+        firmware = remaining_data[: header.image_size - len(header.serialize())]
 
         if len(data) < header.image_size:
             raise ValueError(

--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -12,7 +12,13 @@ import aiohttp
 import attr
 
 from zigpy.config import CONF_OTA_DIR, CONF_OTA_IKEA_URL
-from zigpy.ota.image import ImageKey, OTAImage, OTAImageHeader
+from zigpy.ota.image import (
+    BaseOTAImage,
+    ImageKey,
+    OTAImage,
+    OTAImageHeader,
+    parse_ota_image,
+)
 import zigpy.util
 
 LOGGER = logging.getLogger(__name__)
@@ -47,7 +53,7 @@ class Basic(zigpy.util.LocalLogMixin, ABC):
         """Filter unwanted get_image lookups."""
         return False
 
-    async def get_image(self, key: ImageKey) -> Optional[OTAImage]:
+    async def get_image(self, key: ImageKey) -> Optional[BaseOTAImage]:
         if await self.filter_get_image(key):
             return None
 
@@ -119,12 +125,7 @@ class IKEAImage:
             async with req.get(self.url) as rsp:
                 data = await rsp.read()
 
-        assert len(data) > 24
-        offset = int.from_bytes(data[16:20], "little")
-        size = int.from_bytes(data[20:24], "little")
-        assert len(data) > offset + size
-
-        ota_image, _ = OTAImage.deserialize(data[offset : offset + size])
+        ota_image, _ = parse_ota_image(data)
         assert ota_image.header.key == self.key
 
         LOGGER.debug(
@@ -219,7 +220,7 @@ class LedvanceImage:
             async with req.get(self.url) as rsp:
                 data = await rsp.read()
 
-        img, _ = OTAImage.deserialize(data)
+        img, _ = parse_ota_image(data)
         assert img.header.key == self.key
 
         LOGGER.debug(
@@ -297,43 +298,39 @@ class FileImage:
     def scan_image(cls, file_name: str):
         """Check the header of the image."""
         try:
-            with open(file_name, mode="rb") as file:
-                data = file.read(512)
-                offset = data.index(OTAImageHeader.OTA_HEADER)
-                if offset >= 0:
-                    header, _ = OTAImageHeader.deserialize(data[offset:])
-                    img = cls(file_name=file_name, header=header)
+            with open(file_name, mode="rb") as f:
+                parsed_image, _ = parse_ota_image(f.read())
+                img = cls(file_name=file_name, header=parsed_image.header)
 
-                    LOGGER.debug(
-                        "%s: %s, version: %s, hw_ver: (%s, %s), OTA string: %s",
-                        img.key,
-                        img.file_name,
-                        img.version,
-                        img.header.minimum_hardware_version,
-                        img.header.maximum_hardware_version,
-                        img.header.header_string,
-                    )
-                    return img
+                LOGGER.debug(
+                    "%s: %s, version: %s, hw_ver: (%s, %s), OTA string: %s",
+                    img.key,
+                    img.file_name,
+                    img.version,
+                    img.header.minimum_hardware_version,
+                    img.header.maximum_hardware_version,
+                    img.header.header_string,
+                )
+                return img
         except (OSError, ValueError):
             LOGGER.debug(
                 "File '%s' doesn't appear to be a OTA image", file_name, exc_info=True
             )
         return None
 
-    def fetch_image(self) -> Optional[OTAImage]:
+    def fetch_image(self) -> Optional[BaseOTAImage]:
         """Load image using executor."""
         loop = asyncio.get_event_loop()
         return loop.run_in_executor(None, self._fetch_image)
 
-    def _fetch_image(self) -> Optional[OTAImage]:
+    def _fetch_image(self) -> Optional[BaseOTAImage]:
         """Loads full OTA Image from the file."""
         try:
-            with open(self.file_name, mode="rb") as file:
-                data = file.read()
-                offset = data.index(OTAImageHeader.OTA_HEADER)
-                if offset >= 0:
-                    img = OTAImage.deserialize(data[offset:])[0]
-                    return img
+            with open(self.file_name, mode="rb") as f:
+                data = f.read()
+                img, _ = parse_ota_image(data)
+
+                return img
         except (OSError, ValueError):
             LOGGER.debug("Couldn't load '%s' OTA image", self.file_name, exc_info=True)
         return None

--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -125,7 +125,7 @@ class IKEAImage:
         assert len(data) > offset + size
 
         ota_image, _ = OTAImage.deserialize(data[offset : offset + size])
-        assert ota_image.key == self.key
+        assert ota_image.header.key == self.key
 
         LOGGER.debug(
             "Finished downloading %s bytes from %s for %s ver %s",
@@ -220,11 +220,11 @@ class LedvanceImage:
                 data = await rsp.read()
 
         img, _ = OTAImage.deserialize(data)
-        assert img.key == self.key
+        assert img.header.key == self.key
 
         LOGGER.debug(
             "%s: version: %s, hw_ver: (%s, %s), OTA string: %s",
-            img.key,
+            img.header.key,
             img.header.file_version,
             img.header.minimum_hardware_version,
             img.header.maximum_hardware_version,

--- a/zigpy/ota/validators.py
+++ b/zigpy/ota/validators.py
@@ -3,7 +3,7 @@ import logging
 import typing
 import zlib
 
-from zigpy.ota.image import ElementTagId, OTAImage
+from zigpy.ota.image import BaseOTAImage, ElementTagId, OTAImage
 
 VALID_SILABS_CRC = 0x2144DF1C  # CRC32(anything | CRC32(anything)) == CRC32(0x00000000)
 LOGGER = logging.getLogger(__name__)
@@ -149,10 +149,13 @@ def validate_ota_image(image: OTAImage) -> ValidationResult:
     return ValidationResult.VALID
 
 
-def check_invalid(image: OTAImage) -> bool:
+def check_invalid(image: BaseOTAImage) -> bool:
     """
     Checks if an image is invalid or not. Unknown image types are considered valid.
     """
+
+    if not isinstance(image, OTAImage):
+        return False
 
     try:
         validate_ota_image(image)

--- a/zigpy/ota/validators.py
+++ b/zigpy/ota/validators.py
@@ -141,7 +141,7 @@ def validate_ota_image(image: OTAImage) -> ValidationResult:
 
     for subelement in image.subelements:
         if subelement.tag_id == ElementTagId.UPGRADE_IMAGE:
-            results.append(validate_firmware(subelement))
+            results.append(validate_firmware(subelement.data))
 
     if not results or any(r == ValidationResult.UNKNOWN for r in results):
         return ValidationResult.UNKNOWN


### PR DESCRIPTION
This change centralizes all OTA image parsing into a `zigpy.ota.image.parse_ota_image` function that properly deals with IKEA containers and now Hue SBL images. A side effect of this change is allowing `FileProvider` to properly unwrap IKEA images (rather than scanning for the Zigbee OTA header in the first 512 bytes) and all future weird file types without any necessary changes.

`CachedImage` was rewritten to be a container around any type of image that has a header and can be serialized. I've also added a `CachedImage.cached_data`, which prevents the wrapped image from being repeatedly serialized every time a block is requested.