### PR TITLE
LEDVANCE is OSRAM and SALUS is Computime for OTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Reference implementation of the zigpy library exist in **[Home Assistant](https:
 
 zigpy have code to automatically download and perform OTA (Over-The-Air) firmware updates of Zigbee devices if the OTA firmware image provider source URL for updates is known. The OTA update directory is optional and it can also be used for any offline firmware files that you provide yourself.
 
-Online OTA providers for firmware updates are currently only available for IKEA, LEDVANCE and SALUS devices. Support for OTA updates from other manufacturers could be added to zigpy in the future, if they publish their firmware images publicly.
+Online OTA providers for firmware updates are currently only available for IKEA, LEDVANCE/OSRAM, and SALUS/Computime devices. Support for OTA updates from other manufacturers could be added to zigpy in the future, if they publish their firmware images publicly.
 
 ## How to install and test, report bugs, or contribute to this project
 


### PR DESCRIPTION
Replaces PR https://github.com/zigpy/zigpy/pull/863

Update the OTA section in README.md to read "LEDVANCE/OSRAM" and "SALUS/Computime" instead of "LEDVANCE" and "SALUS" to clarify that both brands are supported.

LEDVANCE and OSRAM "SMART+" brand of Zigbee devices are actually the same products, and SALUS devices are sometimes sold in boxes as Computime branded devices.