### PR TITLE
Allow scanning the topology of specific devices

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -287,6 +287,21 @@ async def test_scan_end_device(topology, make_initialized_device) -> None:
         assert len(dev.zdo.Mgmt_Rtg_req.mock_calls) == 0
 
 
+async def test_scan_explicit_device(topology, make_initialized_device) -> None:
+    dev1 = make_initialized_device(topology._app)
+    dev2 = make_initialized_device(topology._app)
+
+    with patch_device_tables(dev1, neighbors=[], routes=[]):
+        with patch_device_tables(dev2, neighbors=[], routes=[]):
+            await topology.scan(devices=[dev2])
+
+            # Only the second device was scanned
+            assert len(dev1.zdo.Mgmt_Lqi_req.mock_calls) == 0
+            assert len(dev1.zdo.Mgmt_Rtg_req.mock_calls) == 0
+            assert len(dev2.zdo.Mgmt_Lqi_req.mock_calls) == 1
+            assert len(dev2.zdo.Mgmt_Rtg_req.mock_calls) == 1
+
+
 async def test_scan_router_many(topology, make_initialized_device) -> None:
     dev = make_initialized_device(topology._app)
 
@@ -404,7 +419,7 @@ async def test_scan_start_concurrent(mock_scan, topology):
     concurrency = 0
     max_concurrency = 0
 
-    async def _scan():
+    async def _scan(_):
         nonlocal concurrency
         nonlocal max_concurrency
 
@@ -460,7 +475,7 @@ async def test_periodic_scan_failure(mock_scan, topology):
 
 
 async def test_periodic_scan_priority(topology):
-    async def _scan():
+    async def _scan(_):
         await asyncio.sleep(0.5)
 
     with mock.patch.object(topology, "_scan", side_effect=_scan) as mock_scan:

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -347,6 +347,7 @@ async def test_scan_coordinator(topology) -> None:
     app.config[conf.CONF_TOPO_SKIP_COORDINATOR] = False
 
     coordinator = app._device
+    coordinator.node_desc.logical_type = zdo_t.LogicalType.Coordinator
     assert coordinator.nwk == 0x0000
 
     with patch_device_tables(

--- a/zigpy/topology.py
+++ b/zigpy/topology.py
@@ -165,7 +165,9 @@ class Topology(zigpy.util.ListenableMixin):
             )
 
             # Ignore devices that aren't routers
-            if device.node_desc is None or not device.node_desc.is_router:
+            if device.node_desc is None or not (
+                device.node_desc.is_router or device.node_desc.is_coordinator
+            ):
                 continue
 
             # Ignore devices that do not support scanning tables


### PR DESCRIPTION
https://github.com/zigpy/zigpy/pull/1099 removed a feature required by zigpy-deconz