### PR TITLE
`zigpy.state`: optionally keep track of NWK addresses and rename `neighbor_table` to `children`

### DIFF
--- a/zigpy/state.py
+++ b/zigpy/state.py
@@ -59,6 +59,9 @@ class NetworkInformation:
     key_table: list[Key] | None = None
     children: list[NodeInfo] | None = None
 
+    # If exposed by the stack, NWK addresses of other connected devices on the network
+    nwk_addresses: dict[t.EUI64, t.NWK] | None = None
+
     # Dict to keep track of stack-specific network stuff.
     # Z-Stack, for example, has a TCLK_SEED that should be backed up.
     stack_specific: dict[int | str, Any] | None = None
@@ -73,6 +76,8 @@ class NetworkInformation:
             self.stack_specific = {}
         if self.children is None:
             self.children = []
+        if self.nwk_addresses is None:
+            self.nwk_addresses = {}
 
 
 @dataclass


### PR DESCRIPTION
The discussions in https://github.com/zigpy/open-coordinator-backup/pull/8 and https://github.com/zigpy/zigpy/pull/798 have clarified a few misunderstandings I had about how devices are represented in Z-Stack's NVRAM.

I think these changes to `zigpy.state` will provide enough context to replicate the current Z-Stack backup data while also being flexible enough to work with bellows and the zigpy-deconz.

Once we get these compatible backups functional with at least one other stack, I would like to create a new `network_info` database table and periodically back up the network state to it, at least during network formation. This will allow users who don't have debug logging on 24/7 to re-form their original network in case that data is somehow lost.