### PR TITLE
Rename IasZone.ZoneType enum member

### DIFF
--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -26,7 +26,7 @@ class IasZone(Cluster):
         Contact_Switch = 0x0015
         Fire_Sensor = 0x0028
         Water_Sensor = 0x002A
-        Carbon_Monoxide_Sensor = 0x002B
+        Gas_Sensor = 0x002B
         Personal_Emergency_Device = 0x002C
         Vibration_Movement_Sensor = 0x002D
         Remote_Control = 0x010F


### PR DESCRIPTION
According to specification rename IasZone.ZoneType.Carbon_Monoxide_Sensor to  IasZone.ZoneType.Gas_Sensor in   zcl/clusters/security.py