### PR TITLE
Add dst_addressing default parameter to handle_cluster_*_request() method

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -125,14 +125,18 @@ def test_handle_message(ep):
     c = ep.add_input_cluster(0)
     c.handle_message = MagicMock()
     ep.handle_message(sentinel.profile, 0, sentinel.hdr, sentinel.data)
-    c.handle_message.assert_called_once_with(sentinel.hdr, sentinel.data)
+    c.handle_message.assert_called_once_with(
+        sentinel.hdr, sentinel.data, dst_addressing=None
+    )
 
 
 def test_handle_message_output(ep):
     c = ep.add_output_cluster(0)
     c.handle_message = MagicMock()
     ep.handle_message(sentinel.profile, 0, sentinel.hdr, sentinel.data)
-    c.handle_message.assert_called_once_with(sentinel.hdr, sentinel.data)
+    c.handle_message.assert_called_once_with(
+        sentinel.hdr, sentinel.data, dst_addressing=None
+    )
 
 
 def test_handle_request_unknown(ep):

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -131,7 +131,8 @@ async def test_ota_handle_cluster_req_wrapper(ota_cluster):
     ota_cluster._handle_image_block = AsyncMock()
     ota_cluster._handle_upgrade_end = AsyncMock()
 
-    await ota_cluster._handle_cluster_request(sentinel.tsn, 0x01, [sentinel.args])
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(123, 0x01)
+    await ota_cluster._handle_cluster_request(hdr, [sentinel.args])
     assert ota_cluster._handle_query_next_image.call_count == 1
     assert ota_cluster._handle_query_next_image.call_args[0][0] == sentinel.args
     assert ota_cluster._handle_image_block.call_count == 0
@@ -140,7 +141,8 @@ async def test_ota_handle_cluster_req_wrapper(ota_cluster):
     ota_cluster._handle_image_block.reset_mock()
     ota_cluster._handle_upgrade_end.reset_mock()
 
-    await ota_cluster._handle_cluster_request(sentinel.tsn, 0x03, [sentinel.block_args])
+    hdr.command_id = 0x03
+    await ota_cluster._handle_cluster_request(hdr, [sentinel.block_args])
     assert ota_cluster._handle_query_next_image.call_count == 0
     assert ota_cluster._handle_image_block.call_count == 1
     assert ota_cluster._handle_image_block.call_args[0][0] == sentinel.block_args
@@ -149,7 +151,8 @@ async def test_ota_handle_cluster_req_wrapper(ota_cluster):
     ota_cluster._handle_image_block.reset_mock()
     ota_cluster._handle_upgrade_end.reset_mock()
 
-    await ota_cluster._handle_cluster_request(sentinel.tsn, 0x06, [sentinel.end_args])
+    hdr.command_id = 0x06
+    await ota_cluster._handle_cluster_request(hdr, [sentinel.end_args])
     assert ota_cluster._handle_query_next_image.call_count == 0
     assert ota_cluster._handle_image_block.call_count == 0
     assert ota_cluster._handle_upgrade_end.call_count == 1
@@ -158,7 +161,8 @@ async def test_ota_handle_cluster_req_wrapper(ota_cluster):
     ota_cluster._handle_image_block.reset_mock()
     ota_cluster._handle_upgrade_end.reset_mock()
 
-    await ota_cluster._handle_cluster_request(sentinel.tsn, 0x78, [sentinel.just_args])
+    hdr.command_id = 0x78
+    await ota_cluster._handle_cluster_request(hdr, [sentinel.just_args])
     assert ota_cluster._handle_query_next_image.call_count == 0
     assert ota_cluster._handle_image_block.call_count == 0
     assert ota_cluster._handle_upgrade_end.call_count == 0

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -214,7 +214,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.listener_event("unknown_cluster_message", hdr.command_id, args)
             return
 
