### PR TITLE
Replace PyCryptodome with Cryptography

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('setup.py', 'requirements_test.txt') }}
           restore-keys: |
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version }}-
       - name: Create Python virtual environment
@@ -67,7 +67,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('setup.py', 'requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -108,7 +108,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('setup.py', 'requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -151,7 +151,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('setup.py', 'requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -197,7 +197,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('setup.py', 'requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -240,7 +240,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('setup.py', 'requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -286,7 +286,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('setup.py', 'requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -334,7 +334,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('setup.py', 'requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -396,7 +396,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('setup.py', 'requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 import zigpy
 
-REQUIRES = ["aiohttp", "aiosqlite>=0.16.0", "crccheck", "pycryptodome", "voluptuous"]
+REQUIRES = ["aiohttp", "aiosqlite>=0.16.0", "crccheck", "cryptography", "voluptuous"]
 
 setup(
     name="zigpy",

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -6,6 +6,7 @@ import pytest
 
 from zigpy import util
 from zigpy.exceptions import ControllerException
+from zigpy.types.named import KeyData
 
 from .async_mock import AsyncMock, MagicMock, call, patch, sentinel
 
@@ -176,173 +177,29 @@ async def test_retryable_once():
 
 
 def test_zigbee_security_hash():
-    message = bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x4A, 0xF7])
+    message = bytes.fromhex("11223344556677884AF7")
     key = util.aes_mmo_hash(message)
-    assert key == [
-        0x41,
-        0x61,
-        0x8F,
-        0xC0,
-        0xC8,
-        0x3B,
-        0x0E,
-        0x14,
-        0xA5,
-        0x89,
-        0x95,
-        0x4B,
-        0x16,
-        0xE3,
-        0x14,
-        0x66,
-    ]
+    assert key == KeyData.convert("41618FC0C83B0E14A589954B16E31466")
 
-    message = bytes(
-        [
-            0x7A,
-            0x93,
-            0x97,
-            0x23,
-            0xA5,
-            0xC6,
-            0x39,
-            0xB2,
-            0x69,
-            0x16,
-            0x18,
-            0x02,
-            0x81,
-            0x9B,
-        ]
-    )
+    message = bytes.fromhex("7A939723A5C639B269161802819B")
     key = util.aes_mmo_hash(message)
-    assert key == [
-        0xF9,
-        0x39,
-        0x03,
-        0x72,
-        0x16,
-        0x85,
-        0xFD,
-        0x32,
-        0x9D,
-        0x26,
-        0x84,
-        0x9B,
-        0x90,
-        0xF2,
-        0x95,
-        0x9A,
-    ]
+    assert key == KeyData.convert("F93903721685FD329D26849B90F2959A")
 
-    message = bytes(
-        [
-            0x83,
-            0xFE,
-            0xD3,
-            0x40,
-            0x7A,
-            0x93,
-            0x97,
-            0x23,
-            0xA5,
-            0xC6,
-            0x39,
-            0xB2,
-            0x69,
-            0x16,
-            0x18,
-            0x02,
-            0xAE,
-            0xBB,
-        ]
-    )
+    message = bytes.fromhex("83FED3407A939723A5C639B269161802AEBB")
     key = util.aes_mmo_hash(message)
-    assert key == [
-        0x33,
-        0x3C,
-        0x23,
-        0x68,
-        0x60,
-        0x79,
-        0x46,
-        0x8E,
-        0xB2,
-        0x7B,
-        0xA2,
-        0x4B,
-        0xD9,
-        0xC7,
-        0xE5,
-        0x64,
-    ]
+    assert key == KeyData.convert("333C23686079468EB27BA24BD9C7E564")
 
 
 @pytest.mark.parametrize(
     "message, expected_key",
     [
         (
-            bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x4A, 0xF7]),
-            [
-                0x41,
-                0x61,
-                0x8F,
-                0xC0,
-                0xC8,
-                0x3B,
-                0x0E,
-                0x14,
-                0xA5,
-                0x89,
-                0x95,
-                0x4B,
-                0x16,
-                0xE3,
-                0x14,
-                0x66,
-            ],
+            bytes.fromhex("11223344556677884AF7"),
+            KeyData.convert("41618FC0C83B0E14A589954B16E31466"),
         ),
         (
-            bytes(
-                [
-                    0x83,
-                    0xFE,
-                    0xD3,
-                    0x40,
-                    0x7A,
-                    0x93,
-                    0x97,
-                    0x23,
-                    0xA5,
-                    0xC6,
-                    0x39,
-                    0xB2,
-                    0x69,
-                    0x16,
-                    0xD5,
-                    0x05,
-                    0xC3,
-                    0xB5,
-                ]
-            ),
-            [
-                0x66,
-                0xB6,
-                0x90,
-                0x09,
-                0x81,
-                0xE1,
-                0xEE,
-                0x3C,
-                0xA4,
-                0x20,
-                0x6B,
-                0x6B,
-                0x86,
-                0x1C,
-                0x02,
-                0xBB,
-            ],
+            bytes.fromhex("83FED3407A939723A5C639B26916D505C3B5"),
+            KeyData.convert("66B6900981E1EE3CA4206B6B861C02BB"),
         ),
     ],
 )

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -6,6 +6,16 @@ from . import basic
 from .struct import Struct
 
 
+def _hex_string_to_bytes(hex_string: str) -> bytes:
+    """
+    Parses a hex string with optional colon delimiters and whitespace into bytes.
+    """
+
+    # Strips out whitespace and colons
+    cleaned = "".join(hex_string.replace(":", "").split()).upper()
+    return bytes.fromhex(cleaned)
+
+
 class BroadcastAddress(basic.enum16):
     ALL_DEVICES = 0xFFFF
     RESERVED_FFFE = 0xFFFE
@@ -29,7 +39,7 @@ class EUI64(basic.FixedList, item_type=basic.uint8_t, length=8):
     def convert(cls, ieee: str):
         if ieee is None:
             return None
-        ieee = [basic.uint8_t(p, base=16) for p in ieee.split(":")[::-1]]
+        ieee = [basic.uint8_t(p) for p in _hex_string_to_bytes(ieee)[::-1]]
         assert len(ieee) == cls._length
         return cls(ieee)
 
@@ -40,7 +50,7 @@ class KeyData(basic.FixedList, item_type=basic.uint8_t, length=16):
 
     @classmethod
     def convert(cls, key: str) -> KeyData:
-        key = [basic.uint8_t(p, base=16) for p in key.split(":")]
+        key = [basic.uint8_t(p) for p in _hex_string_to_bytes(key)]
         assert len(key) == cls._length
         return cls(key)
 

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -296,7 +296,7 @@ class Struct:
         return instance, data
 
     # TODO: improve? def replace(self: typing.Type[_STRUCT], **kwargs) -> _STRUCT:
-    def replace(self, **kwargs) -> Struct:
+    def replace(self, **kwargs: dict[str, typing.Any]) -> Struct:
         d = self.as_dict().copy()
         d.update(kwargs)
 


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/70350.

https://github.com/zigpy/zigpy/discussions/972#discussion-4027315

This change also adds slightly more lenient parsing to any object with a `convert` method:

```Python
In [9]: t.KeyData.convert("AA:BB:CC:DD:EE:FF:AA:BB:CC:DD:EE:FF:AA:BB:CC:DD")
Out[9]: aa:bb:cc:dd:ee:ff:aa:bb:cc:dd:ee:ff:aa:bb:cc:dd

In [10]: t.KeyData.convert("AABBCCDDEEFFAABB CCDDEEFFAABBCCDD")
Out[10]: aa:bb:cc:dd:ee:ff:aa:bb:cc:dd:ee:ff:aa:bb:cc:dd
```