### PR TITLE
Add additional endpoint configuration option

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -23,6 +23,7 @@ import zigpy.util
 import zigpy.zcl
 import zigpy.zdo
 import zigpy.zdo.types as zdo_types
+from zigpy.config import CONF_ADDITIONAL_ENDPOINTS
 
 DEFAULT_ENDPOINT_ID = 1
 LOGGER = logging.getLogger(__name__)
@@ -538,6 +539,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 output_clusters=[],
             )
         )
+
+        for add_endpoint in self.config.get(CONF_ADDITIONAL_ENDPOINTS):
+            await self.add_endpoint(zdo_types.SimpleDescriptor(**add_endpoint))
 
     async def mrequest(
         self,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -10,6 +10,7 @@ from typing import Any
 import zigpy.appdb
 import zigpy.backups
 import zigpy.config as conf
+from zigpy.config import CONF_ADDITIONAL_ENDPOINTS
 import zigpy.device
 import zigpy.exceptions
 import zigpy.group
@@ -23,7 +24,6 @@ import zigpy.util
 import zigpy.zcl
 import zigpy.zdo
 import zigpy.zdo.types as zdo_types
-from zigpy.config import CONF_ADDITIONAL_ENDPOINTS
 
 DEFAULT_ENDPOINT_ID = 1
 LOGGER = logging.getLogger(__name__)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -10,7 +10,6 @@ from typing import Any
 import zigpy.appdb
 import zigpy.backups
 import zigpy.config as conf
-from zigpy.config import CONF_ADDITIONAL_ENDPOINTS
 import zigpy.device
 import zigpy.exceptions
 import zigpy.group
@@ -540,8 +539,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             )
         )
 
-        for add_endpoint in self.config.get(CONF_ADDITIONAL_ENDPOINTS):
-            await self.add_endpoint(zdo_types.SimpleDescriptor(**add_endpoint))
+        for endpoint in self.config[conf.CONF_ADDITIONAL_ENDPOINTS]:
+            await self.add_endpoint(endpoint)
 
     async def mrequest(
         self,

--- a/zigpy/config/__init__.py
+++ b/zigpy/config/__init__.py
@@ -25,8 +25,8 @@ from zigpy.config.defaults import (
     CONF_TOPO_SKIP_COORDINATOR_DEFAULT,
 )
 from zigpy.config.validators import cv_boolean, cv_hex, cv_key
-from zigpy.zdo.types import SimpleDescriptor
 import zigpy.types as t
+from zigpy.zdo.types import SimpleDescriptor
 
 CONF_DATABASE = "database_path"
 CONF_DEVICE = "device"

--- a/zigpy/config/__init__.py
+++ b/zigpy/config/__init__.py
@@ -25,6 +25,7 @@ from zigpy.config.defaults import (
     CONF_TOPO_SKIP_COORDINATOR_DEFAULT,
 )
 from zigpy.config.validators import cv_boolean, cv_hex, cv_key
+from zigpy.zdo.types import SimpleDescriptor
 import zigpy.types as t
 
 CONF_DATABASE = "database_path"
@@ -53,6 +54,7 @@ CONF_OTA_SALUS = "salus_provider"
 CONF_TOPO_SCAN_PERIOD = "topology_scan_period"
 CONF_TOPO_SCAN_ENABLED = "topology_scan_enabled"
 CONF_TOPO_SKIP_COORDINATOR = "topology_scan_skip_coordinator"
+CONF_ADDITIONAL_ENDPOINTS = "additional_endpoints"
 
 
 SCHEMA_DEVICE = vol.Schema({vol.Required(CONF_DEVICE_PATH): str})
@@ -124,3 +126,5 @@ ZIGPY_SCHEMA = vol.Schema(
 CONFIG_SCHEMA = ZIGPY_SCHEMA.extend(
     {vol.Required(CONF_DEVICE): SCHEMA_DEVICE}, extra=vol.ALLOW_EXTRA
 )
+
+ENDPOINT_SCHEMA = vol.Schema({vol.Optional(CONF_ADDITIONAL_ENDPOINTS): SimpleDescriptor})

--- a/zigpy/config/__init__.py
+++ b/zigpy/config/__init__.py
@@ -127,4 +127,6 @@ CONFIG_SCHEMA = ZIGPY_SCHEMA.extend(
     {vol.Required(CONF_DEVICE): SCHEMA_DEVICE}, extra=vol.ALLOW_EXTRA
 )
 
-ENDPOINT_SCHEMA = vol.Schema({vol.Optional(CONF_ADDITIONAL_ENDPOINTS): SimpleDescriptor})
+ENDPOINT_SCHEMA = vol.Schema(
+    {vol.Optional(CONF_ADDITIONAL_ENDPOINTS): SimpleDescriptor}
+)

--- a/zigpy/config/__init__.py
+++ b/zigpy/config/__init__.py
@@ -26,7 +26,6 @@ from zigpy.config.defaults import (
 )
 from zigpy.config.validators import cv_boolean, cv_hex, cv_key, cv_simple_descriptor
 import zigpy.types as t
-from zigpy.zdo.types import SimpleDescriptor
 
 CONF_DATABASE = "database_path"
 CONF_DEVICE = "device"

--- a/zigpy/config/__init__.py
+++ b/zigpy/config/__init__.py
@@ -24,7 +24,7 @@ from zigpy.config.defaults import (
     CONF_TOPO_SCAN_PERIOD_DEFAULT,
     CONF_TOPO_SKIP_COORDINATOR_DEFAULT,
 )
-from zigpy.config.validators import cv_boolean, cv_hex, cv_key
+from zigpy.config.validators import cv_boolean, cv_hex, cv_key, cv_simple_descriptor
 import zigpy.types as t
 from zigpy.zdo.types import SimpleDescriptor
 
@@ -119,14 +119,11 @@ ZIGPY_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_NWK_VALIDATE_SETTINGS, default=CONF_NWK_VALIDATE_SETTINGS_DEFAULT
         ): cv_boolean,
+        vol.Optional(CONF_ADDITIONAL_ENDPOINTS, default=[]): [cv_simple_descriptor],
     },
     extra=vol.ALLOW_EXTRA,
 )
 
 CONFIG_SCHEMA = ZIGPY_SCHEMA.extend(
     {vol.Required(CONF_DEVICE): SCHEMA_DEVICE}, extra=vol.ALLOW_EXTRA
-)
-
-ENDPOINT_SCHEMA = vol.Schema(
-    {vol.Optional(CONF_ADDITIONAL_ENDPOINTS): SimpleDescriptor}
 )

