### PR TITLE
Load network information after forming a new network

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -593,7 +593,9 @@ async def test_startup_formed(app):
 async def test_startup_not_formed(app):
     app.start_network = AsyncMock()
     app.form_network = AsyncMock()
-    app.load_network_info = AsyncMock(side_effect=NetworkNotFormed())
+    app.load_network_info = AsyncMock(
+        side_effect=[NetworkNotFormed(), NetworkNotFormed(), None]
+    )
     app.permit = AsyncMock()
 
     with pytest.raises(NetworkNotFormed):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -72,6 +72,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
                 LOGGER.info("Forming a new network")
                 await self.form_network()
+                await self.load_network_info(load_devices=False)
 
             LOGGER.debug("Network info: %s", self.state.network_info)
             LOGGER.debug("Node info: %s", self.state.node_info)


### PR DESCRIPTION
Network information should be loaded from the stick after a network is formed. Otherwise, it will be inaccurate for a fresh ZHA installation with a new coordinator.