### PR TITLE
Add context to the "Discarded Event" warning

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -121,9 +121,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def enqueue(self, cb_name: str, *args) -> None:
         """Enqueue an async callback handler action."""
         if not self.running:
-            LOGGER.warning(
-                "Discarding %s event", cb_name
-            )
+            LOGGER.warning("Discarding %s event", cb_name)
             return
         self._callback_handlers.put_nowait((cb_name, args))
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -122,7 +122,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         """Enqueue an async callback handler action."""
         if not self.running:
             LOGGER.warning(
-                "Discarding %s event",
+                "Discarding %s event", cb_name
             )
             return
         self._callback_handlers.put_nowait((cb_name, args))


### PR DESCRIPTION
The `Discarding %s event` warning is logged with the `%s` left as is, instead of replacing the expected context of which event is being discarded.