### PR TITLE
Add big endian int types

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -12,6 +12,8 @@ def test_abstract_ints():
     assert not issubclass(t.uint8_t, t.int_t)
     assert t.int_t._signed is True
     assert t.uint_t._signed is False
+    assert t.int_t._bigendian is False
+    assert t.be_int_t._bigendian is True
 
     with pytest.raises(TypeError):
         t.int_t(0)
@@ -139,6 +141,18 @@ def test_ints_signed():
     n = t.int8s(-126)
     bits = [1, 0] + t.Bits.deserialize(n.serialize())[0]
     assert t.int8s.from_bits(bits) == (n, [1, 0])
+
+
+def test_bigendian_ints():
+    assert t.be_uint32_t(0x12345678).serialize() == b"\x12\x34\x56\x78"
+    assert t.be_uint32_t.deserialize(b"\x12\x34\x56\x78") == (0x12345678, b"")
+    assert t.be_int32s(0x12345678).serialize() == b"\x12\x34\x56\x78"
+    assert t.be_int32s(-1).serialize() == b"\xff\xff\xff\xff"
+    assert t.be_int32s.deserialize(b"\xfe\xdc\xba\x98") == (-0x01234568, b"")
+    assert (
+        t.be_uint32_t(0x12345678).serialize()[::-1]
+        == t.uint32_t(0x12345678).serialize()
+    )
 
 
 def test_bits():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -12,8 +12,8 @@ def test_abstract_ints():
     assert not issubclass(t.uint8_t, t.int_t)
     assert t.int_t._signed is True
     assert t.uint_t._signed is False
-    assert t.int_t._bigendian is False
-    assert t.be_int_t._bigendian is True
+    assert t.int_t._byteorder == "little"
+    assert t.int_t_be._byteorder == "big"
 
     with pytest.raises(TypeError):
         t.int_t(0)
@@ -144,13 +144,13 @@ def test_ints_signed():
 
 
 def test_bigendian_ints():
-    assert t.be_uint32_t(0x12345678).serialize() == b"\x12\x34\x56\x78"
-    assert t.be_uint32_t.deserialize(b"\x12\x34\x56\x78") == (0x12345678, b"")
-    assert t.be_int32s(0x12345678).serialize() == b"\x12\x34\x56\x78"
-    assert t.be_int32s(-1).serialize() == b"\xff\xff\xff\xff"
-    assert t.be_int32s.deserialize(b"\xfe\xdc\xba\x98") == (-0x01234568, b"")
+    assert t.uint32_t_be(0x12345678).serialize() == b"\x12\x34\x56\x78"
+    assert t.uint32_t_be.deserialize(b"\x12\x34\x56\x78") == (0x12345678, b"")
+    assert t.int32s_be(0x12345678).serialize() == b"\x12\x34\x56\x78"
+    assert t.int32s_be(-1).serialize() == b"\xff\xff\xff\xff"
+    assert t.int32s_be.deserialize(b"\xfe\xdc\xba\x98") == (-0x01234568, b"")
     assert (
-        t.be_uint32_t(0x12345678).serialize()[::-1]
+        t.uint32_t_be(0x12345678).serialize()[::-1]
         == t.uint32_t(0x12345678).serialize()
     )
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -81,7 +81,7 @@ class FixedIntType(int):
     _signed = None
     _bits = None
     _size = None  # Only for backwards compatibility, not set for smaller ints
-    _bigendian = None
+    _byteorder = None
 
     min_value: int
     max_value: int
@@ -108,7 +108,7 @@ class FixedIntType(int):
         return f"0b{{:0{self._bits}b}}".format(int(self))
 
     def __init_subclass__(
-        cls, signed=NOT_SET, bits=NOT_SET, repr=NOT_SET, bigendian=NOT_SET
+        cls, signed=NOT_SET, bits=NOT_SET, repr=NOT_SET, byteorder=NOT_SET
     ) -> None:
         super().__init_subclass__()
 
@@ -142,8 +142,8 @@ class FixedIntType(int):
         elif repr is not NOT_SET:
             raise ValueError(f"Invalid repr value {repr!r}. Must be either hex or bin")
 
-        if bigendian is not NOT_SET:
-            cls._bigendian = bigendian
+        if byteorder is not NOT_SET:
+            cls._byteorder = byteorder
 
         # XXX: The enum module uses the first class with __new__ in its __dict__ as the
         #      member type. We have to ensure this is true for every subclass.
@@ -177,9 +177,7 @@ class FixedIntType(int):
         if self._bits % 8 != 0:
             raise TypeError(f"Integer type with {self._bits} bits is not byte aligned")
 
