### PR TITLE
Support devices with temporarily unknown IEEE or NWK addresses

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -209,7 +209,7 @@ async def test_permit_ncp():
 
 async def test_permit(app, ieee):
     app.devices[ieee] = MagicMock()
-    app.devices[ieee].zdo.permit = MagicMock(side_effect=asyncio.coroutine(MagicMock()))
+    app.devices[ieee].zdo.permit = AsyncMock()
     app.permit_ncp = AsyncMock()
     await app.permit(node=(1, 1, 1, 1, 1, 1, 1, 1))
     assert app.devices[ieee].zdo.permit.call_count == 0
@@ -366,11 +366,6 @@ def test_get_device_ieee(app, ieee):
 def test_get_device_both(app, ieee):
     dev = app.add_device(ieee, 8)
     assert app.get_device(ieee=ieee, nwk=8) is dev
-
-
-def test_get_device_missing(app, ieee):
-    with pytest.raises(KeyError):
-        app.get_device(nwk=8)
 
 
 def test_ieee(app):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -708,3 +708,29 @@ async def test_get_device(app):
     app.add_device(t.EUI64.convert("11:11:11:11:22:22:22:33"), 0x0000)
 
     assert app.get_device(nwk=0x0000) is dev_2
+
+
+async def test_get_unknown_device_by_ieee(app):
+    """"Test getting unknown devices."""
+
+    await app.startup()
+
+    dev_unk_nwk = app.get_device(ieee=t.EUI64([0x01] * 8))
+    assert dev_unk_nwk.nwk == t.NWK.unknown()
+    dev_unk_nwk.nwk = t.NWK(0x1234)
+    dev_with_nwk = app.get_device(ieee=t.EUI64([0x01] * 8))
+    assert dev_with_nwk.nwk == t.NWK(0x1234)
+
+
+async def test_get_unknown_device_by_nwk(app):
+    """"Test getting unknown devices."""
+
+    await app.startup()
+
+    nwk = t.NWK(0x1122)
+
+    dev_unk_eui = app.get_device(nwk=nwk)
+    assert dev_unk_eui.ieee == t.EUI64([0x00] * 8)
+    dev_unk_eui.ieee = t.EUI64([0x11] * 8)
+    dev_with_eui = app.get_device(nwk=nwk)
+    assert dev_with_eui.ieee == t.EUI64([0x11] * 8)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -729,3 +729,4 @@ async def test_get_unknown_device_by_nwk(app):
     dev_unk_eui.ieee = t.EUI64([0x11] * 8)
     dev_with_eui = app.get_device(nwk=nwk)
     assert dev_with_eui.ieee == t.EUI64([0x11] * 8)
+    assert dev_with_eui.ieee in app.devices

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -240,3 +240,31 @@ async def test_reply_tsn_override(zdo_f, monkeypatch):
     assert seq == tsn
     assert data[0] == tsn
     assert data[1:3] == b"\xaa\x55"
+
+
+async def test_zdo_nwk_addr_rsp(zdo_f, app):
+    """Test NWK_addr_rsp frame."""
+
+    zdo_addr_rsp = b"a\x00\x08\x07\x06\x05\x04\x03\x02\x01\x34\x12\x00"
+    with patch.object(app, "handle_join") as handle_join_mock:
+        hdr, args = zdo_f.deserialize(zdo_types.ZDOCmd.NWK_addr_rsp, zdo_addr_rsp)
+        zdo_f.handle_message(0, zdo_types.ZDOCmd.NWK_addr_rsp, hdr, args)
+        assert handle_join_mock.call_count == 1
+        assert handle_join_mock.call_args[0][0] == t.NWK(0x1234)
+        assert handle_join_mock.call_args[0][1] == t.EUI64.convert(
+            "01:02:03:04:05:06:07:08"
+        )
+
+
+async def test_zdo_ieee_addr_rsp(zdo_f, app):
+    """Test IEEE_addr_rsp frame."""
+
+    zdo_addr_rsp = b"a\x00\x08\x07\x06\x05\x04\x03\x02\x01\x34\x12\x00"
+    with patch.object(app, "handle_join") as handle_join_mock:
+        hdr, args = zdo_f.deserialize(zdo_types.ZDOCmd.NWK_addr_rsp, zdo_addr_rsp)
+        zdo_f.handle_message(0, zdo_types.ZDOCmd.NWK_addr_rsp, hdr, args)
+        assert handle_join_mock.call_count == 1
+        assert handle_join_mock.call_args[0][0] == t.NWK(0x1234)
+        assert handle_join_mock.call_args[0][1] == t.EUI64.convert(
+            "01:02:03:04:05:06:07:08"
+        )

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -488,6 +488,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
             new_ephemeral_dev = zigpy.device.Device(self, t.EUI64([0x00] * 8), nwk)
             self._ephemeral_devices.append(new_ephemeral_dev)
