### PR TITLE
Do not catch `CancelledError` with `except Exception` in Python 3.7

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -92,6 +92,8 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     args,
                     str(exc),
                 )
+            except asyncio.CancelledError:
+                raise
             except Exception as ex:
                 LOGGER.error(
                     "Unexpected error while processing %s(%s): %s", cb_name, args, ex

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -67,6 +67,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         if start_radio:
             try:
                 await app.startup(auto_form)
+            except asyncio.CancelledError:
+                raise
             except Exception:
                 LOGGER.error("Couldn't start application")
                 await app.pre_shutdown()

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -139,6 +139,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 continue
             try:
                 await ep.initialize()
+            except asyncio.CancelledError:
+                raise
             except Exception as exc:
                 self.warning("Endpoint %s initialization failure: %s", endpoint_id, exc)
                 break

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -59,6 +59,8 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 return
             elif sdr[0] != zdo_status.SUCCESS:
                 raise Exception("Failed to retrieve service descriptor: %s", sdr)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             self.warning(
                 "Failed to discover endpoint_id %s", self.endpoint_id, exc_info=True

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -286,9 +286,7 @@ class CatchingTaskMixin(LocalLogMixin):
             return await target
         except exceptions:
             pass
-        except asyncio.CancelledError:
-            raise
-        except Exception:  # pylint: disable=broad-except
+        except (Exception, asyncio.CancelledError):  # pylint: disable=broad-except
             # Do not print the wrapper in the traceback
             frames = len(inspect.trace()) - 1
             exc_msg = traceback.format_exc(-frames)

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -286,6 +286,8 @@ class CatchingTaskMixin(LocalLogMixin):
             return await target
         except exceptions:
             pass
+        except asyncio.CancelledError:
+            raise
         except Exception:  # pylint: disable=broad-except
             # Do not print the wrapper in the traceback
             frames = len(inspect.trace()) - 1


### PR DESCRIPTION
Ran into a bizarre failing unit test in zigpy-znp caused by `asyncio.CancelledError` being an `Exception` subclass in Python 3.7 but a `BaseException` subclass in Python 3.8 and beyond. This causes coroutines that normally handle exceptions (e.g. infinite loops) to never actually quit when cancelled.

For example, the following task will not stop running in Python 3.7, but will in Python 3.8 and 3.9:

```Python
import asyncio

async def task():
    while True:
        try:
            print("Running...")
            await asyncio.sleep(1)
        except Exception as e:
            print(f"Caught an exception: {e!r}")
        
        await asyncio.sleep(2)

async def main():
    t = asyncio.create_task(task())
    await asyncio.sleep(4)
    print("Stopping task")
    t.cancel()
    await asyncio.sleep(10)

if __name__ == "__main__":
    asyncio.run(main())
```