### PR TITLE
Fix typos in ZCL schemas

### DIFF
--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -336,7 +336,7 @@ class DoorLock(Cluster):
             "set_holiday_schedule",
             {
                 "holiday_schedule_id": t.uint8_t,
-                "loca_start_time": t.LocalTime,
+                "local_start_time": t.LocalTime,
                 "local_end_time": t.LocalTime,
                 "operating_mode_during_holiday": OperatingMode,
             },

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1380,7 +1380,7 @@ class Ota(Cluster):
                 "file_offset": t.uint32_t,
                 "maximum_data_size": t.uint8_t,
                 "request_node_addr?": t.EUI64,
-                "minumum_block_period?": t.uint16_t,
+                "minimum_block_period?": t.uint16_t,
             },
             False,
         ),

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -58,7 +58,7 @@ class ApplianceEventAlerts(Cluster):
         0x00: ZCLCommandDef("get_alerts", {}, False)
     }
     client_commands: dict[int, ZCLCommandDef] = {
-        0x00: ZCLCommandDef("get_alarts_response", {}, True),
+        0x00: ZCLCommandDef("get_alerts_response", {}, True),
         0x01: ZCLCommandDef("alerts_notification", {}, False),
         0x02: ZCLCommandDef("event_notification", {}, False),
     }

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -148,7 +148,7 @@ class Color(Cluster):
         0x02: ZCLCommandDef(
             "step_hue",
             {
-                "setp_mode": StepMode,
+                "step_mode": StepMode,
                 "step_size": t.uint8_t,
                 "transition_time": t.uint8_t,
                 "options_mask?": t.bitmap8,


### PR DESCRIPTION
There were a small handful of typos in the ZCLR7 PR, one of which is currently affecting quirks `hue(setp_mode=...)`.