### PR TITLE
Update typing for the probe method

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -528,5 +528,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    async def probe(cls, device_config: dict[str, Any]) -> bool:
+    async def probe(
+        cls, device_config: dict[str, Any]
+    ) -> bool | dict[str, int | str | bool]:
         """API/Port probe method."""


### PR DESCRIPTION
Allow probe method to return `zigpy.config.SCHEMA_DEVICE` dict, which contains auto detected radio settings.
For example, this could allow radio to autodetect port baudrate.