### PR TITLE
Add `access` and `mandatory` fields to ZCL attribute definitions

### DIFF
--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -835,3 +835,21 @@ def test_zcl_header_is_reply_compat():
     )
     assert not hdr4.is_reply
     assert hdr4.direction == foundation.Direction.Server_to_Client
+
+
+def test_zcl_attribute_access():
+    A = foundation.ZCLAttributeAccess
+
+    assert A.from_str("") == (A.NONE)
+    assert A.from_str("r") == (A.Read)
+    assert A.from_str("r*w") == (A.Read | A.Write_Optional)
+    assert A.from_str("r*wp") == (A.Read | A.Write_Optional | A.Report)
+    assert A.from_str("rp") == (A.Read | A.Report)
+    assert A.from_str("rps") == (A.Read | A.Report | A.Scene)
+    assert A.from_str("rs") == (A.Read | A.Scene)
+    assert A.from_str("rw") == (A.Read | A.Write)
+    assert A.from_str("rwp") == (A.Read | A.Write | A.Report)
+    assert A.from_str("rws") == (A.Read | A.Write | A.Scene)
+
+    with pytest.raises(ValueError):
+        A.from_str("q")

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -673,18 +673,21 @@ def test_zcl_attribute_definition():
         id=0x1234,
         name="test",
         type=t.uint16_t,
+        access="rw",
     )
 
     assert "0x1234" in str(a)
     assert "'test'" in str(a)
     assert "uint16_t" in str(a)
     assert not a.is_manufacturer_specific  # default
-    assert a.access == "rw"  # also default
+    assert a.access == (
+        foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
+    )
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         a.replace(access="x")
 
-    assert a.replace(access="w").access == "w"
+    assert a.replace(access="w").access == foundation.ZCLAttributeAccess.Write
 
 
 def test_zcl_attribute_item_access_warning():

