### PR TITLE
Expose `min_value` and `max_value` on integer types

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -45,6 +45,8 @@ def test_int_too_short():
 def test_fractional_ints_corner():
     assert t.uint1_t._size is None
     assert t.uint1_t._bits == 1
+    assert t.uint1_t.min_value == 0
+    assert t.uint1_t.max_value == 1
 
     assert t.uint1_t(0) == 0
     assert t.uint1_t(1) == 1
@@ -70,6 +72,8 @@ def test_fractional_ints_corner():
 def test_fractional_ints_larger():
     assert t.uint7_t._size is None
     assert t.uint7_t._bits == 7
+    assert t.uint7_t.min_value == 0
+    assert t.uint7_t.max_value == 2**7 - 1
 
     assert t.uint7_t(0) == 0
     assert t.uint7_t(1) == 1


### PR DESCRIPTION
Makes implementing numerical form fields in ZHA possible without having to compute these values directly:

```python
>>> import zigpy.types as t
>>> t.uint8_t.min_value
0
>>> t.uint8_t.max_value
255
>>> t.int16s.min_value
-32768
>>> t.int16s.max_value
32767
```