### PR TITLE
Enabling firmware down grading from local file.

### DIFF
--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -57,7 +57,7 @@ class CachedImage:
         if self.key != ImageKey(manufacturer_id, img_type):
             return False
 
-        if ver >= self.version:
+        if ver == self.version:
             return False
 
         if (


### PR DESCRIPTION
Changing OTA so all not equal versions of firmware version is triggering OTA updating of devices.
For normal updating with online requests shall not being any problem.
If disabling online updates and putting one firmware in the "local OTA update folder" and the firmware version is not equal as in the device is the system saying update is true and sending the local file to the device then its requesting OTA updates.

I have trying up and downgrading one IKEA E27 opal 1000lm 6 times and its working great and is not updating the firmware then the version is the same.

As long the user is not configuring one local OTA folder and  / or not putting any valid OTA files for the device in the system its not making any problems.

Its making much easier testing changed functions in devices that can being firmware depending and also to restoring  "the default scenes" that IKEA is using for there 5 button  remotes and getting it working out of the box if putting the magic group in the light.