### PR TITLE
Implement the full OTA `image_block_response` structure

### DIFF
--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -1,4 +1,5 @@
 import re
+from unittest.mock import ANY
 
 import pytest
 
@@ -110,7 +111,13 @@ async def test_time_cluster_unsupported():
 def ota_cluster():
     ep = MagicMock()
     ep.device.application.ota = MagicMock(spec_set=ota.OTA)
-    return zcl.Cluster._registry[0x0019](ep)
+
+    cluster = zcl.Cluster._registry[0x0019](ep)
+
+    with patch.object(cluster, "reply", AsyncMock()), patch.object(
+        cluster, "request", AsyncMock()
+    ):
+        yield cluster
 
 
 async def test_ota_handle_cluster_req(ota_cluster):
@@ -275,22 +282,34 @@ def _ota_image_block(cluster, has_image=True, correct_version=True, wrong_offset
 
 
 async def test_ota_handle_image_block_no_img(ota_cluster):
-    ota_cluster.image_block_response = AsyncMock()
-
     await _ota_image_block(ota_cluster, has_image=False, correct_version=True)
-    assert ota_cluster.image_block_response.call_count == 1
-    assert (
-        ota_cluster.image_block_response.call_args[0][0] == zcl.foundation.Status.ABORT
+    ota_cluster.reply.assert_called_once_with(
+        False,
+        ota_cluster.commands_by_name["image_block_response"].id,
+        ota_cluster.commands_by_name["image_block_response"].schema,
+        *(
+            ota_cluster.commands_by_name["image_block_response"]
+            .schema(status=zcl.foundation.Status.ABORT)
+            .as_tuple(skip_missing=True)
+        ),
+        manufacturer=None,
+        tsn=ANY
     )
-    assert len(ota_cluster.image_block_response.call_args[0]) == 1
-    ota_cluster.image_block_response.reset_mock()
+    ota_cluster.reply.reset_mock()
 
     await _ota_image_block(ota_cluster, has_image=False, correct_version=False)
-    assert ota_cluster.image_block_response.call_count == 1
-    assert (
-        ota_cluster.image_block_response.call_args[0][0] == zcl.foundation.Status.ABORT
+    ota_cluster.reply.assert_called_once_with(
+        False,
+        ota_cluster.commands_by_name["image_block_response"].id,
+        ota_cluster.commands_by_name["image_block_response"].schema,
+        *(
+            ota_cluster.commands_by_name["image_block_response"]
+            .schema(status=zcl.foundation.Status.ABORT)
+            .as_tuple(skip_missing=True)
+        ),
+        manufacturer=None,
+        tsn=ANY
     )
-    assert len(ota_cluster.image_block_response.call_args[0]) == 1
 
 
 async def test_ota_handle_image_block(ota_cluster):

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -174,7 +174,9 @@ class Struct:
             # Missing fields cause an error if strict
             if value is None and not field.optional:
                 if strict:
-                    raise ValueError(f"Value for field {field.name!r} is required")
+                    raise ValueError(
+                        f"Value for field {field.name!r} is required: {self!r}"
+                    )
                 else:
                     pass  # Python bug, the following `continue` is never covered
                     continue  # pragma: no cover

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1337,7 +1337,7 @@ class Ota(Cluster):
         Apply_after_timeout = 0x00
         Do_not_apply_after_timeout = 0x01
 
-    class image_notify(foundation.CommandSchema):
+    class ImageNotifyCommand(foundation.CommandSchema):
         class PayloadType(t.enum8):
             QueryJitter = 0x00
             QueryJitter_ManufacturerCode = 0x01
@@ -1364,7 +1364,7 @@ class Ota(Cluster):
             )
         )
 
-    class query_next_image(foundation.CommandSchema):
+    class QueryNextImageCommand(foundation.CommandSchema):
         class FieldControl(t.bitmap8):
             HardwareVersion = 0b00000001
 
@@ -1376,7 +1376,7 @@ class Ota(Cluster):
             requires=(lambda s: s.field_control & s.FieldControl.HardwareVersion)
         )
 
-    class image_block(foundation.CommandSchema):
+    class ImageBlockCommand(foundation.CommandSchema):
         class FieldControl(t.bitmap8):
             RequestNodeAddr = 0b00000001
             MinimumBlockPeriod = 0b00000010
@@ -1394,7 +1394,7 @@ class Ota(Cluster):
             requires=(lambda s: s.field_control & s.FieldControl.MinimumBlockPeriod)
         )
 
