### PR TITLE
Remove the ITEAD Sonoff ZBBridge from list of compatible hardware as unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Note! Zigbee 3.0 support or not in zigpy depends primarily on your Zigbee coordi
 ### Known working Zigbee radio modules
 
 - **Silicon Labs EmberZNet based radios** using the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)
-  - [ITEAD Sonoff ZBBridge WiFi-bridge](https://www.itead.cc/smart-home/sonoff-zbbridge.html) (Note! This first have to be flashed with [Tasmota firmware and EmberZNet firmware](https://www.digiblur.com/2020/07/how-to-use-sonoff-zigbee-bridge-with.html))
   - [Elelabs Zigbee USB Adapter](https://elelabs.com/products/elelabs_usb_adapter.html)
   - [Elelabs Zigbee Raspberry Pi Shield](https://elelabs.com/products/elelabs_zigbee_shield.html)
   - [Nortek GoControl QuickStick Combo Model HUSBZB-1 (Z-Wave & Zigbee USB Adapter)](https://www.nortekcontrol.com/products/2gig/husbzb-1-gocontrol-quickstick-combo/)


### PR DESCRIPTION
Remove ITead Sonoff ZBBridge from the list of compatible hardware as WiFi-based bridges/gateways are now infamously unstable.

 - [ITEAD Sonoff ZBBridge](https://www.itead.cc/smart-home/sonoff-zbbridge.html) (Note! This first have to be flashed with [Tasmota firmware and EmberZNet firmware](https://www.digiblur.com/2020/07/how-to-use-sonoff-zigbee-bridge-with.html))

My argument is that having this listed is causing longterm harm to zigpy and ZHA as many first-time users have a horrible experience with stability on it and when they ask for the support they are told that they should buy a USB stick/dongle or Ethernet (wired) bridge/gateway version instead if you want a stable connection between the Zigbee coordinator adapter and bellows/zigpy/ZHA. I believe that not having it listed here would at least make some users stop pointing their fingers bellows/zigpy/ZHA developers.

It might be stable enough for people who have extremely stable WiFi, but is it a product that should be advertised for zigpy/ZHA?

Maybe just list a few wired Ethernet bridges/gateways under compatible hardware instead? ...in a separate pull request of course.

PS: For reference; I was actually the one who originally added ITead Sonoff ZBBridge to the list via PR https://github.com/zigpy/zigpy/pull/447 and https://github.com/zigpy/bellows/pull/285