### PR TITLE
Make `Device.node_desc` start off as `None` instead of being empty

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -578,7 +578,7 @@ async def test_invalid_node_desc(tmpdir):
     app.handle_join(nwk_1, ieee_1, 0)
 
     dev_1 = app.get_device(ieee_1)
-    dev_1.node_desc = zdo_t.NodeDescriptor()
+    dev_1.node_desc = None
     ep = dev_1.add_endpoint(1)
     ep.status = zigpy.endpoint.Status.ZDO_INIT
     app.device_initialized(dev_1)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -381,14 +381,10 @@ def test_handle_message(app, ieee):
 
 
 @patch("zigpy.device.Device.is_initialized", new_callable=PropertyMock)
-@patch("zigpy.device.Device.has_node_descriptor", new_callable=PropertyMock)
 @patch("zigpy.quirks.handle_message_from_uninitialized_sender", new=MagicMock())
-async def test_handle_message_uninitialized_dev(
-    has_node_desc_mock, is_init_mock, app, ieee
-):
+async def test_handle_message_uninitialized_dev(is_init_mock, app, ieee):
     dev = app.add_device(ieee, 0x1234)
     dev.handle_message = MagicMock()
-    has_node_desc_mock.return_value = False
     is_init_mock.return_value = False
 
     assert not dev.initializing

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -338,5 +338,5 @@ def test_device_manufacture_id_override(dev):
     dev.manufacturer_id_override = 2345
     assert dev.manufacturer_id == 2345
 
-    dev.node_desc = zdo_t.NodeDescriptor()
+    dev.node_desc = None
     assert dev.manufacturer_id == 2345

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -401,7 +401,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             q = "UPDATE devices SET nwk=?, status=? WHERE ieee=?"
             await self.execute(q, (device.nwk, device.status, device.ieee))
 
-        if device.has_node_descriptor:
+        if device.node_desc is not None:
             await self._save_node_descriptor(device)
 
         if isinstance(device, zigpy.quirks.CustomDevice):

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -61,7 +61,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._listeners = {}
         self._manufacturer = None
         self._model = None
-        self.node_desc = zdo.types.NodeDescriptor()
+        self.node_desc = None
         self.neighbors = zigpy.neighbor.Neighbors(self)
         self._pending = zigpy.util.Requests()
         self._relays = None
@@ -75,10 +75,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return [ep for epid, ep in self.endpoints.items() if epid != 0]
 
     @property
-    def has_node_descriptor(self) -> bool:
-        return self.node_desc is not None and self.node_desc.is_valid
-
-    @property
     def has_non_zdo_endpoints(self) -> bool:
         return bool(self.non_zdo_endpoints)
 
@@ -90,7 +86,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     @property
     def is_initialized(self) -> bool:
-        return self.has_node_descriptor and self.all_endpoints_init
+        return self.node_desc is not None and self.all_endpoints_init
 
     def schedule_group_membership_scan(self) -> asyncio.Task:
         """Rescan device group's membership."""
@@ -174,7 +170,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         """
 
         # Some devices are improperly initialized and are missing a node descriptor
-        if not self.has_node_descriptor:
+        if self.node_desc is None:
             await self.get_node_descriptor()
 
         # Devices should have endpoints other than ZDO
@@ -262,7 +258,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         timeout=APS_REPLY_TIMEOUT,
         use_ieee=False,
     ):
-        if expect_reply and self.node_desc.is_end_device in (True, None):
+        if expect_reply and (self.node_desc is None or self.node_desc.is_end_device):
             self.debug("Extending timeout for 0x%02x request", sequence)
             timeout = APS_REPLY_TIMEOUT_EXTENDED
         with self._pending.new(sequence) as req:
@@ -400,7 +396,12 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     @property
     def manufacturer_id(self) -> Optional[int]:
         """Return manufacturer id."""
-        return self.manufacturer_id_override or self.node_desc.manufacturer_code
+        if self.manufacturer_id_override:
+            return self.manufacturer_id_override
+        elif self.node_desc is not None:
+            return self.node_desc.manufacturer_code
+        else:
+            return None
 
     @property
     def model(self):


### PR DESCRIPTION
Fixes the broken ZHA visualization in https://github.com/home-assistant/core/issues/53132

The improved device initialization PR (#744) switched away from empty `NodeDescriptor` objects in favor of `None` but `Device.__init__` did not actually set `device.node_desc = None`. The Home Assistant PR to update ZHA to support this behavior (https://github.com/home-assistant/core/pull/52610) unfortunately relied on `node_desc` being `None` and this inconsistently is causing problems.