### PR TITLE
Add Python 3.10 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2
@@ -271,7 +271,7 @@ jobs:
     needs: prepare-base
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
     name: >-
       Run tests Python ${{ matrix.python-version }}
     steps:


### PR DESCRIPTION
Zigpy unit tests pass for me on 3.10, no changes required.

Python 3.7 isn't supported by Home Assistant but we only really have to catch and re-raise `CancelledError` in a few places to "support" it so it's not that much extra work. Maybe we can remove it in the near future.
