### PR TITLE
Fix NWK change logging

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -295,8 +295,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             new_join = True
 
         if dev.nwk != nwk:
-            dev.nwk = nwk
             LOGGER.debug("Device %s changed id (0x%04x => 0x%04x)", ieee, dev.nwk, nwk)
+            dev.nwk = nwk
             new_join = True
 
         # Not all stacks send a ZDO command when a device joins so the last_seen should


### PR DESCRIPTION
Small fix for logging of NWK changes.

Current Code does this:

```
2022-05-18 08:51:45 DEBUG (MainThread) [zigpy.application] Device b0:ce:18:14:00:03:9a:60 changed id (0xa0cc => 0xa0cc)
```

