### PR TITLE
Improved device initialization

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,4 +1,6 @@
 import asyncio
+import logging
+from unittest.mock import PropertyMock
 
 import pytest
 import voluptuous as vol
@@ -241,17 +243,48 @@ def test_permit_with_key(app):
         app.permit_with_key(None, None)
 
 
-async def test_join_handler_skip(app, ieee):
+@patch("zigpy.device.Device.initialize", new_callable=AsyncMock)
+async def test_join_handler_skip(init_mock, app, ieee):
     app.handle_join(1, ieee, None)
-    app.devices[ieee].status = device.Status.ZDO_INIT
+    app.get_device(ieee).node_desc = _devices(1).node_desc
+
     app.handle_join(1, ieee, None)
-    assert app.devices[ieee].status == device.Status.ZDO_INIT
+    assert app.get_device(ieee).node_desc == _devices(1).node_desc
 
 
 async def test_join_handler_change_id(app, ieee):
     app.handle_join(1, ieee, None)
     app.handle_join(2, ieee, None)
     assert app.devices[ieee].nwk == 2
+
+
+@pytest.mark.parametrize("initialized", (True, False))
+async def test_join_handler_rescan_groups(initialized, app, ieee):
+    dev = _devices(1)
+    dev.is_initialized = initialized
+    app.devices[dev.ieee] = dev
+
+    assert dev.schedule_initialize.call_count == 0
+    app.handle_join(dev.nwk, dev.ieee, None)
+
+    if initialized:
+        assert dev.schedule_initialize.call_count == 1
+    else:
+        assert dev.schedule_initialize.call_count == 1
+
+
+async def test_unknown_device_left(app, ieee):
+    with patch.object(app, "listener_event", wraps=app.listener_event):
+        app.handle_leave(0x1234, ieee)
+        app.listener_event.assert_not_called()
+
+
+async def test_known_device_left(app, ieee):
+    dev = app.add_device(ieee, 0x1234)
+
+    with patch.object(app, "listener_event", wraps=app.listener_event):
+        app.handle_leave(0x1234, ieee)
+        app.listener_event.assert_called_once_with("device_left", dev)
 
 
 async def _remove(app, ieee, retval, zdo_reply=True, delivery_failure=True):
@@ -362,16 +395,24 @@ def test_handle_message(app, ieee):
     assert dev.handle_message.call_count == 1
 
 
-def test_handle_message_uninitialized_dev(app, ieee):
+@patch("zigpy.device.Device.has_node_descriptor", new_callable=PropertyMock)
+def test_handle_message_uninitialized_dev(mock1, app, ieee):
     dev = device.Device(app, ieee, 0x1234)
     dev.handle_message = MagicMock()
+
+    dev.has_node_descriptor.return_value = False
+
+    # Power Configuration cluster, not allowed
     app.handle_message(dev, 260, 1, 1, 1, [])
     assert dev.handle_message.call_count == 0
 
-    dev.status = device.Status.ZDO_INIT
+    dev.has_node_descriptor.return_value = True
+
+    # Power Configuration cluster still not allowed
     app.handle_message(dev, 260, 1, 1, 1, [])
     assert dev.handle_message.call_count == 0
 
+    # Basic cluster is allowed
     app.handle_message(dev, 260, 0, 1, 1, [])
     assert dev.handle_message.call_count == 1
 
@@ -484,7 +525,7 @@ def test_app_update_config(app):
         assert app.config[CONF_OTA][CONF_OTA_IKEA] is True
 
 
-def test_uninitialized_message_handlers(app, ieee):
+async def test_uninitialized_message_handlers(app, ieee):
     """Test uninitialized message handlers."""
     handler_1 = MagicMock(return_value=None)
     handler_2 = MagicMock(return_value=True)
@@ -574,3 +615,20 @@ async def test_remove_parent_devices(app):
         assert router_2.zdo.request.await_count == 0
         assert parent.zdo.leave.await_count == 0
         assert parent.zdo.request.await_count == 1
