### PR TITLE
Add a `skip_missing` kwarg to the `as_` methods of `Struct` objects

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -774,3 +774,15 @@ def test_struct_field_repr():
     s1 = TestStruct(foo=1, bar=2, baz="asd")
 
     assert repr(s1) == "TestStruct(foo=2, bar=bar, baz=baz)"
+
+
+def test_skip_missing():
+    class TestStruct(t.Struct):
+        foo: t.uint8_t
+        bar: t.uint16_t
+
+    assert TestStruct(foo=1).as_dict() == {"foo": 1, "bar": None}
+    assert TestStruct(foo=1).as_dict(skip_missing=True) == {"foo": 1}
+
+    assert TestStruct(foo=1).as_tuple() == (1, None)
+    assert TestStruct(foo=1).as_tuple(skip_missing=True) == (1,)

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -184,11 +184,21 @@ class Struct:
 
         return assigned_fields
 
-    def as_dict(self) -> dict[str, typing.Any]:
-        return {f.name: getattr(self, f.name) for f in self.fields}
+    def as_dict(self, *, skip_missing: bool = False) -> dict[str, typing.Any]:
+        d = {}
 
-    def as_tuple(self) -> tuple:
-        return tuple(getattr(self, f.name) for f in self.fields)
+        for f in self.fields:
+            value = getattr(self, f.name)
+
+            if value is None and skip_missing:
+                continue
+
+            d[f.name] = value
+
+        return d
+
+    def as_tuple(self, *, skip_missing: bool = False) -> tuple:
+        return tuple(self.as_dict(skip_missing=skip_missing).values())
 
     def serialize(self) -> bytes:
         chunks = []


### PR DESCRIPTION
This will be used to generate partial matches for device automation triggers in quirks, without having to define separate constants for `"step"` or `"step_mode"`:

```Python
>>> from zigpy.zcl.clusters.general import LevelControl
>>> step = LevelControl.commands_by_name["step"].schema  # this should be improved
>>> step(step_mode=0).as_dict(skip_missing=True)
{'step_mode': <StepMode.Up: 0>}
```