### PR TITLE
Remove ZHA `neighbors` compatibility object

### DIFF
--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -87,8 +87,8 @@ async def test_migration_from_3_to_4(open_twice, test_db):
         maximum_outgoing_transfer_size=82,
         descriptor_capability_field=0,
     )
-    assert len(dev1.neighbors) == 1
-    assert dev1.neighbors[0].neighbor == zdo_t.Neighbor(
+    assert len(app.topology.neighbors[dev1.ieee]) == 1
+    assert app.topology.neighbors[dev1.ieee][0] == zdo_t.Neighbor(
         extended_pan_id=t.ExtendedPanId.convert("81:b1:12:dc:9f:bd:f4:b6"),
         ieee=t.EUI64.convert("ec:1b:bd:ff:fe:54:4f:40"),
         nwk=0x6D1C,
@@ -104,8 +104,8 @@ async def test_migration_from_3_to_4(open_twice, test_db):
 
     dev2 = app.get_device(nwk=0x6D1C)
     assert dev2.node_desc == dev1.node_desc.replace(manufacturer_code=4456)
-    assert len(dev2.neighbors) == 1
-    assert dev2.neighbors[0].neighbor == zdo_t.Neighbor(
+    assert len(app.topology.neighbors[dev2.ieee]) == 1
+    assert app.topology.neighbors[dev2.ieee][0] == zdo_t.Neighbor(
         extended_pan_id=t.ExtendedPanId.convert("81:b1:12:dc:9f:bd:f4:b6"),
         ieee=t.EUI64.convert("00:0d:6f:ff:fe:a6:11:7a"),
         nwk=0xBD4D,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -405,7 +405,6 @@ def _devices(index):
     dev = MagicMock()
     dev.ieee = zigpy.types.EUI64(zigpy.types.uint64_t(start_ieee + index).serialize())
     dev.nwk = zigpy.types.NWK(start_nwk + index)
-    dev.neighbors = []
     dev.node_desc = zdo_t.NodeDescriptor(1, 64, 142, 4388, 82, 255, 0, 255, 0)
     dev.zdo = zigpy.zdo.ZDO(dev)
     return dev

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -45,13 +45,6 @@ class Status(enum.IntEnum):
     ENDPOINTS_INIT = 2
 
 
-class NeighborShim(typing.NamedTuple):
-    """Neighbor class for backwards compatibility."""
-
-    device: Device
-    neighbor: zdo_t.Neighbor
-
-
 class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     """A device on the network"""
 
@@ -78,16 +71,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         # Retained for backwards compatibility, will be removed in a future release
         self.status = Status.NEW
-
-    @property
-    def neighbors(self) -> list[NeighborShim]:
-        """
-        Backwards-compatible neighbors property.
-        """
-        return [
-            NeighborShim(device=self, neighbor=n)
-            for n in self._application.topology.neighbors[self.ieee]
-        ]
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
The `zigpy.neighbors` module is gone so ZHA will not be able to start up anyways and will need to be fixed.