### PR TITLE
Make sure `Device.last_seen` is still a float

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1,5 +1,4 @@
 import asyncio
-from datetime import datetime
 import os
 import sqlite3
 import sys
@@ -178,8 +177,8 @@ async def test_database(tmpdir):
     ts = time.time()
     dev.last_seen = ts
     dev_last_seen = dev.last_seen
-    assert isinstance(dev.last_seen, datetime)
-    assert abs(dev.last_seen.timestamp() - ts) < 0.1
+    assert isinstance(dev.last_seen, float)
+    assert abs(dev.last_seen - ts) < 0.01
 
     # Test a CustomDevice
     custom_ieee = make_ieee(1)
@@ -202,7 +201,7 @@ async def test_database(tmpdir):
     assert dev.endpoints[1].in_clusters[0x0008]._attr_cache[0x0011] == 17
     assert dev.endpoints[99].in_clusters[0x0008]._attr_cache[0x0011] == 17
     custom_dev_last_seen = dev.last_seen
-    assert isinstance(custom_dev_last_seen, datetime)
+    assert isinstance(custom_dev_last_seen, float)
 
     await app.pre_shutdown()
 
@@ -221,7 +220,7 @@ async def test_database(tmpdir):
     assert dev.endpoints[3].device_type == profiles.zll.DeviceType.COLOR_LIGHT
     assert dev.relays == relays_1
     # The timestamp won't be restored exactly but it is more than close enough
-    assert abs((dev.last_seen - dev_last_seen).total_seconds()) < 0.01
+    assert abs(dev.last_seen - dev_last_seen) < 0.01
 
     dev = app2.get_device(custom_ieee)
     # This virtual attribute is added by the quirk, there is no corresponding cluster
@@ -229,7 +228,7 @@ async def test_database(tmpdir):
     assert dev.endpoints[1].in_clusters[0x0008]._attr_cache[0x0011] == 17
     assert dev.endpoints[99].in_clusters[0x0008]._attr_cache[0x0011] == 17
     assert dev.relays == relays_2
-    assert abs((dev.last_seen - custom_dev_last_seen).total_seconds()) < 0.01
+    assert abs(dev.last_seen - custom_dev_last_seen) < 0.01
     dev.relays = None
 
     app.handle_leave(99, ieee)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -440,7 +440,7 @@ def test_device_last_seen(dev, monkeypatch):
 
     dev.last_seen = 0
     epoch = datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
-    assert dev.last_seen == epoch
+    assert dev.last_seen == epoch.timestamp()
 
     dev.listener_event.assert_called_once_with("device_last_seen_updated", epoch)
     dev.listener_event.reset_mock()

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -372,7 +372,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                         status=excluded.status,
                         last_seen=excluded.last_seen"""
         await self.execute(
-            q, (device.ieee, device.nwk, device.status, device.last_seen)
+            q, (device.ieee, device.nwk, device.status, device._last_seen)
         )
 
         if device.node_desc is not None:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -85,8 +85,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.last_seen = datetime.now(timezone.utc)
 
     @property
-    def last_seen(self) -> datetime | None:
-        return self._last_seen
+    def last_seen(self) -> float | None:
+        return self._last_seen.timestamp() if self._last_seen is not None else None
 
     @last_seen.setter
     def last_seen(self, value: datetime | int | float):


### PR DESCRIPTION
0.45.0 changed the data type of `last_seen` to `datetime`. This PR reverts it back to a `float`.