### PR TITLE
Handle request keyword arguments in quirks

### DIFF
--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -186,6 +186,7 @@ class CustomCluster(zigpy.zcl.Cluster):
             expect_reply=expect_reply,
             tries=tries,
             tsn=tsn,
+            **kwargs,
         )
 
     async def client_command(
@@ -204,7 +205,13 @@ class CustomCluster(zigpy.zcl.Cluster):
             manufacturer = self.endpoint.manufacturer_id
 
         return await self.reply(
-            False, command.id, command.schema, *args, manufacturer=manufacturer, tsn=tsn
+            False,
+            command.id,
+            command.schema,
+            *args,
+            manufacturer=manufacturer,
+            tsn=tsn,
+            **kwargs,
         )
 
     async def read_attributes_raw(self, attributes, manufacturer=None):

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -334,7 +334,8 @@ class DynamicBoundedSemaphore(asyncio.Semaphore):
         self._waiters: collections.deque = collections.deque()
         self._wakeup_scheduled: bool = False
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache(maxsize=None)
     def _loop(self) -> asyncio.BaseEventLoop:
         return asyncio.get_running_loop()
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -614,6 +614,9 @@ class OnOff(Cluster):
         Delayed_All_Off = 0x00
         Dying_Light = 0x01
 
+    class OnOffControl(t.bitmap8):
+        Accept_Only_When_On = 0b00000001
+
     DELAYED_ALL_OFF_FADE_TO_OFF = 0x00
     DELAYED_ALL_OFF_NO_FADE = 0x01
     DELAYED_ALL_OFF_DIM_THEN_FADE_TO_OFF = 0x02
@@ -645,7 +648,7 @@ class OnOff(Cluster):
         0x42: ZCLCommandDef(
             "on_with_timed_off",
             {
-                "on_off_control": t.uint8_t,
+                "on_off_control": OnOffControl,
                 "on_time": t.uint16_t,
                 "off_wait_time": t.uint16_t,
             },


### PR DESCRIPTION
Quirks currently do not pass through command keyword arguments, leading to strange errors with quirked devices.