-    class image_page(foundation.CommandSchema):
+    class ImagePageCommand(foundation.CommandSchema):
         class FieldControl(t.bitmap8):
             RequestNodeAddr = 0b00000001
 
@@ -1410,7 +1410,7 @@ class Ota(Cluster):
             requires=lambda s: s.field_control & s.FieldControl.RequestNodeAddr
         )
 
-    class image_block_response(foundation.CommandSchema):
+    class ImageBlockResponseCommand(foundation.CommandSchema):
         # All responses contain at least a status
         status: foundation.Status
 
@@ -1462,9 +1462,9 @@ class Ota(Cluster):
         0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
     }
     server_commands: dict[int, ZCLCommandDef] = {
-        0x01: ZCLCommandDef("query_next_image", query_next_image, False),
-        0x03: ZCLCommandDef("image_block", image_block, False),
-        0x04: ZCLCommandDef("image_page", image_page, False),
+        0x01: ZCLCommandDef("query_next_image", QueryNextImageCommand, False),
+        0x03: ZCLCommandDef("image_block", ImageBlockCommand, False),
+        0x04: ZCLCommandDef("image_page", ImagePageCommand, False),
         0x06: ZCLCommandDef(
             "upgrade_end",
             {
@@ -1488,7 +1488,7 @@ class Ota(Cluster):
         ),
     }
     client_commands: dict[int, ZCLCommandDef] = {
-        0x00: ZCLCommandDef("image_notify", image_notify, False),
+        0x00: ZCLCommandDef("image_notify", ImageNotifyCommand, False),
         0x02: ZCLCommandDef(
             "query_next_image_response",
             {
@@ -1502,7 +1502,7 @@ class Ota(Cluster):
         ),
         0x05: ZCLCommandDef(
             "image_block_response",
-            image_block_response,
+            ImageBlockResponseCommand,
             True,
         ),
         0x07: ZCLCommandDef(

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1651,10 +1651,10 @@ class Ota(Cluster):
     ):
         self.debug(
             (
-                "OTA image_block handler for '%s %s': field_control=%s, "
-                "manufacturer_id=%s, image_type=%s, file_version=%s, "
-                "file_offset=%s, max_data_size=%s, request_node_addr=%s"
-                "block_request_delay=%s"
+                "OTA image_block handler for '%s %s': field_control=%s"
+                ", manufacturer_id=%s, image_type=%s, file_version=%s"
+                ", file_offset=%s, max_data_size=%s, request_node_addr=%s"
+                ", block_request_delay=%s"
             ),
             self.endpoint.manufacturer,
             self.endpoint.model,
@@ -1699,8 +1699,8 @@ class Ota(Cluster):
     ):
         self.debug(
             (
-                "OTA upgrade_end handler for '%s %s': status=%s, "
-                "manufacturer_id=%s, image_type=%s, file_version=%s"
+                "OTA upgrade_end handler for '%s %s': status=%s"
+                ", manufacturer_id=%s, image_type=%s, file_version=%s"
             ),
             self.endpoint.manufacturer,
             self.endpoint.model,

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1589,8 +1589,8 @@ class Ota(Cluster):
         self.debug(
             (
                 "OTA query_next_image handler for '%s %s': "
-                "field_control=%s, manufacture_id=%s, image_type=%s, "
-                "current_file_version=%s, hardware_version=%s, model=%s"
+                "field_control=%s, manufacturer_id=%s, image_type=%s, "
+                "current_file_version=%s, hardware_version=%s, model=%r"
             ),
             self.endpoint.manufacturer,
             self.endpoint.model,

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1678,18 +1678,20 @@ class Ota(Cluster):
             "OTA upgrade progress: %0.1f", 100.0 * file_offset / img.header.image_size
         )
         try:
+            block = img.get_image_block(file_offset, max_data_size)
+        except ValueError:
+            await self.image_block_response(
+                foundation.Status.MALFORMED_COMMAND, tsn=tsn
+            )
+        else:
             await self.image_block_response(
                 foundation.Status.SUCCESS,
                 img.key.manufacturer_id,
                 img.key.image_type,
                 img.version,
                 file_offset,
-                img.get_image_block(file_offset, max_data_size),
+                block,
                 tsn=tsn,
-            )
-        except ValueError:
-            await self.image_block_response(
-                foundation.Status.MALFORMED_COMMAND, tsn=tsn
             )
 
     async def _handle_upgrade_end(


### PR DESCRIPTION
Fixes #1046.

The error in the linked issue is due to unit tests mocking out the request entirely, so the line had coverage but was never actually tested. The correct behavior is for zigpy to send an `ABORT` status.