### PR TITLE
Do not remove children when the parent device is removed

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -142,7 +142,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.listener_event("device_initialized", device)
 
     async def remove(
-        self, ieee: t.EUI64, remove_children: bool = True, rejoin: bool = False
+        self, ieee: t.EUI64, remove_children: bool = False, rejoin: bool = False
     ) -> None:
         """Try to remove a device from the network.
 


### PR DESCRIPTION
I think #896 defaulting to `remove_children=True` will cause unintended behavior:

> This field has a value of 1 if the device being asked to leave the network is also being asked to remove its child devices, if any. Otherwise, it has a value of 0.
