### PR TITLE
Handle stray database rows without crashing

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import sqlite3
 
 import pytest
 
@@ -678,3 +679,45 @@ async def test_appdb_worker_exception(save_mock, tmpdir):
         db_listener.raw_device_initialized(dev_1)
     await db_listener.shutdown()
     assert save_mock.await_count == 3
+
+
+async def test_stray_rows(tmpdir, caplog):
+    db = os.path.join(str(tmpdir), "test.db")
+    app = await make_app(db)
+    await app.pre_shutdown()
+
+    with sqlite3.connect(db) as conn:
+        cur = conn.cursor()
+
+        # All these rows exist without a `device`
+        ieee = "'90:fd:9f:ff:fe:61:64:ab'"
+        cur.execute(f"INSERT INTO endpoints VALUES({ieee},1,260,266,1);")
+        cur.execute(f"INSERT INTO clusters VALUES({ieee},1,0);")
+        cur.execute(f"INSERT INTO output_clusters VALUES({ieee},1,10);")
+        cur.execute(f"INSERT INTO attributes VALUES({ieee},1,0,5,'SP 224');")
+        cur.execute(f"INSERT INTO relays VALUES({ieee},X'01f2fb');")
+        cur.execute(
+            f"INSERT INTO node_descriptors_v4"
+            f" VALUES({ieee},1,0,0,0,0,8,142,4454,82,82,11264,82,0);"
+        )
+        cur.execute(
+            f"INSERT INTO neighbors_v4"
+            f" VALUES({ieee},'8d:b4:1f:73:e7:35:93:1b',"
+            f"'00:0d:6f:00:0a:ff:73:23',0,0,1,2,0,2,0,0,144);"
+        )
+        conn.commit()
+
+    app2 = await make_app(db)
+    assert not app2.devices
+    await app2.pre_shutdown()
+
+    for table in (
+        "endpoints",
+        "clusters",
+        "output_clusters",
+        "attributes",
+        "relays",
+        "node_descriptors_v4",
+        "neighbors_v4",
+    ):
+        assert f"Skipping invalid {table}" in caplog.text

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -696,6 +696,7 @@ async def test_stray_rows(tmpdir, caplog):
         cur.execute(f"INSERT INTO output_clusters VALUES({ieee},1,10);")
         cur.execute(f"INSERT INTO attributes VALUES({ieee},1,0,5,'SP 224');")
         cur.execute(f"INSERT INTO relays VALUES({ieee},X'01f2fb');")
