### PR TITLE
Added start_up_color_temperature/0x4010 (from ZCL v7)

### DIFF
--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -66,6 +66,7 @@ class Color(Cluster):
         0x400A: ("color_capabilities", t.bitmap16),
         0x400B: ("color_temp_physical_min", t.uint16_t),
         0x400C: ("color_temp_physical_max", t.uint16_t),
+        0x4010: ("start_up_color_temperature", t.uint16_t),
     }
     server_commands = {
         0x0000: (


### PR DESCRIPTION
Basically https://github.com/zigpy/zigpy/pull/774 just with ``start_up_color_temperature``

The goal is to remove all lighting related Philips Hue related quirks. (See https://github.com/zigpy/zha-device-handlers/pull/993)
The ``start_up_color_temperature`` (0x4010) attribute is spec in ZCL v7 and https://github.com/zigpy/zigpy/pull/716 would implement this. However, that (way bigger) PR still looks like it's WIP.

In the meantime, https://github.com/zigpy/zigpy/pull/774 was merged to implement ``start_up_on_off `` and ``start_up_current_level``.
This already make these custom Philips clusters redundant: https://github.com/zigpy/zha-device-handlers/blob/8c61c6da4e44906183a4d96e022e67f8c2ba005d/zhaquirks/philips/__init__.py#L93-L104)

The custom Philips color cluster is still needed until ``start_up_color_temperature`` is added to zigpy.
https://github.com/zigpy/zha-device-handlers/blob/8c61c6da4e44906183a4d96e022e67f8c2ba005d/zhaquirks/philips/__init__.py#L107-L111

Related comment: https://github.com/home-assistant/core/pull/54513#issuecomment-897842492
(Basically, newer Hue firmware changes the signatures of many lights and would need another quirk change. As these quirks are almost already redundant, this PR would make it possible to remove all lighting related Hue quirks from zha-device-handlers.)

Tested and working.