### PR TITLE
Include properties in Struct string representations

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -536,3 +536,23 @@ def test_repr():
     ts = TestStruct()
     ts.foo = 1j
     assert repr(ts) == "TestStruct(foo=1j)"
+
+
+def test_repr_properties():
+    class TestStruct(t.Struct):
+        foo: t.uint8_t
+        bar: t.uint8_t
+
+        @property
+        def baz(self):
+            if self.bar is None:
+                return None
+
+            return t.Bool((self.bar & 0xF0) >> 4)
+
+    assert repr(TestStruct(foo=1)) == "TestStruct(foo=1)"
+    assert (
+        repr(TestStruct(foo=1, bar=16))
+        == "TestStruct(foo=1, bar=16, *baz=<Bool.true: 1>)"
+    )
+    assert repr(TestStruct()) == "TestStruct()"

--- a/tests/test_zdo_types.py
+++ b/tests/test_zdo_types.py
@@ -151,6 +151,20 @@ def test_node_descriptor_logical_types():
     assert nd.is_router is False
 
 
+def test_node_descriptor_repr():
+    nd = types.NodeDescriptor(
+        0b11111010, 0xFF, 0xFF, 0xFFFF, 0xFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFF
+    )
+    assert nd.is_coordinator is False
+    assert "*is_coordinator=False" in repr(nd)
+
+    assert nd.is_end_device is True
+    assert "*is_end_device=True" in repr(nd)
+
+    assert nd.is_router is False
+    assert "*is_router=False" in repr(nd)
+
+
 def test_size_prefixed_simple_descriptor():
     sd = types.SizePrefixedSimpleDescriptor()
     sd.endpoint = t.uint8_t(1)

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -193,8 +193,27 @@ class Struct:
         return self.as_dict() == other.as_dict()
 
     def __repr__(self) -> str:
-        kwargs = ", ".join([f"{f.name}={v!r}" for f, v in self.assigned_fields()])
-        return f"{type(self).__name__}({kwargs})"
+        fields = []
+
+        # Assigned fields are displayed as `field=value`
+        for f, v in self.assigned_fields():
+            fields.append(f"{f.name}={v!r}")
+
+        cls = type(self)
+
+        # Properties are displayed as `*prop=value`
+        for attr in dir(cls):
+            cls_attr = getattr(cls, attr)
+
+            if not isinstance(cls_attr, property):
+                continue
+
+            value = getattr(self, attr)
+
+            if value is not None:
+                fields.append(f"*{attr}={value!r}")
+
+        return f"{type(self).__name__}({', '.join(fields)})"
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Some types (namely node and neighbor descriptors) include bitfields, which zigpy does not yet natively support. This change includes all properties in the string representation of a struct.

For example, `zigpy.zdo.types.Neighbor` before:

`
Neighbor(extended_pan_id=a8:c0:3b:db:53:ca:60:a8, ieee=00:0b:57:ff:fe:8d:4f:83, nwk=0xDE0E, packed=37, permit_joining=<PermitJoins.Unknown: 2>, depth=15, lqi=97)
`

And after:

`
Neighbor(extended_pan_id=a8:c0:3b:db:53:ca:60:a8, ieee=00:0b:57:ff:fe:8d:4f:83, nwk=0xDE0E, packed=37, permit_joining=<PermitJoins.Unknown: 2>, depth=15, lqi=97, *device_type=<DeviceType.Router: 1>, *relationship=<Relationship.Sibling: 2>, *rx_on_when_idle=<RxOnWhenIdle.On: 1>)
`

Similarly, `OTAImage.header` before:

`
OTAImageHeader(upgrade_file_id=200208670, header_version=256, header_length=56, field_control=<FieldControl.0: 0>, manufacturer_id=1, image_type=1, file_version=65544, stack_version=2, header_string='TYZS4 115200 1.0.8  MFTEST', image_size=194230)
`

And after (the `key` property is extraneous, maybe it should be handled differently? Perhaps these properties should be decorated to indicate that they're a part of the struct?):

`
OTAImageHeader(upgrade_file_id=200208670, header_version=256, header_length=56, field_control=<FieldControl.0: 0>, manufacturer_id=1, image_type=1, file_version=65544, stack_version=2, header_string='TYZS4 115200 1.0.8  MFTEST', image_size=194230, *device_specific_file=False, *hardware_versions_present=False, *key=ImageKey(manufacturer_id=1, image_type=1), *security_credential_version_present=False)
`

This change will increase the size of log files a little when debug logging is enabled but it will make reading/parsing them a lot easier when these types of objects are present.