-        handler(hdr, args)
+        handler(hdr, args, dst_addressing=dst_addressing)
 
     def request(self, cluster, sequence, data, expect_reply=True, command_id=0x00):
         if self.profile_id == zigpy.profiles.zll.PROFILE_ID and not (

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -202,7 +202,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
             self.listener_event("cluster_command", hdr.tsn, hdr.command_id, args)
             return
         self.listener_event("general_command", hdr, args)
-        self.handle_cluster_general_request(hdr, args)
+        self.handle_cluster_general_request(hdr, args, dst_addressing=dst_addressing)
 
     def handle_cluster_request(
         self,
@@ -216,7 +216,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
         self.debug("No handler for cluster command %s", hdr.command_id)
 
     def handle_cluster_general_request(
-        self, hdr: foundation.ZCLHeader, args: List
+        self,
+        hdr: foundation.ZCLHeader,
+        args: List,
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
     ) -> None:
         if hdr.command_id == foundation.Command.Report_Attributes:
             valuestr = ", ".join(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -187,16 +187,32 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
 
         return self._endpoint.reply(self.cluster_id, tsn, data, command_id=command_id)
 
-    def handle_message(self, hdr: foundation.ZCLHeader, args: List[Any]):
+    def handle_message(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: List[Any],
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ):
         self.debug("ZCL request 0x%04x: %s", hdr.command_id, args)
         if hdr.frame_control.is_cluster:
-            self.handle_cluster_request(hdr, args)
+            self.handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
             self.listener_event("cluster_command", hdr.tsn, hdr.command_id, args)
             return
         self.listener_event("general_command", hdr, args)
         self.handle_cluster_general_request(hdr, args)
 
-    def handle_cluster_request(self, hdr: foundation.ZCLHeader, args: List[Any]):
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: List[Any],
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ):
         self.debug("No handler for cluster command %s", hdr.command_id)
 
     def handle_cluster_general_request(

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -504,7 +504,14 @@ class Time(Cluster):
     server_commands = {}
     client_commands = {}
 
-    def handle_cluster_general_request(self, hdr, *args):
+    def handle_cluster_general_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        *args: List[Any],
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ):
         if hdr.command_id == foundation.Command.Read_Attributes:
             # responses should be in the same order. Is it time to ditch py35?
             data = collections.OrderedDict()
@@ -990,22 +997,20 @@ class Ota(Cluster):
         ] = None,
     ):
         self.create_catching_task(
-            self._handle_cluster_request(
-                hdr.tsn, hdr.command_id, args, dst_addressing=dst_addressing
-            ),
+            self._handle_cluster_request(hdr, args, dst_addressing=dst_addressing),
         )
 
     async def _handle_cluster_request(
         self,
-        tsn,
-        command_id,
-        args,
+        hdr: foundation.ZCLHeader,
+        args: List[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
         ] = None,
     ):
         """Parse OTA commands."""
+        tsn, command_id = hdr.tsn, hdr.command_id
         cmd_name = self.server_commands.get(command_id, [command_id])[0]
 
         if cmd_name == "query_next_image":

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2,7 +2,7 @@
 
 import collections
 from datetime import datetime
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import zigpy.types as t
 from zigpy.zcl import Cluster, foundation
@@ -980,12 +980,31 @@ class Ota(Cluster):
         ),
     }
 
-    def handle_cluster_request(self, hdr: foundation.ZCLHeader, args: List[Any]):
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: List[Any],
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ):
         self.create_catching_task(
-            self._handle_cluster_request(hdr.tsn, hdr.command_id, args),
+            self._handle_cluster_request(
+                hdr.tsn, hdr.command_id, args, dst_addressing=dst_addressing
+            ),
         )
 
-    async def _handle_cluster_request(self, tsn, command_id, args):
+    async def _handle_cluster_request(
+        self,
+        tsn,
+        command_id,
+        args,
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ):
         """Parse OTA commands."""
         cmd_name = self.server_commands.get(command_id, [command_id])[0]
 
@@ -1012,7 +1031,7 @@ class Ota(Cluster):
         current_file_version,
         hardware_version,
         *,
-        tsn
+        tsn,
     ):
         self.debug(
             (
@@ -1073,7 +1092,7 @@ class Ota(Cluster):
         request_node_addr,
         block_request_delay,
         *,
-        tsn=None
+        tsn=None,
     ):
         self.debug(
             (


### PR DESCRIPTION
Add [dst_addressing](https://github.com/zigpy/zigpy/pull/591) parameter to `handle_cluster_request()` and `handle_cluster_request()` general methods. This PR is a continuation of the issue raised in [comment](https://github.com/zigpy/zigpy/pull/622#issuecomment-761615829) as the default response command should not be sent to incoming messages received via GroupAddress or incoming broadcasts. The "dst_addressing" parameter provides the required context to make the decision.