### PR TITLE
Keep track of unsupported attributes on a cluster

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -696,9 +696,9 @@ async def test_unsupported_attribute(tmpdir, dev_init):
     ep.device_type = profiles.zha.DeviceType.PUMP
     clus = ep.add_input_cluster(0)
     ep.add_output_cluster(1)
+    app.device_initialized(dev)
     clus.add_unsupported_attribute(4)
     clus.add_unsupported_attribute("model")
-    app.device_initialized(dev)
     await app.pre_shutdown()
 
     # Everything should've been saved - check that it re-loads

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -696,9 +696,11 @@ async def test_unsupported_attribute(tmpdir, dev_init):
     ep.device_type = profiles.zha.DeviceType.PUMP
     clus = ep.add_input_cluster(0)
     ep.add_output_cluster(1)
+    clus._update_attribute(4, "Custom")
+    clus._update_attribute(5, "Model")
     app.device_initialized(dev)
-    clus.add_unsupported_attribute(4)
-    clus.add_unsupported_attribute("model")
+    clus.add_unsupported_attribute(0x0010)
+    clus.add_unsupported_attribute("physical_env")
     await app.pre_shutdown()
 
     # Everything should've been saved - check that it re-loads
@@ -706,10 +708,10 @@ async def test_unsupported_attribute(tmpdir, dev_init):
     dev = app2.get_device(ieee)
     assert dev.is_initialized == dev_init
     assert dev.endpoints[3].device_type == profiles.zha.DeviceType.PUMP
-    assert 4 in dev.endpoints[3].in_clusters[0].unsupported_attributes
-    assert "manufacturer" in dev.endpoints[3].in_clusters[0].unsupported_attributes
-    assert 5 in dev.endpoints[3].in_clusters[0].unsupported_attributes
-    assert "model" in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    assert 0x0010 in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    assert "location_desc" in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    assert 0x0011 in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
 
     await app2.pre_shutdown()
     os.unlink(db)

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -449,3 +449,10 @@ async def test_v4_to_v6_migration_missing_endpoints(test_db, with_quirk_attribut
         assert dev.endpoints[123].in_clusters[456]._attr_cache[789] == "test"
 
     await app.pre_shutdown()
+
+
+async def test_v5_to_v7_migration(test_db):
+    test_db_v5 = test_db("simple_v5.sql")
+
+    app = await make_app(test_db_v5)
+    await app.pre_shutdown()

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -758,3 +758,33 @@ async def test_configure_reporting_multiple(cluster):
             cluster.endpoint.request.call_args_list[0][0][2]
             == cluster.endpoint.request.call_args_list[1][0][2]
         )
+
+
+def test_unsupported_attr_add(cluster):
+    """Test adding unsupported attributes."""
+
+    assert "manufacturer" not in cluster.unsupported_attributes
+    assert 4 not in cluster.unsupported_attributes
+    assert "model" not in cluster.unsupported_attributes
+    assert 5 not in cluster.unsupported_attributes
+
+    cluster.add_unsupported_attribute(4)
+    assert "manufacturer" in cluster.unsupported_attributes
+    assert 4 in cluster.unsupported_attributes
+
+    cluster.add_unsupported_attribute("model")
+    assert "model" in cluster.unsupported_attributes
+    assert 5 in cluster.unsupported_attributes
+
+
+def test_unsupported_attr_add_no_reverse_attr_name(cluster):
+    """Test adding unsupported attributes without corresponding reverse attr name."""
+
+    assert "no_such_attr" not in cluster.unsupported_attributes
+    assert 0xDEED not in cluster.unsupported_attributes
+
+    cluster.add_unsupported_attribute("no_such_attr")
+    assert "no_such_attr" in cluster.unsupported_attributes
+
+    cluster.add_unsupported_attribute(0xDEED)
+    assert 0xDEED in cluster.unsupported_attributes

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -260,7 +260,7 @@ async def test_read_attributes_uncached(cluster):
     assert failure[99] == 1
     assert {99, 0x0010} == failure.keys()
     assert success[199] == 199
