### PR TITLE
Don't let PersistingListener worker task die

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -92,6 +92,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     args,
                     str(exc),
                 )
+            except Exception as ex:
+                LOGGER.error(
+                    "Unexpected error while processing %s(%s): %s", cb_name, args, ex
+                )
             self._callback_handlers.task_done()
 
     async def shutdown(self) -> None:

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -366,6 +366,13 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 device.status,
             )
             return
+        if not device.node_desc.is_valid:
+            LOGGER.debug(
+                "[0x%04x]: does not have a valid node descriptor, not saving in appdb",
+                device.nwk,
+            )
+            return
+
         try:
             q = "INSERT INTO devices (ieee, nwk, status) VALUES (?, ?, ?)"
             await self.execute(q, (device.ieee, device.nwk, device.status))


### PR DESCRIPTION
Catch, log and swallow exceptions in the `PersistingListener` worker task. Fixes a regression introduced in #588: saving a device with an  invalid node descriptor causes the worker task to be terminated prematurely on an exception. 
the fix:
1. Catch exceptions in the worker, log them and ignore
2. Don't save devices without a valid node descriptor