### PR TITLE
Remove unsupported attributes when they become supported

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -716,7 +716,6 @@ async def test_unsupported_attribute(tmp_path, dev_init):
     assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
     await app2.shutdown()
 
-
     async def mockrequest(
         is_general_req, command, schema, args, manufacturer=None, **kwargs
     ):
@@ -734,9 +733,12 @@ async def test_unsupported_attribute(tmp_path, dev_init):
         cluster = dev.endpoints[3].in_clusters[0]
         assert 0x0010 in dev.endpoints[3].in_clusters[0].unsupported_attributes
         cluster.request = mockrequest
-        response = await cluster.read_attributes([0x0010], allow_cache=False)
+        await cluster.read_attributes([0x0010], allow_cache=False)
         assert 0x0010 not in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        assert "location_desc" not in dev.endpoints[3].in_clusters[0].unsupported_attributes
+        assert (
+            "location_desc"
+            not in dev.endpoints[3].in_clusters[0].unsupported_attributes
+        )
         assert 0x0011 in dev.endpoints[3].in_clusters[0].unsupported_attributes
         assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
         await app3.shutdown()
@@ -748,7 +750,10 @@ async def test_unsupported_attribute(tmp_path, dev_init):
         assert dev.endpoints[3].device_type == profiles.zha.DeviceType.PUMP
         assert 0x0010 not in dev.endpoints[3].in_clusters[0].unsupported_attributes
         assert "Not Removed" == dev.endpoints[3].in_clusters[0].get(0x0010)
-        assert "location_desc" not in dev.endpoints[3].in_clusters[0].unsupported_attributes
+        assert (
+            "location_desc"
+            not in dev.endpoints[3].in_clusters[0].unsupported_attributes
+        )
         assert 0x0011 in dev.endpoints[3].in_clusters[0].unsupported_attributes
         assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
         await app4.shutdown()

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -733,12 +733,9 @@ async def test_unsupported_attribute(tmp_path, dev_init):
     assert 0x0010 in dev.endpoints[3].in_clusters[0].unsupported_attributes
     cluster.request = mockrequest
     await cluster.read_attributes([0x0010], allow_cache=False)
-    if dev_init:
-        assert 0x0010 not in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        assert (
-            "location_desc"
-            not in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        )
+    assert 0x0010 not in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    assert "location_desc" not in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    assert "Not Removed" == dev.endpoints[3].in_clusters[0].get(0x0010)
     assert 0x0011 in dev.endpoints[3].in_clusters[0].unsupported_attributes
     assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
     await app3.shutdown()
@@ -748,13 +745,9 @@ async def test_unsupported_attribute(tmp_path, dev_init):
     dev = app4.get_device(ieee)
     assert dev.is_initialized == dev_init
     assert dev.endpoints[3].device_type == profiles.zha.DeviceType.PUMP
-    if dev_init:
-        assert 0x0010 not in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        assert "Not Removed" == dev.endpoints[3].in_clusters[0].get(0x0010)
-        assert (
-            "location_desc"
-            not in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        )
+    assert 0x0010 not in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    assert "Not Removed" == dev.endpoints[3].in_clusters[0].get(0x0010)
+    assert "location_desc" not in dev.endpoints[3].in_clusters[0].unsupported_attributes
     assert 0x0011 in dev.endpoints[3].in_clusters[0].unsupported_attributes
     assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
     await app4.shutdown()

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -724,39 +724,40 @@ async def test_unsupported_attribute(tmp_path, dev_init):
         rar0010 = _mk_rar(0x0010, "Not Removed", zigpy.zcl.foundation.Status.SUCCESS)
         return [[rar0010]]
 
+    # Now lets remove an unsupported attribute and make sure it is removed
+    app3 = await make_app(db)
+    dev = app3.get_device(ieee)
+    assert dev.is_initialized == dev_init
+    assert dev.endpoints[3].device_type == profiles.zha.DeviceType.PUMP
+    cluster = dev.endpoints[3].in_clusters[0]
+    assert 0x0010 in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    cluster.request = mockrequest
+    await cluster.read_attributes([0x0010], allow_cache=False)
     if dev_init:
-        # Now lets remove an unsupported attribute and make sure it is removed
-        app3 = await make_app(db)
-        dev = app3.get_device(ieee)
-        assert dev.is_initialized == dev_init
-        assert dev.endpoints[3].device_type == profiles.zha.DeviceType.PUMP
-        cluster = dev.endpoints[3].in_clusters[0]
-        assert 0x0010 in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        cluster.request = mockrequest
-        await cluster.read_attributes([0x0010], allow_cache=False)
         assert 0x0010 not in dev.endpoints[3].in_clusters[0].unsupported_attributes
         assert (
             "location_desc"
             not in dev.endpoints[3].in_clusters[0].unsupported_attributes
         )
-        assert 0x0011 in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        await app3.shutdown()
+    assert 0x0011 in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    await app3.shutdown()
 
-        # Everything should've been saved - check that it re-loads
-        app4 = await make_app(db)
-        dev = app4.get_device(ieee)
-        assert dev.is_initialized == dev_init
-        assert dev.endpoints[3].device_type == profiles.zha.DeviceType.PUMP
+    # Everything should've been saved - check that it re-loads
+    app4 = await make_app(db)
+    dev = app4.get_device(ieee)
+    assert dev.is_initialized == dev_init
+    assert dev.endpoints[3].device_type == profiles.zha.DeviceType.PUMP
+    if dev_init:
         assert 0x0010 not in dev.endpoints[3].in_clusters[0].unsupported_attributes
         assert "Not Removed" == dev.endpoints[3].in_clusters[0].get(0x0010)
         assert (
             "location_desc"
             not in dev.endpoints[3].in_clusters[0].unsupported_attributes
         )
-        assert 0x0011 in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
-        await app4.shutdown()
+    assert 0x0011 in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    assert "physical_env" in dev.endpoints[3].in_clusters[0].unsupported_attributes
+    await app4.shutdown()
 
 
 @patch.object(Device, "schedule_initialize", new=mock_dev_init(True))

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -860,16 +860,13 @@ async def test_configure_reporting_multiple_single_fail(cluster):
     assert cluster.unsupported_attributes == {"hw_version", 3}
 
     cluster.endpoint.request.return_value = _mk_cfg_rsp(
-        {
-            3: zcl.foundation.Status.SUCCESS,
-            4: zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE,
-        }
+        {3: zcl.foundation.Status.SUCCESS}
     )
     await cluster.configure_reporting_multiple(
         {3: (5, 15, 20), 4: (6, 16, 26)}, manufacturer=0x2345
     )
     assert cluster.endpoint.request.await_count == 2
-    assert cluster.unsupported_attributes == {"manufacturer", 4}
+    assert cluster.unsupported_attributes == set()
 
 
 async def test_configure_reporting_multiple_single_unreportable(cluster):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -859,6 +859,18 @@ async def test_configure_reporting_multiple_single_fail(cluster):
     assert cluster.endpoint.request.await_count == 1
     assert cluster.unsupported_attributes == {"hw_version", 3}
 
+    cluster.endpoint.request.return_value = _mk_cfg_rsp(
+        {
+            3: zcl.foundation.Status.SUCCESS,
+            4: zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE,
+        }
+    )
+    await cluster.configure_reporting_multiple(
+        {3: (5, 15, 20), 4: (6, 16, 26)}, manufacturer=0x2345
+    )
+    assert cluster.endpoint.request.await_count == 2
+    assert cluster.unsupported_attributes == {"manufacturer", 4}
+
 
 async def test_configure_reporting_multiple_single_unreportable(cluster):
     """Configure reporting returned a single failure response for unreportable attribute."""
@@ -887,6 +899,19 @@ async def test_configure_reporting_multiple_both_unsupp(cluster):
     )
     assert cluster.endpoint.request.await_count == 1
     assert cluster.unsupported_attributes == {"hw_version", 3, "manufacturer", 4}
