### PR TITLE
Bump master version to 0.44.1 to properly re-release

### DIFF
--- a/zigpy/__init__.py
+++ b/zigpy/__init__.py
@@ -1,5 +1,5 @@
 MAJOR_VERSION = 0
 MINOR_VERSION = 44
-PATCH_VERSION = "0"
+PATCH_VERSION = "1"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"


### PR DESCRIPTION
The GitHub release defaulted to the `dev` branch so 0.44.0 was actually `dev@0.45.0.dev0`, not `master` 🤦