### PR TITLE
SALUS devices are sometimes sold as Computime + LEDVANCE and OSRAM "SMART+" Zigbee devices are the same products

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Reference implementation of the zigpy library exist in **[Home Assistant](https:
 
 zigpy have code to automatically download and perform OTA (Over-The-Air) firmware updates of Zigbee devices if the OTA firmware image provider source URL for updates is known. The OTA update directory is optional and it can also be used for any offline firmware files that you provide yourself.
 
-Online OTA providers for firmware updates are currently only available for IKEA, LEDVANCE, and Salus/Computime devices. Support for OTA updates from other manufacturers could be added to zigpy in the future, if they publish their firmware images publicly.
+Online OTA providers for firmware updates are currently only available for IKEA, LEDVANCE, and SALUS/Computime devices. Support for OTA updates from other manufacturers could be added to zigpy in the future, if they publish their firmware images publicly.
 
 ## How to install and test, report bugs, or contribute to this project
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Reference implementation of the zigpy library exist in **[Home Assistant](https:
 
 zigpy have code to automatically download and perform OTA (Over-The-Air) firmware updates of Zigbee devices if the OTA firmware image provider source URL for updates is known. The OTA update directory is optional and it can also be used for any offline firmware files that you provide yourself.
 
-Online OTA providers for firmware updates are currently only available for IKEA, LEDVANCE and SALUS devices. Support for OTA updates from other manufacturers could be added to zigpy in the future, if they publish their firmware images publicly.
+Online OTA providers for firmware updates are currently only available for IKEA, LEDVANCE, and Salus/Computime devices. Support for OTA updates from other manufacturers could be added to zigpy in the future, if they publish their firmware images publicly.
 
 ## How to install and test, report bugs, or contribute to this project
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Reference implementation of the zigpy library exist in **[Home Assistant](https:
 
 zigpy have code to automatically download and perform OTA (Over-The-Air) firmware updates of Zigbee devices if the OTA firmware image provider source URL for updates is known. The OTA update directory is optional and it can also be used for any offline firmware files that you provide yourself.
 
-Online OTA providers for firmware updates are currently only available for IKEA, LEDVANCE, and SALUS/Computime devices. Support for OTA updates from other manufacturers could be added to zigpy in the future, if they publish their firmware images publicly.
+Online OTA providers for firmware updates are currently only available for IKEA, LEDVANCE/OSRAM, and SALUS/Computime devices. Support for OTA updates from other manufacturers could be added to zigpy in the future, if they publish their firmware images publicly.
 
 ## How to install and test, report bugs, or contribute to this project
 


### PR DESCRIPTION
"SALUS" devices are sometimes also sold as "Computime" branded devices, not surprisingly Salus Controls is actually a brand of the Computime Ltd. company ->  https://www.computime.com/businesses/

UPDATE: And "LEDVANCE SMART+" Zigbee devices are also sold as "OSRAM SMART+" branded devices, the reason for that is that LEDVANCE has licensed OSRAM's "SMART+" series of lighting products.