### PR TITLE
Switch to postponed annotation evaluation

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 from unittest import mock
 
@@ -5,6 +7,28 @@ import pytest
 
 import zigpy.types as t
 from zigpy.zcl.foundation import Status
+
+
+@pytest.fixture
+def expose_global():
+    """
+    `typing.get_type_hints` does not work for types defined within functions
+    """
+
+    objects = []
+
+    def inner(obj):
+        assert obj.__name__ not in globals()
+        globals()[obj.__name__] = obj
+
+        objects.append(obj)
+
+        return obj
+
+    yield inner
+
+    for obj in objects:
+        del globals()[obj.__name__]
 
 
 def test_struct_fields():
@@ -95,7 +119,8 @@ def test_struct_construction():
         s1.serialize()
 
 
-def test_nested_structs():
+def test_nested_structs(expose_global):
+    @expose_global
     class InnerStruct(t.Struct):
         b: t.uint8_t
         c: t.uint8_t
@@ -119,11 +144,14 @@ def test_nested_structs():
     assert s.d == 3
 
 
-def test_nested_structs2():
+def test_nested_structs2(expose_global):
+    @expose_global
+    class InnerStruct(t.Struct):
+        b: t.uint8_t
+        c: t.uint8_t
+
     class OuterStruct(t.Struct):
-        class InnerStruct(t.Struct):
-            b: t.uint8_t
-            c: t.uint8_t
+        InnerStruct = InnerStruct
 
         a: t.uint8_t
         inner: None = t.StructField(type=InnerStruct)
@@ -227,7 +255,8 @@ def test_struct_field_invalid_dependencies():
     assert len(ts3.assigned_fields()) == 1
 
 
-def test_struct_multiple_requires():
+def test_struct_multiple_requires(expose_global):
+    @expose_global
     class StrictStatus(t.enum8):
         SUCCESS = 0x00
         FAILURE = 0x01

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -1,4 +1,7 @@
 """OTA Firmware handling."""
+
+from __future__ import annotations
+
 import logging
 import typing
 

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Iterable, Tuple, Union
 
 from . import basic

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -19,26 +19,6 @@ class Struct:
         # We have to use a little introspection to find our real class.
         return next(c for c in cls.__mro__ if c.__name__ != "Optional")
 
-    @classmethod
-    def _annotations(cls) -> typing.List[type]:
-        # First get our proper subclasses
-        subclasses = []
-
-        for subcls in cls._real_cls().__mro__:
-            if subcls is Struct:
-                break
-
-            subclasses.append(subcls)
-
-        annotations = {}
-
-        # Iterate over the annotations *backwards*.
-        # We want subclasses' annotations to override their parent classes'.
-        for subcls in subclasses[::-1]:
-            annotations.update(getattr(subcls, "__annotations__", {}))
-
-        return annotations
-
     def __init_subclass__(cls):
         super().__init_subclass__()
 

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import inspect
 import typing
@@ -96,7 +98,7 @@ class Struct:
         fields = ListSubclass()
 
         # We need both to throw type errors in case a field is not annotated
-        annotations = cls._real_cls()._annotations()
+        annotations = typing.get_type_hints(cls._real_cls())
 
         # Make sure every `StructField` is annotated
         for name in vars(cls._real_cls()):
@@ -120,7 +122,7 @@ class Struct:
             field = field.replace(name=name)
 
             # An annotation of `None` means to use the field's type
-            if annotation is not None:
+            if annotation is not NoneType:
                 if field.type is not None and field.type != annotation:
                     raise TypeError(
                         f"Field {name!r} type annotation conflicts with provided type:"

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1,5 +1,7 @@
 """General Functional Domain"""
 
+from __future__ import annotations
+
 import collections
 from datetime import datetime
 from typing import Any, List, Optional, Tuple, Union

--- a/zigpy/zcl/clusters/lightlink.py
+++ b/zigpy/zcl/clusters/lightlink.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from zigpy import types as t
 from zigpy.zcl import Cluster, foundation
 

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -1,5 +1,7 @@
 """Protocol Interfaces Functional Domain"""
 
+from __future__ import annotations
+
 import zigpy.types as t
 from zigpy.zcl import Cluster
 

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -1,4 +1,7 @@
 """Security and Safety Functional Domain"""
+
+from __future__ import annotations
+
 from typing import Tuple
 
 import zigpy.types as t

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple, Union
 
 import zigpy.types as t

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 
 import zigpy.types as t
@@ -184,17 +186,19 @@ class _NeighborEnums:
         PreviousChild = 0x4
 
 
+class PermitJoins(t.enum8):
+    NotAccepting = 0x0
+    Accepting = 0x1
+    Unknown = 0x2
+
+
 class Neighbor(t.Struct):
     """Neighbor Descriptor"""
 
+    PermitJoins = PermitJoins
     DeviceType = _NeighborEnums.DeviceType
     RxOnWhenIdle = _NeighborEnums.RxOnWhenIdle
     RelationShip = _NeighborEnums.Relationship
-
-    class PermitJoins(t.enum8):
-        NotAccepting = 0x0
-        Accepting = 0x1
-        Unknown = 0x2
 
     extended_pan_id: t.ExtendedPanId
     ieee: t.EUI64
@@ -248,6 +252,10 @@ class Neighbor(t.Struct):
             self.packed = value
         self.packed &= 0b0000_1111
         self.packed |= (value & 0x07) << 4
+
+
+# It's exposed only as `Neighbor.PermitJoins`
+del PermitJoins
 
 
 class Neighbors(t.Struct):


### PR DESCRIPTION
Postponed annotation evaluation is mandatory in Python 3.10 and is already supported by Python 3.7 and above through `from __future__ import annotations`. Everything works except for this construct:

```Python
class Bar:
    class Foo:  pass

    foo: Foo

# NameError: name 'Foo' is not defined
import typing
typing.get_type_hints(Bar)
```

It now unfortunately has to be done like this due to scope issues (unless very hacky stack frame traversal is added to `Struct.__init_subclass__`):

```Python
class Foo:  pass

class Bar:
    Foo = Foo
    foo: Foo  # This refers to the global `Foo`, the one in the class scope is not available

del Foo
```

All but two unit tests pass with the Python 3.10 alpha build (due to major changes to the `enum` module...) so it appears that nothing else is expected to break.