### PR TITLE
Fix direct `Cluster` instances causing errors in `Endpoint.__repr__`

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -480,3 +480,27 @@ def test_endpoint_manufacturer_id(ep):
     """Test manufacturer id."""
     ep.device.manufacturer_id = sentinel.manufacturer_id
     assert ep.manufacturer_id is sentinel.manufacturer_id
+
+
+def test_endpoint_repr(ep):
+    ep.status = endpoint.Status.ZDO_INIT
+
+    # All standard
+    ep.add_input_cluster(0x0001)
+    ep.add_input_cluster(0x0002)
+
+    ep.add_output_cluster(0x0006)
+    ep.add_output_cluster(0x0008)
+
+    # Spec-violating but still happens (https://github.com/zigpy/zigpy/issues/758)
+    ep.add_input_cluster(0xEF00)
+
+    assert "ZDO_INIT" in repr(ep)
+
+    assert "power:0x0001" in repr(ep)
+    assert "device_temperature:0x0002" in repr(ep)
+
+    assert "on_off:0x0006" in repr(ep)
+    assert "level:0x0008" in repr(ep)
+
+    assert "0xEF00" in repr(ep)

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -316,6 +316,6 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             f" id={self.endpoint_id}"
             f" in=[{cluster_repr(self.in_clusters.values())}]"
             f" out=[{cluster_repr(self.out_clusters.values())}]"
-            f" status={self.status}"
+            f" status={self.status!r}"
             f">"
         )

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -62,6 +62,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
     _client_commands_idx: Dict[str, int] = {}
     attridx: Dict[str, int]
     attributes: Dict[int, Tuple[str, Callable]] = {}
+    ep_attribute: str = None
     client_commands: Dict[int, Tuple[str, Tuple, bool]] = {}
     server_commands: Dict[int, Tuple[str, Tuple, bool]] = {}
 


### PR DESCRIPTION
Zigpy allows for `Cluster` itself to be initialized (not a subclass!), whose instances don't have a `ep_attribute` attribute, causing this error (only when debug logging is enabled?).