--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -27,12 +27,16 @@ class Shade(Cluster):
 
     attributes: dict[int, ZCLAttributeDef] = {
         # Shade Information
-        0x0000: ("physical_closed_limit", t.uint16_t),
-        0x0001: ("motor_step_size", t.uint8_t),
-        0x0002: ("status", ShadeStatus),
+        0x0000: ZCLAttributeDef("physical_closed_limit", type=t.uint16_t, access="r"),
+        0x0001: ZCLAttributeDef("motor_step_size", type=t.uint8_t, access="r"),
+        0x0002: ZCLAttributeDef(
+            "status", type=ShadeStatus, access="rw", mandatory=True
+        ),
         # Shade Settings
-        0x0010: ("closed_limit", t.uint16_t),
-        0x0012: ("mode", ShadeMode),
+        0x0010: ZCLAttributeDef(
+            "closed_limit", type=t.uint16_t, access="rw", mandatory=True
+        ),
+        0x0012: ZCLAttributeDef("mode", type=ShadeMode, access="rw", mandatory=True),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -230,49 +234,99 @@ class DoorLock(Cluster):
     name = "Door Lock"
     ep_attribute = "door_lock"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("lock_state", LockState),
-        0x0001: ("lock_type", LockType),
-        0x0002: ("actuator_enabled", t.Bool),
-        0x0003: ("door_state", DoorState),
-        0x0004: ("door_open_events", t.uint32_t),
-        0x0005: ("door_closed_events", t.uint32_t),
-        0x0006: ("open_period", t.uint16_t),
-        0x0010: ("num_of_lock_records_supported", t.uint16_t),
-        0x0011: ("num_of_total_users_supported", t.uint16_t),
-        0x0012: ("num_of_pin_users_supported", t.uint16_t),
-        0x0013: ("num_of_rfid_users_supported", t.uint16_t),
-        0x0014: ("num_of_week_day_schedules_supported_per_user", t.uint8_t),
-        0x0015: ("num_of_year_day_schedules_supported_per_user", t.uint8_t),
-        0x0016: ("num_of_holiday_scheduleds_supported", t.uint8_t),
-        0x0017: ("max_pin_len", t.uint8_t),
-        0x0018: ("min_pin_len", t.uint8_t),
-        0x0019: ("max_rfid_len", t.uint8_t),
-        0x001A: ("min_rfid_len", t.uint8_t),
-        0x0020: ("enable_logging", t.Bool),
-        0x0021: ("language", t.LimitedCharString(3)),
-        0x0022: ("led_settings", t.uint8_t),
-        0x0023: ("auto_relock_time", t.uint32_t),
-        0x0024: ("sound_volume", t.uint8_t),
-        0x0025: ("operating_mode", OperatingMode),
-        0x0026: ("supported_operating_modes", SupportedOperatingModes),
-        0x0027: ("default_configuration_register", DefaultConfigurationRegister),
-        0x0028: ("enable_local_programming", t.Bool),
-        0x0029: ("enable_one_touch_locking", t.Bool),
-        0x002A: ("enable_inside_status_led", t.Bool),
-        0x002B: ("enable_privacy_mode_button", t.Bool),
-        0x0030: ("wrong_code_entry_limit", t.uint8_t),
-        0x0031: ("user_code_temporary_disable_time", t.uint8_t),
-        0x0032: ("send_pin_ota", t.Bool),
-        0x0033: ("require_pin_for_rf_operation", t.Bool),
-        0x0034: ("zigbee_security_level", ZigbeeSecurityLevel),
-        0x0040: ("alarm_mask", AlarmMask),
-        0x0041: ("keypad_operation_event_mask", KeypadOperationEventMask),
-        0x0042: ("rf_operation_event_mask", RFOperationEventMask),
-        0x0043: ("manual_operation_event_mask", ManualOperatitonEventMask),
-        0x0044: ("rfid_operation_event_mask", RFIDOperationEventMask),
-        0x0045: ("keypad_programming_event_mask", KeypadProgrammingEventMask),
-        0x0046: ("rf_programming_event_mask", RFProgrammingEventMask),
-        0x0047: ("rfid_programming_event_mask", RFIDProgrammingEventMask),
+        0x0000: ZCLAttributeDef(
+            "lock_state", type=LockState, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef("lock_type", type=LockType, access="r", mandatory=True),
+        0x0002: ZCLAttributeDef(
+            "actuator_enabled", type=t.Bool, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("door_state", type=DoorState, access="rp"),
+        0x0004: ZCLAttributeDef("door_open_events", type=t.uint32_t, access="rw"),
+        0x0005: ZCLAttributeDef("door_closed_events", type=t.uint32_t, access="rw"),
+        0x0006: ZCLAttributeDef("open_period", type=t.uint16_t, access="rw"),
+        0x0010: ZCLAttributeDef(
+            "num_of_lock_records_supported", type=t.uint16_t, access="r"
+        ),
+        0x0011: ZCLAttributeDef(
+            "num_of_total_users_supported", type=t.uint16_t, access="r"
+        ),
+        0x0012: ZCLAttributeDef(
+            "num_of_pin_users_supported", type=t.uint16_t, access="r"
+        ),
+        0x0013: ZCLAttributeDef(
+            "num_of_rfid_users_supported", type=t.uint16_t, access="r"
+        ),
+        0x0014: ZCLAttributeDef(
+            "num_of_week_day_schedules_supported_per_user", type=t.uint8_t, access="r"
+        ),
+        0x0015: ZCLAttributeDef(
+            "num_of_year_day_schedules_supported_per_user", type=t.uint8_t, access="r"
+        ),
+        0x0016: ZCLAttributeDef(
+            "num_of_holiday_scheduleds_supported", type=t.uint8_t, access="r"
+        ),
+        0x0017: ZCLAttributeDef("max_pin_len", type=t.uint8_t, access="r"),
+        0x0018: ZCLAttributeDef("min_pin_len", type=t.uint8_t, access="r"),
+        0x0019: ZCLAttributeDef("max_rfid_len", type=t.uint8_t, access="r"),
+        0x001A: ZCLAttributeDef("min_rfid_len", type=t.uint8_t, access="r"),
+        0x0020: ZCLAttributeDef("enable_logging", type=t.Bool, access="r*wp"),
+        0x0021: ZCLAttributeDef("language", type=t.LimitedCharString(3), access="r*wp"),
+        0x0022: ZCLAttributeDef("led_settings", type=t.uint8_t, access="r*wp"),
+        0x0023: ZCLAttributeDef("auto_relock_time", type=t.uint32_t, access="r*wp"),
+        0x0024: ZCLAttributeDef("sound_volume", type=t.uint8_t, access="r*wp"),
+        0x0025: ZCLAttributeDef("operating_mode", type=OperatingMode, access="r*wp"),
+        0x0026: ZCLAttributeDef(
+            "supported_operating_modes", type=SupportedOperatingModes, access="r"
+        ),
+        0x0027: ZCLAttributeDef(
+            "default_configuration_register",
+            type=DefaultConfigurationRegister,
+            access="rp",
+        ),
+        0x0028: ZCLAttributeDef("enable_local_programming", type=t.Bool, access="r*wp"),
+        0x0029: ZCLAttributeDef("enable_one_touch_locking", type=t.Bool, access="rwp"),
+        0x002A: ZCLAttributeDef("enable_inside_status_led", type=t.Bool, access="rwp"),
+        0x002B: ZCLAttributeDef(
+            "enable_privacy_mode_button", type=t.Bool, access="rwp"
+        ),
+        0x0030: ZCLAttributeDef(
+            "wrong_code_entry_limit", type=t.uint8_t, access="r*wp"
+        ),
+        0x0031: ZCLAttributeDef(
+            "user_code_temporary_disable_time", type=t.uint8_t, access="r*wp"
+        ),
+        0x0032: ZCLAttributeDef("send_pin_ota", type=t.Bool, access="r*wp"),
+        0x0033: ZCLAttributeDef(
+            "require_pin_for_rf_operation", type=t.Bool, access="r*wp"
+        ),
+        0x0034: ZCLAttributeDef(
+            "zigbee_security_level", type=ZigbeeSecurityLevel, access="rp"
+        ),
+        0x0040: ZCLAttributeDef("alarm_mask", type=AlarmMask, access="rwp"),
+        0x0041: ZCLAttributeDef(
+            "keypad_operation_event_mask", type=KeypadOperationEventMask, access="rwp"
+        ),
+        0x0042: ZCLAttributeDef(
+            "rf_operation_event_mask", type=RFOperationEventMask, access="rwp"
+        ),
+        0x0043: ZCLAttributeDef(
+            "manual_operation_event_mask", type=ManualOperatitonEventMask, access="rwp"
+        ),
+        0x0044: ZCLAttributeDef(
+            "rfid_operation_event_mask", type=RFIDOperationEventMask, access="rwp"
+        ),
+        0x0045: ZCLAttributeDef(
+            "keypad_programming_event_mask",
+            type=KeypadProgrammingEventMask,
+            access="rwp",
+        ),
+        0x0046: ZCLAttributeDef(
+            "rf_programming_event_mask", type=RFProgrammingEventMask, access="rwp"
+        ),
+        0x0047: ZCLAttributeDef(
+            "rfid_programming_event_mask", type=RFIDProgrammingEventMask, access="rwp"
+        ),
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("lock_door", {"pin_code?": t.CharacterString}, False),
@@ -573,27 +627,58 @@ class WindowCovering(Cluster):
 
     attributes: dict[int, ZCLAttributeDef] = {
         # Window Covering Information
-        0x0000: ("window_covering_type", WindowCoveringType),
-        0x0001: ("physical_closed_limit_lift", t.uint16_t),
-        0x0002: ("physical_closed_limit_tilt", t.uint16_t),
-        0x0003: ("current_position_lift", t.uint16_t),
-        0x0004: ("current_position_tilt", t.uint16_t),
-        0x0005: ("number_of_actuations_lift", t.uint16_t),
-        0x0006: ("number_of_actuations_tilt", t.uint16_t),
-        0x0007: ("config_status", ConfigStatus),
-        0x0008: ("current_position_lift_percentage", t.uint8_t),
-        0x0009: ("current_position_tilt_percentage", t.uint8_t),
+        0x0000: ZCLAttributeDef(
+            "window_covering_type", type=WindowCoveringType, access="r", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "physical_closed_limit_lift", type=t.uint16_t, access="r"
+        ),
+        0x0002: ZCLAttributeDef(
+            "physical_closed_limit_tilt", type=t.uint16_t, access="r"
+        ),
+        0x0003: ZCLAttributeDef("current_position_lift", type=t.uint16_t, access="r"),
+        0x0004: ZCLAttributeDef("current_position_tilt", type=t.uint16_t, access="r"),
+        0x0005: ZCLAttributeDef(
+            "number_of_actuations_lift", type=t.uint16_t, access="r"
+        ),
+        0x0006: ZCLAttributeDef(
+            "number_of_actuations_tilt", type=t.uint16_t, access="r"
+        ),
+        0x0007: ZCLAttributeDef(
+            "config_status", type=ConfigStatus, access="r", mandatory=True
+        ),
+        # All subsequent attributes are mandatory if their control types are enabled
+        0x0008: ZCLAttributeDef(
+            "current_position_lift_percentage", type=t.uint8_t, access="rps"
+        ),
+        0x0009: ZCLAttributeDef(
+            "current_position_tilt_percentage", type=t.uint8_t, access="rps"
+        ),
         # Window Covering Settings
-        0x0010: ("installed_open_limit_lift", t.uint16_t),
-        0x0011: ("installed_closed_limit_lift", t.uint16_t),
-        0x0012: ("installed_open_limit_tilt", t.uint16_t),
-        0x0013: ("installed_closed_limit_tilt", t.uint16_t),
-        0x0014: ("velocity_lift", t.uint16_t),
-        0x0015: ("acceleration_time_lift", t.uint16_t),
-        0x0016: ("deceleration_time_lift", t.uint16_t),
-        0x0017: ("window_covering_mode", WindowCoveringMode),
-        0x0018: ("intermediate_setpoints_lift", t.LVBytes),
-        0x0019: ("intermediate_setpoints_tilt", t.LVBytes),
+        0x0010: ZCLAttributeDef(
+            "installed_open_limit_lift", type=t.uint16_t, access="r"
+        ),
+        0x0011: ZCLAttributeDef(
+            "installed_closed_limit_lift", type=t.uint16_t, access="r"
+        ),
+        0x0012: ZCLAttributeDef(
+            "installed_open_limit_tilt", type=t.uint16_t, access="r"
+        ),
+        0x0013: ZCLAttributeDef(
+            "installed_closed_limit_tilt", type=t.uint16_t, access="r"
+        ),
+        0x0014: ZCLAttributeDef("velocity_lift", type=t.uint16_t, access="rw"),
+        0x0015: ZCLAttributeDef("acceleration_time_lift", type=t.uint16_t, access="rw"),
+        0x0016: ZCLAttributeDef("deceleration_time_lift", type=t.uint16_t, access="rw"),
+        0x0017: ZCLAttributeDef(
+            "window_covering_mode", type=WindowCoveringMode, access="rw", mandatory=True
+        ),
+        0x0018: ZCLAttributeDef(
+            "intermediate_setpoints_lift", type=t.LVBytes, access="rw"
+        ),
+        0x0019: ZCLAttributeDef(
+            "intermediate_setpoints_tilt", type=t.LVBytes, access="rw"
+        ),
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("up_open", {}, False),

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -322,7 +322,7 @@ class PowerConfiguration(Cluster):
         0x0050: ZCLAttributeDef(
             "battery_2_manufacturer", type=t.CharacterString, access="rw"
         ),
-        0x0051: ZCLAttributeDef("battery_2_size", type=t.enum8, access="rw"),
+        0x0051: ZCLAttributeDef("battery_2_size", type=BatterySize, access="rw"),
         0x0052: ZCLAttributeDef("battery_2_a_hr_rating", type=t.uint16_t, access="rw"),
         0x0053: ZCLAttributeDef("battery_2_quantity", type=t.uint8_t, access="rw"),
         0x0054: ZCLAttributeDef("battery_2_rated_voltage", type=t.uint8_t, access="rw"),
@@ -355,7 +355,7 @@ class PowerConfiguration(Cluster):
         0x0070: ZCLAttributeDef(
             "battery_3_manufacturer", type=t.CharacterString, access="rw"
         ),
-        0x0071: ZCLAttributeDef("battery_3_size", type=t.enum8, access="rw"),
+        0x0071: ZCLAttributeDef("battery_3_size", type=BatterySize, access="rw"),
         0x0072: ZCLAttributeDef("battery_3_a_hr_rating", type=t.uint16_t, access="rw"),
         0x0073: ZCLAttributeDef("battery_3_quantity", type=t.uint8_t, access="rw"),
         0x0074: ZCLAttributeDef("battery_3_rated_voltage", type=t.uint8_t, access="rw"),

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -200,31 +200,47 @@ class Basic(Cluster):
     ep_attribute = "basic"
     attributes: dict[int, ZCLAttributeDef] = {
         # Basic Device Information
-        0x0000: ZCLAttributeDef("zcl_version", type=t.uint8_t, access="r", mandatory=True),
+        0x0000: ZCLAttributeDef(
+            "zcl_version", type=t.uint8_t, access="r", mandatory=True
+        ),
         0x0001: ZCLAttributeDef("app_version", type=t.uint8_t, access="r"),
         0x0002: ZCLAttributeDef("stack_version", type=t.uint8_t, access="r"),
         0x0003: ZCLAttributeDef("hw_version", type=t.uint8_t, access="r"),
-        0x0004: ZCLAttributeDef("manufacturer", type=t.LimitedCharString(32), access="r"),
+        0x0004: ZCLAttributeDef(
+            "manufacturer", type=t.LimitedCharString(32), access="r"
+        ),
         0x0005: ZCLAttributeDef("model", type=t.LimitedCharString(32), access="r"),
         0x0006: ZCLAttributeDef("date_code", type=t.LimitedCharString(16), access="r"),
-        0x0007: ZCLAttributeDef("power_source", type=PowerSource, access="r", mandatory=True),
-        0x0008: ZCLAttributeDef("generic_device_class", type=GenericDeviceClass, access="r"),
+        0x0007: ZCLAttributeDef(
+            "power_source", type=PowerSource, access="r", mandatory=True
+        ),
+        0x0008: ZCLAttributeDef(
+            "generic_device_class", type=GenericDeviceClass, access="r"
+        ),
         # Lighting is the only non-reserved device type
-        0x0009: ZCLAttributeDef("generic_device_type", type=GenericLightingDeviceType, access="r"),
+        0x0009: ZCLAttributeDef(
+            "generic_device_type", type=GenericLightingDeviceType, access="r"
+        ),
         0x000A: ZCLAttributeDef("product_code", type=t.LVBytes, access="r"),
         0x000B: ZCLAttributeDef("product_url", type=t.CharacterString, access="r"),
-        0x000C: ZCLAttributeDef("manufacturer_version_details", type=t.CharacterString, access="r"),
+        0x000C: ZCLAttributeDef(
+            "manufacturer_version_details", type=t.CharacterString, access="r"
+        ),
         0x000D: ZCLAttributeDef("serial_number", type=t.CharacterString, access="r"),
         0x000E: ZCLAttributeDef("product_label", type=t.CharacterString, access="r"),
         # Basic Device Settings
-        0x0010: ZCLAttributeDef("location_desc", type=t.LimitedCharString(16), "access=rw"),
-        0x0011: ZCLAttributeDef("physical_env", type=PhysicalEnvironment, "access=rw"),
-        0x0012: ZCLAttributeDef("device_enabled", type=t.Bool, "access=rw"),
-        0x0013: ZCLAttributeDef("alarm_mask", type=AlarmMask, "access=rw"),
-        0x0014: ZCLAttributeDef("disable_local_config", type=DisableLocalConfig, "access=rw"),
+        0x0010: ZCLAttributeDef(
+            "location_desc", type=t.LimitedCharString(16), access="rw"
+        ),
+        0x0011: ZCLAttributeDef("physical_env", type=PhysicalEnvironment, access="rw"),
+        0x0012: ZCLAttributeDef("device_enabled", type=t.Bool, access="rw"),
+        0x0013: ZCLAttributeDef("alarm_mask", type=AlarmMask, access="rw"),
+        0x0014: ZCLAttributeDef(
+            "disable_local_config", type=DisableLocalConfig, access="rw"
+        ),
         0x4000: ZCLAttributeDef("sw_build_id", type=t.CharacterString, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("reset_fact_default", {}, False)
@@ -259,72 +275,112 @@ class PowerConfiguration(Cluster):
     ep_attribute = "power"
     attributes: dict[int, ZCLAttributeDef] = {
         # Mains Information
-        0x0000: ("mains_voltage", t.uint16_t, access="r"),
-        0x0001: ("mains_frequency", t.uint8_t, access="r"),
+        0x0000: ZCLAttributeDef("mains_voltage", type=t.uint16_t, access="r"),
+        0x0001: ZCLAttributeDef("mains_frequency", type=t.uint8_t, access="r"),
         # Mains Settings
-        0x0010: ("mains_alarm_mask", MainsAlarmMask, access="rw"),
-        0x0011: ("mains_volt_min_thres", t.uint16_t, access="rw"),
-        0x0012: ("mains_volt_max_thres", t.uint16_t, access="rw"),
-        0x0013: ("mains_voltage_dwell_trip_point", t.uint16_t, access="rw"),
+        0x0010: ZCLAttributeDef("mains_alarm_mask", type=MainsAlarmMask, access="rw"),
+        0x0011: ZCLAttributeDef("mains_volt_min_thres", type=t.uint16_t, access="rw"),
+        0x0012: ZCLAttributeDef("mains_volt_max_thres", type=t.uint16_t, access="rw"),
+        0x0013: ZCLAttributeDef(
+            "mains_voltage_dwell_trip_point", type=t.uint16_t, access="rw"
+        ),
         # Battery Information
-        0x0020: ("battery_voltage", t.uint8_t, access="r"),
-        0x0021: ("battery_percentage_remaining", t.uint8_t, access="rp"),
+        0x0020: ZCLAttributeDef("battery_voltage", type=t.uint8_t, access="r"),
+        0x0021: ZCLAttributeDef(
+            "battery_percentage_remaining", type=t.uint8_t, access="rp"
+        ),
         # Battery Settings
-        0x0030: ("battery_manufacturer", t.LimitedCharString(16), access="rw"),
-        0x0031: ("battery_size", BatterySize, access="rw"),
-        0x0032: ("battery_a_hr_rating", t.uint16_t, access="rw"),  # measured in units of 10mAHr
-        0x0033: ("battery_quantity", t.uint8_t, access="rw"),
-        0x0034: ("battery_rated_voltage", t.uint8_t, access="rw"),  # measured in units of 100mV
-        0x0035: ("battery_alarm_mask", t.bitmap8, access="rw"),
-        0x0036: ("battery_volt_min_thres", t.uint8_t, access="rw"),
-        0x0037: ("battery_volt_thres1", t.uint16_t, access="r*w"),
-        0x0038: ("battery_volt_thres2", t.uint16_t, access="r*w"),
-        0x0039: ("battery_volt_thres3", t.uint16_t, access="r*w"),
-        0x003A: ("battery_percent_min_thres", t.uint8_t, access="r*w"),
-        0x003B: ("battery_percent_thres1", t.uint8_t, access="r*w"),
-        0x003C: ("battery_percent_thres2", t.uint8_t, access="r*w"),
-        0x003D: ("battery_percent_thres3", t.uint8_t, access="r*w"),
-        0x003E: ("battery_alarm_state", t.bitmap32, access="rp"),
+        0x0030: ZCLAttributeDef(
+            "battery_manufacturer", type=t.LimitedCharString(16), access="rw"
+        ),
+        0x0031: ZCLAttributeDef("battery_size", type=BatterySize, access="rw"),
+        0x0032: ZCLAttributeDef(
+            "battery_a_hr_rating", type=t.uint16_t, access="rw"
+        ),  # measured in units of 10mAHr
+        0x0033: ZCLAttributeDef("battery_quantity", type=t.uint8_t, access="rw"),
+        0x0034: ZCLAttributeDef(
+            "battery_rated_voltage", type=t.uint8_t, access="rw"
+        ),  # measured in units of 100mV
+        0x0035: ZCLAttributeDef("battery_alarm_mask", type=t.bitmap8, access="rw"),
+        0x0036: ZCLAttributeDef("battery_volt_min_thres", type=t.uint8_t, access="rw"),
+        0x0037: ZCLAttributeDef("battery_volt_thres1", type=t.uint16_t, access="r*w"),
+        0x0038: ZCLAttributeDef("battery_volt_thres2", type=t.uint16_t, access="r*w"),
+        0x0039: ZCLAttributeDef("battery_volt_thres3", type=t.uint16_t, access="r*w"),
+        0x003A: ZCLAttributeDef(
+            "battery_percent_min_thres", type=t.uint8_t, access="r*w"
+        ),
+        0x003B: ZCLAttributeDef("battery_percent_thres1", type=t.uint8_t, access="r*w"),
+        0x003C: ZCLAttributeDef("battery_percent_thres2", type=t.uint8_t, access="r*w"),
+        0x003D: ZCLAttributeDef("battery_percent_thres3", type=t.uint8_t, access="r*w"),
+        0x003E: ZCLAttributeDef("battery_alarm_state", type=t.bitmap32, access="rp"),
         # Battery 2 Information
-        0x0040: ("battery_2_voltage", t.uint8_t, access="r"),
-        0x0041: ("battery_2_percentage_remaining", t.uint8_t, access="rp"),
+        0x0040: ZCLAttributeDef("battery_2_voltage", type=t.uint8_t, access="r"),
+        0x0041: ZCLAttributeDef(
+            "battery_2_percentage_remaining", type=t.uint8_t, access="rp"
+        ),
         # Battery 2 Settings
-        0x0050: ("battery_2_manufacturer", t.CharacterString, access="rw"),
-        0x0051: ("battery_2_size", t.enum8, access="rw"),
-        0x0052: ("battery_2_a_hr_rating", t.uint16_t, access="rw"),
-        0x0053: ("battery_2_quantity", t.uint8_t, access="rw"),
-        0x0054: ("battery_2_rated_voltage", t.uint8_t, access="rw"),
-        0x0055: ("battery_2_alarm_mask", t.bitmap8, access="rw"),
-        0x0056: ("battery_2_volt_min_thres", t.uint8_t, access="rw"),
-        0x0057: ("battery_2_volt_thres1", t.uint16_t, access="r*w"),
-        0x0058: ("battery_2_volt_thres2", t.uint16_t, access="r*w"),
-        0x0059: ("battery_2_volt_thres3", t.uint16_t, access="r*w"),
-        0x005A: ("battery_2_percent_min_thres", t.uint8_t, access="r*w"),
-        0x005B: ("battery_2_percent_thres1", t.uint8_t, access="r*w"),
-        0x005C: ("battery_2_percent_thres2", t.uint8_t, access="r*w"),
-        0x005D: ("battery_2_percent_thres3", t.uint8_t, access="r*w"),
-        0x005E: ("battery_2_alarm_state", t.bitmap32, access="rp"),
+        0x0050: ZCLAttributeDef(
+            "battery_2_manufacturer", type=t.CharacterString, access="rw"
+        ),
+        0x0051: ZCLAttributeDef("battery_2_size", type=t.enum8, access="rw"),
+        0x0052: ZCLAttributeDef("battery_2_a_hr_rating", type=t.uint16_t, access="rw"),
+        0x0053: ZCLAttributeDef("battery_2_quantity", type=t.uint8_t, access="rw"),
+        0x0054: ZCLAttributeDef("battery_2_rated_voltage", type=t.uint8_t, access="rw"),
+        0x0055: ZCLAttributeDef("battery_2_alarm_mask", type=t.bitmap8, access="rw"),
+        0x0056: ZCLAttributeDef(
+            "battery_2_volt_min_thres", type=t.uint8_t, access="rw"
+        ),
+        0x0057: ZCLAttributeDef("battery_2_volt_thres1", type=t.uint16_t, access="r*w"),
+        0x0058: ZCLAttributeDef("battery_2_volt_thres2", type=t.uint16_t, access="r*w"),
+        0x0059: ZCLAttributeDef("battery_2_volt_thres3", type=t.uint16_t, access="r*w"),
+        0x005A: ZCLAttributeDef(
+            "battery_2_percent_min_thres", type=t.uint8_t, access="r*w"
+        ),
+        0x005B: ZCLAttributeDef(
+            "battery_2_percent_thres1", type=t.uint8_t, access="r*w"
+        ),
+        0x005C: ZCLAttributeDef(
+            "battery_2_percent_thres2", type=t.uint8_t, access="r*w"
+        ),
+        0x005D: ZCLAttributeDef(
+            "battery_2_percent_thres3", type=t.uint8_t, access="r*w"
+        ),
+        0x005E: ZCLAttributeDef("battery_2_alarm_state", type=t.bitmap32, access="rp"),
         # Battery 3 Information
-        0x0060: ("battery_3_voltage", t.uint8_t, access="r"),
-        0x0061: ("battery_3_percentage_remaining", t.uint8_t, access="rp"),
+        0x0060: ZCLAttributeDef("battery_3_voltage", type=t.uint8_t, access="r"),
+        0x0061: ZCLAttributeDef(
+            "battery_3_percentage_remaining", type=t.uint8_t, access="rp"
+        ),
         # Battery 3 Settings
-        0x0070: ("battery_3_manufacturer", t.CharacterString, access="rw"),
-        0x0071: ("battery_3_size", t.enum8, access="rw"),
-        0x0072: ("battery_3_a_hr_rating", t.uint16_t, access="rw"),
-        0x0073: ("battery_3_quantity", t.uint8_t, access="rw"),
-        0x0074: ("battery_3_rated_voltage", t.uint8_t, access="rw"),
-        0x0075: ("battery_3_alarm_mask", t.bitmap8, access="rw"),
-        0x0076: ("battery_3_volt_min_thres", t.uint8_t, access="rw"),
-        0x0077: ("battery_3_volt_thres1", t.uint16_t, access="r*w"),
-        0x0078: ("battery_3_volt_thres2", t.uint16_t, access="r*w"),
-        0x0079: ("battery_3_volt_thres3", t.uint16_t, access="r*w"),
-        0x007A: ("battery_3_percent_min_thres", t.uint8_t, access="r*w"),
-        0x007B: ("battery_3_percent_thres1", t.uint8_t, access="r*w"),
-        0x007C: ("battery_3_percent_thres2", t.uint8_t, access="r*w"),
-        0x007D: ("battery_3_percent_thres3", t.uint8_t, access="r*w"),
-        0x007E: ("battery_3_alarm_state", t.bitmap32, access="rp"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0070: ZCLAttributeDef(
+            "battery_3_manufacturer", type=t.CharacterString, access="rw"
+        ),
+        0x0071: ZCLAttributeDef("battery_3_size", type=t.enum8, access="rw"),
+        0x0072: ZCLAttributeDef("battery_3_a_hr_rating", type=t.uint16_t, access="rw"),
+        0x0073: ZCLAttributeDef("battery_3_quantity", type=t.uint8_t, access="rw"),
+        0x0074: ZCLAttributeDef("battery_3_rated_voltage", type=t.uint8_t, access="rw"),
+        0x0075: ZCLAttributeDef("battery_3_alarm_mask", type=t.bitmap8, access="rw"),
+        0x0076: ZCLAttributeDef(
+            "battery_3_volt_min_thres", type=t.uint8_t, access="rw"
+        ),
+        0x0077: ZCLAttributeDef("battery_3_volt_thres1", type=t.uint16_t, access="r*w"),
+        0x0078: ZCLAttributeDef("battery_3_volt_thres2", type=t.uint16_t, access="r*w"),
+        0x0079: ZCLAttributeDef("battery_3_volt_thres3", type=t.uint16_t, access="r*w"),
+        0x007A: ZCLAttributeDef(
+            "battery_3_percent_min_thres", type=t.uint8_t, access="r*w"
+        ),
+        0x007B: ZCLAttributeDef(
+            "battery_3_percent_thres1", type=t.uint8_t, access="r*w"
+        ),
+        0x007C: ZCLAttributeDef(
+            "battery_3_percent_thres2", type=t.uint8_t, access="r*w"
+        ),
+        0x007D: ZCLAttributeDef(
+            "battery_3_percent_thres3", type=t.uint8_t, access="r*w"
+        ),
+        0x007E: ZCLAttributeDef("battery_3_alarm_state", type=t.bitmap32, access="rp"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -344,18 +400,26 @@ class DeviceTemperature(Cluster):
     ep_attribute = "device_temperature"
     attributes: dict[int, ZCLAttributeDef] = {
         # Device Temperature Information
-        0x0000: ("current_temperature", t.int16s, access="r", mandatory=True),
-        0x0001: ("min_temp_experienced", t.int16s, access="r"),
-        0x0002: ("max_temp_experienced", t.int16s, access="r"),
-        0x0003: ("over_temp_total_dwell", t.uint16_t, access="r"),
+        0x0000: ZCLAttributeDef(
+            "current_temperature", type=t.int16s, access="r", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef("min_temp_experienced", type=t.int16s, access="r"),
+        0x0002: ZCLAttributeDef("max_temp_experienced", type=t.int16s, access="r"),
+        0x0003: ZCLAttributeDef("over_temp_total_dwell", type=t.uint16_t, access="r"),
         # Device Temperature Settings
-        0x0010: ("dev_temp_alarm_mask", DeviceTempAlarmMask, access="rw"),
-        0x0011: ("low_temp_thres", t.int16s, access="rw"),
-        0x0012: ("high_temp_thres", t.int16s, access="rw"),
-        0x0013: ("low_temp_dwell_trip_point", t.uint24_t, access="rw"),
-        0x0014: ("high_temp_dwell_trip_point", t.uint24_t, access="rw"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0010: ZCLAttributeDef(
+            "dev_temp_alarm_mask", type=DeviceTempAlarmMask, access="rw"
+        ),
+        0x0011: ZCLAttributeDef("low_temp_thres", type=t.int16s, access="rw"),
+        0x0012: ZCLAttributeDef("high_temp_thres", type=t.int16s, access="rw"),
+        0x0013: ZCLAttributeDef(
+            "low_temp_dwell_trip_point", type=t.uint24_t, access="rw"
+        ),
+        0x0014: ZCLAttributeDef(
+            "high_temp_dwell_trip_point", type=t.uint24_t, access="rw"
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -379,10 +443,12 @@ class Identify(Cluster):
     cluster_id = 0x0003
     ep_attribute = "identify"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("identify_time", t.uint16_t, access="rw", mandatory=True),
-        # 0x0001: ("identify_commission_state", t.bitmap8),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0000: ZCLAttributeDef(
+            "identify_time", type=t.uint16_t, access="rw", mandatory=True
+        ),
+        # 0x0001: ZCLAttributeDef("identify_commission_state", type=t.bitmap8),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("identify", {"identify_time": t.uint16_t}, False),
@@ -410,9 +476,11 @@ class Groups(Cluster):
     cluster_id = 0x0004
     ep_attribute = "groups"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ZCLAttributeDef("name_support", type=NameSupport, access="r", mandatory=True),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0000: ZCLAttributeDef(
+            "name_support", type=NameSupport, access="r", mandatory=True
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -470,13 +538,19 @@ class Scenes(Cluster):
     attributes: dict[int, ZCLAttributeDef] = {
         # Scene Management Information
         0x0000: ZCLAttributeDef("count", type=t.uint8_t, access="r", mandatory=True),
-        0x0001: ZCLAttributeDef("current_scene", type=t.uint8_t, access="r", mandatory=True),
-        0x0002: ZCLAttributeDef("current_group", type=t.uint16_t, access="r", mandatory=True),
+        0x0001: ZCLAttributeDef(
+            "current_scene", type=t.uint8_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "current_group", type=t.uint16_t, access="r", mandatory=True
+        ),
         0x0003: ZCLAttributeDef("scene_valid", type=t.Bool, access="r", mandatory=True),
-        0x0004: ZCLAttributeDef("name_support", type=NameSupport, access="r", mandatory=True),
+        0x0004: ZCLAttributeDef(
+            "name_support", type=NameSupport, access="r", mandatory=True
+        ),
         0x0005: ZCLAttributeDef("last_configured_by", type=t.EUI64, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -632,8 +706,8 @@ class OnOff(Cluster):
         0x4001: ZCLAttributeDef("on_time", type=t.uint16_t, access="rw"),
         0x4002: ZCLAttributeDef("off_wait_time", type=t.uint16_t, access="rw"),
         0x4003: ZCLAttributeDef("start_up_on_off", type=StartUpOnOff, access="rw"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("off", {}, False),
@@ -675,10 +749,14 @@ class OnOffConfiguration(Cluster):
     name = "On/Off Switch Configuration"
     ep_attribute = "on_off_config"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ZCLAttributeDef("switch_type", type=SwitchType, access="r", mandatory=True),
-        0x0010: ZCLAttributeDef("switch_actions", type=SwitchActions, access="rw", mandatory=True),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0000: ZCLAttributeDef(
+            "switch_type", type=SwitchType, access="r", mandatory=True
+        ),
+        0x0010: ZCLAttributeDef(
+            "switch_actions", type=SwitchActions, access="rw", mandatory=True
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -704,7 +782,9 @@ class LevelControl(Cluster):
     name = "Level control"
     ep_attribute = "level"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ZCLAttributeDef("current_level", type=t.uint8_t, access="rps", mandatory=True),
+        0x0000: ZCLAttributeDef(
+            "current_level", type=t.uint8_t, access="rps", mandatory=True
+        ),
         0x0001: ZCLAttributeDef("remaining_time", type=t.uint16_t, access="r"),
         0x0002: ZCLAttributeDef("min_level", type=t.uint8_t, access="r"),
         0x0003: ZCLAttributeDef("max_level", type=t.uint8_t, access="r"),
@@ -718,8 +798,8 @@ class LevelControl(Cluster):
         0x0013: ZCLAttributeDef("off_transition_time", type=t.uint16_t, access="rw"),
         0x0014: ZCLAttributeDef("default_move_rate", type=t.uint8_t, access="rw"),
         0x4000: ZCLAttributeDef("start_up_current_level", type=t.uint8_t, access="rw"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -795,8 +875,8 @@ class Alarms(Cluster):
     attributes: dict[int, ZCLAttributeDef] = {
         # Alarm Information
         0x0000: ZCLAttributeDef("alarm_count", type=t.uint16_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -838,8 +918,10 @@ class Time(Cluster):
     cluster_id = 0x000A
     ep_attribute = "time"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ZCLAttributeDef("time", type=t.UTCTime, access="r*w", access=True),
-        0x0001: ZCLAttributeDef("time_status", type=t.bitmap8, access="r*w", access=True),
+        0x0000: ZCLAttributeDef("time", type=t.UTCTime, access="r*w", mandatory=True),
+        0x0001: ZCLAttributeDef(
+            "time_status", type=t.bitmap8, access="r*w", mandatory=True
+        ),
         0x0002: ZCLAttributeDef("time_zone", type=t.int32s, access="rw"),
         0x0003: ZCLAttributeDef("dst_start", type=t.uint32_t, access="rw"),
         0x0004: ZCLAttributeDef("dst_end", type=t.uint32_t, access="rw"),
@@ -848,8 +930,8 @@ class Time(Cluster):
         0x0007: ZCLAttributeDef("local_time", type=t.LocalTime, access="r"),
         0x0008: ZCLAttributeDef("last_set_time", type=t.UTCTime, access="r"),
         0x0009: ZCLAttributeDef("valid_until_time", type=t.UTCTime, access="rw"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -898,16 +980,24 @@ class RSSILocation(Cluster):
         0x0003: ZCLAttributeDef("quality_measure", type=t.uint8_t, access="r"),
         0x0004: ZCLAttributeDef("num_of_devices", type=t.uint8_t, access="r"),
         # Location Settings
-        0x0010: ZCLAttributeDef("coordinate1", type=t.int16s, access="rw", mandatory=True),
-        0x0011: ZCLAttributeDef("coordinate2", type=t.int16s, access="rw", mandatory=True),
+        0x0010: ZCLAttributeDef(
+            "coordinate1", type=t.int16s, access="rw", mandatory=True
+        ),
+        0x0011: ZCLAttributeDef(
+            "coordinate2", type=t.int16s, access="rw", mandatory=True
+        ),
         0x0012: ZCLAttributeDef("coordinate3", type=t.int16s, access="rw"),
         0x0013: ZCLAttributeDef("power", type=t.int16s, access="rw", mandatory=True),
-        0x0014: ZCLAttributeDef("path_loss_exponent", type=t.uint16_t, access="rw", mandatory=True),
+        0x0014: ZCLAttributeDef(
+            "path_loss_exponent", type=t.uint16_t, access="rw", mandatory=True
+        ),
         0x0015: ZCLAttributeDef("reporting_period", type=t.uint16_t, access="rw"),
         0x0016: ZCLAttributeDef("calculation_period", type=t.uint16_t, access="rw"),
-        0x0017: ZCLAttributeDef("number_rssi_measurements", type=t.uint8_t, access="rw", mandatory=True),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0017: ZCLAttributeDef(
+            "number_rssi_measurements", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -1030,15 +1120,21 @@ class AnalogInput(Cluster):
         0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
         0x0041: ZCLAttributeDef("max_present_value", type=t.Single, access="r*w"),
         0x0045: ZCLAttributeDef("min_present_value", type=t.Single, access="r*w"),
-        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
-        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="rwp", mandatory=True),
+        0x0051: ZCLAttributeDef(
+            "out_of_service", type=t.Bool, access="r*w", mandatory=True
+        ),
+        0x0055: ZCLAttributeDef(
+            "present_value", type=t.Single, access="rwp", mandatory=True
+        ),
         0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
         0x006A: ZCLAttributeDef("resolution", type=t.Single, access="r*w"),
-        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="rp", mandatory=True),
+        0x006F: ZCLAttributeDef(
+            "status_flags", type=t.bitmap8, access="rp", mandatory=True
+        ),
         0x0075: ZCLAttributeDef("engineering_units", type=t.enum16, access="r*w"),
         0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1051,18 +1147,24 @@ class AnalogOutput(Cluster):
         0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
         0x0041: ZCLAttributeDef("max_present_value", type=t.Single, access="r*w"),
         0x0045: ZCLAttributeDef("min_present_value", type=t.Single, access="r*w"),
-        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
-        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="rwp", mandatory=True),
+        0x0051: ZCLAttributeDef(
+            "out_of_service", type=t.Bool, access="r*w", mandatory=True
+        ),
+        0x0055: ZCLAttributeDef(
+            "present_value", type=t.Single, access="rwp", mandatory=True
+        ),
         # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
         0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
         0x0068: ZCLAttributeDef("relinquish_default", type=t.Single, access="r*w"),
         0x006A: ZCLAttributeDef("resolution", type=t.Single, access="r*w"),
-        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="rp", mandatory=True),
+        0x006F: ZCLAttributeDef(
+            "status_flags", type=t.bitmap8, access="rp", mandatory=True
+        ),
         0x0075: ZCLAttributeDef("engineering_units", type=t.enum16, access="r*w"),
         0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1073,17 +1175,23 @@ class AnalogValue(Cluster):
     ep_attribute = "analog_value"
     attributes: dict[int, ZCLAttributeDef] = {
         0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
-        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
-        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="r/w", mandatory=True),
+        0x0051: ZCLAttributeDef(
+            "out_of_service", type=t.Bool, access="r*w", mandatory=True
+        ),
+        0x0055: ZCLAttributeDef(
+            "present_value", type=t.Single, access="rw", mandatory=True
+        ),
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
         0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
         0x0068: ZCLAttributeDef("relinquish_default", type=t.Single, access="r*w"),
-        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x006F: ZCLAttributeDef(
+            "status_flags", type=t.bitmap8, access="r", mandatory=True
+        ),
         0x0075: ZCLAttributeDef("engineering_units", type=t.enum16, access="r*w"),
         0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1097,14 +1205,20 @@ class BinaryInput(Cluster):
         0x0004: ZCLAttributeDef("active_text", type=t.CharacterString, access="r*w"),
         0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
         0x002E: ZCLAttributeDef("inactive_text", type=t.CharacterString, access="r*w"),
-        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0051: ZCLAttributeDef(
+            "out_of_service", type=t.Bool, access="r*w", mandatory=True
+        ),
         0x0054: ZCLAttributeDef("polarity", type=t.enum8, access="r"),
-        0x0055: ZCLAttributeDef("present_value", type=t.Bool, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef(
+            "present_value", type=t.Bool, access="r*w", mandatory=True
+        ),
         0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
-        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x006F: ZCLAttributeDef(
+            "status_flags", type=t.bitmap8, access="r", mandatory=True
+        ),
         0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1119,19 +1233,29 @@ class BinaryOutput(Cluster):
         0x002E: ZCLAttributeDef("inactive_text", type=t.CharacterString, access="r*w"),
         0x0042: ZCLAttributeDef("minimum_off_time", type=t.uint32_t, access="r*w"),
         0x0043: ZCLAttributeDef("minimum_on_time", type=t.uint32_t, access="r*w"),
-        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0051: ZCLAttributeDef(
+            "out_of_service", type=t.Bool, access="r*w", mandatory=True
+        ),
         0x0054: ZCLAttributeDef("polarity", type=t.enum8, access="r"),
-        0x0055: ZCLAttributeDef("present_value", type=t.Bool, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef(
+            "present_value", type=t.Bool, access="r*w", mandatory=True
+        ),
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
         0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
         0x0068: ZCLAttributeDef("relinquish_default", type=t.Bool, access="r*w"),
-        0x006A: ZCLAttributeDef("resolution", type=t.Single, access="r"),  # Does not seem to be in binary_output
-        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
-        0x0075: ZCLAttributeDef("engineering_units", type=t.enum16, access="r"),  # Does not seem to be in binary_output
+        0x006A: ZCLAttributeDef(
+            "resolution", type=t.Single, access="r"
+        ),  # Does not seem to be in binary_output
+        0x006F: ZCLAttributeDef(
+            "status_flags", type=t.bitmap8, access="r", mandatory=True
+        ),
+        0x0075: ZCLAttributeDef(
+            "engineering_units", type=t.enum16, access="r"
+        ),  # Does not seem to be in binary_output
         0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1146,16 +1270,22 @@ class BinaryValue(Cluster):
         0x002E: ZCLAttributeDef("inactive_text", type=t.CharacterString, access="r*w"),
         0x0042: ZCLAttributeDef("minimum_off_time", type=t.uint32_t, access="r*w"),
         0x0043: ZCLAttributeDef("minimum_on_time", type=t.uint32_t, access="r*w"),
-        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
-        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="r*w", mandatory=True),
+        0x0051: ZCLAttributeDef(
+            "out_of_service", type=t.Bool, access="r*w", mandatory=True
+        ),
+        0x0055: ZCLAttributeDef(
+            "present_value", type=t.Single, access="r*w", mandatory=True
+        ),
         # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
         0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
         0x0068: ZCLAttributeDef("relinquish_default", type=t.Single, access="r*w"),
-        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x006F: ZCLAttributeDef(
+            "status_flags", type=t.bitmap8, access="r", mandatory=True
+        ),
         0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1165,18 +1295,26 @@ class MultistateInput(Cluster):
     cluster_id = 0x0012
     ep_attribute = "multistate_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x000E: ZCLAttributeDef("state_text", type=t.List[t.CharacterString], access="r*w"),
+        0x000E: ZCLAttributeDef(
+            "state_text", type=t.List[t.CharacterString], access="r*w"
+        ),
         0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
         0x004A: ZCLAttributeDef("number_of_states", type=t.uint16_t, access="r*w"),
-        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
-        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="r*w", mandatory=True),
+        0x0051: ZCLAttributeDef(
+            "out_of_service", type=t.Bool, access="r*w", mandatory=True
+        ),
+        0x0055: ZCLAttributeDef(
+            "present_value", type=t.Single, access="r*w", mandatory=True
+        ),
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
         0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
-        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x006F: ZCLAttributeDef(
+            "status_flags", type=t.bitmap8, access="r", mandatory=True
+        ),
         0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1186,19 +1324,29 @@ class MultistateOutput(Cluster):
     cluster_id = 0x0013
     ep_attribute = "multistate_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x000E: ZCLAttributeDef("state_text", type=t.List[t.CharacterString], access="r*w"),
+        0x000E: ZCLAttributeDef(
+            "state_text", type=t.List[t.CharacterString], access="r*w"
+        ),
         0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
-        0x004A: ZCLAttributeDef("number_of_states", type=t.uint16_t, access="r*w", mandatory=True),
-        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
-        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="r*w", mandatory=True),
+        0x004A: ZCLAttributeDef(
+            "number_of_states", type=t.uint16_t, access="r*w", mandatory=True
+        ),
+        0x0051: ZCLAttributeDef(
+            "out_of_service", type=t.Bool, access="r*w", mandatory=True
+        ),
+        0x0055: ZCLAttributeDef(
+            "present_value", type=t.Single, access="r*w", mandatory=True
+        ),
         # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
         0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
         0x0068: ZCLAttributeDef("relinquish_default", type=t.Single, access="r*w"),
-        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x006F: ZCLAttributeDef(
+            "status_flags", type=t.bitmap8, access="r", mandatory=True
+        ),
         0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1210,17 +1358,21 @@ class MultistateValue(Cluster):
     attributes: dict[int, ZCLAttributeDef] = {
         0x000E: ZCLAttributeDef("state_text", t.List[t.CharacterString], access="r*w"),
         0x001C: ZCLAttributeDef("description", t.CharacterString, access="r*w"),
-        0x004A: ZCLAttributeDef("number_of_states", t.uint16_t, access="r*w", mandatory=True),
+        0x004A: ZCLAttributeDef(
+            "number_of_states", t.uint16_t, access="r*w", mandatory=True
+        ),
         0x0051: ZCLAttributeDef("out_of_service", t.Bool, access="r*w", mandatory=True),
-        0x0055: ZCLAttributeDef("present_value", t.Single, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef(
+            "present_value", t.Single, access="r*w", mandatory=True
+        ),
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
         0x0067: ZCLAttributeDef("reliability", t.enum8, access="r*w"),
         0x0068: ZCLAttributeDef("relinquish_default", t.Single, access="r*w"),
         0x006F: ZCLAttributeDef("status_flags", t.bitmap8, access="r", mandatory=True),
         0x0100: ZCLAttributeDef("application_type", t.uint32_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1234,21 +1386,47 @@ class Commissioning(Cluster):
     ep_attribute = "commissioning"
     attributes: dict[int, ZCLAttributeDef] = {
         # Startup Parameters
-        0x0000: ZCLAttributeDef("short_address", type=t.uint16_t, access="rw", mandatory=True),
-        0x0001: ZCLAttributeDef("extended_pan_id", type=t.EUI64, access="rw", mandatory=True),
+        0x0000: ZCLAttributeDef(
+            "short_address", type=t.uint16_t, access="rw", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "extended_pan_id", type=t.EUI64, access="rw", mandatory=True
+        ),
         0x0002: ZCLAttributeDef("pan_id", type=t.uint16_t, access="rw", mandatory=True),
-        0x0003: ZCLAttributeDef("channelmask", type=t.Channels, access="rw", mandatory=True),
-        0x0004: ZCLAttributeDef("protocol_version", type=t.uint8_t, access="rw", mandatory=True),
-        0x0005: ZCLAttributeDef("stack_profile", type=t.uint8_t, access="rw", mandatory=True),
-        0x0006: ZCLAttributeDef("startup_control", type=t.enum8, access="rw", mandatory=True),
-        0x0010: ZCLAttributeDef("trust_center_address", type=t.EUI64, access="rw", mandatory=True),
+        0x0003: ZCLAttributeDef(
+            "channelmask", type=t.Channels, access="rw", mandatory=True
+        ),
+        0x0004: ZCLAttributeDef(
+            "protocol_version", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0005: ZCLAttributeDef(
+            "stack_profile", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0006: ZCLAttributeDef(
+            "startup_control", type=t.enum8, access="rw", mandatory=True
+        ),
+        0x0010: ZCLAttributeDef(
+            "trust_center_address", type=t.EUI64, access="rw", mandatory=True
+        ),
         0x0011: ZCLAttributeDef("trust_center_master_key", type=t.KeyData, access="rw"),
-        0x0012: ZCLAttributeDef("network_key", type=t.KeyData, access="rw", mandatory=True),
-        0x0013: ZCLAttributeDef("use_insecure_join", type=t.Bool, access="rw", mandatory=True),
-        0x0014: ZCLAttributeDef("preconfigured_link_key", type=t.KeyData, access="rw", mandatory=True),
-        0x0015: ZCLAttributeDef("network_key_seq_num", type=t.uint8_t, access="rw", mandatory=True),
-        0x0016: ZCLAttributeDef("network_key_type", type=t.enum8, access="rw", mandatory=True),
-        0x0017: ZCLAttributeDef("network_manager_address", type=t.uint16_t, access="rw", mandatory=True),
+        0x0012: ZCLAttributeDef(
+            "network_key", type=t.KeyData, access="rw", mandatory=True
+        ),
+        0x0013: ZCLAttributeDef(
+            "use_insecure_join", type=t.Bool, access="rw", mandatory=True
+        ),
+        0x0014: ZCLAttributeDef(
+            "preconfigured_link_key", type=t.KeyData, access="rw", mandatory=True
+        ),
+        0x0015: ZCLAttributeDef(
+            "network_key_seq_num", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0016: ZCLAttributeDef(
+            "network_key_type", type=t.enum8, access="rw", mandatory=True
+        ),
+        0x0017: ZCLAttributeDef(
+            "network_manager_address", type=t.uint16_t, access="rw", mandatory=True
+        ),
         # Join Parameters
         0x0020: ZCLAttributeDef("scan_attempts", type=t.uint8_t, access="rw"),
         0x0021: ZCLAttributeDef("time_between_scans", type=t.uint16_t, access="rw"),
@@ -1260,9 +1438,11 @@ class Commissioning(Cluster):
         # Concentrator Parameters
         0x0040: ZCLAttributeDef("concentrator_flag", type=t.Bool, access="rw"),
         0x0041: ZCLAttributeDef("concentrator_radius", type=t.uint8_t, access="rw"),
-        0x0042: ZCLAttributeDef("concentrator_discovery_time", type=t.uint8_t, access="rw"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0042: ZCLAttributeDef(
+            "concentrator_discovery_time", type=t.uint8_t, access="rw"
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -1304,18 +1484,44 @@ class Partition(Cluster):
     cluster_id = 0x0016
     ep_attribute = "partition"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ZCLAttributeDef("maximum_incoming_transfer_size", type=t.uint16_t, access="r", mandatory=True),
-        0x0001: ZCLAttributeDef("maximum_outgoing_transfer_size", type=t.uint16_t, access="r", mandatory=True),
-        0x0002: ZCLAttributeDef("partitioned_frame_size", type=t.uint8_t, access="rw", mandatory=True),
-        0x0003: ZCLAttributeDef("large_frame_size", type=t.uint16_t, access="rw", mandatory=True),
-        0x0004: ZCLAttributeDef("number_of_ack_frame", type=t.uint8_t, access="rw", mandatory=True),
-        0x0005: ZCLAttributeDef("nack_timeout", type=t.uint16_t, access="r", mandatory=True),
-        0x0006: ZCLAttributeDef("interframe_delay", type=t.uint8_t, access="rw", mandatory=True),
-        0x0007: ZCLAttributeDef("number_of_send_retries", type=t.uint8_t, access="r", mandatory=True),
-        0x0008: ZCLAttributeDef("sender_timeout", type=t.uint16_t, access="r", mandatory=True),
-        0x0009: ZCLAttributeDef("receiver_timeout", type=t.uint16_t, access="r", mandatory=True),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0000: ZCLAttributeDef(
+            "maximum_incoming_transfer_size",
+            type=t.uint16_t,
+            access="r",
+            mandatory=True,
+        ),
+        0x0001: ZCLAttributeDef(
+            "maximum_outgoing_transfer_size",
+            type=t.uint16_t,
+            access="r",
+            mandatory=True,
+        ),
+        0x0002: ZCLAttributeDef(
+            "partitioned_frame_size", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef(
+            "large_frame_size", type=t.uint16_t, access="rw", mandatory=True
+        ),
+        0x0004: ZCLAttributeDef(
+            "number_of_ack_frame", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0005: ZCLAttributeDef(
+            "nack_timeout", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0006: ZCLAttributeDef(
+            "interframe_delay", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0007: ZCLAttributeDef(
+            "number_of_send_retries", type=t.uint8_t, access="r", mandatory=True
+        ),
+        0x0008: ZCLAttributeDef(
+            "sender_timeout", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0009: ZCLAttributeDef(
+            "receiver_timeout", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1447,21 +1653,33 @@ class Ota(Cluster):
     cluster_id = 0x0019
     ep_attribute = "ota"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("upgrade_server_id", t.EUI64, access="r", mandatory=True),
-        0x0001: ("file_offset", t.uint32_t, access="r"),
-        0x0002: ("current_file_version", t.uint32_t, access="r"),
-        0x0003: ("current_zigbee_stack_version", t.uint16_t, access="r"),
-        0x0004: ("downloaded_file_version", t.uint32_t, access="r"),
-        0x0005: ("downloaded_zigbee_stack_version", t.uint16_t, access="r"),
-        0x0006: ("image_upgrade_status", ImageUpgradeStatus, access="r", mandatory=True),
-        0x0007: ("manufacturer_id", t.uint16_t, access="r"),
-        0x0008: ("image_type_id", t.uint16_t, access="r"),
-        0x0009: ("minimum_block_req_delay", t.uint16_t, access="r"),
-        0x000A: ("image_stamp", t.uint32_t, access="r"),
-        0x000B: ("upgrade_activation_policy", UpgradeActivationPolicy, access="r"),
-        0x000C: ("upgrade_timeout_policy", UpgradeTimeoutPolicy, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0000: ZCLAttributeDef(
+            "upgrade_server_id", type=t.EUI64, access="r", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef("file_offset", type=t.uint32_t, access="r"),
+        0x0002: ZCLAttributeDef("current_file_version", type=t.uint32_t, access="r"),
+        0x0003: ZCLAttributeDef(
+            "current_zigbee_stack_version", type=t.uint16_t, access="r"
+        ),
+        0x0004: ZCLAttributeDef("downloaded_file_version", type=t.uint32_t, access="r"),
+        0x0005: ZCLAttributeDef(
+            "downloaded_zigbee_stack_version", type=t.uint16_t, access="r"
+        ),
+        0x0006: ZCLAttributeDef(
+            "image_upgrade_status", type=ImageUpgradeStatus, access="r", mandatory=True
+        ),
+        0x0007: ZCLAttributeDef("manufacturer_id", type=t.uint16_t, access="r"),
+        0x0008: ZCLAttributeDef("image_type_id", type=t.uint16_t, access="r"),
+        0x0009: ZCLAttributeDef("minimum_block_req_delay", type=t.uint16_t, access="r"),
+        0x000A: ZCLAttributeDef("image_stamp", type=t.uint32_t, access="r"),
+        0x000B: ZCLAttributeDef(
+            "upgrade_activation_policy", type=UpgradeActivationPolicy, access="r"
+        ),
+        0x000C: ZCLAttributeDef(
+            "upgrade_timeout_policy", type=UpgradeTimeoutPolicy, access="r"
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x01: ZCLCommandDef("query_next_image", QueryNextImageCommand, False),
@@ -1718,13 +1936,23 @@ class PowerProfile(Cluster):
     cluster_id = 0x001A
     ep_attribute = "power_profile"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ZCLAttributeDef("total_profile_num", type=t.uint8_t, access="r", mandatory=True),
-        0x0001: ZCLAttributeDef("multiple_scheduling", type=t.Bool, access="r", mandatory=True),
-        0x0002: ZCLAttributeDef("energy_formatting", type=t.bitmap8, access="r", mandatory=True),
-        0x0003: ZCLAttributeDef("energy_remote", type=t.Bool, access="r", mandatory=True),
-        0x0004: ZCLAttributeDef("schedule_mode", type=t.bitmap8, access="rwp", mandatory=True),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0x0000: ZCLAttributeDef(
+            "total_profile_num", type=t.uint8_t, access="r", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "multiple_scheduling", type=t.Bool, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "energy_formatting", type=t.bitmap8, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef(
+            "energy_remote", type=t.Bool, access="r", mandatory=True
+        ),
+        0x0004: ZCLAttributeDef(
+            "schedule_mode", type=t.bitmap8, access="rwp", mandatory=True
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
 
     class ScheduleRecord(t.Struct):
@@ -1888,11 +2116,15 @@ class ApplianceControl(Cluster):
     cluster_id = 0x001B
     ep_attribute = "appliance_control"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ZCLAttributeDef("start_time", type=t.uint16_t, access="rp", mandatory=True),
-        0x0001: ZCLAttributeDef("finish_time", type=t.uint16_t, access="rp", mandatory=True),
+        0x0000: ZCLAttributeDef(
+            "start_time", type=t.uint16_t, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "finish_time", type=t.uint16_t, access="rp", mandatory=True
+        ),
         0x0002: ZCLAttributeDef("remaining_time", type=t.uint16_t, access="rp"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1903,15 +2135,23 @@ class PollControl(Cluster):
     name = "Poll Control"
     ep_attribute = "poll_control"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ZCLAttributeDef("checkin_interval", type=t.uint32_t, access="rw", mandatory=True),
-        0x0001: ZCLAttributeDef("long_poll_interval", type=t.uint32_t, access="r", mandatory=True),
-        0x0002: ZCLAttributeDef("short_poll_interval", type=t.uint16_t, access="r", mandatory=True),
-        0x0003: ZCLAttributeDef("fast_poll_timeout", type=t.uint16_t, access="rw", mandatory=True),
+        0x0000: ZCLAttributeDef(
+            "checkin_interval", type=t.uint32_t, access="rw", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "long_poll_interval", type=t.uint32_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "short_poll_interval", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef(
+            "fast_poll_timeout", type=t.uint16_t, access="rw", mandatory=True
+        ),
         0x0004: ZCLAttributeDef("checkin_interval_min", type=t.uint32_t, access="r"),
         0x0005: ZCLAttributeDef("long_poll_interval_min", type=t.uint32_t, access="r"),
         0x0006: ZCLAttributeDef("fast_poll_timeout_max", type=t.uint16_t, access="r"),
-        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
-        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -200,31 +200,31 @@ class Basic(Cluster):
     ep_attribute = "basic"
     attributes: dict[int, ZCLAttributeDef] = {
         # Basic Device Information
-        0x0000: ("zcl_version", t.uint8_t),
-        0x0001: ("app_version", t.uint8_t),
-        0x0002: ("stack_version", t.uint8_t),
-        0x0003: ("hw_version", t.uint8_t),
-        0x0004: ("manufacturer", t.LimitedCharString(32)),
-        0x0005: ("model", t.LimitedCharString(32)),
-        0x0006: ("date_code", t.LimitedCharString(16)),
-        0x0007: ("power_source", PowerSource),
-        0x0008: ("generic_device_class", GenericDeviceClass),
+        0x0000: ZCLAttributeDef("zcl_version", type=t.uint8_t, access="r", mandatory=True),
+        0x0001: ZCLAttributeDef("app_version", type=t.uint8_t, access="r"),
+        0x0002: ZCLAttributeDef("stack_version", type=t.uint8_t, access="r"),
+        0x0003: ZCLAttributeDef("hw_version", type=t.uint8_t, access="r"),
+        0x0004: ZCLAttributeDef("manufacturer", type=t.LimitedCharString(32), access="r"),
+        0x0005: ZCLAttributeDef("model", type=t.LimitedCharString(32), access="r"),
+        0x0006: ZCLAttributeDef("date_code", type=t.LimitedCharString(16), access="r"),
+        0x0007: ZCLAttributeDef("power_source", type=PowerSource, access="r", mandatory=True),
+        0x0008: ZCLAttributeDef("generic_device_class", type=GenericDeviceClass, access="r"),
         # Lighting is the only non-reserved device type
-        0x0009: ("generic_device_type", GenericLightingDeviceType),
-        0x000A: ("product_code", t.LVBytes),
-        0x000B: ("product_url", t.CharacterString),
-        0x000C: ("manufacturer_version_details", t.CharacterString),
-        0x000D: ("serial_number", t.CharacterString),
-        0x000E: ("product_label", t.CharacterString),
+        0x0009: ZCLAttributeDef("generic_device_type", type=GenericLightingDeviceType, access="r"),
+        0x000A: ZCLAttributeDef("product_code", type=t.LVBytes, access="r"),
+        0x000B: ZCLAttributeDef("product_url", type=t.CharacterString, access="r"),
+        0x000C: ZCLAttributeDef("manufacturer_version_details", type=t.CharacterString, access="r"),
+        0x000D: ZCLAttributeDef("serial_number", type=t.CharacterString, access="r"),
+        0x000E: ZCLAttributeDef("product_label", type=t.CharacterString, access="r"),
         # Basic Device Settings
-        0x0010: ("location_desc", t.LimitedCharString(16)),
-        0x0011: ("physical_env", PhysicalEnvironment),
-        0x0012: ("device_enabled", t.Bool),
-        0x0013: ("alarm_mask", AlarmMask),
-        0x0014: ("disable_local_config", DisableLocalConfig),
-        0x4000: ("sw_build_id", t.CharacterString),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0010: ZCLAttributeDef("location_desc", type=t.LimitedCharString(16), "access=rw"),
+        0x0011: ZCLAttributeDef("physical_env", type=PhysicalEnvironment, "access=rw"),
+        0x0012: ZCLAttributeDef("device_enabled", type=t.Bool, "access=rw"),
+        0x0013: ZCLAttributeDef("alarm_mask", type=AlarmMask, "access=rw"),
+        0x0014: ZCLAttributeDef("disable_local_config", type=DisableLocalConfig, "access=rw"),
+        0x4000: ZCLAttributeDef("sw_build_id", type=t.CharacterString, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("reset_fact_default", {}, False)
@@ -259,72 +259,72 @@ class PowerConfiguration(Cluster):
     ep_attribute = "power"
     attributes: dict[int, ZCLAttributeDef] = {
         # Mains Information
-        0x0000: ("mains_voltage", t.uint16_t),
-        0x0001: ("mains_frequency", t.uint8_t),
+        0x0000: ("mains_voltage", t.uint16_t, access="r"),
+        0x0001: ("mains_frequency", t.uint8_t, access="r"),
         # Mains Settings
-        0x0010: ("mains_alarm_mask", MainsAlarmMask),
-        0x0011: ("mains_volt_min_thres", t.uint16_t),
-        0x0012: ("mains_volt_max_thres", t.uint16_t),
-        0x0013: ("mains_voltage_dwell_trip_point", t.uint16_t),
+        0x0010: ("mains_alarm_mask", MainsAlarmMask, access="rw"),
+        0x0011: ("mains_volt_min_thres", t.uint16_t, access="rw"),
+        0x0012: ("mains_volt_max_thres", t.uint16_t, access="rw"),
+        0x0013: ("mains_voltage_dwell_trip_point", t.uint16_t, access="rw"),
         # Battery Information
-        0x0020: ("battery_voltage", t.uint8_t),
-        0x0021: ("battery_percentage_remaining", t.uint8_t),
+        0x0020: ("battery_voltage", t.uint8_t, access="r"),
+        0x0021: ("battery_percentage_remaining", t.uint8_t, access="rp"),
         # Battery Settings
-        0x0030: ("battery_manufacturer", t.LimitedCharString(16)),
-        0x0031: ("battery_size", BatterySize),
-        0x0032: ("battery_a_hr_rating", t.uint16_t),  # measured in units of 10mAHr
-        0x0033: ("battery_quantity", t.uint8_t),
-        0x0034: ("battery_rated_voltage", t.uint8_t),  # measured in units of 100mV
-        0x0035: ("battery_alarm_mask", t.bitmap8),
-        0x0036: ("battery_volt_min_thres", t.uint8_t),
-        0x0037: ("battery_volt_thres1", t.uint16_t),
-        0x0038: ("battery_volt_thres2", t.uint16_t),
-        0x0039: ("battery_volt_thres3", t.uint16_t),
-        0x003A: ("battery_percent_min_thres", t.uint8_t),
-        0x003B: ("battery_percent_thres1", t.uint8_t),
-        0x003C: ("battery_percent_thres2", t.uint8_t),
-        0x003D: ("battery_percent_thres3", t.uint8_t),
-        0x003E: ("battery_alarm_state", t.bitmap32),
+        0x0030: ("battery_manufacturer", t.LimitedCharString(16), access="rw"),
+        0x0031: ("battery_size", BatterySize, access="rw"),
+        0x0032: ("battery_a_hr_rating", t.uint16_t, access="rw"),  # measured in units of 10mAHr
+        0x0033: ("battery_quantity", t.uint8_t, access="rw"),
+        0x0034: ("battery_rated_voltage", t.uint8_t, access="rw"),  # measured in units of 100mV
+        0x0035: ("battery_alarm_mask", t.bitmap8, access="rw"),
+        0x0036: ("battery_volt_min_thres", t.uint8_t, access="rw"),
+        0x0037: ("battery_volt_thres1", t.uint16_t, access="r*w"),
+        0x0038: ("battery_volt_thres2", t.uint16_t, access="r*w"),
+        0x0039: ("battery_volt_thres3", t.uint16_t, access="r*w"),
+        0x003A: ("battery_percent_min_thres", t.uint8_t, access="r*w"),
+        0x003B: ("battery_percent_thres1", t.uint8_t, access="r*w"),
+        0x003C: ("battery_percent_thres2", t.uint8_t, access="r*w"),
+        0x003D: ("battery_percent_thres3", t.uint8_t, access="r*w"),
+        0x003E: ("battery_alarm_state", t.bitmap32, access="rp"),
         # Battery 2 Information
-        0x0040: ("battery_2_voltage", t.uint8_t),
-        0x0041: ("battery_2_percentage_remaining", t.uint8_t),
+        0x0040: ("battery_2_voltage", t.uint8_t, access="r"),
+        0x0041: ("battery_2_percentage_remaining", t.uint8_t, access="rp"),
         # Battery 2 Settings
-        0x0050: ("battery_2_manufacturer", t.CharacterString),
-        0x0051: ("battery_2_size", t.enum8),
-        0x0052: ("battery_2_a_hr_rating", t.uint16_t),
-        0x0053: ("battery_2_quantity", t.uint8_t),
-        0x0054: ("battery_2_rated_voltage", t.uint8_t),
-        0x0055: ("battery_2_alarm_mask", t.bitmap8),
-        0x0056: ("battery_2_volt_min_thres", t.uint8_t),
-        0x0057: ("battery_2_volt_thres1", t.uint16_t),
-        0x0058: ("battery_2_volt_thres2", t.uint16_t),
-        0x0059: ("battery_2_volt_thres3", t.uint16_t),
-        0x005A: ("battery_2_percent_min_thres", t.uint8_t),
-        0x005B: ("battery_2_percent_thres1", t.uint8_t),
-        0x005C: ("battery_2_percent_thres2", t.uint8_t),
-        0x005D: ("battery_2_percent_thres3", t.uint8_t),
-        0x005E: ("battery_2_alarm_state", t.bitmap32),
+        0x0050: ("battery_2_manufacturer", t.CharacterString, access="rw"),
+        0x0051: ("battery_2_size", t.enum8, access="rw"),
+        0x0052: ("battery_2_a_hr_rating", t.uint16_t, access="rw"),
+        0x0053: ("battery_2_quantity", t.uint8_t, access="rw"),
+        0x0054: ("battery_2_rated_voltage", t.uint8_t, access="rw"),
+        0x0055: ("battery_2_alarm_mask", t.bitmap8, access="rw"),
+        0x0056: ("battery_2_volt_min_thres", t.uint8_t, access="rw"),
+        0x0057: ("battery_2_volt_thres1", t.uint16_t, access="r*w"),
+        0x0058: ("battery_2_volt_thres2", t.uint16_t, access="r*w"),
+        0x0059: ("battery_2_volt_thres3", t.uint16_t, access="r*w"),
+        0x005A: ("battery_2_percent_min_thres", t.uint8_t, access="r*w"),
+        0x005B: ("battery_2_percent_thres1", t.uint8_t, access="r*w"),
+        0x005C: ("battery_2_percent_thres2", t.uint8_t, access="r*w"),
+        0x005D: ("battery_2_percent_thres3", t.uint8_t, access="r*w"),
+        0x005E: ("battery_2_alarm_state", t.bitmap32, access="rp"),
         # Battery 3 Information
-        0x0060: ("battery_3_voltage", t.uint8_t),
-        0x0061: ("battery_3_percentage_remaining", t.uint8_t),
+        0x0060: ("battery_3_voltage", t.uint8_t, access="r"),
+        0x0061: ("battery_3_percentage_remaining", t.uint8_t, access="rp"),
         # Battery 3 Settings
-        0x0070: ("battery_3_manufacturer", t.CharacterString),
-        0x0071: ("battery_3_size", t.enum8),
-        0x0072: ("battery_3_a_hr_rating", t.uint16_t),
-        0x0073: ("battery_3_quantity", t.uint8_t),
-        0x0074: ("battery_3_rated_voltage", t.uint8_t),
-        0x0075: ("battery_3_alarm_mask", t.bitmap8),
-        0x0076: ("battery_3_volt_min_thres", t.uint8_t),
-        0x0077: ("battery_3_volt_thres1", t.uint16_t),
-        0x0078: ("battery_3_volt_thres2", t.uint16_t),
-        0x0079: ("battery_3_volt_thres3", t.uint16_t),
-        0x007A: ("battery_3_percent_min_thres", t.uint8_t),
-        0x007B: ("battery_3_percent_thres1", t.uint8_t),
-        0x007C: ("battery_3_percent_thres2", t.uint8_t),
-        0x007D: ("battery_3_percent_thres3", t.uint8_t),
-        0x007E: ("battery_3_alarm_state", t.bitmap32),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0070: ("battery_3_manufacturer", t.CharacterString, access="rw"),
+        0x0071: ("battery_3_size", t.enum8, access="rw"),
+        0x0072: ("battery_3_a_hr_rating", t.uint16_t, access="rw"),
+        0x0073: ("battery_3_quantity", t.uint8_t, access="rw"),
+        0x0074: ("battery_3_rated_voltage", t.uint8_t, access="rw"),
+        0x0075: ("battery_3_alarm_mask", t.bitmap8, access="rw"),
+        0x0076: ("battery_3_volt_min_thres", t.uint8_t, access="rw"),
+        0x0077: ("battery_3_volt_thres1", t.uint16_t, access="r*w"),
+        0x0078: ("battery_3_volt_thres2", t.uint16_t, access="r*w"),
+        0x0079: ("battery_3_volt_thres3", t.uint16_t, access="r*w"),
+        0x007A: ("battery_3_percent_min_thres", t.uint8_t, access="r*w"),
+        0x007B: ("battery_3_percent_thres1", t.uint8_t, access="r*w"),
+        0x007C: ("battery_3_percent_thres2", t.uint8_t, access="r*w"),
+        0x007D: ("battery_3_percent_thres3", t.uint8_t, access="r*w"),
+        0x007E: ("battery_3_alarm_state", t.bitmap32, access="rp"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -344,18 +344,18 @@ class DeviceTemperature(Cluster):
     ep_attribute = "device_temperature"
     attributes: dict[int, ZCLAttributeDef] = {
         # Device Temperature Information
-        0x0000: ("current_temperature", t.int16s),
-        0x0001: ("min_temp_experienced", t.int16s),
-        0x0002: ("max_temp_experienced", t.int16s),
-        0x0003: ("over_temp_total_dwell", t.uint16_t),
+        0x0000: ("current_temperature", t.int16s, access="r", mandatory=True),
+        0x0001: ("min_temp_experienced", t.int16s, access="r"),
+        0x0002: ("max_temp_experienced", t.int16s, access="r"),
+        0x0003: ("over_temp_total_dwell", t.uint16_t, access="r"),
         # Device Temperature Settings
-        0x0010: ("dev_temp_alarm_mask", DeviceTempAlarmMask),
-        0x0011: ("low_temp_thres", t.int16s),
-        0x0012: ("high_temp_thres", t.int16s),
-        0x0013: ("low_temp_dwell_trip_point", t.uint24_t),
-        0x0014: ("high_temp_dwell_trip_point", t.uint24_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0010: ("dev_temp_alarm_mask", DeviceTempAlarmMask, access="rw"),
+        0x0011: ("low_temp_thres", t.int16s, access="rw"),
+        0x0012: ("high_temp_thres", t.int16s, access="rw"),
+        0x0013: ("low_temp_dwell_trip_point", t.uint24_t, access="rw"),
+        0x0014: ("high_temp_dwell_trip_point", t.uint24_t, access="rw"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -379,10 +379,10 @@ class Identify(Cluster):
     cluster_id = 0x0003
     ep_attribute = "identify"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("identify_time", t.uint16_t),
+        0x0000: ("identify_time", t.uint16_t, access="rw", mandatory=True),
         # 0x0001: ("identify_commission_state", t.bitmap8),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("identify", {"identify_time": t.uint16_t}, False),
@@ -410,9 +410,9 @@ class Groups(Cluster):
     cluster_id = 0x0004
     ep_attribute = "groups"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("name_support", NameSupport),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("name_support", type=NameSupport, access="r", mandatory=True),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -469,14 +469,14 @@ class Scenes(Cluster):
     ep_attribute = "scenes"
     attributes: dict[int, ZCLAttributeDef] = {
         # Scene Management Information
-        0x0000: ("count", t.uint8_t),
-        0x0001: ("current_scene", t.uint8_t),
-        0x0002: ("current_group", t.uint16_t),
-        0x0003: ("scene_valid", t.Bool),
-        0x0004: ("name_support", NameSupport),
-        0x0005: ("last_configured_by", t.EUI64),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("count", type=t.uint8_t, access="r", mandatory=True),
+        0x0001: ZCLAttributeDef("current_scene", type=t.uint8_t, access="r", mandatory=True),
+        0x0002: ZCLAttributeDef("current_group", type=t.uint16_t, access="r", mandatory=True),
+        0x0003: ZCLAttributeDef("scene_valid", type=t.Bool, access="r", mandatory=True),
+        0x0004: ZCLAttributeDef("name_support", type=NameSupport, access="r", mandatory=True),
+        0x0005: ZCLAttributeDef("last_configured_by", type=t.EUI64, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -627,13 +627,13 @@ class OnOff(Cluster):
     name = "On/Off"
     ep_attribute = "on_off"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("on_off", t.Bool),
-        0x4000: ("global_scene_control", t.Bool),
-        0x4001: ("on_time", t.uint16_t),
-        0x4002: ("off_wait_time", t.uint16_t),
-        0x4003: ("start_up_on_off", StartUpOnOff),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("on_off", type=t.Bool, access="rps", mandatory=True),
+        0x4000: ZCLAttributeDef("global_scene_control", type=t.Bool, access="r"),
+        0x4001: ZCLAttributeDef("on_time", type=t.uint16_t, access="rw"),
+        0x4002: ZCLAttributeDef("off_wait_time", type=t.uint16_t, access="rw"),
+        0x4003: ZCLAttributeDef("start_up_on_off", type=StartUpOnOff, access="rw"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("off", {}, False),
@@ -659,8 +659,7 @@ class OnOff(Cluster):
 
 
 class OnOffConfiguration(Cluster):
-    """Attributes and commands for configuring On/Off
-    switching devices"""
+    """Attributes and commands for configuring On/Off switching devices"""
 
     class SwitchType(t.enum8):
         Toggle = 0x00
@@ -676,10 +675,10 @@ class OnOffConfiguration(Cluster):
     name = "On/Off Switch Configuration"
     ep_attribute = "on_off_config"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("switch_type", SwitchType),
-        0x0010: ("switch_actions", SwitchActions),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("switch_type", type=SwitchType, access="r", mandatory=True),
+        0x0010: ZCLAttributeDef("switch_actions", type=SwitchActions, access="rw", mandatory=True),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -705,22 +704,22 @@ class LevelControl(Cluster):
     name = "Level control"
     ep_attribute = "level"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("current_level", t.uint8_t),
-        0x0001: ("remaining_time", t.uint16_t),
-        0x0002: ("min_level", t.uint8_t),
-        0x0003: ("max_level", t.uint8_t),
-        0x0004: ("current_frequency", t.uint16_t),
-        0x0005: ("min_frequency", t.uint16_t),
-        0x0006: ("max_frequency", t.uint16_t),
-        0x000F: ("options", t.bitmap8),
-        0x0010: ("on_off_transition_time", t.uint16_t),
-        0x0011: ("on_level", t.uint8_t),
-        0x0012: ("on_transition_time", t.uint16_t),
-        0x0013: ("off_transition_time", t.uint16_t),
-        0x0014: ("default_move_rate", t.uint8_t),
-        0x4000: ("start_up_current_level", t.uint8_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("current_level", type=t.uint8_t, access="rps", mandatory=True),
+        0x0001: ZCLAttributeDef("remaining_time", type=t.uint16_t, access="r"),
+        0x0002: ZCLAttributeDef("min_level", type=t.uint8_t, access="r"),
+        0x0003: ZCLAttributeDef("max_level", type=t.uint8_t, access="r"),
+        0x0004: ZCLAttributeDef("current_frequency", type=t.uint16_t, access="rps"),
+        0x0005: ZCLAttributeDef("min_frequency", type=t.uint16_t, access="r"),
+        0x0006: ZCLAttributeDef("max_frequency", type=t.uint16_t, access="r"),
+        0x000F: ZCLAttributeDef("options", type=t.bitmap8, access="rw"),
+        0x0010: ZCLAttributeDef("on_off_transition_time", type=t.uint16_t, access="rw"),
+        0x0011: ZCLAttributeDef("on_level", type=t.uint8_t, access="rw"),
+        0x0012: ZCLAttributeDef("on_transition_time", type=t.uint16_t, access="rw"),
+        0x0013: ZCLAttributeDef("off_transition_time", type=t.uint16_t, access="rw"),
+        0x0014: ZCLAttributeDef("default_move_rate", type=t.uint8_t, access="rw"),
+        0x4000: ZCLAttributeDef("start_up_current_level", type=t.uint8_t, access="rw"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -795,9 +794,9 @@ class Alarms(Cluster):
     ep_attribute = "alarms"
     attributes: dict[int, ZCLAttributeDef] = {
         # Alarm Information
-        0x0000: ("alarm_count", t.uint16_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("alarm_count", type=t.uint16_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -839,18 +838,18 @@ class Time(Cluster):
     cluster_id = 0x000A
     ep_attribute = "time"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("time", t.UTCTime),
-        0x0001: ("time_status", t.bitmap8),
-        0x0002: ("time_zone", t.int32s),
-        0x0003: ("dst_start", t.uint32_t),
-        0x0004: ("dst_end", t.uint32_t),
-        0x0005: ("dst_shift", t.int32s),
-        0x0006: ("standard_time", t.StandardTime),
-        0x0007: ("local_time", t.LocalTime),
-        0x0008: ("last_set_time", t.UTCTime),
-        0x0009: ("valid_until_time", t.UTCTime),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("time", type=t.UTCTime, access="r*w", access=True),
+        0x0001: ZCLAttributeDef("time_status", type=t.bitmap8, access="r*w", access=True),
+        0x0002: ZCLAttributeDef("time_zone", type=t.int32s, access="rw"),
+        0x0003: ZCLAttributeDef("dst_start", type=t.uint32_t, access="rw"),
+        0x0004: ZCLAttributeDef("dst_end", type=t.uint32_t, access="rw"),
+        0x0005: ZCLAttributeDef("dst_shift", type=t.int32s, access="rw"),
+        0x0006: ZCLAttributeDef("standard_time", type=t.StandardTime, access="r"),
+        0x0007: ZCLAttributeDef("local_time", type=t.LocalTime, access="r"),
+        0x0008: ZCLAttributeDef("last_set_time", type=t.UTCTime, access="r"),
+        0x0009: ZCLAttributeDef("valid_until_time", type=t.UTCTime, access="rw"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -893,22 +892,22 @@ class RSSILocation(Cluster):
     ep_attribute = "rssi_location"
     attributes: dict[int, ZCLAttributeDef] = {
         # Location Information
-        0x0000: ("type", t.uint8_t),
-        0x0001: ("method", t.enum8),
-        0x0002: ("age", t.uint16_t),
-        0x0003: ("quality_measure", t.uint8_t),
-        0x0004: ("num_of_devices", t.uint8_t),
+        0x0000: ZCLAttributeDef("type", type=t.uint8_t, access="rw", mandatory=True),
+        0x0001: ZCLAttributeDef("method", type=t.enum8, access="rw", mandatory=True),
+        0x0002: ZCLAttributeDef("age", type=t.uint16_t, access="r"),
+        0x0003: ZCLAttributeDef("quality_measure", type=t.uint8_t, access="r"),
+        0x0004: ZCLAttributeDef("num_of_devices", type=t.uint8_t, access="r"),
         # Location Settings
-        0x0010: ("coordinate1", t.int16s),
-        0x0011: ("coordinate2", t.int16s),
-        0x0012: ("coordinate3", t.int16s),
-        0x0013: ("power", t.int16s),
-        0x0014: ("path_loss_exponent", t.uint16_t),
-        0x0015: ("reporting_period", t.uint16_t),
-        0x0016: ("calculation_period", t.uint16_t),
-        0x0017: ("number_rssi_measurements", t.uint8_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0010: ZCLAttributeDef("coordinate1", type=t.int16s, access="rw", mandatory=True),
+        0x0011: ZCLAttributeDef("coordinate2", type=t.int16s, access="rw", mandatory=True),
+        0x0012: ZCLAttributeDef("coordinate3", type=t.int16s, access="rw"),
+        0x0013: ZCLAttributeDef("power", type=t.int16s, access="rw", mandatory=True),
+        0x0014: ZCLAttributeDef("path_loss_exponent", type=t.uint16_t, access="rw", mandatory=True),
+        0x0015: ZCLAttributeDef("reporting_period", type=t.uint16_t, access="rw"),
+        0x0016: ZCLAttributeDef("calculation_period", type=t.uint16_t, access="rw"),
+        0x0017: ZCLAttributeDef("number_rssi_measurements", type=t.uint8_t, access="rw", mandatory=True),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -1028,18 +1027,18 @@ class AnalogInput(Cluster):
     cluster_id = 0x000C
     ep_attribute = "analog_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x001C: ("description", t.CharacterString),
-        0x0041: ("max_present_value", t.Single),
-        0x0045: ("min_present_value", t.Single),
-        0x0051: ("out_of_service", t.Bool),
-        0x0055: ("present_value", t.Single),
-        0x0067: ("reliability", t.enum8),
-        0x006A: ("resolution", t.Single),
-        0x006F: ("status_flags", t.bitmap8),
-        0x0075: ("engineering_units", t.enum16),
-        0x0100: ("application_type", t.uint32_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
+        0x0041: ZCLAttributeDef("max_present_value", type=t.Single, access="r*w"),
+        0x0045: ZCLAttributeDef("min_present_value", type=t.Single, access="r*w"),
+        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="rwp", mandatory=True),
+        0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
+        0x006A: ZCLAttributeDef("resolution", type=t.Single, access="r*w"),
+        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="rp", mandatory=True),
+        0x0075: ZCLAttributeDef("engineering_units", type=t.enum16, access="r*w"),
+        0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1049,21 +1048,21 @@ class AnalogOutput(Cluster):
     cluster_id = 0x000D
     ep_attribute = "analog_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x001C: ("description", t.CharacterString),
-        0x0041: ("max_present_value", t.Single),
-        0x0045: ("min_present_value", t.Single),
-        0x0051: ("out_of_service", t.Bool),
-        0x0055: ("present_value", t.Single),
-        # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
+        0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
+        0x0041: ZCLAttributeDef("max_present_value", type=t.Single, access="r*w"),
+        0x0045: ZCLAttributeDef("min_present_value", type=t.Single, access="r*w"),
+        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="rwp", mandatory=True),
+        # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        0x0067: ("reliability", t.enum8),
-        0x0068: ("relinquish_default", t.Single),
-        0x006A: ("resolution", t.Single),
-        0x006F: ("status_flags", t.bitmap8),
-        0x0075: ("engineering_units", t.enum16),
-        0x0100: ("application_type", t.uint32_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
+        0x0068: ZCLAttributeDef("relinquish_default", type=t.Single, access="r*w"),
+        0x006A: ZCLAttributeDef("resolution", type=t.Single, access="r*w"),
+        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="rp", mandatory=True),
+        0x0075: ZCLAttributeDef("engineering_units", type=t.enum16, access="r*w"),
+        0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1073,18 +1072,18 @@ class AnalogValue(Cluster):
     cluster_id = 0x000E
     ep_attribute = "analog_value"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x001C: ("description", t.CharacterString),
-        0x0051: ("out_of_service", t.Bool),
-        0x0055: ("present_value", t.Single),
+        0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
+        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="r/w", mandatory=True),
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        0x0067: ("reliability", t.enum8),
-        0x0068: ("relinquish_default", t.Single),
-        0x006F: ("status_flags", t.bitmap8),
-        0x0075: ("engineering_units", t.enum16),
-        0x0100: ("application_type", t.uint32_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
+        0x0068: ZCLAttributeDef("relinquish_default", type=t.Single, access="r*w"),
+        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x0075: ZCLAttributeDef("engineering_units", type=t.enum16, access="r*w"),
+        0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1095,17 +1094,17 @@ class BinaryInput(Cluster):
     name = "Binary Input (Basic)"
     ep_attribute = "binary_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0004: ("active_text", t.CharacterString),
-        0x001C: ("description", t.CharacterString),
-        0x002E: ("inactive_text", t.CharacterString),
-        0x0051: ("out_of_service", t.Bool),
-        0x0054: ("polarity", t.enum8),
-        0x0055: ("present_value", t.Bool),
-        0x0067: ("reliability", t.enum8),
-        0x006F: ("status_flags", t.bitmap8),
-        0x0100: ("application_type", t.uint32_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0004: ZCLAttributeDef("active_text", type=t.CharacterString, access="r*w"),
+        0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
+        0x002E: ZCLAttributeDef("inactive_text", type=t.CharacterString, access="r*w"),
+        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0054: ZCLAttributeDef("polarity", type=t.enum8, access="r"),
+        0x0055: ZCLAttributeDef("present_value", type=t.Bool, access="r*w", mandatory=True),
+        0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
+        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1115,24 +1114,24 @@ class BinaryOutput(Cluster):
     cluster_id = 0x0010
     ep_attribute = "binary_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0004: ("active_text", t.CharacterString),
-        0x001C: ("description", t.CharacterString),
-        0x002E: ("inactive_text", t.CharacterString),
-        0x0042: ("minimum_off_time", t.uint32_t),
-        0x0043: ("minimum_on_time", t.uint32_t),
-        0x0051: ("out_of_service", t.Bool),
-        0x0054: ("polarity", t.enum8),
-        0x0055: ("present_value", t.Bool),
+        0x0004: ZCLAttributeDef("active_text", type=t.CharacterString, access="r*w"),
+        0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
+        0x002E: ZCLAttributeDef("inactive_text", type=t.CharacterString, access="r*w"),
+        0x0042: ZCLAttributeDef("minimum_off_time", type=t.uint32_t, access="r*w"),
+        0x0043: ZCLAttributeDef("minimum_on_time", type=t.uint32_t, access="r*w"),
+        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0054: ZCLAttributeDef("polarity", type=t.enum8, access="r"),
+        0x0055: ZCLAttributeDef("present_value", type=t.Bool, access="r*w", mandatory=True),
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        0x0067: ("reliability", t.enum8),
-        0x0068: ("relinquish_default", t.Bool),
-        0x006A: ("resolution", t.Single),
-        0x006F: ("status_flags", t.bitmap8),
-        0x0075: ("engineering_units", t.enum16),  # Does not seem to be in binary_output
-        0x0100: ("application_type", t.uint32_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
+        0x0068: ZCLAttributeDef("relinquish_default", type=t.Bool, access="r*w"),
+        0x006A: ZCLAttributeDef("resolution", type=t.Single, access="r"),  # Does not seem to be in binary_output
+        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x0075: ZCLAttributeDef("engineering_units", type=t.enum16, access="r"),  # Does not seem to be in binary_output
+        0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1142,21 +1141,21 @@ class BinaryValue(Cluster):
     cluster_id = 0x0011
     ep_attribute = "binary_value"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0004: ("active_text", t.CharacterString),
-        0x001C: ("description", t.CharacterString),
-        0x002E: ("inactive_text", t.CharacterString),
-        0x0042: ("minimum_off_time", t.uint32_t),
-        0x0043: ("minimum_on_time", t.uint32_t),
-        0x0051: ("out_of_service", t.Bool),
-        0x0055: ("present_value", t.Single),
-        # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
+        0x0004: ZCLAttributeDef("active_text", type=t.CharacterString, access="r*w"),
+        0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
+        0x002E: ZCLAttributeDef("inactive_text", type=t.CharacterString, access="r*w"),
+        0x0042: ZCLAttributeDef("minimum_off_time", type=t.uint32_t, access="r*w"),
+        0x0043: ZCLAttributeDef("minimum_on_time", type=t.uint32_t, access="r*w"),
+        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="r*w", mandatory=True),
+        # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        0x0067: ("reliability", t.enum8),
-        0x0068: ("relinquish_default", t.Single),
-        0x006F: ("status_flags", t.bitmap8),
-        0x0100: ("application_type", t.uint32_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
+        0x0068: ZCLAttributeDef("relinquish_default", type=t.Single, access="r*w"),
+        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1166,18 +1165,18 @@ class MultistateInput(Cluster):
     cluster_id = 0x0012
     ep_attribute = "multistate_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x000E: ("state_text", t.List[t.CharacterString]),
-        0x001C: ("description", t.CharacterString),
-        0x004A: ("number_of_states", t.uint16_t),
-        0x0051: ("out_of_service", t.Bool),
-        0x0055: ("present_value", t.Single),
+        0x000E: ZCLAttributeDef("state_text", type=t.List[t.CharacterString], access="r*w"),
+        0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
+        0x004A: ZCLAttributeDef("number_of_states", type=t.uint16_t, access="r*w"),
+        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="r*w", mandatory=True),
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        0x0067: ("reliability", t.enum8),
-        0x006F: ("status_flags", t.bitmap8),
-        0x0100: ("application_type", t.uint32_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
+        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1187,19 +1186,19 @@ class MultistateOutput(Cluster):
     cluster_id = 0x0013
     ep_attribute = "multistate_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x000E: ("state_text", t.List[t.CharacterString]),
-        0x001C: ("description", t.CharacterString),
-        0x004A: ("number_of_states", t.uint16_t),
-        0x0051: ("out_of_service", t.Bool),
-        0x0055: ("present_value", t.Single),
-        # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
+        0x000E: ZCLAttributeDef("state_text", type=t.List[t.CharacterString], access="r*w"),
+        0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
+        0x004A: ZCLAttributeDef("number_of_states", type=t.uint16_t, access="r*w", mandatory=True),
+        0x0051: ZCLAttributeDef("out_of_service", type=t.Bool, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef("present_value", type=t.Single, access="r*w", mandatory=True),
+        # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        0x0067: ("reliability", t.enum8),
-        0x0068: ("relinquish_default", t.Single),
-        0x006F: ("status_flags", t.bitmap8),
-        0x0100: ("application_type", t.uint32_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
+        0x0068: ZCLAttributeDef("relinquish_default", type=t.Single, access="r*w"),
+        0x006F: ZCLAttributeDef("status_flags", type=t.bitmap8, access="r", mandatory=True),
+        0x0100: ZCLAttributeDef("application_type", type=t.uint32_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1209,19 +1208,19 @@ class MultistateValue(Cluster):
     cluster_id = 0x0014
     ep_attribute = "multistate_value"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x000E: ("state_text", t.List[t.CharacterString]),
-        0x001C: ("description", t.CharacterString),
-        0x004A: ("number_of_states", t.uint16_t),
-        0x0051: ("out_of_service", t.Bool),
-        0x0055: ("present_value", t.Single),
+        0x000E: ZCLAttributeDef("state_text", t.List[t.CharacterString], access="r*w"),
+        0x001C: ZCLAttributeDef("description", t.CharacterString, access="r*w"),
+        0x004A: ZCLAttributeDef("number_of_states", t.uint16_t, access="r*w", mandatory=True),
+        0x0051: ZCLAttributeDef("out_of_service", t.Bool, access="r*w", mandatory=True),
+        0x0055: ZCLAttributeDef("present_value", t.Single, access="r*w", mandatory=True),
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        0x0067: ("reliability", t.enum8),
-        0x0068: ("relinquish_default", t.Single),
-        0x006F: ("status_flags", t.bitmap8),
-        0x0100: ("application_type", t.uint32_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0067: ZCLAttributeDef("reliability", t.enum8, access="r*w"),
+        0x0068: ZCLAttributeDef("relinquish_default", t.Single, access="r*w"),
+        0x006F: ZCLAttributeDef("status_flags", t.bitmap8, access="r", mandatory=True),
+        0x0100: ZCLAttributeDef("application_type", t.uint32_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1235,35 +1234,35 @@ class Commissioning(Cluster):
     ep_attribute = "commissioning"
     attributes: dict[int, ZCLAttributeDef] = {
         # Startup Parameters
-        0x0000: ("short_address", t.uint16_t),
-        0x0001: ("extended_pan_id", t.EUI64),
-        0x0002: ("pan_id", t.uint16_t),
-        0x0003: ("channelmask", t.Channels),
-        0x0004: ("protocol_version", t.uint8_t),
-        0x0005: ("stack_profile", t.uint8_t),
-        0x0006: ("startup_control", t.enum8),
-        0x0010: ("trust_center_address", t.EUI64),
-        0x0011: ("trust_center_master_key", t.KeyData),
-        0x0012: ("network_key", t.KeyData),
-        0x0013: ("use_insecure_join", t.Bool),
-        0x0014: ("preconfigured_link_key", t.KeyData),
-        0x0015: ("network_key_seq_num", t.uint8_t),
-        0x0016: ("network_key_type", t.enum8),
-        0x0017: ("network_manager_address", t.uint16_t),
+        0x0000: ZCLAttributeDef("short_address", type=t.uint16_t, access="rw", mandatory=True),
+        0x0001: ZCLAttributeDef("extended_pan_id", type=t.EUI64, access="rw", mandatory=True),
+        0x0002: ZCLAttributeDef("pan_id", type=t.uint16_t, access="rw", mandatory=True),
+        0x0003: ZCLAttributeDef("channelmask", type=t.Channels, access="rw", mandatory=True),
+        0x0004: ZCLAttributeDef("protocol_version", type=t.uint8_t, access="rw", mandatory=True),
+        0x0005: ZCLAttributeDef("stack_profile", type=t.uint8_t, access="rw", mandatory=True),
+        0x0006: ZCLAttributeDef("startup_control", type=t.enum8, access="rw", mandatory=True),
+        0x0010: ZCLAttributeDef("trust_center_address", type=t.EUI64, access="rw", mandatory=True),
+        0x0011: ZCLAttributeDef("trust_center_master_key", type=t.KeyData, access="rw"),
+        0x0012: ZCLAttributeDef("network_key", type=t.KeyData, access="rw", mandatory=True),
+        0x0013: ZCLAttributeDef("use_insecure_join", type=t.Bool, access="rw", mandatory=True),
+        0x0014: ZCLAttributeDef("preconfigured_link_key", type=t.KeyData, access="rw", mandatory=True),
+        0x0015: ZCLAttributeDef("network_key_seq_num", type=t.uint8_t, access="rw", mandatory=True),
+        0x0016: ZCLAttributeDef("network_key_type", type=t.enum8, access="rw", mandatory=True),
+        0x0017: ZCLAttributeDef("network_manager_address", type=t.uint16_t, access="rw", mandatory=True),
         # Join Parameters
-        0x0020: ("scan_attempts", t.uint8_t),
-        0x0021: ("time_between_scans", t.uint16_t),
-        0x0022: ("rejoin_interval", t.uint16_t),
-        0x0023: ("max_rejoin_interval", t.uint16_t),
+        0x0020: ZCLAttributeDef("scan_attempts", type=t.uint8_t, access="rw"),
+        0x0021: ZCLAttributeDef("time_between_scans", type=t.uint16_t, access="rw"),
+        0x0022: ZCLAttributeDef("rejoin_interval", type=t.uint16_t, access="rw"),
+        0x0023: ZCLAttributeDef("max_rejoin_interval", type=t.uint16_t, access="rw"),
         # End Device Parameters
-        0x0030: ("indirect_poll_rate", t.uint16_t),
-        0x0031: ("parent_retry_threshold", t.uint8_t),
+        0x0030: ZCLAttributeDef("indirect_poll_rate", type=t.uint16_t, access="rw"),
+        0x0031: ZCLAttributeDef("parent_retry_threshold", type=t.uint8_t, access="r"),
         # Concentrator Parameters
-        0x0040: ("concentrator_flag", t.Bool),
-        0x0041: ("concentrator_radius", t.uint8_t),
-        0x0042: ("concentrator_discovery_time", t.uint8_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0040: ZCLAttributeDef("concentrator_flag", type=t.Bool, access="rw"),
+        0x0041: ZCLAttributeDef("concentrator_radius", type=t.uint8_t, access="rw"),
+        0x0042: ZCLAttributeDef("concentrator_discovery_time", type=t.uint8_t, access="rw"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -1305,18 +1304,18 @@ class Partition(Cluster):
     cluster_id = 0x0016
     ep_attribute = "partition"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("maximum_incoming_transfer_size", t.uint16_t),
-        0x0001: ("maximum_outgoing_transfer_size", t.uint16_t),
-        0x0002: ("partitioned_frame_size", t.uint8_t),
-        0x0003: ("large_frame_size", t.uint16_t),
-        0x0004: ("number_of_ack_frame", t.uint8_t),
-        0x0005: ("nack_timeout", t.uint16_t),
-        0x0006: ("interframe_delay", t.uint8_t),
-        0x0007: ("number_of_send_retries", t.uint8_t),
-        0x0008: ("sender_timeout", t.uint16_t),
-        0x0009: ("receiver_timeout", t.uint16_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("maximum_incoming_transfer_size", type=t.uint16_t, access="r", mandatory=True),
+        0x0001: ZCLAttributeDef("maximum_outgoing_transfer_size", type=t.uint16_t, access="r", mandatory=True),
+        0x0002: ZCLAttributeDef("partitioned_frame_size", type=t.uint8_t, access="rw", mandatory=True),
+        0x0003: ZCLAttributeDef("large_frame_size", type=t.uint16_t, access="rw", mandatory=True),
+        0x0004: ZCLAttributeDef("number_of_ack_frame", type=t.uint8_t, access="rw", mandatory=True),
+        0x0005: ZCLAttributeDef("nack_timeout", type=t.uint16_t, access="r", mandatory=True),
+        0x0006: ZCLAttributeDef("interframe_delay", type=t.uint8_t, access="rw", mandatory=True),
+        0x0007: ZCLAttributeDef("number_of_send_retries", type=t.uint8_t, access="r", mandatory=True),
+        0x0008: ZCLAttributeDef("sender_timeout", type=t.uint16_t, access="r", mandatory=True),
+        0x0009: ZCLAttributeDef("receiver_timeout", type=t.uint16_t, access="r", mandatory=True),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1448,21 +1447,21 @@ class Ota(Cluster):
     cluster_id = 0x0019
     ep_attribute = "ota"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("upgrade_server_id", t.EUI64),
-        0x0001: ("file_offset", t.uint32_t),
-        0x0002: ("current_file_version", t.uint32_t),
-        0x0003: ("current_zigbee_stack_version", t.uint16_t),
-        0x0004: ("downloaded_file_version", t.uint32_t),
-        0x0005: ("downloaded_zigbee_stack_version", t.uint16_t),
-        0x0006: ("image_upgrade_status", ImageUpgradeStatus),
-        0x0007: ("manufacturer_id", t.uint16_t),
-        0x0008: ("image_type_id", t.uint16_t),
-        0x0009: ("minimum_block_req_delay", t.uint16_t),
-        0x000A: ("image_stamp", t.uint32_t),
-        0x000B: ("upgrade_activation_policy", UpgradeActivationPolicy),
-        0x000C: ("upgrade_timeout_policy", UpgradeTimeoutPolicy),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ("upgrade_server_id", t.EUI64, access="r", mandatory=True),
+        0x0001: ("file_offset", t.uint32_t, access="r"),
+        0x0002: ("current_file_version", t.uint32_t, access="r"),
+        0x0003: ("current_zigbee_stack_version", t.uint16_t, access="r"),
+        0x0004: ("downloaded_file_version", t.uint32_t, access="r"),
+        0x0005: ("downloaded_zigbee_stack_version", t.uint16_t, access="r"),
+        0x0006: ("image_upgrade_status", ImageUpgradeStatus, access="r", mandatory=True),
+        0x0007: ("manufacturer_id", t.uint16_t, access="r"),
+        0x0008: ("image_type_id", t.uint16_t, access="r"),
+        0x0009: ("minimum_block_req_delay", t.uint16_t, access="r"),
+        0x000A: ("image_stamp", t.uint32_t, access="r"),
+        0x000B: ("upgrade_activation_policy", UpgradeActivationPolicy, access="r"),
+        0x000C: ("upgrade_timeout_policy", UpgradeTimeoutPolicy, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x01: ZCLCommandDef("query_next_image", QueryNextImageCommand, False),
@@ -1719,13 +1718,13 @@ class PowerProfile(Cluster):
     cluster_id = 0x001A
     ep_attribute = "power_profile"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("total_profile_num", t.uint8_t),
-        0x0001: ("multiple_scheduling", t.Bool),
-        0x0002: ("energy_formatting", t.bitmap8),
-        0x0003: ("energy_remote", t.Bool),
-        0x0004: ("schedule_mode", t.bitmap8),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("total_profile_num", type=t.uint8_t, access="r", mandatory=True),
+        0x0001: ZCLAttributeDef("multiple_scheduling", type=t.Bool, access="r", mandatory=True),
+        0x0002: ZCLAttributeDef("energy_formatting", type=t.bitmap8, access="r", mandatory=True),
+        0x0003: ZCLAttributeDef("energy_remote", type=t.Bool, access="r", mandatory=True),
+        0x0004: ZCLAttributeDef("schedule_mode", type=t.bitmap8, access="rwp", mandatory=True),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
 
     class ScheduleRecord(t.Struct):
@@ -1889,11 +1888,11 @@ class ApplianceControl(Cluster):
     cluster_id = 0x001B
     ep_attribute = "appliance_control"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("start_time", t.uint16_t),
-        0x0001: ("finish_time", t.uint16_t),
-        0x0002: ("remaining_time", t.uint16_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("start_time", type=t.uint16_t, access="rp", mandatory=True),
+        0x0001: ZCLAttributeDef("finish_time", type=t.uint16_t, access="rp", mandatory=True),
+        0x0002: ZCLAttributeDef("remaining_time", type=t.uint16_t, access="rp"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -1904,15 +1903,15 @@ class PollControl(Cluster):
     name = "Poll Control"
     ep_attribute = "poll_control"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("checkin_interval", t.uint32_t),
-        0x0001: ("long_poll_interval", t.uint32_t),
-        0x0002: ("short_poll_interval", t.uint16_t),
-        0x0003: ("fast_poll_timeout", t.uint16_t),
-        0x0004: ("checkin_interval_min", t.uint32_t),
-        0x0005: ("long_poll_interval_min", t.uint32_t),
-        0x0006: ("fast_poll_timeout_max", t.uint16_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef("checkin_interval", type=t.uint32_t, access="rw", mandatory=True),
+        0x0001: ZCLAttributeDef("long_poll_interval", type=t.uint32_t, access="r", mandatory=True),
+        0x0002: ZCLAttributeDef("short_poll_interval", type=t.uint16_t, access="r", mandatory=True),
+        0x0003: ZCLAttributeDef("fast_poll_timeout", type=t.uint16_t, access="rw", mandatory=True),
+        0x0004: ZCLAttributeDef("checkin_interval_min", type=t.uint32_t, access="r"),
+        0x0005: ZCLAttributeDef("long_poll_interval_min", type=t.uint32_t, access="r"),
+        0x0006: ZCLAttributeDef("fast_poll_timeout_max", type=t.uint16_t, access="r"),
+        0xFFFD: ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -972,10 +972,20 @@ class RSSILocation(Cluster):
 
     cluster_id = 0x000B
     ep_attribute = "rssi_location"
+
+    class LocationMethod(t.enum8):
+        Lateration = 0x00
+        Signposting = 0x01
+        RF_fingerprinting = 0x02
+        Out_of_band = 0x03
+        Centralized = 0x04
+
     attributes: dict[int, ZCLAttributeDef] = {
         # Location Information
         0x0000: ZCLAttributeDef("type", type=t.uint8_t, access="rw", mandatory=True),
-        0x0001: ZCLAttributeDef("method", type=t.enum8, access="rw", mandatory=True),
+        0x0001: ZCLAttributeDef(
+            "method", type=LocationMethod, access="rw", mandatory=True
+        ),
         0x0002: ZCLAttributeDef("age", type=t.uint16_t, access="r"),
         0x0003: ZCLAttributeDef("quality_measure", type=t.uint8_t, access="r"),
         0x0004: ZCLAttributeDef("num_of_devices", type=t.uint8_t, access="r"),
@@ -1116,6 +1126,20 @@ class RSSILocation(Cluster):
 class AnalogInput(Cluster):
     cluster_id = 0x000C
     ep_attribute = "analog_input"
+
+    class Reliability(t.enum8):
+        No_fault_detected = 0
+        No_sensor = 1
+        Over_range = 2
+        Under_range = 3
+        Open_loop = 4
+        Shorted_loop = 5
+        No_output = 6
+        Unreliable_other = 7
+        Process_error = 8
+        Multi_state_fault = 9
+        Configuration_error = 10
+
     attributes: dict[int, ZCLAttributeDef] = {
         0x001C: ZCLAttributeDef("description", type=t.CharacterString, access="r*w"),
         0x0041: ZCLAttributeDef("max_present_value", type=t.Single, access="r*w"),
@@ -1126,7 +1150,7 @@ class AnalogInput(Cluster):
         0x0055: ZCLAttributeDef(
             "present_value", type=t.Single, access="rwp", mandatory=True
         ),
-        0x0067: ZCLAttributeDef("reliability", type=t.enum8, access="r*w"),
+        0x0067: ZCLAttributeDef("reliability", type=Reliability, access="r*w"),
         0x006A: ZCLAttributeDef("resolution", type=t.Single, access="r*w"),
         0x006F: ZCLAttributeDef(
             "status_flags", type=t.bitmap8, access="rp", mandatory=True
@@ -1384,6 +1408,16 @@ class Commissioning(Cluster):
 
     cluster_id = 0x0015
     ep_attribute = "commissioning"
+
+    class StartupControl(t.enum8):
+        Part_of_network = 0x00
+        Form_network = 0x01
+        Rejoin_network = 0x02
+        Start_from_scratch = 0x03
+
+    class NetworkKeyType(t.enum8):
+        Standard = 0x01
+
     attributes: dict[int, ZCLAttributeDef] = {
         # Startup Parameters
         0x0000: ZCLAttributeDef(
@@ -1394,7 +1428,7 @@ class Commissioning(Cluster):
         ),
         0x0002: ZCLAttributeDef("pan_id", type=t.uint16_t, access="rw", mandatory=True),
         0x0003: ZCLAttributeDef(
-            "channelmask", type=t.Channels, access="rw", mandatory=True
+            "channel_mask", type=t.Channels, access="rw", mandatory=True
         ),
         0x0004: ZCLAttributeDef(
             "protocol_version", type=t.uint8_t, access="rw", mandatory=True
@@ -1403,7 +1437,7 @@ class Commissioning(Cluster):
             "stack_profile", type=t.uint8_t, access="rw", mandatory=True
         ),
         0x0006: ZCLAttributeDef(
-            "startup_control", type=t.enum8, access="rw", mandatory=True
+            "startup_control", type=StartupControl, access="rw", mandatory=True
         ),
         0x0010: ZCLAttributeDef(
             "trust_center_address", type=t.EUI64, access="rw", mandatory=True
@@ -1422,7 +1456,7 @@ class Commissioning(Cluster):
             "network_key_seq_num", type=t.uint8_t, access="rw", mandatory=True
         ),
         0x0016: ZCLAttributeDef(
-            "network_key_type", type=t.enum8, access="rw", mandatory=True
+            "network_key_type", type=NetworkKeyType, access="rw", mandatory=True
         ),
         0x0017: ZCLAttributeDef(
             "network_manager_address", type=t.uint16_t, access="rw", mandatory=True

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import zigpy.types as t
-from zigpy.zcl import Cluster
+from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.foundation import ZCLAttributeDef, ZCLCommandDef
 
 
@@ -10,18 +10,30 @@ class ApplianceIdentification(Cluster):
     name = "Appliance Identification"
     ep_attribute = "appliance_id"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("basic_identification", t.uint56_t),
-        0x0010: ("company_name", t.LimitedCharString(16)),
-        0x0011: ("company_id", t.uint16_t),
-        0x0012: ("brand_name", t.LimitedCharString(16)),
-        0x0013: ("brand_id", t.uint16_t),
-        0x0014: ("model", t.LimitedLVBytes(16)),
-        0x0015: ("part_number", t.LimitedLVBytes(16)),
-        0x0016: ("product_revision", t.LimitedLVBytes(6)),
-        0x0017: ("software_revision", t.LimitedLVBytes(6)),
-        0x0018: ("product_type_name", t.LVBytesSize2),
-        0x0019: ("product_type_id", t.uint16_t),
-        0x001A: ("ceced_specification_version", t.uint8_t),
+        0x0000: ZCLAttributeDef(
+            "basic_identification", type=t.uint56_t, access="r", mandatory=True
+        ),
+        0x0010: ZCLAttributeDef(
+            "company_name", type=t.LimitedCharString(16), access="r"
+        ),
+        0x0011: ZCLAttributeDef("company_id", type=t.uint16_t, access="r"),
+        0x0012: ZCLAttributeDef("brand_name", type=t.LimitedCharString(16), access="r"),
+        0x0013: ZCLAttributeDef("brand_id", type=t.uint16_t, access="r"),
+        0x0014: ZCLAttributeDef("model", type=t.LimitedLVBytes(16), access="r"),
+        0x0015: ZCLAttributeDef("part_number", type=t.LimitedLVBytes(16), access="r"),
+        0x0016: ZCLAttributeDef(
+            "product_revision", type=t.LimitedLVBytes(6), access="r"
+        ),
+        0x0017: ZCLAttributeDef(
+            "software_revision", type=t.LimitedLVBytes(6), access="r"
+        ),
+        0x0018: ZCLAttributeDef("product_type_name", type=t.LVBytesSize2, access="r"),
+        0x0019: ZCLAttributeDef("product_type_id", type=t.uint16_t, access="r"),
+        0x001A: ZCLAttributeDef(
+            "ceced_specification_version", type=t.uint8_t, access="r"
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -32,18 +44,40 @@ class MeterIdentification(Cluster):
     name = "Meter Identification"
     ep_attribute = "meter_id"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("company_name", t.LimitedCharString(16)),
-        0x0001: ("meter_type_id", t.uint16_t),
-        0x0004: ("data_quality_id", t.uint16_t),
-        0x0005: ("customer_name", t.LimitedCharString(16)),
-        0x0006: ("model", t.LimitedLVBytes(16)),
-        0x0007: ("part_number", t.LimitedLVBytes(16)),
-        0x0008: ("product_revision", t.LimitedLVBytes(6)),
-        0x000A: ("software_revision", t.LimitedLVBytes(6)),
-        0x000B: ("utility_name", t.LimitedCharString(16)),
-        0x000C: ("pod", t.LimitedCharString(16)),
-        0x000D: ("available_power", t.int24s),
-        0x000E: ("power_threshold", t.int24s),
+        0x0000: ZCLAttributeDef(
+            "company_name", type=t.LimitedCharString(16), access="r", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "meter_type_id", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0004: ZCLAttributeDef(
+            "data_quality_id", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0005: ZCLAttributeDef(
+            "customer_name", type=t.LimitedCharString(16), access="rw"
+        ),
+        0x0006: ZCLAttributeDef("model", type=t.LimitedLVBytes(16), access="r"),
+        0x0007: ZCLAttributeDef("part_number", type=t.LimitedLVBytes(16), access="r"),
+        0x0008: ZCLAttributeDef(
+            "product_revision", type=t.LimitedLVBytes(6), access="r"
+        ),
+        0x000A: ZCLAttributeDef(
+            "software_revision", type=t.LimitedLVBytes(6), access="r"
+        ),
+        0x000B: ZCLAttributeDef(
+            "utility_name", type=t.LimitedCharString(16), access="r"
+        ),
+        0x000C: ZCLAttributeDef(
+            "pod", type=t.LimitedCharString(16), access="r", mandatory=True
+        ),
+        0x000D: ZCLAttributeDef(
+            "available_power", type=t.int24s, access="r", mandatory=True
+        ),
+        0x000E: ZCLAttributeDef(
+            "power_threshold", type=t.int24s, access="r", mandatory=True
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -53,7 +87,10 @@ class ApplianceEventAlerts(Cluster):
     cluster_id = 0x0B02
     name = "Appliance Event Alerts"
     ep_attribute = "appliance_event"
-    attributes: dict[int, ZCLAttributeDef] = {}
+    attributes: dict[int, ZCLAttributeDef] = {
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
+    }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("get_alerts", {}, False)
     }
@@ -69,8 +106,14 @@ class ApplianceStatistics(Cluster):
     name = "Appliance Statistics"
     ep_attribute = "appliance_stats"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("log_max_size", t.uint32_t),
-        0x0001: ("log_queue_max_size", t.uint8_t),
+        0x0000: ZCLAttributeDef(
+            "log_max_size", type=t.uint32_t, access="r", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "log_queue_max_size", type=t.uint8_t, access="r", mandatory=True
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("log", {}, False),
@@ -88,147 +131,251 @@ class ElectricalMeasurement(Cluster):
     cluster_id = 0x0B04
     name = "Electrical Measurement"
     ep_attribute = "electrical_measurement"
+
+    class MeasurementType(t.bitmap32):
+        Active_measurement_AC = 2 << 0
+        Reactive_measurement_AC = 2 << 1
+        Apparent_measurement_AC = 2 << 2
+        Phase_A_measurement = 2 << 3
+        Phase_B_measurement = 2 << 4
+        Phase_C_measurement = 2 << 5
+        DC_measurement = 2 << 6
+        Harmonics_measurement = 2 << 7
+        Power_quality_measurement = 2 << 8
+
+    class DCOverloadAlarmMark(t.bitmap8):
+        Voltage_Overload = 0b00000001
+        Current_Overload = 0b00000010
+
+    class ACAlarmsMask(t.bitmap16):
+        Voltage_Overload = 2 << 0
+        Current_Overload = 2 << 1
+        Active_Power_Overload = 2 << 2
+        Reactive_Power_Overload = 2 << 3
+        Average_RMS_Over_Voltage = 2 << 4
+        Average_RMS_Under_Voltage = 2 << 5
+        RMS_Extreme_Over_Voltage = 2 << 6
+        RMS_Extreme_Under_Voltage = 2 << 7
+        RMS_Voltage_Sag = 2 << 8
+        RMS_Voltage_Swell = 2 << 9
+
     attributes: dict[int, ZCLAttributeDef] = {
         # Basic Information
-        0x0000: ("measurement_type", t.bitmap32),
+        0x0000: ZCLAttributeDef(
+            "measurement_type", type=MeasurementType, access="r", mandatory=True
+        ),
         # DC Measurement
-        0x0100: ("dc_voltage", t.int16s),
-        0x0101: ("dc_voltage_min", t.int16s),
-        0x0102: ("dc_voltage_max", t.int16s),
-        0x0103: ("dc_current", t.int16s),
-        0x0104: ("dc_current_min", t.int16s),
-        0x0105: ("dc_current_max", t.int16s),
-        0x0106: ("dc_power", t.int16s),
-        0x0107: ("dc_power_min", t.int16s),
-        0x0108: ("dc_power_max", t.int16s),
+        0x0100: ZCLAttributeDef("dc_voltage", type=t.int16s, access="rp"),
+        0x0101: ZCLAttributeDef("dc_voltage_min", type=t.int16s, access="r"),
+        0x0102: ZCLAttributeDef("dc_voltage_max", type=t.int16s, access="r"),
+        0x0103: ZCLAttributeDef("dc_current", type=t.int16s, access="rp"),
+        0x0104: ZCLAttributeDef("dc_current_min", type=t.int16s, access="r"),
+        0x0105: ZCLAttributeDef("dc_current_max", type=t.int16s, access="r"),
+        0x0106: ZCLAttributeDef("dc_power", type=t.int16s, access="rp"),
+        0x0107: ZCLAttributeDef("dc_power_min", type=t.int16s, access="r"),
+        0x0108: ZCLAttributeDef("dc_power_max", type=t.int16s, access="r"),
         # DC Formatting
-        0x0200: ("dc_voltage_multiplier", t.uint16_t),
-        0x0201: ("dc_voltage_divisor", t.uint16_t),
-        0x0202: ("dc_current_multiplier", t.uint16_t),
-        0x0203: ("dc_current_divisor", t.uint16_t),
-        0x0204: ("dc_power_multiplier", t.uint16_t),
-        0x0205: ("dc_power_divisor", t.uint16_t),
+        0x0200: ZCLAttributeDef("dc_voltage_multiplier", type=t.uint16_t, access="rp"),
+        0x0201: ZCLAttributeDef("dc_voltage_divisor", type=t.uint16_t, access="rp"),
+        0x0202: ZCLAttributeDef("dc_current_multiplier", type=t.uint16_t, access="rp"),
+        0x0203: ZCLAttributeDef("dc_current_divisor", type=t.uint16_t, access="rp"),
+        0x0204: ZCLAttributeDef("dc_power_multiplier", type=t.uint16_t, access="rp"),
+        0x0205: ZCLAttributeDef("dc_power_divisor", type=t.uint16_t, access="rp"),
         # AC (Non-phase Specific) Measurements
-        0x0300: ("ac_frequency", t.uint16_t),
-        0x0301: ("ac_frequency_min", t.uint16_t),
-        0x0302: ("ac_frequency_max", t.uint16_t),
-        0x0303: ("neutral_current", t.uint16_t),
-        0x0304: ("total_active_power", t.int32s),
-        0x0305: ("total_reactive_power", t.int32s),
-        0x0306: ("total_apparent_power", t.uint32_t),
-        0x0307: ("meas1st_harmonic_current", t.int16s),
-        0x0308: ("meas3rd_harmonic_current", t.int16s),
-        0x0309: ("meas5th_harmonic_current", t.int16s),
-        0x030A: ("meas7th_harmonic_current", t.int16s),
-        0x030B: ("meas9th_harmonic_current", t.int16s),
-        0x030C: ("meas11th_harmonic_current", t.int16s),
-        0x030D: ("meas_phase1st_harmonic_current", t.int16s),
-        0x030E: ("meas_phase3rd_harmonic_current", t.int16s),
-        0x030F: ("meas_phase5th_harmonic_current", t.int16s),
-        0x0310: ("meas_phase7th_harmonic_current", t.int16s),
-        0x0311: ("meas_phase9th_harmonic_current", t.int16s),
-        0x0312: ("meas_phase11th_harmonic_current", t.int16s),
+        0x0300: ZCLAttributeDef("ac_frequency", type=t.uint16_t, access="rp"),
+        0x0301: ZCLAttributeDef("ac_frequency_min", type=t.uint16_t, access="r"),
+        0x0302: ZCLAttributeDef("ac_frequency_max", type=t.uint16_t, access="r"),
+        0x0303: ZCLAttributeDef("neutral_current", type=t.uint16_t, access="rp"),
+        0x0304: ZCLAttributeDef("total_active_power", type=t.int32s, access="rp"),
+        0x0305: ZCLAttributeDef("total_reactive_power", type=t.int32s, access="rp"),
+        0x0306: ZCLAttributeDef("total_apparent_power", type=t.uint32_t, access="rp"),
+        0x0307: ZCLAttributeDef("meas1st_harmonic_current", type=t.int16s, access="rp"),
+        0x0308: ZCLAttributeDef("meas3rd_harmonic_current", type=t.int16s, access="rp"),
+        0x0309: ZCLAttributeDef("meas5th_harmonic_current", type=t.int16s, access="rp"),
+        0x030A: ZCLAttributeDef("meas7th_harmonic_current", type=t.int16s, access="rp"),
+        0x030B: ZCLAttributeDef("meas9th_harmonic_current", type=t.int16s, access="rp"),
+        0x030C: ZCLAttributeDef(
+            "meas11th_harmonic_current", type=t.int16s, access="rp"
+        ),
+        0x030D: ZCLAttributeDef(
+            "meas_phase1st_harmonic_current", type=t.int16s, access="rp"
+        ),
+        0x030E: ZCLAttributeDef(
+            "meas_phase3rd_harmonic_current", type=t.int16s, access="rp"
+        ),
+        0x030F: ZCLAttributeDef(
+            "meas_phase5th_harmonic_current", type=t.int16s, access="rp"
+        ),
+        0x0310: ZCLAttributeDef(
+            "meas_phase7th_harmonic_current", type=t.int16s, access="rp"
+        ),
+        0x0311: ZCLAttributeDef(
+            "meas_phase9th_harmonic_current", type=t.int16s, access="rp"
+        ),
+        0x0312: ZCLAttributeDef(
+            "meas_phase11th_harmonic_current", type=t.int16s, access="rp"
+        ),
         # AC (Non-phase specific) Formatting
-        0x0400: ("ac_frequency_multiplier", t.uint16_t),
-        0x0401: ("ac_frequency_divisor", t.uint16_t),
-        0x0402: ("power_multiplier", t.uint32_t),
-        0x0403: ("power_divisor", t.uint32_t),
-        0x0404: ("harmonic_current_multiplier", t.int8s),
-        0x0405: ("phase_harmonic_current_multiplier", t.int8s),
+        0x0400: ZCLAttributeDef(
+            "ac_frequency_multiplier", type=t.uint16_t, access="rp"
+        ),
+        0x0401: ZCLAttributeDef("ac_frequency_divisor", type=t.uint16_t, access="rp"),
+        0x0402: ZCLAttributeDef("power_multiplier", type=t.uint32_t, access="rp"),
+        0x0403: ZCLAttributeDef("power_divisor", type=t.uint32_t, access="rp"),
+        0x0404: ZCLAttributeDef(
+            "harmonic_current_multiplier", type=t.int8s, access="rp"
+        ),
+        0x0405: ZCLAttributeDef(
+            "phase_harmonic_current_multiplier", type=t.int8s, access="rp"
+        ),
         # AC (Single Phase or Phase A) Measurements
-        0x0500: ("instantaneous_voltage", t.int16s),
-        0x0501: ("instantaneous_line_current", t.uint16_t),
-        0x0502: ("instantaneous_active_current", t.int16s),
-        0x0503: ("instantaneous_reactive_current", t.int16s),
-        0x0504: ("instantaneous_power", t.int16s),
-        0x0505: ("rms_voltage", t.uint16_t),
-        0x0506: ("rms_voltage_min", t.uint16_t),
-        0x0507: ("rms_voltage_max", t.uint16_t),
-        0x0508: ("rms_current", t.uint16_t),
-        0x0509: ("rms_current_min", t.uint16_t),
-        0x050A: ("rms_current_max", t.uint16_t),
-        0x050B: ("active_power", t.int16s),
-        0x050C: ("active_power_min", t.int16s),
-        0x050D: ("active_power_max", t.int16s),
-        0x050E: ("reactive_power", t.int16s),
-        0x050F: ("apparent_power", t.uint16_t),
-        0x0510: ("power_factor", t.int8s),
-        0x0511: ("average_rms_voltage_meas_period", t.uint16_t),
-        0x0512: ("average_rms_over_voltage_counter", t.uint16_t),
-        0x0513: ("average_rms_under_voltage_counter", t.uint16_t),
-        0x0514: ("rms_extreme_over_voltage_period", t.uint16_t),
-        0x0515: ("rms_extreme_under_voltage_period", t.uint16_t),
-        0x0516: ("rms_voltage_sag_period", t.uint16_t),
-        0x0517: ("rms_voltage_swell_period", t.uint16_t),
+        0x0500: ZCLAttributeDef("instantaneous_voltage", type=t.int16s, access="rp"),
+        0x0501: ZCLAttributeDef(
+            "instantaneous_line_current", type=t.uint16_t, access="rp"
+        ),
+        0x0502: ZCLAttributeDef(
+            "instantaneous_active_current", type=t.int16s, access="rp"
+        ),
+        0x0503: ZCLAttributeDef(
+            "instantaneous_reactive_current", type=t.int16s, access="rp"
+        ),
+        0x0504: ZCLAttributeDef("instantaneous_power", type=t.int16s, access="rp"),
+        0x0505: ZCLAttributeDef("rms_voltage", type=t.uint16_t, access="rp"),
+        0x0506: ZCLAttributeDef("rms_voltage_min", type=t.uint16_t, access="r"),
+        0x0507: ZCLAttributeDef("rms_voltage_max", type=t.uint16_t, access="r"),
+        0x0508: ZCLAttributeDef("rms_current", type=t.uint16_t, access="rp"),
+        0x0509: ZCLAttributeDef("rms_current_min", type=t.uint16_t, access="r"),
+        0x050A: ZCLAttributeDef("rms_current_max", type=t.uint16_t, access="r"),
+        0x050B: ZCLAttributeDef("active_power", type=t.int16s, access="rp"),
+        0x050C: ZCLAttributeDef("active_power_min", type=t.int16s, access="r"),
+        0x050D: ZCLAttributeDef("active_power_max", type=t.int16s, access="r"),
+        0x050E: ZCLAttributeDef("reactive_power", type=t.int16s, access="rp"),
+        0x050F: ZCLAttributeDef("apparent_power", type=t.uint16_t, access="rp"),
+        0x0510: ZCLAttributeDef("power_factor", type=t.int8s, access="r"),
+        0x0511: ZCLAttributeDef(
+            "average_rms_voltage_meas_period", type=t.uint16_t, access="rw"
+        ),
+        0x0512: ZCLAttributeDef(
+            "average_rms_over_voltage_counter", type=t.uint16_t, access="rw"
+        ),
+        0x0513: ZCLAttributeDef(
+            "average_rms_under_voltage_counter", type=t.uint16_t, access="rw"
+        ),
+        0x0514: ZCLAttributeDef(
+            "rms_extreme_over_voltage_period", type=t.uint16_t, access="rw"
+        ),
+        0x0515: ZCLAttributeDef(
+            "rms_extreme_under_voltage_period", type=t.uint16_t, access="rw"
+        ),
+        0x0516: ZCLAttributeDef("rms_voltage_sag_period", type=t.uint16_t, access="rw"),
+        0x0517: ZCLAttributeDef(
+            "rms_voltage_swell_period", type=t.uint16_t, access="rw"
+        ),
         # AC Formatting
-        0x0600: ("ac_voltage_multiplier", t.uint16_t),
-        0x0601: ("ac_voltage_divisor", t.uint16_t),
-        0x0602: ("ac_current_multiplier", t.uint16_t),
-        0x0603: ("ac_current_divisor", t.uint16_t),
-        0x0604: ("ac_power_multiplier", t.uint16_t),
-        0x0605: ("ac_power_divisor", t.uint16_t),
+        0x0600: ZCLAttributeDef("ac_voltage_multiplier", type=t.uint16_t, access="rp"),
+        0x0601: ZCLAttributeDef("ac_voltage_divisor", type=t.uint16_t, access="rp"),
+        0x0602: ZCLAttributeDef("ac_current_multiplier", type=t.uint16_t, access="rp"),
+        0x0603: ZCLAttributeDef("ac_current_divisor", type=t.uint16_t, access="rp"),
+        0x0604: ZCLAttributeDef("ac_power_multiplier", type=t.uint16_t, access="rp"),
+        0x0605: ZCLAttributeDef("ac_power_divisor", type=t.uint16_t, access="rp"),
         # DC Manufacturer Threshold Alarms
-        0x0700: ("dc_overload_alarms_mask", t.bitmap8),
-        0x0701: ("dc_voltage_overload", t.int16s),
-        0x0702: ("dc_current_overload", t.int16s),
+        0x0700: ZCLAttributeDef(
+            "dc_overload_alarms_mask", type=DCOverloadAlarmMark, access="rp"
+        ),
+        0x0701: ZCLAttributeDef("dc_voltage_overload", type=t.int16s, access="rp"),
+        0x0702: ZCLAttributeDef("dc_current_overload", type=t.int16s, access="rp"),
         # AC Manufacturer Threshold Alarms
-        0x0800: ("ac_alarms_mask", t.bitmap16),
-        0x0801: ("ac_voltage_overload", t.int16s),
-        0x0802: ("ac_current_overload", t.int16s),
-        0x0803: ("ac_active_power_overload", t.int16s),
-        0x0804: ("ac_reactive_power_overload", t.int16s),
-        0x0805: ("average_rms_over_voltage", t.int16s),
-        0x0806: ("average_rms_under_voltage", t.int16s),
-        0x0807: ("rms_extreme_over_voltage", t.int16s),
-        0x0808: ("rms_extreme_under_voltage", t.int16s),
-        0x0809: ("rms_voltage_sag", t.int16s),
-        0x080A: ("rms_voltage_swell", t.int16s),
+        0x0800: ZCLAttributeDef("ac_alarms_mask", type=ACAlarmsMask, access="rw"),
+        0x0801: ZCLAttributeDef("ac_voltage_overload", type=t.int16s, access="r"),
+        0x0802: ZCLAttributeDef("ac_current_overload", type=t.int16s, access="r"),
+        0x0803: ZCLAttributeDef("ac_active_power_overload", type=t.int16s, access="r"),
+        0x0804: ZCLAttributeDef(
+            "ac_reactive_power_overload", type=t.int16s, access="r"
+        ),
+        0x0805: ZCLAttributeDef("average_rms_over_voltage", type=t.int16s, access="r"),
+        0x0806: ZCLAttributeDef("average_rms_under_voltage", type=t.int16s, access="r"),
+        0x0807: ZCLAttributeDef("rms_extreme_over_voltage", type=t.int16s, access="rw"),
+        0x0808: ZCLAttributeDef(
+            "rms_extreme_under_voltage", type=t.int16s, access="rw"
+        ),
+        0x0809: ZCLAttributeDef("rms_voltage_sag", type=t.int16s, access="rw"),
+        0x080A: ZCLAttributeDef("rms_voltage_swell", type=t.int16s, access="rw"),
         # AC Phase B Measurements
-        0x0901: ("line_current_ph_b", t.uint16_t),
-        0x0902: ("active_current_ph_b", t.int16s),
-        0x0903: ("reactive_current_ph_b", t.int16s),
-        0x0905: ("rms_voltage_ph_b", t.uint16_t),
-        0x0906: ("rms_voltage_min_ph_b", t.uint16_t),
-        0x0907: ("rms_voltage_max_ph_b", t.uint16_t),
-        0x0908: ("rms_current_ph_b", t.uint16_t),
-        0x0909: ("rms_current_min_ph_b", t.uint16_t),
-        0x090A: ("rms_current_max_ph_b", t.uint16_t),
-        0x090B: ("active_power_ph_b", t.int16s),
-        0x090C: ("active_power_min_ph_b", t.int16s),
-        0x090D: ("active_power_max_ph_b", t.int16s),
-        0x090E: ("reactive_power_ph_b", t.int16s),
-        0x090F: ("apparent_power_ph_b", t.uint16_t),
-        0x0910: ("power_factor_ph_b", t.int8s),
-        0x0911: ("average_rms_voltage_measure_period_ph_b", t.uint16_t),
-        0x0912: ("average_rms_over_voltage_counter_ph_b", t.uint16_t),
-        0x0913: ("average_under_voltage_counter_ph_b", t.uint16_t),
-        0x0914: ("rms_extreme_over_voltage_period_ph_b", t.uint16_t),
-        0x0915: ("rms_extreme_under_voltage_period_ph_b", t.uint16_t),
-        0x0916: ("rms_voltage_sag_period_ph_b", t.uint16_t),
-        0x0917: ("rms_voltage_swell_period_ph_b", t.uint16_t),
+        0x0901: ZCLAttributeDef("line_current_ph_b", type=t.uint16_t, access="rp"),
+        0x0902: ZCLAttributeDef("active_current_ph_b", type=t.int16s, access="rp"),
+        0x0903: ZCLAttributeDef("reactive_current_ph_b", type=t.int16s, access="rp"),
+        0x0905: ZCLAttributeDef("rms_voltage_ph_b", type=t.uint16_t, access="rp"),
+        0x0906: ZCLAttributeDef("rms_voltage_min_ph_b", type=t.uint16_t, access="r"),
+        0x0907: ZCLAttributeDef("rms_voltage_max_ph_b", type=t.uint16_t, access="r"),
+        0x0908: ZCLAttributeDef("rms_current_ph_b", type=t.uint16_t, access="rp"),
+        0x0909: ZCLAttributeDef("rms_current_min_ph_b", type=t.uint16_t, access="r"),
+        0x090A: ZCLAttributeDef("rms_current_max_ph_b", type=t.uint16_t, access="r"),
+        0x090B: ZCLAttributeDef("active_power_ph_b", type=t.int16s, access="rp"),
+        0x090C: ZCLAttributeDef("active_power_min_ph_b", type=t.int16s, access="r"),
+        0x090D: ZCLAttributeDef("active_power_max_ph_b", type=t.int16s, access="r"),
+        0x090E: ZCLAttributeDef("reactive_power_ph_b", type=t.int16s, access="rp"),
+        0x090F: ZCLAttributeDef("apparent_power_ph_b", type=t.uint16_t, access="rp"),
+        0x0910: ZCLAttributeDef("power_factor_ph_b", type=t.int8s, access="r"),
+        0x0911: ZCLAttributeDef(
+            "average_rms_voltage_measure_period_ph_b", type=t.uint16_t, access="rw"
+        ),
+        0x0912: ZCLAttributeDef(
+            "average_rms_over_voltage_counter_ph_b", type=t.uint16_t, access="rw"
+        ),
+        0x0913: ZCLAttributeDef(
+            "average_under_voltage_counter_ph_b", type=t.uint16_t, access="rw"
+        ),
+        0x0914: ZCLAttributeDef(
+            "rms_extreme_over_voltage_period_ph_b", type=t.uint16_t, access="rw"
+        ),
+        0x0915: ZCLAttributeDef(
+            "rms_extreme_under_voltage_period_ph_b", type=t.uint16_t, access="rw"
+        ),
+        0x0916: ZCLAttributeDef(
+            "rms_voltage_sag_period_ph_b", type=t.uint16_t, access="rw"
+        ),
+        0x0917: ZCLAttributeDef(
+            "rms_voltage_swell_period_ph_b", type=t.uint16_t, access="rw"
+        ),
         # AC Phase C Measurements
-        0x0A01: ("line_current_ph_c", t.uint16_t),
-        0x0A02: ("active_current_ph_c", t.int16s),
-        0x0A03: ("reactive_current_ph_c", t.int16s),
-        0x0A05: ("rms_voltage_ph_c", t.uint16_t),
-        0x0A06: ("rms_voltage_min_ph_c", t.uint16_t),
-        0x0A07: ("rms_voltage_max_ph_c", t.uint16_t),
-        0x0A08: ("rms_current_ph_c", t.uint16_t),
-        0x0A09: ("rms_current_min_ph_c", t.uint16_t),
-        0x0A0A: ("rms_current_max_ph_c", t.uint16_t),
-        0x0A0B: ("active_power_ph_c", t.int16s),
-        0x0A0C: ("active_power_min_ph_c", t.int16s),
-        0x0A0D: ("active_power_max_ph_c", t.int16s),
-        0x0A0E: ("reactive_power_ph_c", t.int16s),
-        0x0A0F: ("apparent_power_ph_c", t.uint16_t),
-        0x0A10: ("power_factor_ph_c", t.int8s),
-        0x0A11: ("average_rms_voltage_meas_period_ph_c", t.uint16_t),
-        0x0A12: ("average_rms_over_voltage_counter_ph_c", t.uint16_t),
-        0x0A13: ("average_under_voltage_counter_ph_c", t.uint16_t),
-        0x0A14: ("rms_extreme_over_voltage_period_ph_c", t.uint16_t),
-        0x0A15: ("rms_extreme_under_voltage_period_ph_c", t.uint16_t),
-        0x0A16: ("rms_voltage_sag_period_ph_c", t.uint16_t),
-        0x0A17: ("rms_voltage_swell_period_ph__c", t.uint16_t),
+        0x0A01: ZCLAttributeDef("line_current_ph_c", type=t.uint16_t, access="rp"),
+        0x0A02: ZCLAttributeDef("active_current_ph_c", type=t.int16s, access="rp"),
+        0x0A03: ZCLAttributeDef("reactive_current_ph_c", type=t.int16s, access="rp"),
+        0x0A05: ZCLAttributeDef("rms_voltage_ph_c", type=t.uint16_t, access="rp"),
+        0x0A06: ZCLAttributeDef("rms_voltage_min_ph_c", type=t.uint16_t, access="r"),
+        0x0A07: ZCLAttributeDef("rms_voltage_max_ph_c", type=t.uint16_t, access="r"),
+        0x0A08: ZCLAttributeDef("rms_current_ph_c", type=t.uint16_t, access="rp"),
+        0x0A09: ZCLAttributeDef("rms_current_min_ph_c", type=t.uint16_t, access="r"),
+        0x0A0A: ZCLAttributeDef("rms_current_max_ph_c", type=t.uint16_t, access="r"),
+        0x0A0B: ZCLAttributeDef("active_power_ph_c", type=t.int16s, access="rp"),
+        0x0A0C: ZCLAttributeDef("active_power_min_ph_c", type=t.int16s, access="r"),
+        0x0A0D: ZCLAttributeDef("active_power_max_ph_c", type=t.int16s, access="r"),
+        0x0A0E: ZCLAttributeDef("reactive_power_ph_c", type=t.int16s, access="rp"),
+        0x0A0F: ZCLAttributeDef("apparent_power_ph_c", type=t.uint16_t, access="rp"),
+        0x0A10: ZCLAttributeDef("power_factor_ph_c", type=t.int8s, access="r"),
+        0x0A11: ZCLAttributeDef(
+            "average_rms_voltage_meas_period_ph_c", type=t.uint16_t, access="rw"
+        ),
+        0x0A12: ZCLAttributeDef(
+            "average_rms_over_voltage_counter_ph_c", type=t.uint16_t, access="rw"
+        ),
+        0x0A13: ZCLAttributeDef(
+            "average_under_voltage_counter_ph_c", type=t.uint16_t, access="rw"
+        ),
+        0x0A14: ZCLAttributeDef(
+            "rms_extreme_over_voltage_period_ph_c", type=t.uint16_t, access="rw"
+        ),
+        0x0A15: ZCLAttributeDef(
+            "rms_extreme_under_voltage_period_ph_c", type=t.uint16_t, access="rw"
+        ),
+        0x0A16: ZCLAttributeDef(
+            "rms_voltage_sag_period_ph_c", type=t.uint16_t, access="rw"
+        ),
+        0x0A17: ZCLAttributeDef(
+            "rms_voltage_swell_period_ph_c", type=t.uint16_t, access="rw"
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("get_profile_info", {}, False),
@@ -245,39 +392,51 @@ class Diagnostic(Cluster):
     ep_attribute = "diagnostic"
     attributes: dict[int, ZCLAttributeDef] = {
         # Hardware Information
-        0x0000: ("number_of_resets", t.uint16_t),
-        0x0001: ("persistent_memory_writes", t.uint16_t),
+        0x0000: ZCLAttributeDef("number_of_resets", type=t.uint16_t, access="r"),
+        0x0001: ZCLAttributeDef(
+            "persistent_memory_writes", type=t.uint16_t, access="r"
+        ),
         # Stack/Network Information
-        0x0100: ("mac_rx_bcast", t.uint32_t),
-        0x0101: ("mac_tx_bcast", t.uint32_t),
-        0x0102: ("mac_rx_ucast", t.uint32_t),
-        0x0103: ("mac_tx_ucast", t.uint32_t),
-        0x0104: ("mac_tx_ucast_retry", t.uint16_t),
-        0x0105: ("mac_tx_ucast_fail", t.uint16_t),
-        0x0106: ("aps_rx_bcast", t.uint16_t),
-        0x0107: ("aps_tx_bcast", t.uint16_t),
-        0x0108: ("aps_rx_ucast", t.uint16_t),
-        0x0109: ("aps_tx_ucast_success", t.uint16_t),
-        0x010A: ("aps_tx_ucast_retry", t.uint16_t),
-        0x010B: ("aps_tx_ucast_fail", t.uint16_t),
-        0x010C: ("route_disc_initiated", t.uint16_t),
-        0x010D: ("neighbor_added", t.uint16_t),
-        0x010E: ("neighbor_removed", t.uint16_t),
-        0x010F: ("neighbor_stale", t.uint16_t),
-        0x0110: ("join_indication", t.uint16_t),
-        0x0111: ("child_moved", t.uint16_t),
-        0x0112: ("nwk_fc_failure", t.uint16_t),
-        0x0113: ("aps_fc_failure", t.uint16_t),
-        0x0114: ("aps_unauthorized_key", t.uint16_t),
-        0x0115: ("nwk_decrypt_failures", t.uint16_t),
-        0x0116: ("aps_decrypt_failures", t.uint16_t),
-        0x0117: ("packet_buffer_allocate_failures", t.uint16_t),
-        0x0118: ("relayed_ucast", t.uint16_t),
-        0x0119: ("phy_to_mac_queue_limit_reached", t.uint16_t),
-        0x011A: ("packet_validate_drop_count", t.uint16_t),
-        0x011B: ("average_mac_retry_per_aps_message_sent", t.uint16_t),
-        0x011C: ("last_message_lqi", t.uint8_t),
-        0x011D: ("last_message_rssi", t.int8s),
+        0x0100: ZCLAttributeDef("mac_rx_bcast", type=t.uint32_t, access="r"),
+        0x0101: ZCLAttributeDef("mac_tx_bcast", type=t.uint32_t, access="r"),
+        0x0102: ZCLAttributeDef("mac_rx_ucast", type=t.uint32_t, access="r"),
+        0x0103: ZCLAttributeDef("mac_tx_ucast", type=t.uint32_t, access="r"),
+        0x0104: ZCLAttributeDef("mac_tx_ucast_retry", type=t.uint16_t, access="r"),
+        0x0105: ZCLAttributeDef("mac_tx_ucast_fail", type=t.uint16_t, access="r"),
+        0x0106: ZCLAttributeDef("aps_rx_bcast", type=t.uint16_t, access="r"),
+        0x0107: ZCLAttributeDef("aps_tx_bcast", type=t.uint16_t, access="r"),
+        0x0108: ZCLAttributeDef("aps_rx_ucast", type=t.uint16_t, access="r"),
+        0x0109: ZCLAttributeDef("aps_tx_ucast_success", type=t.uint16_t, access="r"),
+        0x010A: ZCLAttributeDef("aps_tx_ucast_retry", type=t.uint16_t, access="r"),
+        0x010B: ZCLAttributeDef("aps_tx_ucast_fail", type=t.uint16_t, access="r"),
+        0x010C: ZCLAttributeDef("route_disc_initiated", type=t.uint16_t, access="r"),
+        0x010D: ZCLAttributeDef("neighbor_added", type=t.uint16_t, access="r"),
+        0x010E: ZCLAttributeDef("neighbor_removed", type=t.uint16_t, access="r"),
+        0x010F: ZCLAttributeDef("neighbor_stale", type=t.uint16_t, access="r"),
+        0x0110: ZCLAttributeDef("join_indication", type=t.uint16_t, access="r"),
+        0x0111: ZCLAttributeDef("child_moved", type=t.uint16_t, access="r"),
+        0x0112: ZCLAttributeDef("nwk_fc_failure", type=t.uint16_t, access="r"),
+        0x0113: ZCLAttributeDef("aps_fc_failure", type=t.uint16_t, access="r"),
+        0x0114: ZCLAttributeDef("aps_unauthorized_key", type=t.uint16_t, access="r"),
+        0x0115: ZCLAttributeDef("nwk_decrypt_failures", type=t.uint16_t, access="r"),
+        0x0116: ZCLAttributeDef("aps_decrypt_failures", type=t.uint16_t, access="r"),
+        0x0117: ZCLAttributeDef(
+            "packet_buffer_allocate_failures", type=t.uint16_t, access="r"
+        ),
+        0x0118: ZCLAttributeDef("relayed_ucast", type=t.uint16_t, access="r"),
+        0x0119: ZCLAttributeDef(
+            "phy_to_mac_queue_limit_reached", type=t.uint16_t, access="r"
+        ),
+        0x011A: ZCLAttributeDef(
+            "packet_validate_drop_count", type=t.uint16_t, access="r"
+        ),
+        0x011B: ZCLAttributeDef(
+            "average_mac_retry_per_aps_message_sent", type=t.uint16_t, access="r"
+        ),
+        0x011C: ZCLAttributeDef("last_message_lqi", type=t.uint8_t, access="r"),
+        0x011D: ZCLAttributeDef("last_message_rssi", type=t.int8s, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}

--- a/zigpy/zcl/clusters/hvac.py
+++ b/zigpy/zcl/clusters/hvac.py
@@ -56,32 +56,46 @@ class Pump(Cluster):
     ep_attribute = "pump"
     attributes: dict[int, ZCLAttributeDef] = {
         # Pump Information
-        0x0000: ("max_pressure", t.int16s),
-        0x0001: ("max_speed", t.uint16_t),
-        0x0002: ("max_flow", t.uint16_t),
-        0x0003: ("min_const_pressure", t.int16s),
-        0x0004: ("max_const_pressure", t.int16s),
-        0x0005: ("min_comp_pressure", t.int16s),
-        0x0006: ("max_comp_pressure", t.int16s),
-        0x0007: ("min_const_speed", t.uint16_t),
-        0x0008: ("max_const_speed", t.uint16_t),
-        0x0009: ("min_const_flow", t.uint16_t),
-        0x000A: ("max_const_flow", t.uint16_t),
-        0x000B: ("min_const_temp", t.int16s),
-        0x000C: ("max_const_temp", t.int16s),
+        0x0000: ZCLAttributeDef(
+            "max_pressure", type=t.int16s, access="r", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "max_speed", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_flow", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("min_const_pressure", type=t.int16s, access="r"),
+        0x0004: ZCLAttributeDef("max_const_pressure", type=t.int16s, access="r"),
+        0x0005: ZCLAttributeDef("min_comp_pressure", type=t.int16s, access="r"),
+        0x0006: ZCLAttributeDef("max_comp_pressure", type=t.int16s, access="r"),
+        0x0007: ZCLAttributeDef("min_const_speed", type=t.uint16_t, access="r"),
+        0x0008: ZCLAttributeDef("max_const_speed", type=t.uint16_t, access="r"),
+        0x0009: ZCLAttributeDef("min_const_flow", type=t.uint16_t, access="r"),
+        0x000A: ZCLAttributeDef("max_const_flow", type=t.uint16_t, access="r"),
+        0x000B: ZCLAttributeDef("min_const_temp", type=t.int16s, access="r"),
+        0x000C: ZCLAttributeDef("max_const_temp", type=t.int16s, access="r"),
         # Pump Dynamic Information
-        0x0010: ("pump_status", PumpStatus),
-        0x0011: ("effective_operation_mode", OperationMode),
-        0x0012: ("effective_control_mode", ControlMode),
-        0x0013: ("capacity", t.int16s),
-        0x0014: ("speed", t.uint16_t),
-        0x0015: ("lifetime_running_hours", t.uint24_t),
-        0x0016: ("power", t.uint24_t),
-        0x0017: ("lifetime_energy_consumed", t.uint32_t),
+        0x0010: ZCLAttributeDef("pump_status", type=PumpStatus, access="rp"),
+        0x0011: ZCLAttributeDef(
+            "effective_operation_mode", type=OperationMode, access="r", mandatory=True
+        ),
+        0x0012: ZCLAttributeDef(
+            "effective_control_mode", type=ControlMode, access="r", mandatory=True
+        ),
+        0x0013: ZCLAttributeDef("capacity", type=t.int16s, access="rp", mandatory=True),
+        0x0014: ZCLAttributeDef("speed", type=t.uint16_t, access="r"),
+        0x0015: ZCLAttributeDef("lifetime_running_hours", type=t.uint24_t, access="rw"),
+        0x0016: ZCLAttributeDef("power", type=t.uint24_t, access="rw"),
+        0x0017: ZCLAttributeDef(
+            "lifetime_energy_consumed", type=t.uint32_t, access="r"
+        ),
         # Pump Settings
-        0x0020: ("operation_mode", OperationMode),
-        0x0021: ("control_mode", ControlMode),
-        0x0022: ("alarm_mask", AlarmMask),
+        0x0020: ZCLAttributeDef(
+            "operation_mode", type=OperationMode, access="rw", mandatory=True
+        ),
+        0x0021: ZCLAttributeDef("control_mode", type=ControlMode, access="rw"),
+        0x0022: ZCLAttributeDef("alarm_mask", type=AlarmMask, access="r"),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -274,58 +288,111 @@ class Thermostat(Cluster):
     ep_attribute = "thermostat"
     attributes: dict[int, ZCLAttributeDef] = {
         # Thermostat Information
-        0x0000: ("local_temperature", t.int16s),
-        0x0001: ("outdoor_temperature", t.int16s),
-        0x0002: ("occupancy", Occupancy),
-        0x0003: ("abs_min_heat_setpoint_limit", t.int16s),
-        0x0004: ("abs_max_heat_setpoint_limit", t.int16s),
-        0x0005: ("abs_min_cool_setpoint_limit", t.int16s),
-        0x0006: ("abs_max_cool_setpoint_limit", t.int16s),
-        0x0007: ("pi_cooling_demand", t.uint8_t),
-        0x0008: ("pi_heating_demand", t.uint8_t),
-        0x0009: ("system_type_config", SystemType),
+        0x0000: ZCLAttributeDef(
+            "local_temperature", type=t.int16s, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef("outdoor_temperature", type=t.int16s, access="r"),
+        0x0002: ZCLAttributeDef("occupancy", type=Occupancy, access="r"),
+        0x0003: ZCLAttributeDef(
+            "abs_min_heat_setpoint_limit", type=t.int16s, access="r"
+        ),
+        0x0004: ZCLAttributeDef(
+            "abs_max_heat_setpoint_limit", type=t.int16s, access="r"
+        ),
+        0x0005: ZCLAttributeDef(
+            "abs_min_cool_setpoint_limit", type=t.int16s, access="r"
+        ),
+        0x0006: ZCLAttributeDef(
+            "abs_max_cool_setpoint_limit", type=t.int16s, access="r"
+        ),
+        0x0007: ZCLAttributeDef("pi_cooling_demand", type=t.uint8_t, access="rp"),
+        0x0008: ZCLAttributeDef("pi_heating_demand", type=t.uint8_t, access="rp"),
+        0x0009: ZCLAttributeDef("system_type_config", type=SystemType, access="r*w"),
         # Thermostat Settings
-        0x0010: ("local_temperature_calibration", t.int8s),
-        0x0011: ("occupied_cooling_setpoint", t.int16s),
-        0x0012: ("occupied_heating_setpoint", t.int16s),
-        0x0013: ("unoccupied_cooling_setpoint", t.int16s),
-        0x0014: ("unoccupied_heating_setpoint", t.int16s),
-        0x0015: ("min_heat_setpoint_limit", t.int16s),
-        0x0016: ("max_heat_setpoint_limit", t.int16s),
-        0x0017: ("min_cool_setpoint_limit", t.int16s),
-        0x0018: ("max_cool_setpoint_limit", t.int16s),
-        0x0019: ("min_setpoint_dead_band", t.int8s),
-        0x001A: ("remote_sensing", RemoteSensing),
-        0x001B: ("ctrl_sequence_of_oper", ControlSequenceOfOperation),
-        0x001C: ("system_mode", SystemMode),
-        0x001D: ("alarm_mask", AlarmMask),
-        0x001E: ("running_mode", RunningMode),
-        # ...
-        0x0020: ("start_of_week", StartOfWeek),
-        0x0021: ("number_of_weekly_transitions", t.uint8_t),
-        0x0022: ("number_of_daily_transitions", t.uint8_t),
-        0x0023: ("temp_setpoint_hold", TemperatureSetpointHold),
-        0x0024: ("temp_setpoint_hold_duration", t.uint16_t),
-        0x0025: ("programing_oper_mode", ProgrammingOperationMode),
-        0x0029: ("running_state", RunningState),
-        0x0030: ("setpoint_change_source", SetpointChangeSource),
-        0x0031: ("setpoint_change_amount", t.int16s),
-        0x0032: ("setpoint_change_source_timestamp", t.UTCTime),
-        0x0034: ("occupied_setback", t.uint8_t),
-        0x0035: ("occupied_setback_min", t.uint8_t),
-        0x0036: ("occupied_setback_max", t.uint8_t),
-        0x0037: ("unoccupied_setback", t.uint8_t),
-        0x0038: ("unoccupied_setback_min", t.uint8_t),
-        0x0039: ("unoccupied_setback_max", t.uint8_t),
-        0x003A: ("emergency_heat_delta", t.uint8_t),
-        0x0040: ("ac_type", ACType),
-        0x0041: ("ac_capacity", t.uint16_t),
-        0x0042: ("ac_refrigerant_type", ACRefrigerantType),
-        0x0043: ("ac_compressor_type", ACCompressorType),
-        0x0044: ("ac_error_code", ACErrorCode),
-        0x0045: ("ac_louver_position", ACLouverPosition),
-        0x0046: ("ac_coil_temperature", t.int16s),
-        0x0047: ("ac_capacity_format", ACCapacityFormat),
+        0x0010: ZCLAttributeDef(
+            "local_temperature_calibration", type=t.int8s, access="rw"
+        ),
+        # At least one of these two attribute sets will be available
+        0x0011: ZCLAttributeDef(
+            "occupied_cooling_setpoint", type=t.int16s, access="rws"
+        ),
+        0x0012: ZCLAttributeDef(
+            "occupied_heating_setpoint", type=t.int16s, access="rws"
+        ),
+        0x0013: ZCLAttributeDef(
+            "unoccupied_cooling_setpoint", type=t.int16s, access="rw"
+        ),
+        0x0014: ZCLAttributeDef(
+            "unoccupied_heating_setpoint", type=t.int16s, access="rw"
+        ),
+        0x0015: ZCLAttributeDef("min_heat_setpoint_limit", type=t.int16s, access="rw"),
+        0x0016: ZCLAttributeDef("max_heat_setpoint_limit", type=t.int16s, access="rw"),
+        0x0017: ZCLAttributeDef("min_cool_setpoint_limit", type=t.int16s, access="rw"),
+        0x0018: ZCLAttributeDef("max_cool_setpoint_limit", type=t.int16s, access="rw"),
+        0x0019: ZCLAttributeDef("min_setpoint_dead_band", type=t.int8s, access="r*w"),
+        0x001A: ZCLAttributeDef("remote_sensing", type=RemoteSensing, access="rw"),
+        0x001B: ZCLAttributeDef(
+            "ctrl_sequence_of_oper",
+            type=ControlSequenceOfOperation,
+            access="rw",
+            mandatory=True,
+        ),
+        0x001C: ZCLAttributeDef(
+            "system_mode", type=SystemMode, access="rws", mandatory=True
+        ),
+        0x001D: ZCLAttributeDef("alarm_mask", type=AlarmMask, access="r"),
+        0x001E: ZCLAttributeDef("running_mode", type=RunningMode, access="r"),
+        # Schedule
+        0x0020: ZCLAttributeDef("start_of_week", type=StartOfWeek, access="r"),
+        0x0021: ZCLAttributeDef(
+            "number_of_weekly_transitions", type=t.uint8_t, access="r"
+        ),
+        0x0022: ZCLAttributeDef(
+            "number_of_daily_transitions", type=t.uint8_t, access="r"
+        ),
+        0x0023: ZCLAttributeDef(
+            "temp_setpoint_hold", type=TemperatureSetpointHold, access="rw"
+        ),
+        0x0024: ZCLAttributeDef(
+            "temp_setpoint_hold_duration", type=t.uint16_t, access="rw"
+        ),
+        0x0025: ZCLAttributeDef(
+            "programing_oper_mode", type=ProgrammingOperationMode, access="rwp"
+        ),
+        # HVAC Relay
+        0x0029: ZCLAttributeDef("running_state", type=RunningState, access="r"),
+        # Thermostat Setpoint Change Tracking
+        0x0030: ZCLAttributeDef(
+            "setpoint_change_source", type=SetpointChangeSource, access="r"
+        ),
+        0x0031: ZCLAttributeDef("setpoint_change_amount", type=t.int16s, access="r"),
+        0x0032: ZCLAttributeDef(
+            "setpoint_change_source_timestamp", type=t.UTCTime, access="r"
+        ),
+        0x0034: ZCLAttributeDef("occupied_setback", type=t.uint8_t, access="rw"),
+        0x0035: ZCLAttributeDef("occupied_setback_min", type=t.uint8_t, access="r"),
+        0x0036: ZCLAttributeDef("occupied_setback_max", type=t.uint8_t, access="r"),
+        0x0037: ZCLAttributeDef("unoccupied_setback", type=t.uint8_t, access="rw"),
+        0x0038: ZCLAttributeDef("unoccupied_setback_min", type=t.uint8_t, access="r"),
+        0x0039: ZCLAttributeDef("unoccupied_setback_max", type=t.uint8_t, access="r"),
+        0x003A: ZCLAttributeDef("emergency_heat_delta", type=t.uint8_t, access="rw"),
+        # AC Information
+        0x0040: ZCLAttributeDef("ac_type", type=ACType, access="rw"),
+        0x0041: ZCLAttributeDef("ac_capacity", type=t.uint16_t, access="rw"),
+        0x0042: ZCLAttributeDef(
+            "ac_refrigerant_type", type=ACRefrigerantType, access="rw"
+        ),
+        0x0043: ZCLAttributeDef(
+            "ac_compressor_type", type=ACCompressorType, access="rw"
+        ),
+        0x0044: ZCLAttributeDef("ac_error_code", type=ACErrorCode, access="rw"),
+        0x0045: ZCLAttributeDef(
+            "ac_louver_position", type=ACLouverPosition, access="rw"
+        ),
+        0x0046: ZCLAttributeDef("ac_coil_temperature", type=t.int16s, access="r"),
+        0x0047: ZCLAttributeDef(
+            "ac_capacity_format", type=ACCapacityFormat, access="rw"
+        ),
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -400,8 +467,8 @@ class Fan(Cluster):
     ep_attribute = "fan"
     attributes: dict[int, ZCLAttributeDef] = {
         # Fan Control Status
-        0x0000: ("fan_mode", FanMode),
-        0x0001: ("fan_mode_sequence", FanModeSequence),
+        0x0000: ZCLAttributeDef("fan_mode", type=FanMode, access=""),
+        0x0001: ZCLAttributeDef("fan_mode_sequence", type=FanModeSequence, access=""),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -426,15 +493,29 @@ class Dehumidification(Cluster):
     ep_attribute = "dehumidification"
     attributes: dict[int, ZCLAttributeDef] = {
         # Dehumidification Information
-        0x0000: ("relative_humidity", t.uint8_t),
-        0x0001: ("dehumid_cooling", t.uint8_t),
+        0x0000: ZCLAttributeDef("relative_humidity", type=t.uint8_t, access="r"),
+        0x0001: ZCLAttributeDef(
+            "dehumidification_cooling", type=t.uint8_t, access="rp", mandatory=True
+        ),
         # Dehumidification Settings
-        0x0010: ("rh_dehumid_setpoint", t.uint8_t),
-        0x0011: ("relative_humidity_mode", RelativeHumidityMode),
-        0x0012: ("dehumid_lockout", DehumidificationLockout),
-        0x0013: ("dehumid_hysteresis", t.uint8_t),
-        0x0014: ("dehumid_max_cool", t.uint8_t),
-        0x0015: ("relative_humid_display", RelativeHumidityDisplay),
+        0x0010: ZCLAttributeDef(
+            "rh_dehumidification_setpoint", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0011: ZCLAttributeDef(
+            "relative_humidity_mode", type=RelativeHumidityMode, access="rw"
+        ),
+        0x0012: ZCLAttributeDef(
+            "dehumidification_lockout", type=DehumidificationLockout, access="rw"
+        ),
+        0x0013: ZCLAttributeDef(
+            "dehumidification_hysteresis", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0014: ZCLAttributeDef(
+            "dehumidification_max_cool", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0015: ZCLAttributeDef(
+            "relative_humidity_display", type=RelativeHumidityDisplay, access="rw"
+        ),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -465,9 +546,20 @@ class UserInterface(Cluster):
     name = "Thermostat User Interface Configuration"
     ep_attribute = "thermostat_ui"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("temperature_display_mode", TemperatureDisplayMode),
-        0x0001: ("keypad_lockout", KeypadLockout),
-        0x0002: ("schedule_programming_visibility", ScheduleProgrammingVisibility),
+        0x0000: ZCLAttributeDef(
+            "temperature_display_mode",
+            type=TemperatureDisplayMode,
+            access="rw",
+            mandatory=True,
+        ),
+        0x0001: ZCLAttributeDef(
+            "keypad_lockout", type=KeypadLockout, access="rw", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "schedule_programming_visibility",
+            type=ScheduleProgrammingVisibility,
+            access="rw",
+        ),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -74,64 +74,80 @@ class Color(Cluster):
     ep_attribute = "light_color"
     attributes: dict[int, ZCLAttributeDef] = {
         # Color Information
-        0x0000: ("current_hue", t.uint8_t),
-        0x0001: ("current_saturation", t.uint8_t),
-        0x0002: ("remaining_time", t.uint16_t),
-        0x0003: ("current_x", t.uint16_t),
-        0x0004: ("current_y", t.uint16_t),
-        0x0005: ("drift_compensation", DriftCompensation),
-        0x0006: ("compensation_text", t.CharacterString),
-        0x0007: ("color_temperature", t.uint16_t),
-        0x0008: ("color_mode", t.enum8),
-        0x000F: ("options", Options),
+        0x0000: ZCLAttributeDef("current_hue", type=t.uint8_t, access="rp"),
+        0x0001: ZCLAttributeDef("current_saturation", type=t.uint8_t, access="rps"),
+        0x0002: ZCLAttributeDef("remaining_time", type=t.uint16_t, access="r"),
+        0x0003: ZCLAttributeDef("current_x", type=t.uint16_t, access="rps"),
+        0x0004: ZCLAttributeDef("current_y", type=t.uint16_t, access="rps"),
+        0x0005: ZCLAttributeDef(
+            "drift_compensation", type=DriftCompensation, access="r"
+        ),
+        0x0006: ZCLAttributeDef(
+            "compensation_text", type=t.CharacterString, access="r"
+        ),
+        0x0007: ZCLAttributeDef("color_temperature", type=t.uint16_t, access="rps"),
+        0x0008: ZCLAttributeDef("color_mode", type=t.enum8, access="r", mandatory=True),
+        0x000F: ZCLAttributeDef("options", type=Options, access="rw", mandatory=True),
         # Defined Primaries Information
-        0x0010: ("num_primaries", t.uint8_t),
-        0x0011: ("primary1_x", t.uint16_t),
-        0x0012: ("primary1_y", t.uint16_t),
-        0x0013: ("primary1_intensity", t.uint8_t),
-        0x0015: ("primary2_x", t.uint16_t),
-        0x0016: ("primary2_y", t.uint16_t),
-        0x0017: ("primary2_intensity", t.uint8_t),
-        0x0019: ("primary3_x", t.uint16_t),
-        0x001A: ("primary3_y", t.uint16_t),
-        0x001B: ("primary3_intensity", t.uint8_t),
+        0x0010: ZCLAttributeDef("num_primaries", type=t.uint8_t, access="r"),
+        0x0011: ZCLAttributeDef("primary1_x", type=t.uint16_t, access="r"),
+        0x0012: ZCLAttributeDef("primary1_y", type=t.uint16_t, access="r"),
+        0x0013: ZCLAttributeDef("primary1_intensity", type=t.uint8_t, access="r"),
+        0x0015: ZCLAttributeDef("primary2_x", type=t.uint16_t, access="r"),
+        0x0016: ZCLAttributeDef("primary2_y", type=t.uint16_t, access="r"),
+        0x0017: ZCLAttributeDef("primary2_intensity", type=t.uint8_t, access="r"),
+        0x0019: ZCLAttributeDef("primary3_x", type=t.uint16_t, access="r"),
+        0x001A: ZCLAttributeDef("primary3_y", type=t.uint16_t, access="r"),
+        0x001B: ZCLAttributeDef("primary3_intensity", type=t.uint8_t, access="r"),
         # Additional Defined Primaries Information
-        0x0020: ("primary4_x", t.uint16_t),
-        0x0021: ("primary4_y", t.uint16_t),
-        0x0022: ("primary4_intensity", t.uint8_t),
-        0x0024: ("primary5_x", t.uint16_t),
-        0x0025: ("primary5_y", t.uint16_t),
-        0x0026: ("primary5_intensity", t.uint8_t),
-        0x0028: ("primary6_x", t.uint16_t),
-        0x0029: ("primary6_y", t.uint16_t),
-        0x002A: ("primary6_intensity", t.uint8_t),
+        0x0020: ZCLAttributeDef("primary4_x", type=t.uint16_t, access="r"),
+        0x0021: ZCLAttributeDef("primary4_y", type=t.uint16_t, access="r"),
+        0x0022: ZCLAttributeDef("primary4_intensity", type=t.uint8_t, access="r"),
+        0x0024: ZCLAttributeDef("primary5_x", type=t.uint16_t, access="r"),
+        0x0025: ZCLAttributeDef("primary5_y", type=t.uint16_t, access="r"),
+        0x0026: ZCLAttributeDef("primary5_intensity", type=t.uint8_t, access="r"),
+        0x0028: ZCLAttributeDef("primary6_x", type=t.uint16_t, access="r"),
+        0x0029: ZCLAttributeDef("primary6_y", type=t.uint16_t, access="r"),
+        0x002A: ZCLAttributeDef("primary6_intensity", type=t.uint8_t, access="r"),
         # Defined Color Point Settings
-        0x0030: ("white_point_x", t.uint16_t),
-        0x0031: ("white_point_y", t.uint16_t),
-        0x0032: ("color_point_r_x", t.uint16_t),
-        0x0033: ("color_point_r_y", t.uint16_t),
-        0x0034: ("color_point_r_intensity", t.uint8_t),
-        0x0036: ("color_point_g_x", t.uint16_t),
-        0x0037: ("color_point_g_y", t.uint16_t),
-        0x0038: ("color_point_g_intensity", t.uint8_t),
-        0x003A: ("color_point_b_x", t.uint16_t),
-        0x003B: ("color_point_b_y", t.uint16_t),
-        0x003C: ("color_point_b_intensity", t.uint8_t),
+        0x0030: ZCLAttributeDef("white_point_x", type=t.uint16_t, access="r"),
+        0x0031: ZCLAttributeDef("white_point_y", type=t.uint16_t, access="r"),
+        0x0032: ZCLAttributeDef("color_point_r_x", type=t.uint16_t, access="r"),
+        0x0033: ZCLAttributeDef("color_point_r_y", type=t.uint16_t, access="r"),
+        0x0034: ZCLAttributeDef("color_point_r_intensity", type=t.uint8_t, access="r"),
+        0x0036: ZCLAttributeDef("color_point_g_x", type=t.uint16_t, access="r"),
+        0x0037: ZCLAttributeDef("color_point_g_y", type=t.uint16_t, access="r"),
+        0x0038: ZCLAttributeDef("color_point_g_intensity", type=t.uint8_t, access="r"),
+        0x003A: ZCLAttributeDef("color_point_b_x", type=t.uint16_t, access="r"),
+        0x003B: ZCLAttributeDef("color_point_b_y", type=t.uint16_t, access="r"),
+        0x003C: ZCLAttributeDef("color_point_b_intensity", type=t.uint8_t, access="r"),
         # ...
-        0x4000: ("enhanced_current_hue", t.uint16_t),
-        0x4001: ("enhanced_color_mode", EnhancedColorMode),
-        0x4002: ("color_loop_active", t.uint8_t),
-        0x4003: ("color_loop_direction", t.uint8_t),
-        0x4004: ("color_loop_time", t.uint16_t),
-        0x4005: ("color_loop_start_enhanced_hue", t.uint16_t),
-        0x4006: ("color_loop_stored_enhanced_hue", t.uint16_t),
-        0x400A: ("color_capabilities", ColorCapabilities),
-        0x400B: ("color_temp_physical_min", t.uint16_t),
-        0x400C: ("color_temp_physical_max", t.uint16_t),
-        0x400D: ("couple_color_temp_to_level_min", t.uint16_t),
-        0x4010: ("start_up_color_temperature", t.uint16_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x4000: ZCLAttributeDef("enhanced_current_hue", type=t.uint16_t, access="rs"),
+        0x4001: ZCLAttributeDef(
+            "enhanced_color_mode", type=EnhancedColorMode, access="r", mandatory=True
+        ),
+        0x4002: ZCLAttributeDef("color_loop_active", type=t.uint8_t, access="rs"),
+        0x4003: ZCLAttributeDef("color_loop_direction", type=t.uint8_t, access="rs"),
+        0x4004: ZCLAttributeDef("color_loop_time", type=t.uint16_t, access="rs"),
+        0x4005: ZCLAttributeDef(
+            "color_loop_start_enhanced_hue", type=t.uint16_t, access="r"
+        ),
+        0x4006: ZCLAttributeDef(
+            "color_loop_stored_enhanced_hue", type=t.uint16_t, access="r"
+        ),
+        0x400A: ZCLAttributeDef(
+            "color_capabilities", type=ColorCapabilities, access="r", mandatory=True
+        ),
+        0x400B: ZCLAttributeDef("color_temp_physical_min", type=t.uint16_t, access="r"),
+        0x400C: ZCLAttributeDef("color_temp_physical_max", type=t.uint16_t, access="r"),
+        0x400D: ZCLAttributeDef(
+            "couple_color_temp_to_level_min", type=t.uint16_t, access="r"
+        ),
+        0x4010: ZCLAttributeDef(
+            "start_up_color_temperature", type=t.uint16_t, access="rw"
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef(
@@ -358,27 +374,43 @@ class Ballast(Cluster):
     ep_attribute = "light_ballast"
     attributes: dict[int, ZCLAttributeDef] = {
         # Ballast Information
-        0x0000: ("physical_min_level", t.uint8_t),
-        0x0001: ("physical_max_level", t.uint8_t),
-        0x0002: ("ballast_status", BallastStatus),
+        0x0000: ZCLAttributeDef(
+            "physical_min_level", type=t.uint8_t, access="r", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "physical_max_level", type=t.uint8_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef("ballast_status", type=BallastStatus, access="r"),
         # Ballast Settings
-        0x0010: ("min_level", t.uint8_t),
-        0x0011: ("max_level", t.uint8_t),
-        0x0012: ("power_on_level", t.uint8_t),
-        0x0013: ("power_on_fade_time", t.uint16_t),
-        0x0014: ("intrinsic_ballast_factor", t.uint8_t),
-        0x0015: ("ballast_factor_adjustment", t.uint8_t),
+        0x0010: ZCLAttributeDef(
+            "min_level", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0011: ZCLAttributeDef(
+            "max_level", type=t.uint8_t, access="rw", mandatory=True
+        ),
+        0x0012: ZCLAttributeDef("power_on_level", type=t.uint8_t, access="rw"),
+        0x0013: ZCLAttributeDef("power_on_fade_time", type=t.uint16_t, access="rw"),
+        0x0014: ZCLAttributeDef(
+            "intrinsic_ballast_factor", type=t.uint8_t, access="rw"
+        ),
+        0x0015: ZCLAttributeDef(
+            "ballast_factor_adjustment", type=t.uint8_t, access="rw"
+        ),
         # Lamp Information
-        0x0020: ("lamp_quantity", t.uint8_t),
+        0x0020: ZCLAttributeDef("lamp_quantity", type=t.uint8_t, access="r"),
         # Lamp Settings
-        0x0030: ("lamp_type", t.LimitedCharString(16)),
-        0x0031: ("lamp_manufacturer", t.LimitedCharString(16)),
-        0x0032: ("lamp_rated_hours", t.uint24_t),
-        0x0033: ("lamp_burn_hours", t.uint24_t),
-        0x0034: ("lamp_alarm_mode", LampAlarmMode),
-        0x0035: ("lamp_burn_hours_trip_point", t.uint24_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0030: ZCLAttributeDef("lamp_type", type=t.LimitedCharString(16), access="rw"),
+        0x0031: ZCLAttributeDef(
+            "lamp_manufacturer", type=t.LimitedCharString(16), access="rw"
+        ),
+        0x0032: ZCLAttributeDef("lamp_rated_hours", type=t.uint24_t, access="rw"),
+        0x0033: ZCLAttributeDef("lamp_burn_hours", type=t.uint24_t, access="rw"),
+        0x0034: ZCLAttributeDef("lamp_alarm_mode", type=LampAlarmMode, access="rw"),
+        0x0035: ZCLAttributeDef(
+            "lamp_burn_hours_trip_point", type=t.uint24_t, access="rw"
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -86,7 +86,9 @@ class Color(Cluster):
             "compensation_text", type=t.CharacterString, access="r"
         ),
         0x0007: ZCLAttributeDef("color_temperature", type=t.uint16_t, access="rps"),
-        0x0008: ZCLAttributeDef("color_mode", type=t.enum8, access="r", mandatory=True),
+        0x0008: ZCLAttributeDef(
+            "color_mode", type=ColorMode, access="r", mandatory=True
+        ),
         0x000F: ZCLAttributeDef("options", type=Options, access="rw", mandatory=True),
         # Defined Primaries Information
         0x0010: ZCLAttributeDef("num_primaries", type=t.uint8_t, access="r"),

--- a/zigpy/zcl/clusters/measurement.py
+++ b/zigpy/zcl/clusters/measurement.py
@@ -55,7 +55,7 @@ class IlluminanceLevelSensing(Cluster):
     attributes: dict[int, ZCLAttributeDef] = {
         # Illuminance Level Sensing Information
         0x0000: ZCLAttributeDef(
-            "level_status", type=t.enum8, access="r", mandatory=True
+            "level_status", type=LevelStatus, access="r", mandatory=True
         ),
         0x0001: ZCLAttributeDef("light_sensor_type", type=LightSensorType, access="r"),
         # Illuminance Level Sensing Settings

--- a/zigpy/zcl/clusters/measurement.py
+++ b/zigpy/zcl/clusters/measurement.py
@@ -7,19 +7,34 @@ from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.foundation import ZCLAttributeDef, ZCLCommandDef
 
 
+class LightSensorType(t.enum8):
+    Photodiode = 0x00
+    CMOS = 0x01
+    Unknown = 0xFF
+
+
 class IlluminanceMeasurement(Cluster):
     cluster_id = 0x0400
     name = "Illuminance Measurement"
     ep_attribute = "illuminance"
+
+    LightSensorType = LightSensorType
+
     attributes: dict[int, ZCLAttributeDef] = {
         # Illuminance Measurement Information
-        0x0000: ("measured_value", t.uint16_t),
-        0x0001: ("min_measured_value", t.uint16_t),
-        0x0002: ("max_measured_value", t.uint16_t),
-        0x0003: ("tolerance", t.uint16_t),
-        0x0004: ("light_sensor_type", t.enum8),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.uint16_t, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
+        0x0004: ZCLAttributeDef("light_sensor_type", type=LightSensorType, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -29,14 +44,26 @@ class IlluminanceLevelSensing(Cluster):
     cluster_id = 0x0401
     name = "Illuminance Level Sensing"
     ep_attribute = "illuminance_level"
+
+    class LevelStatus(t.enum8):
+        Illuminance_On_Target = 0x00
+        Illuminance_Below_Target = 0x01
+        Illuminance_Above_Target = 0x02
+
+    LightSensorType = LightSensorType
+
     attributes: dict[int, ZCLAttributeDef] = {
         # Illuminance Level Sensing Information
-        0x0000: ("level_status", t.enum8),
-        0x0001: ("light_sensor_type", t.enum8),
+        0x0000: ZCLAttributeDef(
+            "level_status", type=t.enum8, access="r", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef("light_sensor_type", type=LightSensorType, access="r"),
         # Illuminance Level Sensing Settings
-        0x0010: ("illuminance_target_level", t.uint16_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0010: ZCLAttributeDef(
+            "illuminance_target_level", type=t.uint16_t, access="rw", mandatory=True
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -48,14 +75,20 @@ class TemperatureMeasurement(Cluster):
     ep_attribute = "temperature"
     attributes: dict[int, ZCLAttributeDef] = {
         # Temperature Measurement Information
-        0x0000: ("measured_value", t.int16s),
-        0x0001: ("min_measured_value", t.int16s),
-        0x0002: ("max_measured_value", t.int16s),
-        0x0003: ("tolerance", t.uint16_t),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.int16s, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.int16s, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.int16s, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
         # 0x0010: ('min_percent_change', UNKNOWN),
         # 0x0011: ('min_absolute_change', UNKNOWN),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -67,12 +100,24 @@ class PressureMeasurement(Cluster):
     ep_attribute = "pressure"
     attributes: dict[int, ZCLAttributeDef] = {
         # Pressure Measurement Information
-        0x0000: ("measured_value", t.int16s),
-        0x0001: ("min_measured_value", t.int16s),
-        0x0002: ("max_measured_value", t.int16s),
-        0x0003: ("tolerance", t.uint16_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.int16s, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.int16s, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.int16s, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
+        # Extended attribute set
+        0x0010: ZCLAttributeDef("scaled_value", type=t.int16s, access="r"),
+        0x0011: ZCLAttributeDef("min_scaled_value", type=t.int16s, access="r"),
+        0x0012: ZCLAttributeDef("max_scaled_value", type=t.int16s, access="r"),
+        0x0013: ZCLAttributeDef("scaled_tolerance", type=t.uint16_t, access="r"),
+        0x0014: ZCLAttributeDef("scale", type=t.int8s, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -84,12 +129,18 @@ class FlowMeasurement(Cluster):
     ep_attribute = "flow"
     attributes: dict[int, ZCLAttributeDef] = {
         # Flow Measurement Information
-        0x0000: ("measured_value", t.uint16_t),
-        0x0001: ("min_measured_value", t.uint16_t),
-        0x0002: ("max_measured_value", t.uint16_t),
-        0x0003: ("tolerance", t.uint16_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.uint16_t, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -101,12 +152,18 @@ class RelativeHumidity(Cluster):
     ep_attribute = "humidity"
     attributes: dict[int, ZCLAttributeDef] = {
         # Relative Humidity Measurement Information
-        0x0000: ("measured_value", t.uint16_t),
-        0x0001: ("min_measured_value", t.uint16_t),
-        0x0002: ("max_measured_value", t.uint16_t),
-        0x0003: ("tolerance", t.uint16_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.uint16_t, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -116,20 +173,56 @@ class OccupancySensing(Cluster):
     cluster_id = 0x0406
     name = "Occupancy Sensing"
     ep_attribute = "occupancy"
+
+    class Occupancy(t.bitmap8):
+        Unoccupied = 0b00000000
+        Occupied = 0b00000001
+
+    class OccupancySensorType(t.enum8):
+        PIR = 0x00
+        Ultrasonic = 0x01
+        PIR_and_Ultrasonic = 0x02
+        Physical_Contact = 0x03
+
+    class OccupancySensorTypeBitmap(t.bitmap8):
+        PIR = 0b00000001
+        Ultrasonic = 0b00000010
+        Physical_Contact = 0b00000100
+
     attributes: dict[int, ZCLAttributeDef] = {
         # Occupancy Sensor Information
-        0x0000: ("occupancy", t.bitmap8),
-        0x0001: ("occupancy_sensor_type", t.enum8),
+        0x0000: ZCLAttributeDef(
+            "occupancy", type=Occupancy, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "occupancy_sensor_type_bitmap", type=t.bitmap8, access="r", mandatory=True
+        ),
         # PIR Configuration
-        0x0010: ("pir_o_to_u_delay", t.uint16_t),
-        0x0011: ("pir_u_to_o_delay", t.uint16_t),
-        0x0012: ("pir_u_to_o_threshold", t.uint8_t),
+        0x0010: ZCLAttributeDef("pir_o_to_u_delay", type=t.uint16_t, access="rw"),
+        0x0011: ZCLAttributeDef("pir_u_to_o_delay", type=t.uint16_t, access="rw"),
+        0x0012: ZCLAttributeDef("pir_u_to_o_threshold", type=t.uint8_t, access="rw"),
         # Ultrasonic Configuration
-        0x0020: ("ultrasonic_o_to_u_delay", t.uint16_t),
-        0x0021: ("ultrasonic_u_to_o_delay", t.uint16_t),
-        0x0022: ("ultrasonic_u_to_o_threshold", t.uint8_t),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0020: ZCLAttributeDef(
+            "ultrasonic_o_to_u_delay", type=t.uint16_t, access="rw"
+        ),
+        0x0021: ZCLAttributeDef(
+            "ultrasonic_u_to_o_delay", type=t.uint16_t, access="rw"
+        ),
+        0x0022: ZCLAttributeDef(
+            "ultrasonic_u_to_o_threshold", type=t.uint8_t, access="rw"
+        ),
+        # Physical Contact Configuration
+        0x0030: ZCLAttributeDef(
+            "physical_contact_o_to_u_delay", type=t.uint16_t, access="rw"
+        ),
+        0x0031: ZCLAttributeDef(
+            "physical_contact_u_to_o_delay", type=t.uint16_t, access="rw"
+        ),
+        0x0032: ZCLAttributeDef(
+            "physical_contact_u_to_o_threshold", type=t.uint8_t, access="rw"
+        ),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -141,10 +234,18 @@ class LeafWetness(Cluster):
     ep_attribute = "leaf_wetness"
     attributes: dict[int, ZCLAttributeDef] = {
         # Leaf Wetness Measurement Information
-        0x0000: ("measured_value", t.uint16_t),
-        0x0001: ("min_measured_value", t.uint16_t),
-        0x0002: ("max_measured_value", t.uint16_t),
-        0x0003: ("tolerance", t.uint16_t),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.uint16_t, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -156,10 +257,18 @@ class SoilMoisture(Cluster):
     ep_attribute = "soil_moisture"
     attributes: dict[int, ZCLAttributeDef] = {
         # Soil Moisture Measurement Information
-        0x0000: ("measured_value", t.uint16_t),
-        0x0001: ("min_measured_value", t.uint16_t),
-        0x0002: ("max_measured_value", t.uint16_t),
-        0x0003: ("tolerance", t.uint16_t),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.uint16_t, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -171,10 +280,18 @@ class PH(Cluster):
     ep_attribute = "ph"
     attributes: dict[int, ZCLAttributeDef] = {
         # pH Measurement Information
-        0x0000: ("measured_value", t.uint16_t),
-        0x0001: ("min_measured_value", t.uint16_t),
-        0x0002: ("max_measured_value", t.uint16_t),
-        0x0003: ("tolerance", t.uint16_t),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.uint16_t, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -186,10 +303,18 @@ class ElectricalConductivity(Cluster):
     ep_attribute = "electrical_conductivity"
     attributes: dict[int, ZCLAttributeDef] = {
         # Electrical Conductivity Information
-        0x0000: ("measured_value", t.uint16_t),
-        0x0001: ("min_measured_value", t.uint16_t),
-        0x0002: ("max_measured_value", t.uint16_t),
-        0x0003: ("tolerance", t.uint16_t),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.uint16_t, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -201,10 +326,18 @@ class WindSpeed(Cluster):
     ep_attribute = "wind_speed"
     attributes: dict[int, ZCLAttributeDef] = {
         # Wind Speed Measurement Information
-        0x0000: ("measured_value", t.uint16_t),
-        0x0001: ("min_measured_value", t.uint16_t),
-        0x0002: ("max_measured_value", t.uint16_t),
-        0x0003: ("tolerance", t.uint16_t),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.uint16_t, access="rp", mandatory=True
+        ),
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.uint16_t, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.uint16_t, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -214,12 +347,18 @@ class _ConcentrationMixin:
     """Mixin for the common attributes of the concentration measurement clusters"""
 
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("measured_value", t.Single),  # fraction of 1 (one)
-        0x0001: ("min_measured_value", t.Single),
-        0x0002: ("max_measured_value", t.Single),
-        0x0003: ("tolerance", t.Single),
-        0xFFFD: ("cluster_revision", t.uint16_t),
-        0xFFFE: ("attr_reporting_status", foundation.AttributeReportingStatus),
+        0x0000: ZCLAttributeDef(
+            "measured_value", type=t.Single, access="rp", mandatory=True
+        ),  # fraction of 1 (one)
+        0x0001: ZCLAttributeDef(
+            "min_measured_value", type=t.Single, access="r", mandatory=True
+        ),
+        0x0002: ZCLAttributeDef(
+            "max_measured_value", type=t.Single, access="r", mandatory=True
+        ),
+        0x0003: ZCLAttributeDef("tolerance", type=t.Single, access="r"),
+        0xFFFD: foundation.ZCL_CLUSTER_REVISION_ATTR,
+        0xFFFE: foundation.ZCL_REPORTING_STATUS_ATTR,
     }
 
     server_commands: dict[int, ZCLCommandDef] = {}

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -16,9 +16,9 @@ class GenericTunnel(Cluster):
     cluster_id = 0x0600
     ep_attribute = "generic_tunnel"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0001: ("max_income_trans_size", t.uint16_t),
-        0x0002: ("max_outgo_trans_size", t.uint16_t),
-        0x0003: ("protocol_addr", t.LVBytes),
+        0x0001: ZCLAttributeDef("max_income_trans_size", type=t.uint16_t),
+        0x0002: ZCLAttributeDef("max_outgo_trans_size", type=t.uint16_t),
+        0x0003: ZCLAttributeDef("protocol_addr", type=t.LVBytes),
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("match_protocol_addr", {}, False)
@@ -43,13 +43,13 @@ class AnalogInputRegular(Cluster):
     cluster_id = 0x0602
     ep_attribute = "bacnet_regular_analog_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0016: ("cov_increment", t.Single),
-        0x001F: ("device_type", t.CharacterString),
-        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
-        0x004D: ("object_name", t.CharacterString),
-        0x004F: ("object_type", t.enum16),
-        0x0076: ("update_interval", t.uint8_t),
-        0x00A8: ("profile_name", t.CharacterString),
+        0x0016: ZCLAttributeDef("cov_increment", type=t.Single),
+        0x001F: ZCLAttributeDef("device_type", type=t.CharacterString),
+        0x004B: ZCLAttributeDef("object_id", type=t.FixedList[4, t.uint8_t]),
+        0x004D: ZCLAttributeDef("object_name", type=t.CharacterString),
+        0x004F: ZCLAttributeDef("object_type", type=t.enum16),
+        0x0076: ZCLAttributeDef("update_interval", type=t.uint8_t),
+        0x00A8: ZCLAttributeDef("profile_name", type=t.CharacterString),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -59,17 +59,17 @@ class AnalogInputExtended(Cluster):
     cluster_id = 0x0603
     ep_attribute = "bacnet_extended_analog_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("acked_transitions", t.bitmap8),
-        0x0011: ("notification_class", t.uint16_t),
-        0x0019: ("deadband", t.Single),
-        0x0023: ("event_enable", t.bitmap8),
-        0x0024: ("event_state", t.enum8),
-        0x002D: ("high_limit", t.Single),
-        0x0034: ("limit_enable", t.bitmap8),
-        0x003B: ("low_limit", t.Single),
-        0x0048: ("notify_type", t.enum8),
-        0x0071: ("time_delay", t.uint8_t),
-        # 0x0082: ('event_time_stamps', TODO.array) # Array[3] of (16-bit unsigned
+        0x0000: ZCLAttributeDef("acked_transitions", type=t.bitmap8),
+        0x0011: ZCLAttributeDef("notification_class", type=t.uint16_t),
+        0x0019: ZCLAttributeDef("deadband", type=t.Single),
+        0x0023: ZCLAttributeDef("event_enable", type=t.bitmap8),
+        0x0024: ZCLAttributeDef("event_state", type=t.enum8),
+        0x002D: ZCLAttributeDef("high_limit", type=t.Single),
+        0x0034: ZCLAttributeDef("limit_enable", type=t.bitmap8),
+        0x003B: ZCLAttributeDef("low_limit", type=t.Single),
+        0x0048: ZCLAttributeDef("notify_type", type=t.enum8),
+        0x0071: ZCLAttributeDef("time_delay", type=t.uint8_t),
+        # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array) # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
     }
     server_commands: dict[int, ZCLCommandDef] = {
@@ -85,13 +85,13 @@ class AnalogOutputRegular(Cluster):
     cluster_id = 0x0604
     ep_attribute = "bacnet_regular_analog_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0016: ("cov_increment", t.Single),
-        0x001F: ("device_type", t.CharacterString),
-        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
-        0x004D: ("object_name", t.CharacterString),
-        0x004F: ("object_type", t.enum16),
-        0x0076: ("update_interval", t.uint8_t),
-        0x00A8: ("profile_name", t.CharacterString),
+        0x0016: ZCLAttributeDef("cov_increment", type=t.Single),
+        0x001F: ZCLAttributeDef("device_type", type=t.CharacterString),
+        0x004B: ZCLAttributeDef("object_id", type=t.FixedList[4, t.uint8_t]),
+        0x004D: ZCLAttributeDef("object_name", type=t.CharacterString),
+        0x004F: ZCLAttributeDef("object_type", type=t.enum16),
+        0x0076: ZCLAttributeDef("update_interval", type=t.uint8_t),
+        0x00A8: ZCLAttributeDef("profile_name", type=t.CharacterString),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -101,17 +101,17 @@ class AnalogOutputExtended(Cluster):
     cluster_id = 0x0605
     ep_attribute = "bacnet_extended_analog_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("acked_transitions", t.bitmap8),
-        0x0011: ("notification_class", t.uint16_t),
-        0x0019: ("deadband", t.Single),
-        0x0023: ("event_enable", t.bitmap8),
-        0x0024: ("event_state", t.enum8),
-        0x002D: ("high_limit", t.Single),
-        0x0034: ("limit_enable", t.bitmap8),
-        0x003B: ("low_limit", t.Single),
-        0x0048: ("notify_type", t.enum8),
-        0x0071: ("time_delay", t.uint8_t),
-        # 0x0082: ('event_time_stamps', TODO.array)# Array[3] of (16-bit unsigned
+        0x0000: ZCLAttributeDef("acked_transitions", type=t.bitmap8),
+        0x0011: ZCLAttributeDef("notification_class", type=t.uint16_t),
+        0x0019: ZCLAttributeDef("deadband", type=t.Single),
+        0x0023: ZCLAttributeDef("event_enable", type=t.bitmap8),
+        0x0024: ZCLAttributeDef("event_state", type=t.enum8),
+        0x002D: ZCLAttributeDef("high_limit", type=t.Single),
+        0x0034: ZCLAttributeDef("limit_enable", type=t.bitmap8),
+        0x003B: ZCLAttributeDef("low_limit", type=t.Single),
+        0x0048: ZCLAttributeDef("notify_type", type=t.enum8),
+        0x0071: ZCLAttributeDef("time_delay", type=t.uint8_t),
+        # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array)# Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
     }
     server_commands: dict[int, ZCLCommandDef] = {}
@@ -122,11 +122,11 @@ class AnalogValueRegular(Cluster):
     cluster_id = 0x0606
     ep_attribute = "bacnet_regular_analog_value"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0016: ("cov_increment", t.Single),
-        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
-        0x004D: ("object_name", t.CharacterString),
-        0x004F: ("object_type", t.enum16),
-        0x00A8: ("profile_name", t.CharacterString),
+        0x0016: ZCLAttributeDef("cov_increment", type=t.Single),
+        0x004B: ZCLAttributeDef("object_id", type=t.FixedList[4, t.uint8_t]),
+        0x004D: ZCLAttributeDef("object_name", type=t.CharacterString),
+        0x004F: ZCLAttributeDef("object_type", type=t.enum16),
+        0x00A8: ZCLAttributeDef("profile_name", type=t.CharacterString),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -136,17 +136,17 @@ class AnalogValueExtended(Cluster):
     cluster_id = 0x0607
     ep_attribute = "bacnet_extended_analog_value"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("acked_transitions", t.bitmap8),
-        0x0011: ("notification_class", t.uint16_t),
-        0x0019: ("deadband", t.Single),
-        0x0023: ("event_enable", t.bitmap8),
-        0x0024: ("event_state", t.enum8),
-        0x002D: ("high_limit", t.Single),
-        0x0034: ("limit_enable", t.bitmap8),
-        0x003B: ("low_limit", t.Single),
-        0x0048: ("notify_type", t.enum8),
-        0x0071: ("time_delay", t.uint8_t),
-        # 0x0082: ('event_time_stamps', TODO.array),  # Array[3] of (16-bit unsigned
+        0x0000: ZCLAttributeDef("acked_transitions", type=t.bitmap8),
+        0x0011: ZCLAttributeDef("notification_class", type=t.uint16_t),
+        0x0019: ZCLAttributeDef("deadband", type=t.Single),
+        0x0023: ZCLAttributeDef("event_enable", type=t.bitmap8),
+        0x0024: ZCLAttributeDef("event_state", type=t.enum8),
+        0x002D: ZCLAttributeDef("high_limit", type=t.Single),
+        0x0034: ZCLAttributeDef("limit_enable", type=t.bitmap8),
+        0x003B: ZCLAttributeDef("low_limit", type=t.Single),
+        0x0048: ZCLAttributeDef("notify_type", type=t.enum8),
+        0x0071: ZCLAttributeDef("time_delay", type=t.uint8_t),
+        # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
     }
     server_commands: dict[int, ZCLCommandDef] = {}
@@ -157,16 +157,16 @@ class BinaryInputRegular(Cluster):
     cluster_id = 0x0608
     ep_attribute = "bacnet_regular_binary_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x000F: ("change_of_state_count", t.uint32_t),
-        0x0010: ("change_of_state_time", DateTime),
-        0x001F: ("device_type", t.CharacterString),
-        0x0021: ("elapsed_active_time", t.uint32_t),
-        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
-        0x004D: ("object_name", t.CharacterString),
-        0x004F: ("object_type", t.enum16),
-        0x0072: ("time_of_at_reset", DateTime),
-        0x0073: ("time_of_sc_reset", DateTime),
-        0x00A8: ("profile_name", t.CharacterString),
+        0x000F: ZCLAttributeDef("change_of_state_count", type=t.uint32_t),
+        0x0010: ZCLAttributeDef("change_of_state_time", type=DateTime),
+        0x001F: ZCLAttributeDef("device_type", type=t.CharacterString),
+        0x0021: ZCLAttributeDef("elapsed_active_time", type=t.uint32_t),
+        0x004B: ZCLAttributeDef("object_id", type=t.FixedList[4, t.uint8_t]),
+        0x004D: ZCLAttributeDef("object_name", type=t.CharacterString),
+        0x004F: ZCLAttributeDef("object_type", type=t.enum16),
+        0x0072: ZCLAttributeDef("time_of_at_reset", type=DateTime),
+        0x0073: ZCLAttributeDef("time_of_sc_reset", type=DateTime),
+        0x00A8: ZCLAttributeDef("profile_name", type=t.CharacterString),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -176,14 +176,14 @@ class BinaryInputExtended(Cluster):
     cluster_id = 0x0609
     ep_attribute = "bacnet_extended_binary_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("acked_transitions", t.bitmap8),
-        0x0006: ("alarm_value", t.Bool),
-        0x0011: ("notification_class", t.uint16_t),
-        0x0023: ("event_enable", t.bitmap8),
-        0x0024: ("event_state", t.enum8),
-        0x0048: ("notify_type", t.enum8),
-        0x0071: ("time_delay", t.uint8_t),
-        # 0x0082: ('event_time_stamps', TODO.array),  # Array[3] of (16-bit unsigned
+        0x0000: ZCLAttributeDef("acked_transitions", type=t.bitmap8),
+        0x0006: ZCLAttributeDef("alarm_value", type=t.Bool),
+        0x0011: ZCLAttributeDef("notification_class", type=t.uint16_t),
+        0x0023: ZCLAttributeDef("event_enable", type=t.bitmap8),
+        0x0024: ZCLAttributeDef("event_state", type=t.enum8),
+        0x0048: ZCLAttributeDef("notify_type", type=t.enum8),
+        0x0071: ZCLAttributeDef("time_delay", type=t.uint8_t),
+        # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
     }
     server_commands: dict[int, ZCLCommandDef] = {}
@@ -194,17 +194,17 @@ class BinaryOutputRegular(Cluster):
     cluster_id = 0x060A
     ep_attribute = "bacnet_regular_binary_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x000F: ("change_of_state_count", t.uint32_t),
-        0x0010: ("change_of_state_time", DateTime),
-        0x001F: ("device_type", t.CharacterString),
-        0x0021: ("elapsed_active_time", t.uint32_t),
-        0x0028: ("feed_back_value", t.enum8),
-        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
-        0x004D: ("object_name", t.CharacterString),
-        0x004F: ("object_type", t.enum16),
-        0x0072: ("time_of_at_reset", DateTime),
-        0x0073: ("time_of_sc_reset", DateTime),
-        0x00A8: ("profile_name", t.CharacterString),
+        0x000F: ZCLAttributeDef("change_of_state_count", type=t.uint32_t),
+        0x0010: ZCLAttributeDef("change_of_state_time", type=DateTime),
+        0x001F: ZCLAttributeDef("device_type", type=t.CharacterString),
+        0x0021: ZCLAttributeDef("elapsed_active_time", type=t.uint32_t),
+        0x0028: ZCLAttributeDef("feed_back_value", type=t.enum8),
+        0x004B: ZCLAttributeDef("object_id", type=t.FixedList[4, t.uint8_t]),
+        0x004D: ZCLAttributeDef("object_name", type=t.CharacterString),
+        0x004F: ZCLAttributeDef("object_type", type=t.enum16),
+        0x0072: ZCLAttributeDef("time_of_at_reset", type=DateTime),
+        0x0073: ZCLAttributeDef("time_of_sc_reset", type=DateTime),
+        0x00A8: ZCLAttributeDef("profile_name", type=t.CharacterString),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -214,13 +214,13 @@ class BinaryOutputExtended(Cluster):
     cluster_id = 0x060B
     ep_attribute = "bacnet_extended_binary_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("acked_transitions", t.bitmap8),
-        0x0011: ("notification_class", t.uint16_t),
-        0x0023: ("event_enable", t.bitmap8),
-        0x0024: ("event_state", t.enum8),
-        0x0048: ("notify_type", t.enum8),
-        0x0071: ("time_delay", t.uint8_t),
-        # 0x0082: ('event_time_stamps', TODO.array),  # Array[3] of (16-bit unsigned
+        0x0000: ZCLAttributeDef("acked_transitions", type=t.bitmap8),
+        0x0011: ZCLAttributeDef("notification_class", type=t.uint16_t),
+        0x0023: ZCLAttributeDef("event_enable", type=t.bitmap8),
+        0x0024: ZCLAttributeDef("event_state", type=t.enum8),
+        0x0048: ZCLAttributeDef("notify_type", type=t.enum8),
+        0x0071: ZCLAttributeDef("time_delay", type=t.uint8_t),
+        # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
     }
     server_commands: dict[int, ZCLCommandDef] = {}
@@ -231,15 +231,15 @@ class BinaryValueRegular(Cluster):
     cluster_id = 0x060C
     ep_attribute = "bacnet_regular_binary_value"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x000F: ("change_of_state_count", t.uint32_t),
-        0x0010: ("change_of_state_time", DateTime),
-        0x0021: ("elapsed_active_time", t.uint32_t),
-        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
-        0x004D: ("object_name", t.CharacterString),
-        0x004F: ("object_type", t.enum16),
-        0x0072: ("time_of_at_reset", DateTime),
-        0x0073: ("time_of_sc_reset", DateTime),
-        0x00A8: ("profile_name", t.CharacterString),
+        0x000F: ZCLAttributeDef("change_of_state_count", type=t.uint32_t),
+        0x0010: ZCLAttributeDef("change_of_state_time", type=DateTime),
+        0x0021: ZCLAttributeDef("elapsed_active_time", type=t.uint32_t),
+        0x004B: ZCLAttributeDef("object_id", type=t.FixedList[4, t.uint8_t]),
+        0x004D: ZCLAttributeDef("object_name", type=t.CharacterString),
+        0x004F: ZCLAttributeDef("object_type", type=t.enum16),
+        0x0072: ZCLAttributeDef("time_of_at_reset", type=DateTime),
+        0x0073: ZCLAttributeDef("time_of_sc_reset", type=DateTime),
+        0x00A8: ZCLAttributeDef("profile_name", type=t.CharacterString),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -249,14 +249,14 @@ class BinaryValueExtended(Cluster):
     cluster_id = 0x060D
     ep_attribute = "bacnet_extended_binary_value"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("acked_transitions", t.bitmap8),
-        0x0006: ("alarm_value", t.Bool),
-        0x0011: ("notification_class", t.uint16_t),
-        0x0023: ("event_enable", t.bitmap8),
-        0x0024: ("event_state", t.enum8),
-        0x0048: ("notify_type", t.enum8),
-        0x0071: ("time_delay", t.uint8_t),
-        # 0x0082: ('event_time_stamps', TODO.array),  # Array[3] of (16-bit unsigned
+        0x0000: ZCLAttributeDef("acked_transitions", type=t.bitmap8),
+        0x0006: ZCLAttributeDef("alarm_value", type=t.Bool),
+        0x0011: ZCLAttributeDef("notification_class", type=t.uint16_t),
+        0x0023: ZCLAttributeDef("event_enable", type=t.bitmap8),
+        0x0024: ZCLAttributeDef("event_state", type=t.enum8),
+        0x0048: ZCLAttributeDef("notify_type", type=t.enum8),
+        0x0071: ZCLAttributeDef("time_delay", type=t.uint8_t),
+        # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
     }
     server_commands: dict[int, ZCLCommandDef] = {}
@@ -267,11 +267,11 @@ class MultistateInputRegular(Cluster):
     cluster_id = 0x060E
     ep_attribute = "bacnet_regular_multistate_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x001F: ("device_type", t.CharacterString),
-        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
-        0x004D: ("object_name", t.CharacterString),
-        0x004F: ("object_type", t.enum16),
-        0x00A8: ("profile_name", t.CharacterString),
+        0x001F: ZCLAttributeDef("device_type", type=t.CharacterString),
+        0x004B: ZCLAttributeDef("object_id", type=t.FixedList[4, t.uint8_t]),
+        0x004D: ZCLAttributeDef("object_name", type=t.CharacterString),
+        0x004F: ZCLAttributeDef("object_type", type=t.enum16),
+        0x00A8: ZCLAttributeDef("profile_name", type=t.CharacterString),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -281,15 +281,15 @@ class MultistateInputExtended(Cluster):
     cluster_id = 0x060F
     ep_attribute = "bacnet_extended_multistate_input"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("acked_transitions", t.bitmap8),
-        0x0006: ("alarm_value", t.uint16_t),
-        0x0011: ("notification_class", t.uint16_t),
-        0x0023: ("event_enable", t.bitmap8),
-        0x0024: ("event_state", t.enum8),
-        0x0025: ("fault_values", t.uint16_t),
-        0x0048: ("notify_type", t.enum8),
-        0x0071: ("time_delay", t.uint8_t),
-        # 0x0082: ('event_time_stamps', TODO.array),  # Array[3] of (16-bit unsigned
+        0x0000: ZCLAttributeDef("acked_transitions", type=t.bitmap8),
+        0x0006: ZCLAttributeDef("alarm_value", type=t.uint16_t),
+        0x0011: ZCLAttributeDef("notification_class", type=t.uint16_t),
+        0x0023: ZCLAttributeDef("event_enable", type=t.bitmap8),
+        0x0024: ZCLAttributeDef("event_state", type=t.enum8),
+        0x0025: ZCLAttributeDef("fault_values", type=t.uint16_t),
+        0x0048: ZCLAttributeDef("notify_type", type=t.enum8),
+        0x0071: ZCLAttributeDef("time_delay", type=t.uint8_t),
+        # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
     }
     server_commands: dict[int, ZCLCommandDef] = {}
@@ -300,12 +300,12 @@ class MultistateOutputRegular(Cluster):
     cluster_id = 0x0610
     ep_attribute = "bacnet_regular_multistate_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x001F: ("device_type", t.CharacterString),
-        0x0028: ("feed_back_value", t.enum8),
-        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
-        0x004D: ("object_name", t.CharacterString),
-        0x004F: ("object_type", t.enum16),
-        0x00A8: ("profile_name", t.CharacterString),
+        0x001F: ZCLAttributeDef("device_type", type=t.CharacterString),
+        0x0028: ZCLAttributeDef("feed_back_value", type=t.enum8),
+        0x004B: ZCLAttributeDef("object_id", type=t.FixedList[4, t.uint8_t]),
+        0x004D: ZCLAttributeDef("object_name", type=t.CharacterString),
+        0x004F: ZCLAttributeDef("object_type", type=t.enum16),
+        0x00A8: ZCLAttributeDef("profile_name", type=t.CharacterString),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -315,13 +315,13 @@ class MultistateOutputExtended(Cluster):
     cluster_id = 0x0611
     ep_attribute = "bacnet_extended_multistate_output"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("acked_transitions", t.bitmap8),
-        0x0011: ("notification_class", t.uint16_t),
-        0x0023: ("event_enable", t.bitmap8),
-        0x0024: ("event_state", t.enum8),
-        0x0048: ("notify_type", t.enum8),
-        0x0071: ("time_delay", t.uint8_t),
-        # 0x0082: ('event_time_stamps', TODO.array),  # Array[3] of (16-bit unsigned
+        0x0000: ZCLAttributeDef("acked_transitions", type=t.bitmap8),
+        0x0011: ZCLAttributeDef("notification_class", type=t.uint16_t),
+        0x0023: ZCLAttributeDef("event_enable", type=t.bitmap8),
+        0x0024: ZCLAttributeDef("event_state", type=t.enum8),
+        0x0048: ZCLAttributeDef("notify_type", type=t.enum8),
+        0x0071: ZCLAttributeDef("time_delay", type=t.uint8_t),
+        # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
     }
     server_commands: dict[int, ZCLCommandDef] = {}
@@ -332,10 +332,10 @@ class MultistateValueRegular(Cluster):
     cluster_id = 0x0612
     ep_attribute = "bacnet_regular_multistate_value"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x004B: ("object_id", t.FixedList[4, t.uint8_t]),
-        0x004D: ("object_name", t.CharacterString),
-        0x004F: ("object_type", t.enum16),
-        0x00A8: ("profile_name", t.CharacterString),
+        0x004B: ZCLAttributeDef("object_id", type=t.FixedList[4, t.uint8_t]),
+        0x004D: ZCLAttributeDef("object_name", type=t.CharacterString),
+        0x004F: ZCLAttributeDef("object_type", type=t.enum16),
+        0x00A8: ZCLAttributeDef("profile_name", type=t.CharacterString),
     }
     server_commands: dict[int, ZCLCommandDef] = {}
     client_commands: dict[int, ZCLCommandDef] = {}
@@ -345,15 +345,15 @@ class MultistateValueExtended(Cluster):
     cluster_id = 0x0613
     ep_attribute = "bacnet_extended_multistate_value"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("acked_transitions", t.bitmap8),
-        0x0006: ("alarm_value", t.uint16_t),
-        0x0011: ("notification_class", t.uint16_t),
-        0x0023: ("event_enable", t.bitmap8),
-        0x0024: ("event_state", t.enum8),
-        0x0025: ("fault_values", t.uint16_t),
-        0x0048: ("notify_type", t.enum8),
-        0x0071: ("time_delay", t.uint8_t),
-        # 0x0082: ('event_time_stamps', TODO.array),  # Array[3] of (16-bit unsigned
+        0x0000: ZCLAttributeDef("acked_transitions", type=t.bitmap8),
+        0x0006: ZCLAttributeDef("alarm_value", type=t.uint16_t),
+        0x0011: ZCLAttributeDef("notification_class", type=t.uint16_t),
+        0x0023: ZCLAttributeDef("event_enable", type=t.bitmap8),
+        0x0024: ZCLAttributeDef("event_state", type=t.enum8),
+        0x0025: ZCLAttributeDef("fault_values", type=t.uint16_t),
+        0x0048: ZCLAttributeDef("notify_type", type=t.enum8),
+        0x0071: ZCLAttributeDef("time_delay", type=t.uint8_t),
+        # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
     }
     server_commands: dict[int, ZCLCommandDef] = {}

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -25,141 +25,311 @@ class Metering(Cluster):
     cluster_id = 0x0702
     ep_attribute = "smartenergy_metering"
     attributes: dict[int, ZCLAttributeDef] = {
-        0x0000: ("current_summ_delivered", t.uint48_t),
-        0x0001: ("current_summ_received", t.uint48_t),
-        0x0002: ("current_max_demand_delivered", t.uint48_t),
-        0x0003: ("current_max_demand_received", t.uint48_t),
-        0x0004: ("dft_summ", t.uint48_t),
-        0x0005: ("daily_freeze_time", t.uint16_t),
-        0x0006: ("power_factor", t.int8s),
-        0x0007: ("reading_snapshot_time", t.UTCTime),
-        0x0008: ("current_max_demand_delivered_time", t.UTCTime),
-        0x0009: ("current_max_demand_received_time", t.UTCTime),
-        0x000A: ("default_update_period", t.uint8_t),
-        0x000B: ("fast_poll_update_period", t.uint8_t),
-        0x000C: ("current_block_period_consump_delivered", t.uint48_t),
-        0x000D: ("daily_consump_target", t.uint24_t),
-        0x000E: ("current_block", t.enum8),
-        0x000F: ("profile_interval_period", t.enum8),
+        0x0000: ZCLAttributeDef("current_summ_delivered", type=t.uint48_t, access="r"),
+        0x0001: ZCLAttributeDef("current_summ_received", type=t.uint48_t, access="r"),
+        0x0002: ZCLAttributeDef(
+            "current_max_demand_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0003: ZCLAttributeDef(
+            "current_max_demand_received", type=t.uint48_t, access="r"
+        ),
+        0x0004: ZCLAttributeDef("dft_summ", type=t.uint48_t, access="r"),
+        0x0005: ZCLAttributeDef("daily_freeze_time", type=t.uint16_t, access="r"),
+        0x0006: ZCLAttributeDef("power_factor", type=t.int8s, access="r"),
+        0x0007: ZCLAttributeDef("reading_snapshot_time", type=t.UTCTime, access="r"),
+        0x0008: ZCLAttributeDef(
+            "current_max_demand_delivered_time", type=t.UTCTime, access="r"
+        ),
+        0x0009: ZCLAttributeDef(
+            "current_max_demand_received_time", type=t.UTCTime, access="r"
+        ),
+        0x000A: ZCLAttributeDef("default_update_period", type=t.uint8_t, access="r"),
+        0x000B: ZCLAttributeDef("fast_poll_update_period", type=t.uint8_t, access="r"),
+        0x000C: ZCLAttributeDef(
+            "current_block_period_consump_delivered", type=t.uint48_t, access="r"
+        ),
+        0x000D: ZCLAttributeDef("daily_consump_target", type=t.uint24_t, access="r"),
+        0x000E: ZCLAttributeDef("current_block", type=t.enum8, access="r"),
+        0x000F: ZCLAttributeDef("profile_interval_period", type=t.enum8, access="r"),
         # 0x0010: ('interval_read_reporting_period', UNKNOWN),  # Deprecated
-        0x0011: ("preset_reading_time", t.uint16_t),
-        0x0012: ("volume_per_report", t.uint16_t),
-        0x0013: ("flow_restriction", t.uint8_t),
-        0x0014: ("supply_status", t.enum8),
-        0x0015: ("current_in_energy_carrier_summ", t.uint48_t),
-        0x0016: ("current_out_energy_carrier_summ", t.uint48_t),
-        0x0017: ("inlet_temperature", t.int24s),
-        0x0018: ("outlet_temperature", t.int24s),
-        0x0019: ("control_temperature", t.int24s),
-        0x001A: ("current_in_energy_carrier_demand", t.int24s),
-        0x001B: ("current_out_energy_carrier_demand", t.int24s),
-        0x001D: ("current_block_period_consump_received", t.uint48_t),
-        0x001E: ("current_block_received", t.uint48_t),
-        0x001F: ("dft_summation_received", t.uint48_t),
-        0x0020: ("active_register_tier_delivered", t.enum8),
-        0x0021: ("active_register_tier_received", t.enum8),
-        0x0022: ("last_block_switch_time", t.UTCTime),
+        0x0011: ZCLAttributeDef("preset_reading_time", type=t.uint16_t, access="r"),
+        0x0012: ZCLAttributeDef("volume_per_report", type=t.uint16_t, access="r"),
+        0x0013: ZCLAttributeDef("flow_restriction", type=t.uint8_t, access="r"),
+        0x0014: ZCLAttributeDef("supply_status", type=t.enum8, access="r"),
+        0x0015: ZCLAttributeDef(
+            "current_in_energy_carrier_summ", type=t.uint48_t, access="r"
+        ),
+        0x0016: ZCLAttributeDef(
+            "current_out_energy_carrier_summ", type=t.uint48_t, access="r"
+        ),
+        0x0017: ZCLAttributeDef("inlet_temperature", type=t.int24s, access="r"),
+        0x0018: ZCLAttributeDef("outlet_temperature", type=t.int24s, access="r"),
+        0x0019: ZCLAttributeDef("control_temperature", type=t.int24s, access="r"),
+        0x001A: ZCLAttributeDef(
+            "current_in_energy_carrier_demand", type=t.int24s, access="r"
+        ),
+        0x001B: ZCLAttributeDef(
+            "current_out_energy_carrier_demand", type=t.int24s, access="r"
+        ),
+        0x001D: ZCLAttributeDef(
+            "current_block_period_consump_received", type=t.uint48_t, access="r"
+        ),
+        0x001E: ZCLAttributeDef("current_block_received", type=t.uint48_t, access="r"),
+        0x001F: ZCLAttributeDef("dft_summation_received", type=t.uint48_t, access="r"),
+        0x0020: ZCLAttributeDef(
+            "active_register_tier_delivered", type=t.enum8, access="r"
+        ),
+        0x0021: ZCLAttributeDef(
+            "active_register_tier_received", type=t.enum8, access="r"
+        ),
+        0x0022: ZCLAttributeDef("last_block_switch_time", type=t.UTCTime, access="r"),
         # 0x0100: ('change_reporting_profile', UNKNOWN),
-        0x0100: ("current_tier1_summ_delivered", t.uint48_t),
-        0x0101: ("current_tier1_summ_received", t.uint48_t),
-        0x0102: ("current_tier2_summ_delivered", t.uint48_t),
-        0x0103: ("current_tier2_summ_received", t.uint48_t),
-        0x0104: ("current_tier3_summ_delivered", t.uint48_t),
-        0x0105: ("current_tier3_summ_received", t.uint48_t),
-        0x0106: ("current_tier4_summ_delivered", t.uint48_t),
-        0x0107: ("current_tier4_summ_received", t.uint48_t),
-        0x0108: ("current_tier5_summ_delivered", t.uint48_t),
-        0x0109: ("current_tier5_summ_received", t.uint48_t),
-        0x010A: ("current_tier6_summ_delivered", t.uint48_t),
-        0x010B: ("current_tier6_summ_received", t.uint48_t),
-        0x010C: ("current_tier7_summ_delivered", t.uint48_t),
-        0x010D: ("current_tier7_summ_received", t.uint48_t),
-        0x010E: ("current_tier8_summ_delivered", t.uint48_t),
-        0x010F: ("current_tier8_summ_received", t.uint48_t),
-        0x0110: ("current_tier9_summ_delivered", t.uint48_t),
-        0x0111: ("current_tier9_summ_received", t.uint48_t),
-        0x0112: ("current_tier10_summ_delivered", t.uint48_t),
-        0x0113: ("current_tier10_summ_received", t.uint48_t),
-        0x0114: ("current_tier11_summ_delivered", t.uint48_t),
-        0x0115: ("current_tier11_summ_received", t.uint48_t),
-        0x0116: ("current_tier12_summ_delivered", t.uint48_t),
-        0x0117: ("current_tier12_summ_received", t.uint48_t),
-        0x0118: ("current_tier13_summ_delivered", t.uint48_t),
-        0x0119: ("current_tier13_summ_received", t.uint48_t),
-        0x011A: ("current_tier14_summ_delivered", t.uint48_t),
-        0x011B: ("current_tier14_summ_received", t.uint48_t),
-        0x011C: ("current_tier15_summ_delivered", t.uint48_t),
-        0x011D: ("current_tier15_summ_received", t.uint48_t),
-        0x0200: ("status", t.bitmap8),
-        0x0201: ("remaining_battery_life", t.uint8_t),
-        0x0202: ("hours_in_operation", t.uint24_t),
-        0x0203: ("hours_in_fault", t.uint24_t),
-        0x0204: ("extended_status", t.bitmap64),
-        0x0205: ("remaining_battery_life_days", t.uint16_t),
-        0x0206: ("current_meter_id", t.LVBytes),
-        0x0207: ("iambient_consumption_indicator", t.enum8),
-        0x0300: ("unit_of_measure", t.enum8),
-        0x0301: ("multiplier", t.uint24_t),
-        0x0302: ("divisor", t.uint24_t),
-        0x0303: ("summation_formatting", t.bitmap8),
-        0x0304: ("demand_formatting", t.bitmap8),
-        0x0305: ("historical_consump_formatting", t.bitmap8),
-        0x0306: ("metering_device_type", t.bitmap8),
-        0x0307: ("site_id", t.LimitedLVBytes(32)),
-        0x0308: ("meter_serial_number", t.LimitedLVBytes(24)),
-        0x0309: ("energy_carrier_unit_of_meas", t.enum8),
-        0x030A: ("energy_carrier_summ_formatting", t.bitmap8),
-        0x030B: ("energy_carrier_demand_formatting", t.bitmap8),
-        0x030C: ("temperature_unit_of_measure", t.enum8),
-        0x030D: ("temperature_formatting", t.bitmap8),
-        0x030E: ("module_serial_number", t.LimitedLVBytes(24)),
-        0x030F: ("operating_tariff_label_delivered", t.LimitedLVBytes(24)),
-        0x0310: ("operating_tariff_label_received", t.LimitedLVBytes(24)),
-        0x0311: ("customer_id_number", t.LimitedLVBytes(24)),
-        0x0312: ("alternative_unit_of_measure", t.enum8),
-        0x0313: ("alternative_demand_formatting", t.bitmap8),
-        0x0314: ("alternative_consumption_formatting", t.bitmap8),
-        0x0400: ("instantaneous_demand", t.int24s),
-        0x0401: ("currentday_consump_delivered", t.uint24_t),
-        0x0402: ("currentday_consump_received", t.uint24_t),
-        0x0403: ("previousday_consump_delivered", t.uint24_t),
-        0x0404: ("previousday_consump_received", t.uint24_t),
-        0x0405: ("cur_part_profile_int_start_time_delivered", t.uint32_t),
-        0x0406: ("cur_part_profile_int_start_time_received", t.uint32_t),
-        0x0407: ("cur_part_profile_int_value_delivered", t.uint24_t),
-        0x0408: ("cur_part_profile_int_value_received", t.uint24_t),
-        0x0409: ("current_day_max_pressure", t.uint48_t),
-        0x040A: ("current_day_min_pressure", t.uint48_t),
-        0x040B: ("previous_day_max_pressure", t.uint48_t),
-        0x040C: ("previous_day_min_pressure", t.uint48_t),
-        0x040D: ("current_day_max_demand", t.int24s),
-        0x040E: ("previous_day_max_demand", t.int24s),
-        0x040F: ("current_month_max_demand", t.int24s),
-        0x0410: ("current_year_max_demand", t.int24s),
-        0x0411: ("currentday_max_energy_carr_demand", t.int24s),
-        0x0412: ("previousday_max_energy_carr_demand", t.int24s),
-        0x0413: ("cur_month_max_energy_carr_demand", t.int24s),
-        0x0414: ("cur_month_min_energy_carr_demand", t.int24s),
-        0x0415: ("cur_year_max_energy_carr_demand", t.int24s),
-        0x0416: ("cur_year_min_energy_carr_demand", t.int24s),
-        0x0500: ("max_number_of_periods_delivered", t.uint8_t),
-        0x0600: ("current_demand_delivered", t.uint24_t),
-        0x0601: ("demand_limit", t.uint24_t),
-        0x0602: ("demand_integration_period", t.uint8_t),
-        0x0603: ("number_of_demand_subintervals", t.uint8_t),
-        0x0604: ("demand_limit_arm_duration", t.uint16_t),
-        0x0800: ("generic_alarm_mask", t.bitmap16),
-        0x0801: ("electricity_alarm_mask", t.bitmap32),
-        0x0802: ("gen_flow_pressure_alarm_mask", t.bitmap16),
-        0x0803: ("water_specific_alarm_mask", t.bitmap16),
-        0x0804: ("heat_cool_specific_alarm_mask", t.bitmap16),
-        0x0805: ("gas_specific_alarm_mask", t.bitmap16),
-        0x0806: ("extended_generic_alarm_mask", t.bitmap48),
-        0x0807: ("manufacture_alarm_mask", t.bitmap16),
-        0x0A00: ("bill_to_date", t.uint32_t),
-        0x0A01: ("bill_to_date_time_stamp", t.uint32_t),
-        0x0A02: ("projected_bill", t.uint32_t),
-        0x0A03: ("projected_bill_time_stamp", t.uint32_t),
+        0x0100: ZCLAttributeDef(
+            "current_tier1_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0101: ZCLAttributeDef(
+            "current_tier1_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0102: ZCLAttributeDef(
+            "current_tier2_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0103: ZCLAttributeDef(
+            "current_tier2_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0104: ZCLAttributeDef(
+            "current_tier3_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0105: ZCLAttributeDef(
+            "current_tier3_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0106: ZCLAttributeDef(
+            "current_tier4_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0107: ZCLAttributeDef(
+            "current_tier4_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0108: ZCLAttributeDef(
+            "current_tier5_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0109: ZCLAttributeDef(
+            "current_tier5_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x010A: ZCLAttributeDef(
+            "current_tier6_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x010B: ZCLAttributeDef(
+            "current_tier6_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x010C: ZCLAttributeDef(
+            "current_tier7_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x010D: ZCLAttributeDef(
+            "current_tier7_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x010E: ZCLAttributeDef(
+            "current_tier8_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x010F: ZCLAttributeDef(
+            "current_tier8_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0110: ZCLAttributeDef(
+            "current_tier9_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0111: ZCLAttributeDef(
+            "current_tier9_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0112: ZCLAttributeDef(
+            "current_tier10_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0113: ZCLAttributeDef(
+            "current_tier10_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0114: ZCLAttributeDef(
+            "current_tier11_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0115: ZCLAttributeDef(
+            "current_tier11_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0116: ZCLAttributeDef(
+            "current_tier12_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0117: ZCLAttributeDef(
+            "current_tier12_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0118: ZCLAttributeDef(
+            "current_tier13_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x0119: ZCLAttributeDef(
+            "current_tier13_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x011A: ZCLAttributeDef(
+            "current_tier14_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x011B: ZCLAttributeDef(
+            "current_tier14_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x011C: ZCLAttributeDef(
+            "current_tier15_summ_delivered", type=t.uint48_t, access="r"
+        ),
+        0x011D: ZCLAttributeDef(
+            "current_tier15_summ_received", type=t.uint48_t, access="r"
+        ),
+        0x0200: ZCLAttributeDef("status", type=t.bitmap8, access="r"),
+        0x0201: ZCLAttributeDef("remaining_battery_life", type=t.uint8_t, access="r"),
+        0x0202: ZCLAttributeDef("hours_in_operation", type=t.uint24_t, access="r"),
+        0x0203: ZCLAttributeDef("hours_in_fault", type=t.uint24_t, access="r"),
+        0x0204: ZCLAttributeDef("extended_status", type=t.bitmap64, access="r"),
+        0x0205: ZCLAttributeDef(
+            "remaining_battery_life_days", type=t.uint16_t, access="r"
+        ),
+        0x0206: ZCLAttributeDef("current_meter_id", type=t.LVBytes, access="r"),
+        0x0207: ZCLAttributeDef(
+            "iambient_consumption_indicator", type=t.enum8, access="r"
+        ),
+        0x0300: ZCLAttributeDef("unit_of_measure", type=t.enum8, access="r"),
+        0x0301: ZCLAttributeDef("multiplier", type=t.uint24_t, access="r"),
+        0x0302: ZCLAttributeDef("divisor", type=t.uint24_t, access="r"),
+        0x0303: ZCLAttributeDef("summation_formatting", type=t.bitmap8, access="r"),
+        0x0304: ZCLAttributeDef("demand_formatting", type=t.bitmap8, access="r"),
+        0x0305: ZCLAttributeDef(
+            "historical_consump_formatting", type=t.bitmap8, access="r"
+        ),
+        0x0306: ZCLAttributeDef("metering_device_type", type=t.bitmap8, access="r"),
+        0x0307: ZCLAttributeDef("site_id", type=t.LimitedLVBytes(32), access="r"),
+        0x0308: ZCLAttributeDef(
+            "meter_serial_number", type=t.LimitedLVBytes(24), access="r"
+        ),
+        0x0309: ZCLAttributeDef(
+            "energy_carrier_unit_of_meas", type=t.enum8, access="r"
+        ),
+        0x030A: ZCLAttributeDef(
+            "energy_carrier_summ_formatting", type=t.bitmap8, access="r"
+        ),
+        0x030B: ZCLAttributeDef(
+            "energy_carrier_demand_formatting", type=t.bitmap8, access="r"
+        ),
+        0x030C: ZCLAttributeDef(
+            "temperature_unit_of_measure", type=t.enum8, access="r"
+        ),
+        0x030D: ZCLAttributeDef("temperature_formatting", type=t.bitmap8, access="r"),
+        0x030E: ZCLAttributeDef(
+            "module_serial_number", type=t.LimitedLVBytes(24), access="r"
+        ),
+        0x030F: ZCLAttributeDef(
+            "operating_tariff_label_delivered", type=t.LimitedLVBytes(24), access="r"
+        ),
+        0x0310: ZCLAttributeDef(
+            "operating_tariff_label_received", type=t.LimitedLVBytes(24), access="r"
+        ),
+        0x0311: ZCLAttributeDef(
+            "customer_id_number", type=t.LimitedLVBytes(24), access="r"
+        ),
+        0x0312: ZCLAttributeDef(
+            "alternative_unit_of_measure", type=t.enum8, access="r"
+        ),
+        0x0313: ZCLAttributeDef(
+            "alternative_demand_formatting", type=t.bitmap8, access="r"
+        ),
+        0x0314: ZCLAttributeDef(
+            "alternative_consumption_formatting", type=t.bitmap8, access="r"
+        ),
+        0x0400: ZCLAttributeDef("instantaneous_demand", type=t.int24s, access="r"),
+        0x0401: ZCLAttributeDef(
+            "currentday_consump_delivered", type=t.uint24_t, access="r"
+        ),
+        0x0402: ZCLAttributeDef(
+            "currentday_consump_received", type=t.uint24_t, access="r"
+        ),
+        0x0403: ZCLAttributeDef(
+            "previousday_consump_delivered", type=t.uint24_t, access="r"
+        ),
+        0x0404: ZCLAttributeDef(
+            "previousday_consump_received", type=t.uint24_t, access="r"
+        ),
+        0x0405: ZCLAttributeDef(
+            "cur_part_profile_int_start_time_delivered", type=t.uint32_t, access="r"
+        ),
+        0x0406: ZCLAttributeDef(
+            "cur_part_profile_int_start_time_received", type=t.uint32_t, access="r"
+        ),
+        0x0407: ZCLAttributeDef(
+            "cur_part_profile_int_value_delivered", type=t.uint24_t, access="r"
+        ),
+        0x0408: ZCLAttributeDef(
+            "cur_part_profile_int_value_received", type=t.uint24_t, access="r"
+        ),
+        0x0409: ZCLAttributeDef(
+            "current_day_max_pressure", type=t.uint48_t, access="r"
+        ),
+        0x040A: ZCLAttributeDef(
+            "current_day_min_pressure", type=t.uint48_t, access="r"
+        ),
+        0x040B: ZCLAttributeDef(
+            "previous_day_max_pressure", type=t.uint48_t, access="r"
+        ),
+        0x040C: ZCLAttributeDef(
+            "previous_day_min_pressure", type=t.uint48_t, access="r"
+        ),
+        0x040D: ZCLAttributeDef("current_day_max_demand", type=t.int24s, access="r"),
+        0x040E: ZCLAttributeDef("previous_day_max_demand", type=t.int24s, access="r"),
+        0x040F: ZCLAttributeDef("current_month_max_demand", type=t.int24s, access="r"),
+        0x0410: ZCLAttributeDef("current_year_max_demand", type=t.int24s, access="r"),
+        0x0411: ZCLAttributeDef(
+            "currentday_max_energy_carr_demand", type=t.int24s, access="r"
+        ),
+        0x0412: ZCLAttributeDef(
+            "previousday_max_energy_carr_demand", type=t.int24s, access="r"
+        ),
+        0x0413: ZCLAttributeDef(
+            "cur_month_max_energy_carr_demand", type=t.int24s, access="r"
+        ),
+        0x0414: ZCLAttributeDef(
+            "cur_month_min_energy_carr_demand", type=t.int24s, access="r"
+        ),
+        0x0415: ZCLAttributeDef(
+            "cur_year_max_energy_carr_demand", type=t.int24s, access="r"
+        ),
+        0x0416: ZCLAttributeDef(
+            "cur_year_min_energy_carr_demand", type=t.int24s, access="r"
+        ),
+        0x0500: ZCLAttributeDef(
+            "max_number_of_periods_delivered", type=t.uint8_t, access="r"
+        ),
+        0x0600: ZCLAttributeDef(
+            "current_demand_delivered", type=t.uint24_t, access="r"
+        ),
+        0x0601: ZCLAttributeDef("demand_limit", type=t.uint24_t, access="r"),
+        0x0602: ZCLAttributeDef(
+            "demand_integration_period", type=t.uint8_t, access="r"
+        ),
+        0x0603: ZCLAttributeDef(
+            "number_of_demand_subintervals", type=t.uint8_t, access="r"
+        ),
+        0x0604: ZCLAttributeDef(
+            "demand_limit_arm_duration", type=t.uint16_t, access="r"
+        ),
+        0x0800: ZCLAttributeDef("generic_alarm_mask", type=t.bitmap16, access="r"),
+        0x0801: ZCLAttributeDef("electricity_alarm_mask", type=t.bitmap32, access="r"),
+        0x0802: ZCLAttributeDef(
+            "gen_flow_pressure_alarm_mask", type=t.bitmap16, access="r"
+        ),
+        0x0803: ZCLAttributeDef(
+            "water_specific_alarm_mask", type=t.bitmap16, access="r"
+        ),
+        0x0804: ZCLAttributeDef(
+            "heat_cool_specific_alarm_mask", type=t.bitmap16, access="r"
+        ),
+        0x0805: ZCLAttributeDef("gas_specific_alarm_mask", type=t.bitmap16, access="r"),
+        0x0806: ZCLAttributeDef(
+            "extended_generic_alarm_mask", type=t.bitmap48, access="r"
+        ),
+        0x0807: ZCLAttributeDef("manufacture_alarm_mask", type=t.bitmap16, access="r"),
+        0x0A00: ZCLAttributeDef("bill_to_date", type=t.uint32_t, access="r"),
+        0x0A01: ZCLAttributeDef("bill_to_date_time_stamp", type=t.uint32_t, access="r"),
+        0x0A02: ZCLAttributeDef("projected_bill", type=t.uint32_t, access="r"),
+        0x0A03: ZCLAttributeDef(
+            "projected_bill_time_stamp", type=t.uint32_t, access="r"
+        ),
     }
     server_commands: dict[int, ZCLCommandDef] = {
         0x00: ZCLCommandDef("get_profile", {}, False),

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import enum
+import functools
 import keyword
 import typing
 import warnings
@@ -762,6 +763,7 @@ class ZCLAttributeAccess(enum.Flag):
     _names: dict[ZCLAttributeAccess, str]
 
     @classmethod
+    @functools.lru_cache(None)
     def from_str(cls: ZCLAttributeAccess, value: str) -> ZCLAttributeAccess:
         orig_value = value
         access = cls.NONE


### PR DESCRIPTION
Adds a new `access` enum flag and a boolean `mandatory` flag for all ZCL cluster attributes. This should give ZHA more information about which attributes can be read from Home Assistant's web interface.

```python
In [1]: from zigpy.zcl.clusters.general import AnalogInput

In [2]: AnalogInput.attributes_by_name["status_flags"].access
Out[2]: <ZCLAttributeAccess.Report|Read: 9>

In [3]: AnalogInput.attributes_by_name["status_flags"].mandatory
Out[4]: True
```