### PR TITLE
Persist `Device.last_seen` in the database

### DIFF
--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -3,7 +3,19 @@ import sys
 
 if sys.version_info[:2] < (3, 8):
     from asynctest.mock import *  # noqa
+    from asynctest.mock import MagicMock as _MagicMock
 
     AsyncMock = CoroutineMock  # noqa: F405
+
+    class MagicMock(_MagicMock):
+        async def __aenter__(self):
+            return self.aenter
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def __aiter__(self):
+            return self.aiter
+
 else:
     from unittest.mock import *  # noqa

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import sys
 import threading
+import time
 
 import aiosqlite
 import pytest
@@ -173,8 +174,12 @@ async def test_database(tmpdir):
     dev.model = "Model"
     assert dev.get_signature()[SIG_MANUFACTURER] == "Custom"
     assert dev.get_signature()[SIG_MODEL] == "Model"
+
+    ts = time.time()
+    dev.last_seen = ts
     dev_last_seen = dev.last_seen
-    assert isinstance(dev_last_seen, datetime)
+    assert isinstance(dev.last_seen, datetime)
+    assert abs(dev.last_seen.timestamp() - ts) < 0.1
 
     # Test a CustomDevice
     custom_ieee = make_ieee(1)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 import logging
 import types
 from typing import Any
@@ -22,9 +23,11 @@ from zigpy.zdo import types as zdo_t
 
 LOGGER = logging.getLogger(__name__)
 
-DB_VERSION = 7
+DB_VERSION = 8
 DB_V = f"_v{DB_VERSION}"
 MIN_SQLITE_VERSION = (3, 24, 0)
+
+UNIX_EPOCH = datetime.fromtimestamp(0, tz=timezone.utc)
 
 
 def _import_compatible_sqlite3(min_version: tuple[int, int, int]) -> types.ModuleType:
@@ -71,6 +74,16 @@ def _register_sqlite_adapters():
         return t.EUI64.convert(s.decode())
 
     sqlite3.register_converter("ieee", convert_ieee)
+
+    def adapt_datetime(dt):
+        return int(dt.timestamp() * 1000)
+
+    sqlite3.register_adapter(datetime, adapt_datetime)
+
+    def convert_timestamp(ts):
+        return datetime.fromtimestamp(int(ts.decode("ascii"), 10) / 1000, timezone.utc)
+
+    sqlite3.register_converter("unix_timestamp", convert_timestamp)
 
 
 def aiosqlite_connect(
@@ -205,6 +218,18 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def device_left(self, device: zigpy.typing.DeviceType) -> None:
         pass
 
+    def device_last_seen_updated(
+        self, device: zigpy.typing.DeviceType, last_seen: datetime
+    ) -> None:
+        """Device last_seen time is updated."""
+        self.enqueue("_save_device_last_seen", device.ieee, last_seen)
+
+    async def _save_device_last_seen(self, ieee: t.EUI64, last_seen: datetime) -> None:
+        await self.execute(
+            f"UPDATE devices{DB_V} SET last_seen=? WHERE ieee=?", (ieee, last_seen)
+        )
+        await self._db.commit()
+
     def device_relays_updated(
         self, device: zigpy.typing.DeviceType, relays: t.Relays | None
     ) -> None:
@@ -337,10 +362,16 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         self.enqueue("_save_device", device)
 
     async def _save_device(self, device: zigpy.typing.DeviceType) -> None:
-        q = f"""INSERT INTO devices{DB_V} (ieee, nwk, status) VALUES (?, ?, ?)
+        q = f"""INSERT INTO devices{DB_V} (ieee, nwk, status, last_seen)
+                    VALUES (?, ?, ?, ?)
                     ON CONFLICT (ieee)
-                    DO UPDATE SET nwk=excluded.nwk, status=excluded.status"""
-        await self.execute(q, (device.ieee, device.nwk, device.status))
+                    DO UPDATE SET
+                        nwk=excluded.nwk,
+                        status=excluded.status,
+                        last_seen=excluded.last_seen"""
+        await self.execute(
+            q, (device.ieee, device.nwk, device.status, device.last_seen)
+        )
 
         if device.node_desc is not None:
             await self._save_node_descriptor(device)
@@ -529,9 +560,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
     async def _load_devices(self) -> None:
         async with self.execute(f"SELECT * FROM devices{DB_V}") as cursor:
-            async for (ieee, nwk, status) in cursor:
+            async for (ieee, nwk, status, last_seen) in cursor:
                 dev = self._application.add_device(ieee, nwk)
                 dev.status = zigpy.device.Status(status)
+                dev._last_seen = last_seen
 
     async def _load_node_descriptors(self) -> None:
         async with self.execute(f"SELECT * FROM node_descriptors{DB_V}") as cursor:
@@ -640,6 +672,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 (self._migrate_to_v5, 5),
                 (self._migrate_to_v6, 6),
                 (self._migrate_to_v7, 7),
+                (self._migrate_to_v8, 8),
             ]:
                 if db_version >= min(to_db_version, DB_VERSION):
                     continue
