### PR TITLE
Only update `last_seen` on RX

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -106,11 +106,9 @@ async def test_request(dev):
         dev._pending[seq].result.set_result(sentinel.result)
 
     dev.application.send_packet = AsyncMock(side_effect=mock_req)
-    assert dev.last_seen is None
     r = await dev.request(1, 2, 3, 3, seq, b"")
     assert r is sentinel.result
     assert dev._application.send_packet.call_count == 1
-    assert dev.last_seen is not None
 
 
 async def test_request_without_reply(dev):
@@ -120,11 +118,9 @@ async def test_request_without_reply(dev):
         dev._pending[seq].result.set_result(sentinel.result)
 
     dev.application.send_packet = AsyncMock(side_effect=mock_req)
-    assert dev.last_seen is None
     r = await dev.request(1, 2, 3, 3, seq, b"", expect_reply=False)
     assert r is None
     assert dev._application.send_packet.call_count == 1
-    assert dev.last_seen is not None
 
 
 async def test_failed_request(dev):
@@ -167,7 +163,11 @@ async def test_handle_message(dev):
     hdr.direction = sentinel.direction
     dev.deserialize = MagicMock(return_value=[hdr, sentinel.args])
     ep.handle_message = MagicMock()
+
+    assert dev.last_seen is None
     dev.handle_message(99, 98, 3, 3, b"abcd")
+    assert dev.last_seen is not None
+
     assert ep.handle_message.call_count == 1
 
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -307,8 +307,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 extended_timeout=extended_timeout,
             )
 
-            self.update_last_seen()
-
             if not expect_reply:
                 return None
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -384,6 +384,10 @@ class enum16(enum_factory(uint16_t)):  # noqa: N801
     pass
 
 
+class enum32(enum_factory(uint32_t)):  # noqa: N801
+    pass
+
+
 class bitmap2(bitmap_factory(uint2_t)):
     pass
 


### PR DESCRIPTION
Alternative to https://github.com/zigpy/zigpy-znp/pull/190 that also fixes https://github.com/home-assistant/core/issues/80519. The below screenshot shows that an offline device is considered unavailable after this change when used with a ZNP coordinator:

<img width="628" alt="image" src="https://user-images.githubusercontent.com/32534428/197595354-5594592d-4e31-4923-aa1c-cf7f501f0f56.png">

I believe the vast majority of packets are going to be a request/reply pair, or are themselves unsolicited updates from a device. The only devices I'm aware of that would fall back to explicit `Basic` cluster polling are devices like King of Fans controllers, which do not generate a ZCL default response.