### PR TITLE
Use the V2 Codecov uploader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,4 +403,4 @@ jobs:
           coverage report --fail-under=99
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
The V1 action was apparently sunset in February: https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1