### PR TITLE
Update to Inovelli OTA configuration due to firmware versioning change

### DIFF
--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -547,7 +547,7 @@ class INOVELLIImage:
 
     @classmethod
     def new(cls, data, model):
-        ver = int(data["version"], 10)
+        ver = float(data["version"])
         url = data["firmware"]
 
         res = cls(


### PR DESCRIPTION
Minor tweak from int to float for Inovelli OTA updates as the firmware versioning is being changed from 00000010 to 1.10 as an example in order to display consistently across different hubs.