### PR TITLE
Set the request header's `direction` bit according to the cluster type

### DIFF
--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -277,9 +277,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             tsn = self._endpoint.device.application.get_sequence()
 
         if general:
-            hdr = foundation.ZCLHeader.general(tsn, command_id, manufacturer)
+            hdr = foundation.ZCLHeader.general(
+                tsn, command_id, manufacturer, is_reply=self.is_client
+            )
         else:
-            hdr = foundation.ZCLHeader.cluster(tsn, command_id, manufacturer)
+            hdr = foundation.ZCLHeader.cluster(
+                tsn, command_id, manufacturer, is_reply=self.is_client
+            )
 
         self.debug("Sending request header: %r", hdr)
         self.debug("Sending request: %r", request)


### PR DESCRIPTION
Fixes #1018

I'm a little wary of merging this change without more runtime testing, especially with quirks. Are there any known devices that rely on the current behavior to work properly?