+
+
+async def test_startup_log_on_uninitialized_device(app, ieee, caplog):
+    class App(zigpy.application.ControllerApplication):
+        async def _noop(self, *args, **kwargs):
+            pass
+
+        startup = request = permit_ncp = probe = shutdown = _noop
+
+        async def _load_db(self):
+            self.add_device(ieee, 1)
+
+    caplog.set_level(logging.WARNING)
+
+    await App.new(ZIGPY_SCHEMA({CONF_DATABASE: "/dev/null"}))
+    assert len(caplog.records) == 1
+    assert "Device is partially initialized" in caplog.text

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -396,7 +396,7 @@ def test_handle_message(app, ieee):
 
 
 @patch("zigpy.device.Device.has_node_descriptor", new_callable=PropertyMock)
-def test_handle_message_uninitialized_dev(mock1, app, ieee):
+async def test_handle_message_uninitialized_dev(mock1, app, ieee):
     dev = device.Device(app, ieee, 0x1234)
     dev.handle_message = MagicMock()
 
@@ -415,6 +415,8 @@ def test_handle_message_uninitialized_dev(mock1, app, ieee):
     # Basic cluster is allowed
     app.handle_message(dev, 260, 0, 1, 1, [])
     assert dev.handle_message.call_count == 1
+
+    assert dev.initializing
 
 
 async def test_broadcast(app):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -63,7 +63,7 @@ async def test_initialize_fail(dev):
     await dev.initialize()
 
     assert not dev.is_initialized
-    assert not dev.did_zdo_init
+    assert not dev.has_non_zdo_endpoints
 
 
 @patch("zigpy.device.Device.get_node_descriptor", AsyncMock())

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -294,19 +294,17 @@ async def test_init_endpoint_info_null_padded_manuf_model(ep):
 async def test_get_model_info_delivery_error(ep):
     manufacturer = b"Mock Manufacturer"
     model = b"Mock Model"
-    mod, man = await _get_model_info(ep, manufacturer, model, fail=True)
 
-    assert man is None
-    assert mod is None
+    with pytest.raises(zigpy.exceptions.ZigbeeException):
+        await _get_model_info(ep, manufacturer, model, fail=True)
 
 
 async def test_get_model_info_timeout(ep):
     manufacturer = b"Mock Manufacturer"
     model = b"Mock Model"
-    mod, man = await _get_model_info(ep, manufacturer, model, fail=True, timeout=True)
 
-    assert man is None
-    assert mod is None
+    with pytest.raises(asyncio.TimeoutError):
+        await _get_model_info(ep, manufacturer, model, fail=True, timeout=True)
 
 
 def _group_add_mock(ep, status=ZCLStatus.SUCCESS, no_groups_cluster=False):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -62,7 +62,10 @@ async def test_initialize_fail(ep):
         return [1, None, None]
 
     ep._device.zdo.Simple_Desc_req = mockrequest
-    await ep.initialize()
+
+    # The request succeeds but the response is invalid
+    with pytest.raises(zigpy.exceptions.InvalidResponse):
+        await ep.initialize()
 
     assert ep.status == endpoint.Status.NEW
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -264,6 +264,15 @@ async def test_init_endpoint_info_none(ep):
     assert mod is None
 
 
+async def test_get_model_info_missing_basic_cluster(ep):
+    assert zcl.clusters.general.Basic.cluster_id not in ep.in_clusters
+
+    model, manuf = await ep.get_model_info()
+
+    assert model is None
+    assert manuf is None
+
+
 async def test_init_endpoint_info_null_padded_manuf(ep):
     manufacturer = b"Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07"
     model = b"Mock Model"

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -134,12 +134,8 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         self.enqueue("_update_device_nwk", device.ieee, device.nwk)
 
     async def _update_device_nwk(self, ieee: t.EUI64, nwk: t.NWK) -> None:
-        try:
-            await self.execute("UPDATE devices SET nwk=? WHERE ieee=?", (nwk, ieee))
-        except aiosqlite.OperationalError:
-            pass
-        else:
-            await self._db.commit()
+        await self.execute("UPDATE devices SET nwk=? WHERE ieee=?", (nwk, ieee))
+        await self._db.commit()
 
     def raw_device_initialized(self, device: zigpy.typing.DeviceType) -> None:
         self.enqueue("_save_device", device)
@@ -168,7 +164,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def attribute_updated(
         self, cluster: zigpy.typing.ClusterType, attrid: int, value: Any
     ) -> None:
-        if cluster.endpoint.device.is_initialized:
+        if not cluster.endpoint.device.is_initialized:
             return
 
         self.enqueue(
@@ -506,7 +502,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._load_group_members()
         await self._load_relays()
         await self._load_neighbors()
-        await self._cleanup()
         await self._finish_loading()
 
     async def _load_attributes(self, filter: str = None) -> None:
@@ -545,9 +540,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
     async def _load_devices(self) -> None:
         async with self.execute("SELECT * FROM devices") as cursor:
-            async for (ieee, nwk, status) in cursor:
+            async for (ieee, nwk, _) in cursor:
                 dev = self._application.add_device(ieee, nwk)
-                dev.status = status
+                dev.status = zigpy.device.Status.ENDPOINTS_INIT  # DB status is ignored
 
     async def _load_node_descriptors(self) -> None:
         async with self.execute("SELECT * FROM node_descriptors_v4") as cursor:
@@ -614,27 +609,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         for dev in self._application.devices.values():
             dev.add_context_listener(self)
             dev.neighbors.add_context_listener(self)
-
-    async def _cleanup(self) -> None:
-        """Validate and clean-up devices."""
-
-        # remove devices without any endpoints
-        devices_to_remove = []
-        for device in self._application.devices.values():
-            if device.nwk == 0x0000:
-                continue
-            if {ep_id for ep_id in device.endpoints if ep_id != 0x00}:
-                continue
-            # if device has no endpoints but ZDO, then remove this device
-            devices_to_remove.append(device)
-
-        if not devices_to_remove:
-            return
-
-        # remove devices from ControllerApplication
-        for device in devices_to_remove:
-            self._application.devices.pop(device.ieee)
-            await self._remove_device(device)
 
     async def _run_migrations(self):
         async with self._db.execute("PRAGMA user_version") as cursor:

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -415,7 +415,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             return
 
         await self._save_endpoints(device)
-        for ep in device._non_zdo_endpoints:
+        for ep in device.non_zdo_endpoints:
             await self._save_input_clusters(ep)
             await self._save_attribute_cache(ep)
             await self._save_output_clusters(ep)
@@ -424,7 +424,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     async def _save_endpoints(self, device: zigpy.typing.DeviceType) -> None:
         q = "INSERT OR REPLACE INTO endpoints VALUES (?, ?, ?, ?, ?)"
         endpoints = []
-        for ep in device._non_zdo_endpoints:
+        for ep in device.non_zdo_endpoints:
             device_type = getattr(ep, "device_type", None)
             eprow = (
                 device.ieee,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -157,6 +157,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         if not dev:
             LOGGER.debug("Device not found for removal: %s", ieee)
             return
+
+        dev.cancel_initialization()
+
         LOGGER.info("Removing device 0x%04x (%s)", dev.nwk, ieee)
         asyncio.create_task(self._remove_device(dev))
         if dev.node_desc.is_valid and dev.node_desc.is_end_device:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -213,6 +213,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         )
 
         if not sender.is_initialized:
+            if not sender.initializing:
+                sender.schedule_initialize()
+
             if not sender.has_node_descriptor and dst_ep != 0:
                 # only allow ZDO responses while initializing device
                 LOGGER.debug(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -252,14 +252,13 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """
 
         ieee = t.EUI64(ieee)
-        LOGGER.info("Device 0x%04x (%s) joined the network", nwk, ieee)
 
         try:
             dev = self.get_device(ieee)
-            LOGGER.debug("Device already exists")
+            LOGGER.info("Device 0x%04x (%s) joined the network", nwk, ieee)
         except KeyError:
-            LOGGER.debug("Device is unknown, creating a new one")
             dev = self.add_device(ieee, nwk)
+            LOGGER.info("New device 0x%04x (%s) joined the network", nwk, ieee)
 
         if dev.nwk != nwk:
             dev.nwk = nwk

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -79,7 +79,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             await app.pre_shutdown()
             raise
 
-        # Re-initialize partially-initialized devices
         for device in app.devices.values():
             if not device.is_initialized:
                 LOGGER.warning("Device is partially initialized: %s", device)
@@ -212,7 +211,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.listener_event(
             "handle_message", sender, profile, cluster, src_ep, dst_ep, message
         )
-        if sender.is_partially_initialized:
+
+        if not sender.is_initialized:
             if not sender.has_node_descriptor and dst_ep != 0:
                 # only allow ZDO responses while initializing device
                 LOGGER.debug(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -293,9 +293,11 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         if new_join:
             self.listener_event("device_joined", dev)
             dev.schedule_initialize()
-
-        # Rescan groups for devices that are already initialized
-        if dev.is_initialized:
+        elif not dev.is_initialized:
+            # Re-initialize partially-initialized devices but don't emit "device_joined"
+            dev.schedule_initialize()
+        else:
+            # Rescan groups for devices that are not newly joining and initialized
             dev.schedule_group_membership_scan()
 
     def handle_leave(self, nwk, ieee):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -83,7 +83,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         for device in app.devices.values():
             if device.is_partially_initialized:
                 LOGGER.warning("Device is partially initialized: %s", device)
-                device.schedule_initialize()
 
         return app
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -279,17 +279,20 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         try:
             dev = self.get_device(ieee)
             LOGGER.info("Device 0x%04x (%s) joined the network", nwk, ieee)
+            new_join = False
         except KeyError:
             dev = self.add_device(ieee, nwk)
             LOGGER.info("New device 0x%04x (%s) joined the network", nwk, ieee)
+            new_join = True
 
         if dev.nwk != nwk:
             dev.nwk = nwk
             LOGGER.debug("Device %s changed id (0x%04x => 0x%04x)", ieee, dev.nwk, nwk)
+            new_join = True
 
-        self.listener_event("device_joined", dev)
-
-        dev.schedule_initialize()
+        if new_join:
+            self.listener_event("device_joined", dev)
+            dev.schedule_initialize()
 
         # Rescan groups for devices that are already initialized
         if dev.is_initialized:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -318,10 +318,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     ):
         self.last_seen = time.time()
 
-        if not self.is_initialized and not self.initializing:
-            self.warning("Received a message from an uninitialized device")
-            self.schedule_initialize()
-
         try:
             hdr, args = self.deserialize(src_ep, cluster, message)
         except ValueError as e:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -71,7 +71,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.status = Status.NEW
 
     @property
-    def _non_zdo_endpoints(self):
+    def non_zdo_endpoints(self):
         return [ep for epid, ep in self.endpoints.items() if epid != 0]
 
     @property
@@ -79,13 +79,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return self.node_desc is not None and self.node_desc.is_valid
 
     @property
-    def did_zdo_init(self) -> bool:
-        return bool(self._non_zdo_endpoints)
+    def has_non_zdo_endpoints(self) -> bool:
+        return bool(self.non_zdo_endpoints)
 
     @property
     def all_endpoints_init(self) -> bool:
-        return self.did_zdo_init and all(
-            ep.status != zigpy.endpoint.Status.NEW for ep in self._non_zdo_endpoints
+        return self.has_non_zdo_endpoints and all(
+            ep.status != zigpy.endpoint.Status.NEW for ep in self.non_zdo_endpoints
         )
 
     @property
@@ -103,7 +103,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     async def group_membership_scan(self) -> None:
         """Sync up group membership."""
-        for ep in self._non_zdo_endpoints:
+        for ep in self.non_zdo_endpoints:
             await ep.group_membership_scan()
 
     @property
@@ -178,7 +178,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             await self.get_node_descriptor()
 
         # Devices should have endpoints other than ZDO
-        if self.did_zdo_init:
+        if self.has_non_zdo_endpoints:
             self.info("Already have endpoints: %s", self.endpoints)
         else:
             self.info("Discovering endpoints")
@@ -203,7 +203,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         if self.all_endpoints_init:
             self.info("All endpoints are already initialized")
         else:
-            for ep in self._non_zdo_endpoints:
+            for ep in self.non_zdo_endpoints:
                 if ep.status != zigpy.endpoint.Status.NEW:
                     continue
 
@@ -227,11 +227,11 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return ep
 
     async def add_to_group(self, grp_id: int, name: str = None):
-        for ep in self._non_zdo_endpoints:
+        for ep in self.non_zdo_endpoints:
             await ep.add_to_group(grp_id, name)
 
     async def remove_from_group(self, grp_id: int):
-        for ep in self._non_zdo_endpoints:
+        for ep in self.non_zdo_endpoints:
             await ep.remove_from_group(grp_id)
 
     async def request(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -138,6 +138,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         return node_desc
 
+    @zigpy.util.retryable(
+        (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException), tries=3, delay=0.5
+    )
     async def _initialize(self):
         """
         Discover all basic information about a device.

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -166,7 +166,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 )
 
             self.application.listener_event("device_init_failure", self)
-            await self.application.remove(self.ieee)
 
     @zigpy.util.retryable(
         (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException), tries=3, delay=0.5

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -174,8 +174,6 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         for names in (["manufacturer", "model"], ["manufacturer"], ["model"]):
             success, failure = await self.basic.read_attributes(names, allow_cache=True)
 
-            LOGGER.warning("%s %s", success, failure)
-
             if "model" in success:
                 self._model = success["model"]
 

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -50,9 +50,6 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._model = None
 
     async def initialize(self):
-        if self.status != Status.NEW:
-            return self._model, self._manufacturer
-
         self.info("Discovering endpoint information")
 
         if self.profile_id is not None or self.status == Status.ENDPOINT_INACTIVE:

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -16,3 +16,7 @@ class APIException(ZigbeeException):
 
 class DeliveryError(ZigbeeException):
     """Message delivery failed in some way"""
+
+
+class InvalidResponse(ZigbeeException):
+    """A ZDO or ZCL response has an unsuccessful status code"""


### PR DESCRIPTION
This is a continuation of the discussion started with https://github.com/zigpy/zigpy/pull/711#issuecomment-843597383 and my attempt at implementing some of the changes.

It's currently a WIP and no unit tests have been updated. That being said, IKEA remotes and bulbs feel like they join much more quickly.

Changes:
 - No errors are caught during device initialization, the whole process has to work.
 - Device initialization is cancelled and re-started every time a device joins or announces itself.
   - Initialization more or less starts where it left off after every restart and can safely be called on already-initialized devices, in case they have no node descriptor or are missing some sort of information. This is done at startup and after any message is received from a partially-initialized device.
 - A new `status_changed` device event that's sent after each stage during initialization. Could be used for more ZHA progress.
 - NWK changes are explicitly saved to the database in a new event.

TODO:
 - Some sort of event to signal that initialization has failed. That way, the user will know that the device needs to be re-joined (maybe with a message telling them to keep the device awake if it's a sensor).
 - See if delaying requests until after the device announces itself (or a few seconds have elapsed since the TC indication) is a better approach.