### PR TITLE
Only enable APS ACKs for packets without implicit delivery notification

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -807,7 +807,7 @@ def packet(app, device):
         data=t.SerializableBytes(b"test data"),
         source_route=None,
         extended_timeout=False,
-        tx_options=t.TransmitOptions.ACK,
+        tx_options=t.TransmitOptions.NONE,
     )
 
 
@@ -861,6 +861,14 @@ async def test_request(app, device, packet):
     app.build_source_route_to.assert_called_once_with(dest=device)
     app.send_packet.assert_called_once_with(
         packet=packet.replace(source_route=[0x000A, 0x000B])
+    )
+    app.send_packet.reset_mock()
+
+    # Test sending without waiting for a reply
+    status, msg = await send_request(app, expect_reply=False)
+
+    app.send_packet.assert_called_once_with(
+        packet=packet.replace(tx_options=t.TransmitOptions.ACK)
     )
     app.send_packet.reset_mock()
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -651,6 +651,11 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         else:
             source_route = None
 
+        tx_options = t.TransmitOptions.NONE
+
+        if not expect_reply:
+            tx_options |= t.TransmitOptions.ACK
+
         await self.send_packet(
             t.ZigbeePacket(
                 src=src,
@@ -663,9 +668,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 data=t.SerializableBytes(data),
                 extended_timeout=extended_timeout,
                 source_route=source_route,
-                tx_options=(
-                    t.TransmitOptions.ACK if expect_reply else t.TransmitOptions.NONE
-                ),
+                tx_options=tx_options,
             )
         )
 


### PR DESCRIPTION
I think the current logic may be inverted. Instead, how about:

 - If a packet will be receiving a reply, we know when it was not received because no response was sent by the recipient.
 - If a packet will *not* be receiving a reply, we will have no way to know when it sends successfully, so we should enable APS ACKs to receive a low-level response from the device.

Thoughts?

Probably will fix https://github.com/home-assistant/core/issues/81057, since the Conbee struggles with APS ACKs it seems.