-    assert cluster.unsupported_attributes == {0x0010}
+    assert cluster.unsupported_attributes == {0x0010, "location_desc"}
 
 
 async def test_read_attributes_cached(cluster):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -784,6 +784,7 @@ def test_unsupported_attr_add_no_reverse_attr_name(cluster):
     assert 0xDEED not in cluster.unsupported_attributes
 
     cluster.add_unsupported_attribute("no_such_attr")
+    cluster.add_unsupported_attribute("no_such_attr")
     assert "no_such_attr" in cluster.unsupported_attributes
 
     cluster.add_unsupported_attribute(0xDEED)

--- a/zigpy/appdb_schemas/schema_v6.sql
+++ b/zigpy/appdb_schemas/schema_v6.sql
@@ -178,3 +178,22 @@ CREATE TABLE relays_v6 (
 
 CREATE UNIQUE INDEX relays_idx_v6
     ON relays_v6(ieee);
+
+
+-- unsupported attributes
+DROP TABLE IF EXISTS unsupported_attributes_v6;
+CREATE TABLE unsupported_attributes_v6 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+    attrid INTEGER NOT NULL,
+
+    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
+    -- DB but whose values still need to be cached
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v6(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX unsupported_attributes_idx_v6
+    ON unsupported_attributes_v6(ieee, endpoint_id, cluster, attrid);

--- a/zigpy/appdb_schemas/schema_v6.sql
+++ b/zigpy/appdb_schemas/schema_v6.sql
@@ -178,22 +178,3 @@ CREATE TABLE relays_v6 (
 
 CREATE UNIQUE INDEX relays_idx_v6
     ON relays_v6(ieee);
-
-
--- unsupported attributes
-DROP TABLE IF EXISTS unsupported_attributes_v6;
-CREATE TABLE unsupported_attributes_v6 (
-    ieee ieee NOT NULL,
-    endpoint_id INTEGER NOT NULL,
-    cluster INTEGER NOT NULL,
-    attrid INTEGER NOT NULL,
-
-    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
-    -- DB but whose values still need to be cached
-    FOREIGN KEY(ieee)
-        REFERENCES devices_v6(ieee)
-        ON DELETE CASCADE
-);
-
-CREATE UNIQUE INDEX unsupported_attributes_idx_v6
-    ON unsupported_attributes_v6(ieee, endpoint_id, cluster, attrid);

--- a/zigpy/appdb_schemas/schema_v7.sql
+++ b/zigpy/appdb_schemas/schema_v7.sql
@@ -188,8 +188,6 @@ CREATE TABLE unsupported_attributes_v7 (
     cluster INTEGER NOT NULL,
     attrid INTEGER NOT NULL,
 
-    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
-    -- DB but whose values still need to be cached
     FOREIGN KEY(ieee)
         REFERENCES devices_v7(ieee)
         ON DELETE CASCADE,

--- a/zigpy/appdb_schemas/schema_v7.sql
+++ b/zigpy/appdb_schemas/schema_v7.sql
@@ -1,0 +1,202 @@
+PRAGMA user_version = 7;
+
+-- devices
+DROP TABLE IF EXISTS devices_v7;
+CREATE TABLE devices_v7 (
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    status INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX devices_idx_v7
+    ON devices_v7(ieee);
+
+
+-- endpoints
+DROP TABLE IF EXISTS endpoints_v7;
+CREATE TABLE endpoints_v7 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    profile_id INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v7(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX endpoint_idx_v7
+    ON endpoints_v7(ieee, endpoint_id);
+
+
+-- clusters
+DROP TABLE IF EXISTS in_clusters_v7;
+CREATE TABLE in_clusters_v7 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v7(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX in_clusters_idx_v7
+    ON in_clusters_v7(ieee, endpoint_id, cluster);
+
+
+-- neighbors
+DROP TABLE IF EXISTS neighbors_v7;
+CREATE TABLE neighbors_v7 (
+    device_ieee ieee NOT NULL,
+    extended_pan_id ieee NOT NULL,
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    rx_on_when_idle INTEGER NOT NULL,
+    relationship INTEGER NOT NULL,
+    reserved1 INTEGER NOT NULL,
+    permit_joining INTEGER NOT NULL,
+    reserved2 INTEGER NOT NULL,
+    depth INTEGER NOT NULL,
+    lqi INTEGER NOT NULL,
+
+    FOREIGN KEY(device_ieee)
+        REFERENCES devices_v7(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX neighbors_idx_v7
+    ON neighbors_v7(device_ieee);
+
+
+-- node descriptors
+DROP TABLE IF EXISTS node_descriptors_v7;
+CREATE TABLE node_descriptors_v7 (
+    ieee ieee NOT NULL,
+
+    logical_type INTEGER NOT NULL,
+    complex_descriptor_available INTEGER NOT NULL,
+    user_descriptor_available INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    aps_flags INTEGER NOT NULL,
+    frequency_band INTEGER NOT NULL,
+    mac_capability_flags INTEGER NOT NULL,
+    manufacturer_code INTEGER NOT NULL,
+    maximum_buffer_size INTEGER NOT NULL,
+    maximum_incoming_transfer_size INTEGER NOT NULL,
+    server_mask INTEGER NOT NULL,
+    maximum_outgoing_transfer_size INTEGER NOT NULL,
+    descriptor_capability_field INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v7(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX node_descriptors_idx_v7
+    ON node_descriptors_v7(ieee);
+
+
+-- output clusters
+DROP TABLE IF EXISTS out_clusters_v7;
+CREATE TABLE out_clusters_v7 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v7(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX out_clusters_idx_v7
+    ON out_clusters_v7(ieee, endpoint_id, cluster);
+
+
+-- attributes
+DROP TABLE IF EXISTS attributes_cache_v7;
+CREATE TABLE attributes_cache_v7 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+    attrid INTEGER NOT NULL,
+    value BLOB NOT NULL,
+
+    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
+    -- DB but whose values still need to be cached
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v7(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX attributes_idx_v7
+    ON attributes_cache_v7(ieee, endpoint_id, cluster, attrid);
+
+
+-- groups
+DROP TABLE IF EXISTS groups_v7;
+CREATE TABLE groups_v7 (
+    group_id INTEGER NOT NULL,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX groups_idx_v7
+    ON groups_v7(group_id);
+
+
+-- group members
+DROP TABLE IF EXISTS group_members_v7;
+CREATE TABLE group_members_v7 (
+    group_id INTEGER NOT NULL,
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+
+    FOREIGN KEY(group_id)
+        REFERENCES groups_v7(group_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v7(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX group_members_idx_v7
+    ON group_members_v7(group_id, ieee, endpoint_id);
+
+
+-- relays
+DROP TABLE IF EXISTS relays_v7;
+CREATE TABLE relays_v7 (
+    ieee ieee NOT NULL,
+    relays BLOB NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v7(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX relays_idx_v7
+    ON relays_v7(ieee);
+
+
+-- unsupported attributes
+DROP TABLE IF EXISTS unsupported_attributes_v7;
+CREATE TABLE unsupported_attributes_v7 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+    attrid INTEGER NOT NULL,
+
+    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
+    -- DB but whose values still need to be cached
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v7(ieee)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id, cluster)
+        REFERENCES in_clusters_v7(ieee, endpoint_id, cluster)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX unsupported_attributes_idx_v7
+    ON unsupported_attributes_v7(ieee, endpoint_id, cluster, attrid);

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -284,6 +284,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
             for idx, attribute in enumerate(attribute_ids):
                 if attribute in self._attr_cache:
                     success[attributes[idx]] = self._attr_cache[attribute]
+                elif attribute in self.unsupported_attributes:
+                    failure[attributes[idx]] = foundation.Status.UNSUPPORTED_ATTRIBUTE
                 else:
                     to_read.append(attribute)
         else:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -640,7 +640,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
             )
         )
 
-    def add_unsupported_attribute(self, attr: int | str) -> None:
+    def add_unsupported_attribute(
+        self, attr: int | str, inhibit_events: bool = False
+    ) -> None:
         """Adds unsupported attribute."""
 
         if attr in self.unsupported_attributes:
@@ -648,12 +650,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
 
         self.unsupported_attributes.add(attr)
         if isinstance(attr, int):
-            self.listener_event("unsupported_attribute_added", attr)
+            if not inhibit_events:
+                self.listener_event("unsupported_attribute_added", attr)
             reverse_attr = self.attributes.get(attr, (None,))[0]
         else:
             reverse_attr = self.attridx.get(attr)
-        if reverse_attr is not None:
-            self.add_unsupported_attribute(reverse_attr)
+        if not (reverse_attr is None or reverse_attr in self.unsupported_attributes):
+            self.add_unsupported_attribute(reverse_attr, inhibit_events)
 
 
 class ClusterPersistingListener:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -641,6 +641,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
 
         self.unsupported_attributes.add(attr)
         if isinstance(attr, int):
+            self.listener_event("unsupported_attribute_added", attr)
             reverse_attr = self.attributes.get(attr, (None,))[0]
         else:
             reverse_attr = self.attridx.get(attr)
@@ -661,6 +662,10 @@ class ClusterPersistingListener:
 
     def general_command(self, *args, **kwargs):
         pass
+
+    def unsupported_attribute_added(self, attrid: int) -> None:
+        """An unsupported attribute was added."""
+        self._applistener.unsupported_attribute_added(self._cluster, attrid)
 
 
 # Import to populate the registry

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -639,6 +639,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
     def add_unsupported_attribute(self, attr: int | str) -> None:
         """Adds unsupported attribute."""
 
+        if attr in self.unsupported_attributes:
+            return
+
         self.unsupported_attributes.add(attr)
         if isinstance(attr, int):
             self.listener_event("unsupported_attribute_added", attr)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import enum
 import functools
@@ -69,6 +71,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
     def __init__(self, endpoint: EndpointType, is_server: bool = True):
         self._endpoint: EndpointType = endpoint
         self._attr_cache: Dict[int, Any] = {}
+        self.unsupported_attributes: set[int | str] = set()
         self._listeners = {}
         if is_server:
             self._type: ClusterType = ClusterType.Server
@@ -632,6 +635,17 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
                 tsn=hdr.tsn,
             )
         )
+
+    def add_unsupported_attribute(self, attr: int | str) -> None:
+        """Adds unsupported attribute."""
+
+        self.unsupported_attributes.add(attr)
+        if isinstance(attr, int):
+            reverse_attr = self.attributes.get(attr, (None,))[0]
+        else:
+            reverse_attr = self.attridx.get(attr)
+        if reverse_attr is not None:
+            self.unsupported_attributes.add(reverse_attr)
 
 
 class ClusterPersistingListener:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -649,7 +649,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
         else:
             reverse_attr = self.attridx.get(attr)
         if reverse_attr is not None:
-            self.unsupported_attributes.add(reverse_attr)
+            self.add_unsupported_attribute(reverse_attr)
 
 
 class ClusterPersistingListener:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -319,7 +319,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
                     success[orig_attribute] = value
                 else:
                     if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
-                        self.unsupported_attributes.add(record.attrid)
+                        self.add_unsupported_attribute(record.attrid)
                     failure[orig_attribute] = record.status
 
         return success, failure

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -263,14 +263,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
 
     async def read_attributes(
         self,
-        attributes,
-        allow_cache=False,
-        only_cache=False,
-        manufacturer=None,
+        attributes: list[int | str],
+        allow_cache: bool = False,
+        only_cache: bool = False,
+        manufacturer: int | t.uint16_t | None = None,
     ):
         success, failure = {}, {}
-        attribute_ids = []
-        orig_attributes = {}
+        attribute_ids: list[int] = []
+        orig_attributes: dict[int, int | str] = {}
         for attribute in attributes:
             if isinstance(attribute, str):
                 attrid = self.attridx[attribute]
@@ -316,6 +316,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, metaclass=Registry):
                     self._update_attribute(record.attrid, value)
                     success[orig_attribute] = value
                 else:
+                    if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
+                        self.unsupported_attributes.add(record.attrid)
                     failure[orig_attribute] = record.status
 
         return success, failure


### PR DESCRIPTION
Keep track of unsupported attributes on a cluster. If for a `read_attributes` or `configure_attributes` requests, some of the attributes fail to be processed with a `UNSUPPORTED_ATTRIBUTE` ZCL status, then store this attributes. Next time, application can change its behavior based on what attributes are supported.
For example, if the "apparent power" attribute is not supported, then there's no need to create a sensor entity for this attribute.