### PR TITLE
Add a neighbor field in NetworkState object

### DIFF
--- a/zigpy/state.py
+++ b/zigpy/state.py
@@ -57,6 +57,7 @@ class NetworkInformation:
     network_key: Key | None = None
     tc_link_key: Key | None = None
     key_table: list[Key] | None = None
+    neighbor_table: list[NodeInfo] | None = None
 
     # Dict to keep track of stack-specific network stuff.
     # Z-Stack, for example, has a TCLK_SEED that should be backed up.
@@ -70,6 +71,8 @@ class NetworkInformation:
             self.key_table = []
         if self.stack_specific is None:
             self.stack_specific = {}
+        if self.neighbor_table is None:
+            self.neighbor_table = []
 
 
 @dataclass


### PR DESCRIPTION
An attempt was made to address https://github.com/zigpy/zigpy-znp/pull/85 comments

@puddly for visibility. Would something like this work for ZNP?