### PR TITLE
Upgrade pre commit deps to fix CI failing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: autoflake8
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
 
   - repo: https://github.com/fsouza/autoflake8
-    rev: v0.3.1
+    rev: v0.3.2
     hooks:
       - id: autoflake8
 
@@ -18,12 +18,12 @@ repos:
           - --quiet
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 4.0.1
     hooks:
       - id: flake8
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.2
+    rev: 5.10.1
     hooks:
       - id: isort
 
@@ -33,6 +33,6 @@ repos:
       - id: codespell
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.942
     hooks:
       - id: mypy

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -106,16 +106,16 @@ def test_ints_signed():
     assert int7s(0) == 0
     assert int7s(1) == 1
     assert int7s(-1) == -1
-    assert int7s(2 ** 6 - 1) == 2 ** 6 - 1
-    assert int7s(-(2 ** 6)) == -(2 ** 6)
+    assert int7s(2**6 - 1) == 2**6 - 1
+    assert int7s(-(2**6)) == -(2**6)
 
     with pytest.raises(ValueError):
-        int7s(2 ** 6)
+        int7s(2**6)
 
     with pytest.raises(ValueError):
-        int7s(-(2 ** 6) - 1)
+        int7s(-(2**6) - 1)
 
-    n = int7s(2 ** 6 - 1)
+    n = int7s(2**6 - 1)
 
     with pytest.raises(TypeError):
         n.serialize()
@@ -123,7 +123,7 @@ def test_ints_signed():
     assert int7s(0).bits() == [0, 0, 0, 0, 0, 0, 0]
     assert int7s(1).bits() == [0, 0, 0, 0, 0, 0, 1]
     assert int7s(-1).bits() == [1, 1, 1, 1, 1, 1, 1]
-    assert int7s(2 ** 6 - 1).bits() == [0, 1, 1, 1, 1, 1, 1]
+    assert int7s(2**6 - 1).bits() == [0, 1, 1, 1, 1, 1, 1]
 
     assert int7s.from_bits([1, 0, 1, 0, 1, 1, 0, 1, 1, 1]) == (0b0110111, [1, 0, 1])
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -60,7 +60,7 @@ class FixedIntType(int):
 
         n = super().__new__(cls, *args, **kwargs)
 
-        if not cls._signed and not 0 <= n <= 2 ** cls._bits - 1:
+        if not cls._signed and not 0 <= n <= 2**cls._bits - 1:
             raise ValueError(f"{int(n)} is not an unsigned {cls._bits} bit integer")
         elif (
             cls._signed and not -(2 ** (cls._bits - 1)) <= n <= 2 ** (cls._bits - 1) - 1
@@ -121,7 +121,7 @@ class FixedIntType(int):
             n |= bit & 1
 
         if cls._signed and n >= 2 ** (cls._bits - 1):
-            n -= 2 ** cls._bits
+            n -= 2**cls._bits
 
         return cls(n), bits[: -cls._bits]
 
@@ -418,7 +418,7 @@ class BaseFloat(float):
         src_exp = src_biased_exp - 2 ** (src._exponent_bits - 1)
 
         if src_biased_exp == (1 << src._exponent_bits) - 1:
-            dst_biased_exp = 2 ** dst._exponent_bits - 1
+            dst_biased_exp = 2**dst._exponent_bits - 1
         elif src_biased_exp == 0:
             dst_biased_exp = 0
         else:


### PR DESCRIPTION
Black was broken by a new Click release (https://github.com/psf/black/issues/2964) and CI is currently broken for all zigpy projects that rely on it.