### PR TITLE
Prefer recently-registered quirks when there are multiple matches

### DIFF
--- a/tests/test_quirks_registry.py
+++ b/tests/test_quirks_registry.py
@@ -48,8 +48,8 @@ def test_add_to_registry_new_sig(fake_dev):
     assert manuf_dict.__getitem__.call_args[0][0] is mock.sentinel.dev_manufacturer
     assert model_dict.__getitem__.call_count == 1
     assert model_dict.__getitem__.call_args[0][0] is mock.sentinel.dev_model
-    assert quirk_list.append.call_count == 1
-    assert quirk_list.append.call_args[0][0] is fake_dev
+    assert quirk_list.insert.call_count == 1
+    assert quirk_list.insert.call_args[0][1] is fake_dev
     quirk_list.reset_mock()
     model_dict.reset_mock()
     manuf_dict.reset_mock()
@@ -91,9 +91,9 @@ def test_add_to_registry_models_info(fake_dev):
     assert model_dict.__getitem__.call_count == 2
     assert model_dict.__getitem__.call_args_list[0][0][0] is mock.sentinel.model_1
     assert model_dict.__getitem__.call_args_list[1][0][0] is mock.sentinel.model_2
-    assert quirk_list.append.call_count == 2
-    assert quirk_list.append.call_args_list[0][0][0] is fake_dev
-    assert quirk_list.append.call_args_list[1][0][0] is fake_dev
+    assert quirk_list.insert.call_count == 2
+    assert quirk_list.insert.call_args_list[0][0][1] is fake_dev
+    assert quirk_list.insert.call_args_list[1][0][1] is fake_dev
     quirk_list.reset_mock()
     model_dict.reset_mock()
     manuf_dict.reset_mock()
@@ -131,7 +131,7 @@ def test_remove_new_sig(fake_dev):
     assert manuf_dict.__getitem__.call_args[0][0] is mock.sentinel.dev_manufacturer
     assert model_dict.__getitem__.call_count == 1
     assert model_dict.__getitem__.call_args[0][0] is mock.sentinel.dev_model
-    assert quirk_list.append.call_count == 0
+    assert quirk_list.insert.call_count == 0
     assert quirk_list.remove.call_count == 1
     assert quirk_list.remove.call_args[0][0] is fake_dev
 
@@ -172,7 +172,7 @@ def test_remove_models_info(fake_dev):
     assert model_dict.__getitem__.call_count == 2
     assert model_dict.__getitem__.call_args_list[0][0][0] is mock.sentinel.model_1
     assert model_dict.__getitem__.call_args_list[1][0][0] is mock.sentinel.model_2
-    assert quirk_list.append.call_count == 0
+    assert quirk_list.insert.call_count == 0
     assert quirk_list.remove.call_count == 2
     assert quirk_list.remove.call_args_list[0][0][0] is fake_dev
     assert quirk_list.remove.call_args_list[1][0][0] is fake_dev

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -33,11 +33,11 @@ class DeviceRegistry:
         models_info = custom_device.signature.get(SIG_MODELS_INFO)
         if models_info:
             for manuf, model in models_info:
-                self.registry[manuf][model].append(custom_device)
+                self.registry[manuf][model].insert(0, custom_device)
         else:
             manufacturer = custom_device.signature.get(SIG_MANUFACTURER)
             model = custom_device.signature.get(SIG_MODEL)
-            self.registry[manufacturer][model].append(custom_device)
+            self.registry[manufacturer][model].insert(0, custom_device)
 
     def remove(self, custom_device: CustomDeviceType) -> None:
         models_info = custom_device.signature.get(SIG_MODELS_INFO)


### PR DESCRIPTION
This is the first step in setting up zhaquirks for custom quirks. Reversing the zigpy quirk matching order to prioritize more recently registered quirks is necessary because a custom quirk may attempt to import custom clusters from `zhaquirks` itself when replacing an existing quirk, which will cause the existing quirk to be registered first and always match.

May require some real-world testing but I don't think any quirks exist that rely on load order like this.

Thank you @dmulcahey for coming up with this much simpler solution and steering me away from rewriting `zigpy.quirks` to requiring quirks to be explicitly registered 😄 