@@ -797,5 +830,32 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 "attributes_cache_v6": "attributes_cache_v7",
                 "neighbors_v6": "neighbors_v7",
                 "node_descriptors_v6": "node_descriptors_v7",
+            }
+        )
+
+    async def _migrate_to_v8(self):
+        """Schema v8 added the `devices_v8.last_seen` column."""
+
+        async with self.execute("SELECT * FROM devices_v7") as cursor:
+            async for (ieee, nwk, status) in cursor:
+                # Set the default `last_seen` to the unix epoch
+                await self.execute(
+                    "INSERT INTO devices_v8 VALUES (?, ?, ?, ?)",
+                    (ieee, nwk, status, UNIX_EPOCH),
+                )
+
+        # Copy the devices table first, it should have no conflicts
+        await self._migrate_tables(
+            {
+                "endpoints_v7": "endpoints_v8",
+                "in_clusters_v7": "in_clusters_v8",
+                "out_clusters_v7": "out_clusters_v8",
+                "groups_v7": "groups_v8",
+                "group_members_v7": "group_members_v8",
+                "relays_v7": "relays_v8",
+                "attributes_cache_v7": "attributes_cache_v8",
+                "neighbors_v7": "neighbors_v8",
+                "node_descriptors_v7": "node_descriptors_v8",
+                "unsupported_attributes_v7": "unsupported_attributes_v8",
             }
         )

