### PR TITLE
Add a recursive `Struct.to_dict` and a `Struct.from_dict` method

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -782,3 +782,19 @@ def test_skip_missing():
 
     assert TestStruct(foo=1).as_tuple() == (1, None)
     assert TestStruct(foo=1).as_tuple(skip_missing=True) == (1,)
+
+
+def test_from_dict(expose_global):
+    @expose_global
+    class InnerStruct(t.Struct):
+        field1: t.uint8_t
+        field2: t.CharacterString
+
+    class TestStruct(t.Struct):
+        foo: t.uint8_t
+        bar: InnerStruct
+        baz: t.CharacterString
+
+    s = TestStruct(foo=1, bar=InnerStruct(field1=2, field2="field2"), baz="field3")
+
+    assert s == TestStruct.from_dict(s.as_dict(recursive=True))

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -186,7 +186,23 @@ class Struct:
 
         return assigned_fields
 
-    def as_dict(self, *, skip_missing: bool = False) -> dict[str, typing.Any]:
+    @classmethod
+    def from_dict(cls: type[_STRUCT], obj: dict[str, typing.Any]) -> _STRUCT:
+        parsed = {}
+
+        for key, value in obj.items():
+            field = getattr(cls.fields, key)
+
+            if issubclass(field.type, Struct):
+                parsed[field.name] = field.type.from_dict(value)
+            else:
+                parsed[field.name] = value
+
+        return cls(**parsed)
+
+    def as_dict(
+        self, *, skip_missing: bool = False, recursive: bool = False
+    ) -> dict[str, typing.Any]:
         d = {}
 
         for f in self.fields:
@@ -194,8 +210,12 @@ class Struct:
 
             if value is None and skip_missing:
                 continue
-
-            d[f.name] = value
+            elif recursive and isinstance(value, Struct):
+                d[f.name] = value.as_dict(
+                    skip_missing=skip_missing, recursive=recursive
+                )
+            else:
+                d[f.name] = value
 
         return d
 


### PR DESCRIPTION
This will allow for structs to be constructed from dictionaries and vice versa, allowing for complex commands to be sent via ZHA's cluster API.