### PR TITLE
Implement `__repr__` and `convert` for the `KeyData` type

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -547,6 +547,19 @@ def test_eui64_convert():
     assert t.EUI64.convert(None) is None
 
 
+def test_keydata():
+    data = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
+    extra = b"extra"
+
+    key, rest = t.KeyData.deserialize(data + extra)
+    assert rest == extra
+    assert key == t.KeyData.convert("00:01:02:03:04:05:06:07:08:09:0a:0b:0c:0d:0e:0f")
+    assert repr(key) == "00:01:02:03:04:05:06:07:08:09:0a:0b:0c:0d:0e:0f"
+    assert list(key) == list(data)
+    assert key.serialize() == data
+    assert t.KeyData(key) == key
+
+
 def test_enum_uint():
     class TestBitmap(t.bitmap16):
         ALL = 0xFFFF

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -35,7 +35,14 @@ class EUI64(basic.FixedList, item_type=basic.uint8_t, length=8):
 
 
 class KeyData(basic.FixedList, item_type=basic.uint8_t, length=16):
-    pass
+    def __repr__(self):
+        return ":".join(f"{i:02x}" for i in self)
+
+    @classmethod
+    def convert(cls, key: str) -> KeyData:
+        key = [basic.uint8_t(p, base=16) for p in key.split(":")]
+        assert len(key) == cls._length
+        return cls(key)
 
 
 class Bool(basic.enum8):


### PR DESCRIPTION
Makes `KeyData` behave like `EUI64`.

Before:

```Python
Key(key=[91, 231, 111, 247, 2, 144, 217, 203, 87, 138, 85, 134, 119, 39, 1, 242], tx_counter=0, rx_counter=0, seq=0, partner_ieee=ff:ff:ff:ff:ff:ff:ff:ff)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

After:

```Python
Key(key=5b:e7:6f:f7:02:90:d9:cb:57:8a:55:86:77:27:01:f2, tx_counter=0, rx_counter=0, seq=0, partner_ieee=ff:ff:ff:ff:ff:ff:ff:ff)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```