### PR TITLE
Add a `create_new` kwarg to `BackupManager.restore_backup`

### DIFF
--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -319,3 +320,20 @@ async def test_add_backup(backup_factory):
 
     backups.add_backup(backup4)
     assert backups.backups == [backup2, backup4]
+
+
+async def test_restore_backup_create_new(backup):
+    app = AsyncMock()
+    backups = zigpy.backups.BackupManager(app)
+    backups.create_backup = AsyncMock()
+
+    await backups.restore_backup(backup)
+    app.write_network_info.assert_called_once()
+    backups.create_backup.assert_called_once()
+
+    app.reset_mock()
+    backups.create_backup.reset_mock()
+
+    await backups.restore_backup(backup, create_new=False)
+    app.write_network_info.assert_called_once()
+    backups.create_backup.assert_not_called()  # Won't be called

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -127,7 +127,11 @@ class BackupManager(ListenableMixin):
         return backup
 
     async def restore_backup(
-        self, backup: NetworkBackup, counter_increment: int = 10000
+        self,
+        backup: NetworkBackup,
+        counter_increment: int = 10000,
+        *,
+        create_new: bool = True,
     ) -> None:
         if not backup.is_complete():
             raise ValueError("Backup is incomplete, it is not possible to restore")
@@ -145,7 +149,8 @@ class BackupManager(ListenableMixin):
             node_info=new_backup.node_info,
         )
 
-        await self.create_backup()
+        if create_new:
+            await self.create_backup()
 
     def add_backup(self, backup: NetworkBackup):
         """


### PR DESCRIPTION
Cherry picked from https://github.com/zigpy/zigpy/pull/1037.

ZHA is currently using this kwarg but it's not in the latest zigpy release...