### PR TITLE
Refactor Cluster.handle_cluster_request() method

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -700,7 +700,8 @@ def test_general_command_reply(cluster):
 
 
 def test_handle_cluster_request_handler(cluster):
-    cluster.handle_cluster_request(sentinel.tsn, sentinel.command_id, sentinel.args)
+    hdr = foundation.ZCLHeader.cluster(123, 0x00)
+    cluster.handle_cluster_request(hdr, [sentinel.arg1, sentinel.arg2])
 
 
 async def test_handle_cluster_general_request_disable_default_rsp(endpoint):

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -121,7 +121,8 @@ def ota_cluster():
 async def test_ota_handle_cluster_req(ota_cluster):
     ota_cluster._handle_cluster_request = AsyncMock()
 
-    ota_cluster.handle_cluster_request(sentinel.tsn, sentinel.cmd, sentinel.args)
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(123, 0x00)
+    ota_cluster.handle_cluster_request(hdr, sentinel.args)
     assert ota_cluster._handle_cluster_request.call_count == 1
 
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -187,17 +187,17 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
 
         return self._endpoint.reply(self.cluster_id, tsn, data, command_id=command_id)
 
-    def handle_message(self, hdr, args):
+    def handle_message(self, hdr: foundation.ZCLHeader, args: List[Any]):
         self.debug("ZCL request 0x%04x: %s", hdr.command_id, args)
         if hdr.frame_control.is_cluster:
-            self.handle_cluster_request(hdr.tsn, hdr.command_id, args)
+            self.handle_cluster_request(hdr, args)
             self.listener_event("cluster_command", hdr.tsn, hdr.command_id, args)
             return
         self.listener_event("general_command", hdr, args)
         self.handle_cluster_general_request(hdr, args)
 
-    def handle_cluster_request(self, tsn, command_id, args):
-        self.debug("No handler for cluster command %s", command_id)
+    def handle_cluster_request(self, hdr: foundation.ZCLHeader, args: List[Any]):
+        self.debug("No handler for cluster command %s", hdr.command_id)
 
     def handle_cluster_general_request(
         self, hdr: foundation.ZCLHeader, args: List

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2,7 +2,7 @@
 
 import collections
 from datetime import datetime
-from typing import Tuple
+from typing import Any, List, Tuple
 
 import zigpy.types as t
 from zigpy.zcl import Cluster, foundation
@@ -980,9 +980,9 @@ class Ota(Cluster):
         ),
     }
 
-    def handle_cluster_request(self, tsn, command_id, args):
+    def handle_cluster_request(self, hdr: foundation.ZCLHeader, args: List[Any]):
         self.create_catching_task(
-            self._handle_cluster_request(tsn, command_id, args),
+            self._handle_cluster_request(hdr.tsn, hdr.command_id, args),
         )
 
     async def _handle_cluster_request(self, tsn, command_id, args):


### PR DESCRIPTION
Change method signature, send the actual ZCL header to provide more context to the handler.
This PR is a result to the [comment](https://github.com/zigpy/zigpy/pull/622#issuecomment-761615829) and is aimed to provide more context to the command handler, like whether a default response should be suppressed or not.