+            new_ephemeral_dev.schedule_initialize()
             return new_ephemeral_dev
 
         # search by IEEE

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -458,7 +458,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         except KeyError:
             if skip_ephemeral:
                 raise
-        return self.get_ephemeral_device(ieee=ieee, nwk=nwk)
+        eph_dev = self.get_ephemeral_device(ieee=ieee, nwk=nwk)
+        if eph_dev.address_is_known:
+            self.devices[eph_dev.ieee] = eph_dev
+        return eph_dev
 
     def _get_device(self, ieee=None, nwk=None) -> zigpy.device.Device:
         if ieee is not None:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -51,9 +51,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     manufacturer_id_override = None
 
-    def __init__(self, application, ieee, nwk):
+    def __init__(self, application: ControllerApplication, ieee: EUI64, nwk: NWK):
         self._application: ControllerApplication = application
-        self._ieee: EUI64 = ieee
+        self._ieee: EUI64 = EUI64(ieee)
         self.nwk: NWK = NWK(nwk)
         self.zdo: zdo.ZDO = zdo.ZDO(self)
         self.endpoints: dict[int, zdo.ZDO | zigpy.endpoint.Endpoint] = {0: self.zdo}

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -394,6 +394,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def ieee(self) -> EUI64:
         return self._ieee
 
+    @ieee.setter
+    def ieee(self, ieee) -> None:
+        self._ieee = EUI64(ieee)
+
     @property
     def manufacturer(self) -> str | None:
         return self._manufacturer

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -532,7 +532,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def expired(self) -> bool:
         """Return True if either NWK or IEEE are still not known."""
 
-        if self.nwk != NWK.unknown() and self.ieee != EUI64([0x00] * 8):
+        if self.address_is_known:
             return False
 
         return time.time() - self._created_ts >= EPHEMERAL_DEVICE_EXP

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -129,7 +129,12 @@ class Date(Struct):
 
 
 class NWK(basic.uint16_t, repr="hex"):
-    pass
+    """Short Network Address."""
+
+    @classmethod
+    def unknown(cls) -> NWK:
+        """Unknown NWK address."""
+        return cls(0xFFFE)
 
 
 class PanId(NWK):

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -180,6 +180,60 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
             self.Match_Desc_rsp(0, local_addr, [t.uint8_t(1)], tsn=hdr.tsn)
         )
 
+    def handle_nwk_addr_rsp(
+        self,
+        hdr: types.ZDOHeader,
+        status: types.Status,
+        remote_device_ieee: t.EUI64,
+        remote_device_nwk: t.NWK,
+        num_assoc_devices: t.uint8_t | None = None,
+        start_index: t.uint8_t | None = None,
+        associated_device_list: t.List[t.NWK] | None = None,
+        dst_addressing: t.Addressing.Group
+        | t.Addressing.IEEE
+        | t.Addressing.NWK
+        | None = None,
+    ):
+        """Handle ZDO NWK_addr_rsp command.
+
+        Handle a response to a NWK_addr_req command, inquiring as to the NWK address
+        of the Remote Device or the NWK address of an address held in the neighbor table
+        The destination addressing on this command is unicast."""
+
+        if status != types.Status.SUCCESS:
+            return
+
+        self._device.application.handle_join(
+            remote_device_nwk, remote_device_ieee, parent_nwk=None
+        )
+
+    def handle_ieee_addr_rsp(
+        self,
+        hdr: types.ZDOHeader,
+        status: types.Status,
+        remote_device_ieee: t.EUI64,
+        remote_device_nwk: t.NWK,
+        num_assoc_devices: t.uint8_t | None = None,
+        start_index: t.uint8_t | None = None,
+        associated_device_list: t.List[t.NWK] | None = None,
+        dst_addressing: t.Addressing.Group
+        | t.Addressing.IEEE
+        | t.Addressing.NWK
+        | None = None,
+    ):
+        """Handle ZDO IEEE_addr_rsp command.
+
+        Handle a response to a NWK_addr_req command inquiring as to the NWK address
+        of the Remote Device or the NWK address of an address held in the neighbor table.
+        The destination addressing on this command is unicast"""
+
+        if status != types.Status.SUCCESS:
+            return
+
+        self._device.application.handle_join(
+            remote_device_nwk, remote_device_ieee, parent_nwk=None
+        )
+
     def bind(self, cluster):
         return self.Bind_req(
             self._device.ieee,


### PR DESCRIPTION
Add support for devices with temporarily unknown IEEE or NWK addresses. If `get_device()` does not find the device, then create an "ephemeral" device, so the deserialize/serialize ZDO method would work to allow discovery of the missing address information via ZDO requests.

Previously, each radio lib had to handle "unknown" devices on its own, this allows handling unknown device discovery in zigpy. 

Tested with EZSP and deConz radios. For NWK address discovery, radio lib should support IEEE addressing mode. 

