### PR TITLE
Remove Python 3.7 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7.7', 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2


### PR DESCRIPTION
Required for https://github.com/zigpy/zigpy/pull/1008 to pass CI