### PR TITLE
Allow installation on Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
     license="GPL-3.0",
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=REQUIRES,
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     package_data={"": ["appdb_schemas/schema_v*.sql"]},
 )


### PR DESCRIPTION
Allows you to do `pip install zigpy` on Python 3.7.  