### PR TITLE
Fix device end device removal error with new topology code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ ignore =
     E203,
     E501,
     W503
+per-file-ignores =
+    tests/*.py:F811
 
 [isort]
 profile = black

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 """Common fixtures."""
+from __future__ import annotations
+
 import copy
 import logging
 import typing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Common fixtures."""
 import logging
+import typing
 from unittest.mock import Mock, patch
 
 import pytest
@@ -11,6 +12,10 @@ import zigpy.types as t
 import zigpy.zdo.types as zdo_t
 
 from .async_mock import MagicMock
+
+if typing.TYPE_CHECKING:
+    import zigpy.device
+
 
 NCP_IEEE = t.EUI64.convert("aa:11:22:bb:33:44:be:ef")
 
@@ -95,3 +100,104 @@ def app_mock():
     patch.object(app, "send_packet", MagicMock())
 
     return app
+
+
+def make_ieee(start=0):
+    return t.EUI64(map(t.uint8_t, range(start, start + 8)))
+
+
+def make_node_desc(
+    *, logical_type: zdo_t.LogicalType = zdo_t.LogicalType.Router
+) -> zdo_t.NodeDescriptor:
+    return zdo_t.NodeDescriptor(
+        logical_type=logical_type,
+        complex_descriptor_available=0,
+        user_descriptor_available=0,
+        reserved=0,
+        aps_flags=0,
+        frequency_band=zdo_t.NodeDescriptor.FrequencyBand.Freq2400MHz,
+        mac_capability_flags=zdo_t.NodeDescriptor.MACCapabilityFlags.AllocateAddress,
+        manufacturer_code=4174,
+        maximum_buffer_size=82,
+        maximum_incoming_transfer_size=82,
+        server_mask=0,
+        maximum_outgoing_transfer_size=82,
+        descriptor_capability_field=zdo_t.NodeDescriptor.DescriptorCapability.NONE,
+    )
+
+
+@pytest.fixture
+def make_initialized_device():
+    count = 1
+
+    def inner(app):
+        nonlocal count
+
+        dev = app.add_device(nwk=0x1000 + count, ieee=make_ieee(count))
+        dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+
+        ep = dev.add_endpoint(1)
+        ep.status = zigpy.endpoint.Status.ZDO_INIT
+        ep.profile_id = 260
+        ep.device_type = zigpy.profiles.zha.DeviceType.PUMP
+
+        count += 1
+
+        return dev
+
+    return inner
+
+
+def make_neighbor(
+    *,
+    ieee: t.EUI64,
+    nwk: t.NWK,
+    device_type: zdo_t.Neighbor.DeviceType = zdo_t.Neighbor.DeviceType.Router,
+    rx_on_when_idle=True,
+    relationship: zdo_t.Neighbor.Relationship = zdo_t.Neighbor.Relationship.Child,
+) -> zdo_t.Neighbor:
+    return zdo_t.Neighbor(
+        extended_pan_id=make_ieee(start=0),
+        ieee=ieee,
+        nwk=nwk,
+        device_type=device_type,
+        rx_on_when_idle=int(rx_on_when_idle),
+        relationship=relationship,
+        reserved1=0,
+        permit_joining=0,
+        reserved2=0,
+        depth=15,
+        lqi=250,
+    )
+
+
+def make_neighbor_from_device(
+    device: zigpy.device.Device,
+    *,
+    relationship: zdo_t.Neighbor.Relationship = zdo_t.Neighbor.Relationship.Child,
+):
+    assert device.node_desc is not None
+    return make_neighbor(
+        ieee=device.ieee,
+        nwk=device.nwk,
+        device_type=zdo_t.Neighbor.DeviceType(int(device.node_desc.logical_type)),
+        rx_on_when_idle=device.node_desc.is_receiver_on_when_idle,
+        relationship=relationship,
+    )
+
+
+def make_route(
+    *,
+    dest_nwk: t.NWK,
+    next_hop: t.NWK,
+    status: zdo_t.RouteStatus = zdo_t.RouteStatus.Active,
+) -> zdo_t.Route:
+    return zdo_t.Route(
+        DstNWK=dest_nwk,
+        RouteStatus=status,
+        MemoryConstrained=0,
+        ManyToOne=0,
+        RouteRecordRequired=0,
+        Reserved=0,
+        NextHop=next_hop,
+    )

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -25,10 +25,8 @@ from zigpy.zcl.foundation import Status as ZCLStatus
 from zigpy.zdo import types as zdo_t
 
 from tests.async_mock import AsyncMock, MagicMock, patch
-from tests.conftest import App
-from tests.test_backups import (  # noqa: F401; pylint: disable=unused-variable
-    backup_factory,
-)
+from tests.conftest import App, make_ieee
+from tests.test_backups import backup_factory  # noqa: F401
 
 
 @pytest.fixture(autouse=True)
@@ -67,10 +65,6 @@ async def make_app(database_file):
             )
         )
     return app
-
-
-def make_ieee(start=0):
-    return t.EUI64(map(t.uint8_t, range(start, start + 8)))
 
 
 class FakeCustomDevice(CustomDevice):

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -12,7 +12,8 @@ import zigpy.types as t
 from zigpy.zdo import types as zdo_t
 
 from tests.async_mock import AsyncMock, MagicMock, patch
-from tests.test_appdb import app, auto_kill_aiosqlite, make_app  # noqa: F401
+from tests.conftest import app  # noqa: F401
+from tests.test_appdb import auto_kill_aiosqlite, make_app  # noqa: F401
 
 
 @pytest.fixture

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -12,7 +12,7 @@ import zigpy.types as t
 from zigpy.zdo import types as zdo_t
 
 from tests.async_mock import AsyncMock, MagicMock, patch
-from tests.test_appdb import auto_kill_aiosqlite, make_app  # noqa: F401
+from tests.test_appdb import app, auto_kill_aiosqlite, make_app  # noqa: F401
 
 
 @pytest.fixture
@@ -454,8 +454,7 @@ async def test_v5_to_v7_migration(test_db):
     await app.shutdown()
 
 
-async def test_migration_missing_tables():
-    app = MagicMock()
+async def test_migration_missing_tables(app):
     conn = MagicMock()
     conn.close = AsyncMock()
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -777,7 +777,6 @@ def packet(app, device):
 
 
 async def test_request(app, device, packet):
-    app.send_packet = AsyncMock(spec_set=app.send_packet)
     app.build_source_route_to = MagicMock(spec_set=app.build_source_route_to)
 
     async def send_request(app, **kwargs):
@@ -853,7 +852,6 @@ def test_build_source_route_no_relays(app):
 
 
 async def test_send_mrequest(app, packet):
-    app.send_packet = AsyncMock(spec_set=app.send_packet)
 
     status, msg = await app.mrequest(
         group_id=0xABCD,
@@ -880,7 +878,6 @@ async def test_send_mrequest(app, packet):
 
 
 async def test_send_broadcast(app, packet):
-    app.send_packet = AsyncMock(spec_set=app.send_packet)
 
     status, msg = await app.broadcast(
         profile=0x1234,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -23,6 +23,7 @@ from .conftest import (
     App,
     make_app,
     make_ieee,
+    make_neighbor,
     make_neighbor_from_device,
     make_node_desc,
 )
@@ -403,6 +404,7 @@ async def test_remove_parent_devices(app, make_initialized_device):
         make_neighbor_from_device(router_2),
         make_neighbor_from_device(router_1),
         make_neighbor_from_device(end_device),
+        make_neighbor(ieee=make_ieee(123), nwk=0x9876),
     ]
 
     p1 = patch.object(end_device.zdo, "leave", AsyncMock())

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -9,6 +9,7 @@ import zigpy.types as t
 import zigpy.zdo.types as zdo_t
 
 from tests.async_mock import AsyncMock
+from tests.conftest import app  # noqa: F401
 
 
 @pytest.fixture
@@ -327,8 +328,7 @@ async def test_add_backup(backup_factory):
     assert backups.backups == [backup4, backup5]
 
 
-async def test_restore_backup_create_new(backup):
-    app = AsyncMock()
+async def test_restore_backup_create_new(app, backup):
     backups = zigpy.backups.BackupManager(app)
     backups.create_backup = AsyncMock()
 
@@ -336,7 +336,7 @@ async def test_restore_backup_create_new(backup):
     app.write_network_info.assert_called_once()
     backups.create_backup.assert_called_once()
 
-    app.reset_mock()
+    app.write_network_info.reset_mock()
     backups.create_backup.reset_mock()
 
     await backups.restore_backup(backup, create_new=False)

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -14,96 +14,13 @@ import zigpy.topology
 import zigpy.types as t
 import zigpy.zdo.types as zdo_t
 
-from tests.conftest import App
-from tests.test_appdb import make_ieee
+from tests.conftest import App, make_ieee, make_neighbor, make_route
 
 
 @pytest.fixture(autouse=True)
 def remove_request_delay():
     with mock.patch("zigpy.topology.REQUEST_DELAY", new=(0, 0)):
         yield
-
-
-def make_neighbor(
-    *,
-    ieee: t.EUI64,
-    nwk: t.NWK,
-    device_type: zdo_t.Neighbor.DeviceType = zdo_t.Neighbor.DeviceType.Router,
-    rx_on_when_idle=True,
-    relationship: zdo_t.Neighbor.Relationship = zdo_t.Neighbor.Relationship.Child,
-) -> zdo_t.Neighbor:
-    return zdo_t.Neighbor(
-        extended_pan_id=make_ieee(start=0),
-        ieee=ieee,
-        nwk=nwk,
-        device_type=device_type,
-        rx_on_when_idle=int(rx_on_when_idle),
-        relationship=relationship,
-        reserved1=0,
-        permit_joining=0,
-        reserved2=0,
-        depth=15,
-        lqi=250,
-    )
-
-
-def make_route(
-    *,
-    dest_nwk: t.NWK,
-    next_hop: t.NWK,
-    status: zdo_t.RouteStatus = zdo_t.RouteStatus.Active,
-) -> zdo_t.Route:
-    return zdo_t.Route(
-        DstNWK=dest_nwk,
-        RouteStatus=status,
-        MemoryConstrained=0,
-        ManyToOne=0,
-        RouteRecordRequired=0,
-        Reserved=0,
-        NextHop=next_hop,
-    )
-
-
-def make_node_desc(
-    *, logical_type: zdo_t.LogicalType = zdo_t.LogicalType.Router
-) -> zdo_t.NodeDescriptor:
-    return zdo_t.NodeDescriptor(
-        logical_type=logical_type,
-        complex_descriptor_available=0,
-        user_descriptor_available=0,
-        reserved=0,
-        aps_flags=0,
-        frequency_band=zdo_t.NodeDescriptor.FrequencyBand.Freq2400MHz,
-        mac_capability_flags=zdo_t.NodeDescriptor.MACCapabilityFlags.AllocateAddress,
-        manufacturer_code=4174,
-        maximum_buffer_size=82,
-        maximum_incoming_transfer_size=82,
-        server_mask=0,
-        maximum_outgoing_transfer_size=82,
-        descriptor_capability_field=zdo_t.NodeDescriptor.DescriptorCapability.NONE,
-    )
-
-
-@pytest.fixture
-def make_initialized_device():
-    count = 1
-
-    def inner(app):
-        nonlocal count
-
-        dev = app.add_device(nwk=0x1000 + count, ieee=make_ieee(count))
-        dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
-
-        ep = dev.add_endpoint(1)
-        ep.status = zigpy.endpoint.Status.ZDO_INIT
-        ep.profile_id = 260
-        ep.device_type = zigpy.profiles.zha.DeviceType.PUMP
-
-        count += 1
-
-        return dev
-
-    return inner
 
 
 @pytest.fixture

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -21,12 +21,12 @@ def test_commands():
 
 
 @pytest.fixture
-def zdo_f(app_mock):
+def zdo_f(app):
     ieee = t.EUI64(map(t.uint8_t, [0, 1, 2, 3, 4, 5, 6, 7]))
-    dev = zigpy.device.Device(app_mock, ieee, 65535)
+    dev = zigpy.device.Device(app, ieee, 65535)
     dev.request = AsyncMock()
 
-    app_mock.devices[dev.ieee] = dev
+    app.devices[dev.ieee] = dev
 
     return zdo.ZDO(dev)
 
@@ -45,9 +45,9 @@ def test_deserialize_unknown(zdo_f):
 
 async def test_request(zdo_f):
     await zdo_f.request(2, 65535)
-    app_mock = zdo_f._device._application
+    app = zdo_f._device._application
     assert zdo_f.device.request.call_count == 1
-    assert app_mock.get_sequence.call_count == 1
+    assert app.get_sequence.call_count == 1
 
 
 async def test_bind(zdo_f):
@@ -93,12 +93,12 @@ async def test_permit(zdo_f):
     assert zdo_f.device.request.call_args[0][1] == 0x0036
 
 
-async def test_broadcast(app_mock):
-    await zigpy.zdo.broadcast(app_mock, 0x0036, 0, 0, 60, 0)
+async def test_broadcast(app):
+    await zigpy.zdo.broadcast(app, 0x0036, 0, 0, 60, 0)
 
-    assert app_mock.send_packet.call_count == 1
+    assert app.send_packet.call_count == 1
 
-    packet = app_mock.send_packet.mock_calls[0].args[0]
+    packet = app.send_packet.mock_calls[0].args[0]
     assert packet.dst.addr_mode == t.AddrMode.Broadcast
     assert packet.cluster_id == 0x0036
 


### PR DESCRIPTION
Unit tests were mocking too much of `Device` to actually catch this error.

I'd like to slowly start migrating unit tests to use fewer mocks and real objects (or at the very least `spec_set`).