+        cur.execute(f"INSERT INTO group_members VALUES(123,{ieee},456);")
         cur.execute(
             f"INSERT INTO node_descriptors_v4"
             f" VALUES({ieee},1,0,0,0,0,8,142,4454,82,82,11264,82,0);"

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -520,7 +520,15 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             query = "SELECT * FROM attributes"
         async with self.execute(query) as cursor:
             async for (ieee, endpoint_id, cluster, attrid, value) in cursor:
-                dev = self._application.get_device(ieee)
+                try:
+                    dev = self._application.get_device(ieee)
+                except KeyError:
+                    LOGGER.warning(
+                        "Skipping invalid attributes row: %r",
+                        (ieee, endpoint_id, cluster, attrid, value),
+                    )
+                    continue
+
                 if endpoint_id in dev.endpoints:
                     ep = dev.endpoints[endpoint_id]
                     if cluster in ep.in_clusters:
@@ -556,14 +564,30 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     async def _load_node_descriptors(self) -> None:
         async with self.execute("SELECT * FROM node_descriptors_v4") as cursor:
             async for (ieee, *fields) in cursor:
-                dev = self._application.get_device(ieee)
+                try:
+                    dev = self._application.get_device(ieee)
+                except KeyError:
+                    LOGGER.warning(
+                        "Skipping invalid node_descriptors_v4 row: %r",
+                        (ieee,) + tuple(fields),
+                    )
+                    continue
+
                 dev.node_desc = zdo_t.NodeDescriptor(*fields)
                 assert dev.node_desc.is_valid
 
     async def _load_endpoints(self) -> None:
         async with self.execute("SELECT * FROM endpoints") as cursor:
             async for (ieee, epid, profile_id, device_type, status) in cursor:
-                dev = self._application.get_device(ieee)
+                try:
+                    dev = self._application.get_device(ieee)
+                except KeyError:
+                    LOGGER.warning(
+                        "Skipping invalid endpoints row: %r",
+                        (ieee, epid, profile_id, device_type, status),
+                    )
+                    continue
+
                 ep = dev.add_endpoint(epid)
                 ep.profile_id = profile_id
                 ep.device_type = device_type
@@ -576,13 +600,29 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     async def _load_clusters(self) -> None:
         async with self.execute("SELECT * FROM clusters") as cursor:
             async for (ieee, endpoint_id, cluster) in cursor:
-                dev = self._application.get_device(ieee)
+                try:
+                    dev = self._application.get_device(ieee)
+                except KeyError:
+                    LOGGER.warning(
+                        "Skipping invalid clusters row: %r",
+                        (ieee, endpoint_id, cluster),
+                    )
+                    continue
+
                 ep = dev.endpoints[endpoint_id]
                 ep.add_input_cluster(cluster)
 
         async with self.execute("SELECT * FROM output_clusters") as cursor:
             async for (ieee, endpoint_id, cluster) in cursor:
-                dev = self._application.get_device(ieee)
+                try:
+                    dev = self._application.get_device(ieee)
+                except KeyError:
+                    LOGGER.warning(
+                        "Skipping invalid output_clusters row: %r",
+                        (ieee, endpoint_id, cluster),
+                    )
+                    continue
+
                 ep = dev.endpoints[endpoint_id]
                 ep.add_output_cluster(cluster)
 
@@ -594,22 +634,40 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     async def _load_group_members(self) -> None:
         async with self.execute("SELECT * FROM group_members") as cursor:
             async for (group_id, ieee, ep_id) in cursor:
-                group = self._application.groups[group_id]
-                group.add_member(
-                    self._application.get_device(ieee).endpoints[ep_id],
-                    suppress_event=True,
-                )
+                try:
+                    group = self._application.groups[group_id]
+                    dev = self._application.get_device(ieee)
+                except KeyError:
+                    LOGGER.warning(
+                        "Skipping invalid group_members row: %r",
+                        (group_id, ieee, ep_id),
+                    )
+                    continue
+
+                group.add_member(dev.endpoints[ep_id], suppress_event=True)
 
     async def _load_relays(self) -> None:
         async with self.execute("SELECT * FROM relays") as cursor:
             async for (ieee, value) in cursor:
-                dev = self._application.get_device(ieee)
+                try:
+                    dev = self._application.get_device(ieee)
+                except KeyError:
+                    LOGGER.warning("Skipping invalid relays row: %r", (ieee, value))
+                    continue
+
                 dev.relays = t.Relays.deserialize(value)[0]
 
     async def _load_neighbors(self) -> None:
         async with self.execute("SELECT * FROM neighbors_v4") as cursor:
             async for ieee, *fields in cursor:
-                dev = self._application.get_device(ieee)
+                try:
+                    dev = self._application.get_device(ieee)
+                except KeyError:
+                    LOGGER.warning(
+                        "Skipping invalid neighbors_v4 row: %r", (ieee,) + tuple(fields)
+                    )
+                    continue
+
                 neighbor = zdo_t.Neighbor(*fields)
                 assert neighbor.is_valid
                 dev.neighbors.add_neighbor(neighbor)


### PR DESCRIPTION
Zigpy currently fails to start up if the database contains stray rows, which somehow happens with various user databases. Since #711 is going to take a bit more time to merge, it seems simpler to just temporarily fix this problem in time for the next release.