### PR TITLE
Fix `None` node descriptor issues with device removal and the topology scanner

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -161,7 +161,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         LOGGER.info("Removing device 0x%04x (%s)", dev.nwk, ieee)
         asyncio.create_task(self._remove_device(dev))
-        if dev.node_desc.is_valid and dev.node_desc.is_end_device:
+        if dev.node_desc is not None and dev.node_desc.is_end_device:
             parents = [
                 parent
                 for parent in self.devices.values()
@@ -182,7 +182,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Send a remove request then pop the device."""
         try:
             await asyncio.wait_for(
-                device.zdo.leave(), timeout=30 if device.node_desc.is_end_device else 7
+                device.zdo.leave(),
+                timeout=30
+                if device.node_desc is not None and device.node_desc.is_end_device
+                else 7,
             )
         except (zigpy.exceptions.DeliveryError, asyncio.TimeoutError) as ex:
             LOGGER.debug("Sending 'zdo_leave_req' failed: %s", ex)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -452,7 +452,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             signature[SIG_MANUFACTURER] = self.manufacturer
         if self._model is not None:
             signature[SIG_MODEL] = self._model
-        if self.node_desc.is_valid:
+        if self.node_desc is not None:
             signature[SIG_NODE_DESC] = self.node_desc.as_dict()
 
         for endpoint_id, endpoint in self.endpoints.items():

--- a/zigpy/topology.py
+++ b/zigpy/topology.py
@@ -68,7 +68,9 @@ class Topology(zigpy.util.ListenableMixin):
         """Scan topology."""
 
         devices_to_scan = [
-            dev for dev in self._app.devices.values() if not dev.node_desc.is_end_device
+            dev
+            for dev in self._app.devices.values()
+            if dev.node_desc is not None and not dev.node_desc.is_end_device
         ]
         for device in devices_to_scan:
             if (


### PR DESCRIPTION
I've looked over every reference to `Device.node_desc` in both zigpy and ZHA to hopefully make sure this is the last node descriptor bugfix PR.

Related PR: https://github.com/zigpy/zigpy-xbee/pull/119
HA issue: https://github.com/home-assistant/core/issues/53838#issuecomment-894806418