### PR TITLE
Detect logging with bad format strings during unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import logging
+
+import pytest
+
+
+class FailOnBadFormattingHandler(logging.Handler):
+    def emit(self, record):
+        try:
+            record.msg % record.args
+        except Exception as e:
+            pytest.fail(
+                f"Failed to format log message {record.msg!r} with {record.args!r}: {e}"
+            )
+
+
+@pytest.fixture(autouse=True)
+def raise_on_bad_log_formatting():
+    handler = FailOnBadFormattingHandler()
+
+    root = logging.getLogger()
+    root.addHandler(handler)
+
+    try:
+        yield
+    finally:
+        root.removeHandler(handler)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -495,7 +495,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._db.commit()
 
     async def load(self) -> None:
-        LOGGER.debug("Loading application state from %s")
+        LOGGER.debug("Loading application state")
         await self._load_devices()
         await self._load_node_descriptors()
         await self._load_endpoints()


### PR DESCRIPTION
Causes unit tests to fail if a logging formatting string is invalid (#745).