### PR TITLE
Truncate the SQLite journal file instead of deleting it

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -849,3 +849,12 @@ def test_pysqlite_load_failure(stdlib_version, pysqlite3_version):
     ):
         with pytest.raises(RuntimeError):
             zigpy.appdb._import_compatible_sqlite3(zigpy.appdb.MIN_SQLITE_VERSION)
+
+
+async def test_appdb_no_leftover_journal(tmp_path):
+    db = tmp_path / "test.db"
+    app = await make_app(str(db))
+    await app.shutdown()
+
+    assert db.exists()
+    assert set(db.parent.glob(db.with_suffix(".*").name)) == {db}

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -122,6 +122,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 LOGGER.error("SQLite database file is corrupted!\n%s", status)
 
         await self.execute("PRAGMA foreign_keys = ON")
+        await self.execute("PRAGMA journal_mode = TRUNCATE")
         await self._run_migrations()
 
     @classmethod

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -171,6 +171,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._callback_handlers.join()
         if not self._worker_task.done():
             self._worker_task.cancel()
+
+        # Delete the journal on shutdown
+        await self.execute("PRAGMA journal_mode = DELETE")
         await self._db.close()
 
     def enqueue(self, cb_name: str, *args) -> None:


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/73067

SQLite allows the application to configure its journal file behavior (https://www.sqlite.org/pragma.html#pragma_journal_mode). The current behavior is to delete the `-journal` file every time a transaction completes, but we instead can just truncate the file and then delete it on shutdown.

Related issue: https://github.com/coleifer/pysqlite3/issues/41
See also: https://bugs.chromium.org/p/chromium/issues/detail?id=118470