### PR TITLE
Add ZCL7 start up attributes to `OnOff` and `LevelControl` clusters

### DIFF
--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -386,6 +386,12 @@ class OnOff(Cluster):
     """Attributes and commands for switching devices between
     ‘On’ and ‘Off’ states."""
 
+    class StartUpOnOff(t.enum8):
+        Off = 0x00
+        On = 0x01
+        Toggle = 0x02
+        PreviousValue = 0xFF
+
     cluster_id = 0x0006
     name = "On/Off"
     ep_attribute = "on_off"
@@ -394,6 +400,7 @@ class OnOff(Cluster):
         0x4000: ("global_scene_control", t.Bool),
         0x4001: ("on_time", t.uint16_t),
         0x4002: ("off_wait_time", t.uint16_t),
+        0x4003: ("start_up_on_off", StartUpOnOff),
     }
     server_commands = {
         0x0000: ("off", (), False),
@@ -427,6 +434,10 @@ class LevelControl(Cluster):
     """Attributes and commands for controlling devices that
     can be set to a level between fully ‘On’ and fully ‘Off’."""
 
+    class StartUpCurrentLevel(t.enum8):
+        Minimum = 0x00
+        PreviousValue = 0xFF
+
     cluster_id = 0x0008
     name = "Level control"
     ep_attribute = "level"
@@ -438,6 +449,7 @@ class LevelControl(Cluster):
         0x0012: ("on_transition_time", t.uint16_t),
         0x0013: ("off_transition_time", t.uint16_t),
         0x0014: ("default_move_rate", t.uint8_t),
+        0x4000: ("start_up_current_level", StartUpCurrentLevel),
     }
     server_commands = {
         0x0000: ("move_to_level", (t.uint8_t, t.uint16_t), False),


### PR DESCRIPTION
Not sure if we need a new type for "integers with special values", like `StartUpCurrentLevel`:

 - `0x00` is the minimum
 - `0xFF` is the previous value
 - every other value is handled normally

