### PR TITLE
Ignore all GBL image padding

### DIFF
--- a/tests/test_ota_validators.py
+++ b/tests/test_ota_validators.py
@@ -122,17 +122,10 @@ def test_parse_silabs_gbl():
     assert tag2 == (b"BBBB", b"foo" * 20)
     assert checksum[0] == b"\xFC\x04\x04\xFC" and len(checksum[1]) == 4
 
-    # No padding is allowed
-    with pytest.raises(ValidationError):
-        list(validators.parse_silabs_gbl(image + b"\xFF"))
-
-    # Unless the padding is entirely null bytes
+    # Arbitrary padding is allowed
     parsed_image = [header, tag1, tag2, checksum]
     assert list(validators.parse_silabs_gbl(image + b"\x00")) == parsed_image
-    assert list(validators.parse_silabs_gbl(image + b"\x00" * 10)) == parsed_image
-
-    with pytest.raises(ValidationError):
-        list(validators.parse_silabs_gbl(image + b"\x00\x01\x00"))
+    assert list(validators.parse_silabs_gbl(image + b"\xAB\xCD\xEF")) == parsed_image
 
     # Normal truncated images are detected
     with pytest.raises(ValidationError):

--- a/zigpy/ota/validators.py
+++ b/zigpy/ota/validators.py
@@ -96,11 +96,7 @@ def parse_silabs_gbl(data: bytes) -> typing.Iterable[typing.Tuple[bytes, bytes]]
         if tag != b"\xFC\x04\x04\xFC":
             continue
 
-        # GBL images aren't expected to contain padding but Hue images are padded with
-        # null bytes
-        if data.strip(b"\x00"):
-            raise ValidationError("Image padding contains invalid bytes")
-
+        # GBL images aren't expected to contain padding but some are (i.e. Hue)
         unpadded_image = orig_data[: -len(data)] if data else orig_data
         computed_crc = zlib.crc32(unpadded_image)
 


### PR DESCRIPTION
GBL images are not supposed to have trailing padding. I was only aware of Hue images that had `\x00` padding but apparently other images exist with `\xFF` padding. If an image is structurally sound and its CRC is valid, it should be accepted.