### PR TITLE
Re-migrate V4 database which was forcibly downgraded to v3

### DIFF
--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -28,7 +28,7 @@ def test_db_v3(tmpdir):
 
 
 @pytest.fixture
-async def test_db_v4_downgraded_to_v3(test_db_v3):
+async def test_db_v4_downgraded_to_v3(test_db_v3, loop):
     """V4 database forcibly downgraded to v3."""
 
     app = await make_app(test_db_v3)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -674,6 +674,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         # Version 4 introduced migrations and expanded tables
         if db_version < 4:
             await self.execute("BEGIN TRANSACTION")
+            await self.execute("DROP TABLE IF EXISTS node_descriptors_v4")
+            await self.execute("DROP TABLE IF EXISTS neighbors_v4")
+            await self._create_table_node_descriptors()
+            await self._create_table_neighbors()
             await self.execute("PRAGMA user_version = 4")
 
             async with self.execute("SELECT * FROM node_descriptors") as cur:


### PR DESCRIPTION
Drop existing v4 tables and re-migrate from v3 schema if user downgraded zigpy and then upgraded again.

Fixes https://github.com/home-assistant/core/issues/52394