### PR TITLE
Log the entire listener exception traceback when an error occurs

### DIFF
--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -50,8 +50,12 @@ class ListenableMixin:
                 else:
                     result.append(method(*args))
             except Exception as e:
-                LOGGER.warning("Error calling listener %r%r: %r", method, args, e)
-                LOGGER.debug("Error calling listener %r%r", method, args, exc_info=e)
+                LOGGER.warning(
+                    "Error calling listener %r with args %r: %r", method, args, e
+                )
+                LOGGER.debug(
+                    "Error calling listener %r with args %r", method, args, exc_info=e
+                )
         return result
 
     async def async_event(self, method_name, *args):
@@ -70,9 +74,14 @@ class ListenableMixin:
         results = []
         for result in await asyncio.gather(*tasks, return_exceptions=True):
             if isinstance(result, Exception):
-                LOGGER.warning("Error calling listener %r%r: %r", method, args, result)
+                LOGGER.warning(
+                    "Error calling listener %r with args %r: %r", method, args, result
+                )
                 LOGGER.debug(
-                    "Error calling listener %r%r", method, args, exc_info=result
+                    "Error calling listener %r with args %r",
+                    method,
+                    args,
+                    exc_info=result,
                 )
             else:
                 results.append(result)

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -50,7 +50,8 @@ class ListenableMixin:
                 else:
                     result.append(method(*args))
             except Exception as e:
-                LOGGER.warning("Error calling listener.%s: %s", method_name, e)
+                LOGGER.warning("Error calling listener %r%r: %r", method, args, e)
+                LOGGER.debug("Error calling listener %r%r", method, args, exc_info=e)
         return result
 
     async def async_event(self, method_name, *args):
@@ -69,7 +70,10 @@ class ListenableMixin:
         results = []
         for result in await asyncio.gather(*tasks, return_exceptions=True):
             if isinstance(result, Exception):
-                LOGGER.warning("Error calling listener: %s", result)
+                LOGGER.warning("Error calling listener %r%r: %r", method, args, result)
+                LOGGER.debug(
+                    "Error calling listener %r%r", method, args, exc_info=result
+                )
             else:
                 results.append(result)
         return results


### PR DESCRIPTION
This improves error logging by logging the `repr` of the exception as opposed to its string (since `str(Exception()) == ''`) and by always logging the full traceback at the `DEBUG` level.