### PR TITLE
Updates to the Inovelli OTA config

### DIFF
--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -131,8 +131,7 @@ class OTA(zigpy.util.ListenableMixin):
     ) -> Optional[CachedImage]:
         if manufacturer_id in (
             zigpy.ota.provider.Salus.MANUFACTURER_ID,
-            zigpy.ota.provider.Inovelli.MANUFACTURER_ID,
-        ):  # Salus/computime/Inovelli do not pass a useful image_type
+        ):  # Salus/computime do not pass a useful image_type
             # in the message from the device. So construct key based on model name.
             key = ImageKey(manufacturer_id, model)
         else:

--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -630,8 +630,7 @@ class INOVELLIImage:
     @classmethod
     def new(cls, data):
         res = cls(
-            manufacturer_id=Inovelli.MANUFACTURER_ID,
-            image_type=data["image_type"]
+            manufacturer_id=Inovelli.MANUFACTURER_ID, image_type=data["image_type"]
         )
         res.version = int(data["version"], 16)
         res.url = data["firmware"]


### PR DESCRIPTION
Updates as Inovelli has added the image_type and manufacturer_id fields to their firmware.json file. This removes the workaround present using the model instead of the image_type and enables users to push firmware both locally and direct from Inovelli.