### PR TITLE
Fix/Update to #991, Inovelli OTA configuration

### DIFF
--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -547,7 +547,7 @@ class INOVELLIImage:
 
     @classmethod
     def new(cls, data, model):
-        ver = float(data["version"])
+        ver = int(data["version"], 16)
         url = data["firmware"]
 
         res = cls(


### PR DESCRIPTION
Correction from PR #991, need to stick with int but specify base 16 instead of base 10 due to the firmware check using the hex value instead of the previously expected 1.11, etc value from the sw_build_id.