--- a/zigpy/config/validators.py
+++ b/zigpy/config/validators.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import typing
+
 import voluptuous as vol
 
 import zigpy.types as t
+import zigpy.zdo.types as zdo_t
 
 
 def cv_boolean(value: bool | int | str) -> bool:
@@ -51,3 +54,18 @@ def cv_key(key: list[int]) -> t.KeyData:
         raise vol.Invalid("Key bytes must be within (0..255) range")
 
     return t.KeyData(key)
+
+
+def cv_simple_descriptor(obj: dict[str, typing.Any]) -> zdo_t.SimpleDescriptor:
+    """Validates a ZDO simple descriptor."""
+    if isinstance(obj, zdo_t.SimpleDescriptor):
+        return obj
+    elif not isinstance(obj, dict):
+        raise vol.Invalid("Not a dictionary")
+
+    descriptor = zdo_t.SimpleDescriptor(**obj)
+
+    if not descriptor.is_valid:
+        raise vol.Invalid(f"Invalid simple descriptor {descriptor!r}")
+
+    return descriptor


### PR DESCRIPTION
This PR adds a configuration option to allow adding additional endpoints.

This is required for xbee end devices as they require 0xE6 and 0xE8 endpoints and by default zigpy ignores those.

Example configuration.

```
zha:
  zigpy_config:
    additional_endpoints:
      - endpoint: 0xE6
        profile: 0xC105
        device_type: 0x0000
        device_version: 0b0000
        input_clusters: []
        output_clusters: [0x21]
      - endpoint: 0xE8
        profile: 0xC105
        device_type: 0x0000
        device_version: 0b0000
        input_clusters: []
        output_clusters: [0x21]
```