--- a/zigpy/appdb_schemas/schema_v8.sql
+++ b/zigpy/appdb_schemas/schema_v8.sql
@@ -1,0 +1,201 @@
+PRAGMA user_version = 8;
+
+-- devices
+DROP TABLE IF EXISTS devices_v8;
+CREATE TABLE devices_v8 (
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+    last_seen unix_timestamp NOT NULL
+);
+
+CREATE UNIQUE INDEX devices_idx_v8
+    ON devices_v8(ieee);
+
+
+-- endpoints
+DROP TABLE IF EXISTS endpoints_v8;
+CREATE TABLE endpoints_v8 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    profile_id INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v8(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX endpoint_idx_v8
+    ON endpoints_v8(ieee, endpoint_id);
+
+
+-- clusters
+DROP TABLE IF EXISTS in_clusters_v8;
+CREATE TABLE in_clusters_v8 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v8(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX in_clusters_idx_v8
+    ON in_clusters_v8(ieee, endpoint_id, cluster);
+
+
+-- neighbors
+DROP TABLE IF EXISTS neighbors_v8;
+CREATE TABLE neighbors_v8 (
+    device_ieee ieee NOT NULL,
+    extended_pan_id ieee NOT NULL,
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    rx_on_when_idle INTEGER NOT NULL,
+    relationship INTEGER NOT NULL,
+    reserved1 INTEGER NOT NULL,
+    permit_joining INTEGER NOT NULL,
+    reserved2 INTEGER NOT NULL,
+    depth INTEGER NOT NULL,
+    lqi INTEGER NOT NULL,
+
+    FOREIGN KEY(device_ieee)
+        REFERENCES devices_v8(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX neighbors_idx_v8
+    ON neighbors_v8(device_ieee);
+
+
+-- node descriptors
+DROP TABLE IF EXISTS node_descriptors_v8;
+CREATE TABLE node_descriptors_v8 (
+    ieee ieee NOT NULL,
+
+    logical_type INTEGER NOT NULL,
+    complex_descriptor_available INTEGER NOT NULL,
+    user_descriptor_available INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    aps_flags INTEGER NOT NULL,
+    frequency_band INTEGER NOT NULL,
+    mac_capability_flags INTEGER NOT NULL,
+    manufacturer_code INTEGER NOT NULL,
+    maximum_buffer_size INTEGER NOT NULL,
+    maximum_incoming_transfer_size INTEGER NOT NULL,
+    server_mask INTEGER NOT NULL,
+    maximum_outgoing_transfer_size INTEGER NOT NULL,
+    descriptor_capability_field INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v8(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX node_descriptors_idx_v8
+    ON node_descriptors_v8(ieee);
+
+
+-- output clusters
+DROP TABLE IF EXISTS out_clusters_v8;
+CREATE TABLE out_clusters_v8 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v8(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX out_clusters_idx_v8
+    ON out_clusters_v8(ieee, endpoint_id, cluster);
+
+
+-- attributes
+DROP TABLE IF EXISTS attributes_cache_v8;
+CREATE TABLE attributes_cache_v8 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+    attrid INTEGER NOT NULL,
+    value BLOB NOT NULL,
+
+    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
+    -- DB but whose values still need to be cached
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v8(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX attributes_idx_v8
+    ON attributes_cache_v8(ieee, endpoint_id, cluster, attrid);
+
+
+-- groups
+DROP TABLE IF EXISTS groups_v8;
+CREATE TABLE groups_v8 (
+    group_id INTEGER NOT NULL,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX groups_idx_v8
+    ON groups_v8(group_id);
+
+
+-- group members
+DROP TABLE IF EXISTS group_members_v8;
+CREATE TABLE group_members_v8 (
+    group_id INTEGER NOT NULL,
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+
+    FOREIGN KEY(group_id)
+        REFERENCES groups_v8(group_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v8(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX group_members_idx_v8
+    ON group_members_v8(group_id, ieee, endpoint_id);
+
+
+-- relays
+DROP TABLE IF EXISTS relays_v8;
+CREATE TABLE relays_v8 (
+    ieee ieee NOT NULL,
+    relays BLOB NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v8(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX relays_idx_v8
+    ON relays_v8(ieee);
+
+
+-- unsupported attributes
+DROP TABLE IF EXISTS unsupported_attributes_v8;
+CREATE TABLE unsupported_attributes_v8 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+    attrid INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v8(ieee)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id, cluster)
+        REFERENCES in_clusters_v8(ieee, endpoint_id, cluster)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX unsupported_attributes_idx_v8
+    ON unsupported_attributes_v8(ieee, endpoint_id, cluster, attrid);

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -299,6 +299,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             LOGGER.debug("Device %s changed id (0x%04x => 0x%04x)", ieee, dev.nwk, nwk)
             new_join = True
 
+        # Not all stacks send a ZDO command when a device joins so the last_seen should
+        # be updated
+        dev.update_last_seen()
+
         if new_join:
             self.listener_event("device_joined", dev)
             dev.schedule_initialize()


### PR DESCRIPTION
`last_seen` will now be persisted in the database and loaded on startup.

I've also added a runtime check to `_migrate_tables` to ensure that all "old" tables are explicitly specified in the migration. This will protect against migrations that accidentally leave out a new table introduced in an earlier migration (like I almost did when making this PR 😃).
