### PR TITLE
Make Bool type an enum8

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -385,7 +385,7 @@ async def test_write_wrong_attribute(cluster):
 
 async def test_write_attributes_wrong_type(cluster):
     with patch.object(cluster, "_write_attributes", new=AsyncMock()):
-        await cluster.write_attributes({18: 2})
+        await cluster.write_attributes({18: 0x2222})
         assert cluster._write_attributes.call_count == 1
 
 

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -1,4 +1,3 @@
-import enum
 from typing import Iterable, Tuple, Union
 
 from . import basic
@@ -37,7 +36,7 @@ class KeyData(basic.FixedList, item_type=basic.uint8_t, length=16):
     pass
 
 
-class Bool(basic.uint8_t, enum.Enum):
+class Bool(basic.enum8):
     false = 0
     true = 1
 


### PR DESCRIPTION
Make the `zigpy.types.named.Bool` an `enum8` type, to allow other than 0 & 1 value for the bool type, as some devices are overloading this type with other values, requiring more complex handling/work arounds