### PR TITLE
Update python version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ To setup a development environment, fork the repository and create a virtual env
 ```shell
 $ git clone git@github.com:youruser/zigpy.git
 $ cd zigpy
-$ virtualenv -p python3.7 venv
+$ virtualenv -p python3.8 venv
 $ source venv/bin/activate
 (venv) $ pip install --upgrade pip pre-commit tox
 (venv) $ pre-commit install            # install pre-commit as a Git hook


### PR DESCRIPTION
The Python version 3.7 in the example results in an error.

````
$ pip install -e '.[testing]'
...
ERROR: Package 'zigpy' requires a different Python: 3.7.16 not in '>=3.8'
````

Updating to 3.8 resolves this.