### PR TITLE
Reduce DB filesystem writes

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,5 +6,6 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-timeout
+freezegun
 
 pysqlite3-binary; platform_system=="Linux"

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timezone
 import pathlib
 import sqlite3
 import sys
@@ -6,6 +7,7 @@ import threading
 import time
 
 import aiosqlite
+import freezegun
 import pytest
 
 from zigpy import profiles
@@ -777,18 +779,35 @@ async def test_last_seen(tmp_path):
     next_last_seen = dev.last_seen
     assert abs(next_last_seen - old_last_seen) < 0.01
 
-    await asyncio.sleep(0.1)
-
-    # Now the last_seen will update
     app = await make_app(db)
     dev = app.get_device(ieee=ieee)
-    dev.update_last_seen()
+
+    # Last-seen is only written to the db every 30s (no write case)
+    now = datetime.fromtimestamp(dev.last_seen + 5, timezone.utc)
+    with freezegun.freeze_time(now):
+        dev.update_last_seen()
+
+    await app.shutdown()
+
+    app = await make_app(db)
+    dev = app.get_device(ieee=ieee)
+    assert dev.last_seen == next_last_seen  # no change
+    await app.shutdown()
+
+    app = await make_app(db)
+    dev = app.get_device(ieee=ieee)
+
+    # Last-seen is only written to the db every 30s (write case)
+    now = datetime.fromtimestamp(dev.last_seen + 35, timezone.utc)
+    with freezegun.freeze_time(now):
+        dev.update_last_seen()
+
     await app.shutdown()
 
     # And it will be updated when the database next loads
     app = await make_app(db)
     dev = app.get_device(ieee=ieee)
-    assert dev.last_seen > next_last_seen + 0.1
+    assert dev.last_seen >= next_last_seen + 35  # updated
     await app.shutdown()
 
 

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -864,15 +864,6 @@ def test_pysqlite_load_failure(stdlib_version, pysqlite3_version):
             zigpy.appdb._import_compatible_sqlite3(zigpy.appdb.MIN_SQLITE_VERSION)
 
 
-async def test_appdb_no_leftover_journal(tmp_path):
-    db = tmp_path / "test.db"
-    app = await make_app(db)
-    await app.shutdown()
-
-    assert db.exists()
-    assert set(db.parent.glob(db.with_suffix(".*").name)) == {db}
-
-
 async def test_appdb_network_backups(tmp_path, backup_factory):  # noqa: F811
     db = tmp_path / "test.db"
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -128,7 +128,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         # Truncate the SQLite journal file instead of deleting it after transactions
         await self._set_isolation_level(None)
-        await self.execute("PRAGMA journal_mode = TRUNCATE")
+        await self.execute("PRAGMA journal_mode = WAL")
+        await self.execute("PRAGMA synchronous = normal")
+        await self.execute("PRAGMA temp_store = memory")
         await self._set_isolation_level("DEFERRED")
 
         await self.execute("PRAGMA foreign_keys = ON")
@@ -185,7 +187,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         # Delete the journal on shutdown
         await self._set_isolation_level(None)
-        await self.execute("PRAGMA journal_mode = DELETE")
+        await self.execute("PRAGMA wal_checkpoint;")
         await self._set_isolation_level("DEFERRED")
 
         await self._db.close()

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -251,8 +251,8 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         else:
             q = f"""INSERT INTO relays{DB_V} VALUES (?, ?)
                         ON CONFLICT (ieee)
-                        DO UPDATE SET relays=excluded.relays"""
-            await self.execute(q, (ieee, relays.serialize()))
+                        DO UPDATE SET relays=excluded.relays WHERE relays != ?"""
+            await self.execute(q, (ieee, relays.serialize(), relays.serialize()))
 
         await self._db.commit()
 
@@ -494,7 +494,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         q = f"""INSERT INTO attributes_cache{DB_V} VALUES (?, ?, ?, ?, ?)
                     ON CONFLICT (ieee, endpoint_id, cluster, attrid)
                     DO UPDATE SET
-                        value=excluded.value"""
+                        value=excluded.value WHERE value != excluded.value"""
         await self.execute(q, (ieee, endpoint_id, cluster_id, attrid, value))
         await self._db.commit()
 


### PR DESCRIPTION
 - switches the journal to WAL mode (big change)
 - optimizes a few common queries to not perform writes unnecessarily (minor change)

Should address https://github.com/home-assistant/core/issues/77049

I've also reduced the frequency with which `last_seen` timestamps are updated per-device to once every 30s. In theory this can cause `last_seen` to roll backwards if the value is cached somewhere and then zigpy is restarted.