### PR TITLE
Allow ZDO deserialization to fail without logging a warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
           . venv/bin/activate
           pytest \
             -qq \
-            --timeout=15 \
+            --timeout=20 \
             --durations=10 \
             --cov zigpy \
             -o console_output_style=count \

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -39,9 +39,8 @@ def test_deserialize(zdo_f):
 
 
 def test_deserialize_unknown(zdo_f):
-    hdr, args = zdo_f.deserialize(0x0100, b"\x01")
-    assert hdr.tsn == 1
-    assert hdr.is_reply is False
+    with pytest.raises(ValueError):
+        hdr, args = zdo_f.deserialize(0x0100, b"\x01")
 
 
 async def test_request(zdo_f):


### PR DESCRIPTION
Packets with a destination endpoint of `0` are attempted  to be deserialized as ZDO. If they are not in fact ZDO, deserialization is expected to fail and the packet is passed along, but an unnecessary warning is logged.

```Python
ZigbeePacket(src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x5C94), src_ep=2, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=0, source_route=None, extended_timeout=False, tsn=29, profile_id=260, cluster_id=64561, data=Serialized[b'\x15/\x12\n$\x10'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=255, rssi=-58)
```