### PR TITLE
Store attributes in db after successful write

### DIFF
--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -547,11 +547,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         if len(records) == 1 and records[0].status == foundation.Status.SUCCESS:
             for attr_rec in attrs:
                 self._attr_cache[attr_rec.attrid] = attr_rec.value.value
+                self.listener_event("attribute_updated", attr_rec.attrid, attr_rec.value.value)
         else:
             failed = [rec.attrid for rec in records]
             for attr_rec in attrs:
                 if attr_rec.attrid not in failed:
                     self._attr_cache[attr_rec.attrid] = attr_rec.value.value
+                    self.listener_event("attribute_updated", attr_rec.attrid, attr_rec.value.value)
 
         return result
 


### PR DESCRIPTION
This PR adds attribute updated events after attribute writes which will cause attributes to be written to the database after writing their value successfully. This is needed to correctly support configuration entities for things such as StartupOnOff, StartupLevel, OnOffTransitionTime etc. 