### PR TITLE
Internally pass schema `args` and `kwargs` without expansion to avoid collisions

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -973,14 +973,24 @@ async def test_zcl_request_direction():
     ep.request = AsyncMock()
 
     ep.add_input_cluster(zcl.clusters.general.OnOff.cluster_id)
+    ep.add_input_cluster(zcl.clusters.lighting.Color.cluster_id)
     ep.add_output_cluster(zcl.clusters.general.OnOff.cluster_id)
 
+    # Input cluster
     await ep.in_clusters[zcl.clusters.general.OnOff.cluster_id].on()
     hdr1, _ = foundation.ZCLHeader.deserialize(ep.request.mock_calls[0].args[2])
     assert hdr1.direction == foundation.Direction.Server_to_Client
 
     ep.request.reset_mock()
 
+    # Output cluster
     await ep.out_clusters[zcl.clusters.general.OnOff.cluster_id].on()
     hdr2, _ = foundation.ZCLHeader.deserialize(ep.request.mock_calls[0].args[2])
     assert hdr2.direction == foundation.Direction.Client_to_Server
+
+    # Color cluster that also uses `direction` as a kwarg
+    await ep.light_color.move_to_hue(
+        hue=0,
+        direction=zcl.clusters.lighting.Color.Direction.Shortest_distance,
+        transition_time=10,
+    )

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -244,15 +244,17 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
     def _create_request(
         self,
+        *,
         general: bool,
         command_id: foundation.GeneralCommand | int,
         schema: dict | t.Struct,
-        *args,
         manufacturer: int | None = None,
         tsn: int | None = None,
         disable_default_response: bool,
         direction: foundation.Direction,
-        **kwargs,
+        # Schema args and kwargs
+        args: tuple[Any, ...],
+        kwargs: Any,
     ) -> tuple[foundation.ZCLHeader, bytes]:
         # Convert out-of-band dict schemas to struct schemas
         if isinstance(schema, (tuple, list)):
@@ -300,10 +302,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         **kwargs,
     ):
         hdr, request = self._create_request(
-            general,
-            command_id,
-            schema,
-            *args,
+            general=general,
+            command_id=command_id,
+            schema=schema,
             manufacturer=manufacturer,
             tsn=tsn,
             disable_default_response=self.is_client,
@@ -312,7 +313,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 if self.is_client
                 else foundation.Direction.Server_to_Client
             ),
-            **kwargs,
+            args=args,
+            kwargs=kwargs,
         )
 
         self.debug("Sending request header: %r", hdr)
@@ -338,15 +340,15 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         **kwargs,
     ):
         hdr, request = self._create_request(
-            general,
-            command_id,
-            schema,
-            *args,
+            general=general,
+            command_id=command_id,
+            schema=schema,
             manufacturer=manufacturer,
             tsn=tsn,
             disable_default_response=True,
             direction=foundation.Direction.Client_to_Server,
-            **kwargs,
+            args=args,
+            kwargs=kwargs,
         )
 
         self.debug("Sending reply header: %r", hdr)


### PR DESCRIPTION
`direction` is used by both the zigpy-internal `_create_request` and commands like `Color.move_to_hue`.

https://github.com/home-assistant/core/issues/79808