+
+    cluster.endpoint.request.return_value = _mk_cfg_rsp(
+        {
+            3: zcl.foundation.Status.SUCCESS,
+            4: zcl.foundation.Status.SUCCESS,
+        }
+    )
+
+    await cluster.configure_reporting_multiple(
+        {3: (5, 15, 20), 4: (6, 16, 26)}, manufacturer=0x2345
+    )
+    assert cluster.endpoint.request.await_count == 2
+    assert cluster.unsupported_attributes == set()
 
 
 def test_unsupported_attr_add(cluster):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -920,6 +920,50 @@ def test_unsupported_attr_add_no_reverse_attr_name(cluster):
     assert 0xDEED in cluster.unsupported_attributes
 
 
+def test_unsupported_attr_remove(cluster):
+    """Test removing unsupported attributes."""
+
+    assert "manufacturer" not in cluster.unsupported_attributes
+    assert 4 not in cluster.unsupported_attributes
+    assert "model" not in cluster.unsupported_attributes
+    assert 5 not in cluster.unsupported_attributes
+
+    cluster.add_unsupported_attribute(4)
+    assert "manufacturer" in cluster.unsupported_attributes
+    assert 4 in cluster.unsupported_attributes
+
+    cluster.add_unsupported_attribute("model")
+    assert "model" in cluster.unsupported_attributes
+    assert 5 in cluster.unsupported_attributes
+
+    cluster.remove_unsupported_attribute(4)
+    assert "manufacturer" not in cluster.unsupported_attributes
+    assert 4 not in cluster.unsupported_attributes
+
+    cluster.remove_unsupported_attribute("model")
+    assert "model" not in cluster.unsupported_attributes
+    assert 5 not in cluster.unsupported_attributes
+
+
+def test_unsupported_attr_remove_no_reverse_attr_name(cluster):
+    """Test removing unsupported attributes without corresponding reverse attr name."""
+
+    assert "no_such_attr" not in cluster.unsupported_attributes
+    assert 0xDEED not in cluster.unsupported_attributes
+
+    cluster.add_unsupported_attribute("no_such_attr")
+    assert "no_such_attr" in cluster.unsupported_attributes
+
+    cluster.add_unsupported_attribute(0xDEED)
+    assert 0xDEED in cluster.unsupported_attributes
+
+    cluster.remove_unsupported_attribute("no_such_attr")
+    assert "no_such_attr" not in cluster.unsupported_attributes
+
+    cluster.remove_unsupported_attribute(0xDEED)
+    assert 0xDEED not in cluster.unsupported_attributes
+
+
 def test_zcl_command_duplicate_name_prevention():
     assert 0x1234 not in zcl.clusters.CLUSTERS_BY_ID
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -270,8 +270,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def attribute_updated(
         self, cluster: zigpy.typing.ClusterType, attrid: int, value: Any
     ) -> None:
-        if not cluster.endpoint.device.is_initialized:
-            return
 
         self.enqueue(
             "_save_attribute",
@@ -285,8 +283,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def unsupported_attribute_added(
         self, cluster: zigpy.typing.ClusterType, attrid: int
     ) -> None:
-        if not cluster.endpoint.device.is_initialized:
-            return
 
         self.enqueue(
             "_unsupported_attribute_added",
@@ -308,8 +304,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def unsupported_attribute_removed(
         self, cluster: zigpy.typing.ClusterType, attrid: int
     ) -> None:
-        if not cluster.endpoint.device.is_initialized:
-            return
 
         self.enqueue(
             "_unsupported_attribute_removed",

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -304,7 +304,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                    DO NOTHING"""
         await self.execute(q, (ieee, endpoint_id, cluster_id, attrid))
         await self._db.commit()
-    
+
     def unsupported_attribute_removed(
         self, cluster: zigpy.typing.ClusterType, attrid: int
     ) -> None:

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -304,6 +304,30 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                    DO NOTHING"""
         await self.execute(q, (ieee, endpoint_id, cluster_id, attrid))
         await self._db.commit()
+    
+    def unsupported_attribute_removed(
+        self, cluster: zigpy.typing.ClusterType, attrid: int
+    ) -> None:
+        if not cluster.endpoint.device.is_initialized:
+            return
+
+        self.enqueue(
+            "_unsupported_attribute_removed",
+            cluster.endpoint.device.ieee,
+            cluster.endpoint.endpoint_id,
+            cluster.cluster_id,
+            attrid,
+        )
+
+    async def _unsupported_attribute_removed(
+        self, ieee: t.EUI64, endpoint_id: int, cluster_id: int, attrid: int
+    ) -> None:
+        q = f"""DELETE FROM unsupported_attributes{DB_V} WHERE ieee = ?
+                                                         AND endpoint_id = ?
+                                                         AND cluster = ?
+                                                         AND attrid = ?"""
+        await self.execute(q, (ieee, endpoint_id, cluster_id, attrid))
+        await self._db.commit()
 
     def neighbors_updated(self, neighbors: zigpy.neighbor.Neighbors) -> None:
         """Neighbor update from ZDO_Lqi_rsp."""

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -635,9 +635,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             {attribute: (min_interval, max_interval, reportable_change)},
             manufacturer=manufacturer,
         )
-        for res in response:
-            if res.status == foundation.Status.SUCCESS:
-                self.remove_unsupported_attribute(res.attrid)
         return response
 
     async def configure_reporting_multiple(
@@ -684,6 +681,10 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             ]
             for attr in success:
                 self.remove_unsupported_attribute(attr)
+        elif isinstance(records, list) and (
+            len(records) == 1 and records[0].status == foundation.Status.SUCCESS
+        ):
+            self.remove_unsupported_attribute(records[0].attrid)
         return res
 
     def command(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -631,10 +631,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         manufacturer: int | None = None,
     ) -> list[foundation.ConfigureReportingResponseRecord]:
         """Configure attribute reporting for a single attribute."""
-        return await self.configure_reporting_multiple(
+        response = await self.configure_reporting_multiple(
             {attribute: (min_interval, max_interval, reportable_change)},
             manufacturer=manufacturer,
         )
+        for res in response:
+            if res.status == foundation.Status.SUCCESS:
+                self.remove_unsupported_attribute(res.attrid)
+        return response
 
     async def configure_reporting_multiple(
         self,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -686,7 +686,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         ):
             # we get a single success when all are supported
             for attr in attributes.keys():
-                self.remove_unsupported_attribute(records[0].attrid)
+                self.remove_unsupported_attribute(attr)
         return res
 
     def command(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -684,7 +684,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         elif isinstance(records, list) and (
             len(records) == 1 and records[0].status == foundation.Status.SUCCESS
         ):
-            self.remove_unsupported_attribute(records[0].attrid)
+            # we get a single success when all are supported
+            for attr in attributes.keys():
+                self.remove_unsupported_attribute(records[0].attrid)
         return res
 
     def command(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -676,9 +676,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 self.add_unsupported_attribute(attr)
 
             success = [
-                r.attrid
-                for r in records
-                if r.status == foundation.Status.SUCCESS
+                r.attrid for r in records if r.status == foundation.Status.SUCCESS
             ]
             for attr in success:
                 self.remove_unsupported_attribute(attr)
@@ -897,7 +895,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 self.add_unsupported_attribute(attrdef.name, inhibit_events)
             else:
                 self.add_unsupported_attribute(attrdef.id, inhibit_events)
-    
+
     def remove_unsupported_attribute(
         self, attr: int | str, inhibit_events: bool = False
     ) -> None:
@@ -939,7 +937,7 @@ class ClusterPersistingListener:
     def unsupported_attribute_added(self, attrid: int) -> None:
         """An unsupported attribute was added."""
         self._applistener.unsupported_attribute_added(self._cluster, attrid)
-    
+
     def unsupported_attribute_removed(self, attrid: int) -> None:
         """Remove an unsupported attribute."""
         self._applistener.unsupported_attribute_removed(self._cluster, attrid)


### PR DESCRIPTION
This PR removes unsupported attributes if they become supported in the future. This can be from a firmware update or a quirk update etc. 

~~@puddly let me know if you want to do this differently. I think I covered everything. I have an outstanding note in one of the tests for something that is a bit confusing.~~