-        return self.to_bytes(
-            self._bits // 8, "big" if self._bigendian else "little", signed=self._signed
-        )
+        return self.to_bytes(self._bits // 8, self._byteorder, signed=self._signed)
 
     @classmethod
     def deserialize(cls, data: bytes) -> tuple[FixedIntType, bytes]:
@@ -191,18 +189,16 @@ class FixedIntType(int):
         if len(data) < byte_size:
             raise ValueError(f"Data is too short to contain {byte_size} bytes")
 
-        r = cls.from_bytes(
-            data[:byte_size], "big" if cls._bigendian else "little", signed=cls._signed
-        )
+        r = cls.from_bytes(data[:byte_size], cls._byteorder, signed=cls._signed)
         data = data[byte_size:]
         return r, data
 
 
-class uint_t(FixedIntType, signed=False, bigendian=False):
+class uint_t(FixedIntType, signed=False, byteorder="little"):
     pass
 
 
-class int_t(FixedIntType, signed=True, bigendian=False):
+class int_t(FixedIntType, signed=True, byteorder="little"):
     pass
 
 
@@ -298,67 +294,67 @@ class uint64_t(uint_t, bits=64):
     pass
 
 
-class be_uint_t(FixedIntType, signed=False, bigendian=True):
+class uint_t_be(FixedIntType, signed=False, byteorder="big"):
     pass
 
 
-class be_int_t(FixedIntType, signed=True, bigendian=True):
+class int_t_be(FixedIntType, signed=True, byteorder="big"):
     pass
 
 
-class be_int16s(be_int_t, bits=16):
+class int16s_be(int_t_be, bits=16):
     pass
 
 
-class be_int24s(be_int_t, bits=24):
+class int24s_be(int_t_be, bits=24):
     pass
 
 
-class be_int32s(be_int_t, bits=32):
+class int32s_be(int_t_be, bits=32):
     pass
 
 
-class be_int40s(be_int_t, bits=40):
+class int40s_be(int_t_be, bits=40):
     pass
 
 
-class be_int48s(be_int_t, bits=48):
+class int48s_be(int_t_be, bits=48):
     pass
 
 
-class be_int56s(be_int_t, bits=56):
+class int56s_be(int_t_be, bits=56):
     pass
 
 
-class be_int64s(be_int_t, bits=64):
+class int64s_be(int_t_be, bits=64):
     pass
 
 
-class be_uint16_t(be_uint_t, bits=16):
+class uint16_t_be(uint_t_be, bits=16):
     pass
 
 
-class be_uint24_t(be_uint_t, bits=24):
+class uint24_t_be(uint_t_be, bits=24):
     pass
 
 
-class be_uint32_t(be_uint_t, bits=32):
+class uint32_t_be(uint_t_be, bits=32):
     pass
 
 
-class be_uint40_t(be_uint_t, bits=40):
+class uint40_t_be(uint_t_be, bits=40):
     pass
 
 
-class be_uint48_t(be_uint_t, bits=48):
+class uint48_t_be(uint_t_be, bits=48):
     pass
 
 
-class be_uint56_t(be_uint_t, bits=56):
+class uint56_t_be(uint_t_be, bits=56):
     pass
 
 
-class be_uint64_t(be_uint_t, bits=64):
+class uint64_t_be(uint_t_be, bits=64):
     pass
 
 
@@ -470,11 +466,11 @@ class enum32(enum_factory(uint32_t)):  # noqa: N801
     pass
 
 
-class be_enum16(enum_factory(be_uint16_t)):  # noqa: N801
+class enum16_be(enum_factory(uint16_t_be)):  # noqa: N801
     pass
 
 
-class be_enum32(enum_factory(be_uint32_t)):  # noqa: N801
+class enum32_be(enum_factory(uint32_t_be)):  # noqa: N801
     pass
 
 
@@ -534,31 +530,31 @@ class bitmap64(bitmap_factory(uint64_t)):
     pass
 
 
-class be_bitmap16(bitmap_factory(be_uint16_t)):
+class bitmap16_be(bitmap_factory(uint16_t_be)):
     pass
 
 
-class be_bitmap24(bitmap_factory(be_uint24_t)):
+class bitmap24_be(bitmap_factory(uint24_t_be)):
     pass
 
 
-class be_bitmap32(bitmap_factory(be_uint32_t)):
+class bitmap32_be(bitmap_factory(uint32_t_be)):
     pass
 
 
-class be_bitmap40(bitmap_factory(be_uint40_t)):
+class bitmap40_be(bitmap_factory(uint40_t_be)):
     pass
 
 
-class be_bitmap48(bitmap_factory(be_uint48_t)):
+class bitmap48_be(bitmap_factory(uint48_t_be)):
     pass
 
 
-class be_bitmap56(bitmap_factory(be_uint56_t)):
+class bitmap56_be(bitmap_factory(uint56_t_be)):
     pass
 
 
-class be_bitmap64(bitmap_factory(be_uint64_t)):
+class bitmap64_be(bitmap_factory(uint64_t_be)):
     pass
 
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -144,6 +144,8 @@ class FixedIntType(int):
 
         if byteorder is not NOT_SET:
             cls._byteorder = byteorder
+        elif cls._byteorder is None:
+            cls._byteorder = "little"
 
         # XXX: The enum module uses the first class with __new__ in its __dict__ as the
         #      member type. We have to ensure this is true for every subclass.
@@ -194,11 +196,11 @@ class FixedIntType(int):
         return r, data
 
 
-class uint_t(FixedIntType, signed=False, byteorder="little"):
+class uint_t(FixedIntType, signed=False):
     pass
 
 
-class int_t(FixedIntType, signed=True, byteorder="little"):
+class int_t(FixedIntType, signed=True):
     pass
 
 


### PR DESCRIPTION
There are several places where we can replace workarounds and reimplementations with a central implementation of big endian types.
[Example1](https://github.com/zigpy/zha-device-handlers/blob/31245e0e3643c5011be849a4ebbda39a5eb379e6/zhaquirks/tuya/__init__.py#L129)
[Example2](https://github.com/zigpy/zha-device-handlers/blob/790c90b2bf490345d959776abaa03abb515da785/zhaquirks/xiaomi/aqara/feeder_acn001.py#L148)
[Example3](https://github.com/zigpy/zigpy-xbee/blob/dev/zigpy_xbee/types.py#L33)