### PR TITLE
Return `UNKNOWN` as a validation result for unknown OTA image types

### DIFF
--- a/tests/test_ota_validators.py
+++ b/tests/test_ota_validators.py
@@ -222,6 +222,12 @@ def test_validate_ota_image_empty():
     assert validators.validate_ota_image(image) == ValidationResult.UNKNOWN
 
 
+def test_check_invalid_unknown():
+    image = mock.Mock()
+
+    assert validators.validate_ota_image(image) == ValidationResult.UNKNOWN
+
+
 def test_check_invalid():
     image = OTAImage()
 
@@ -236,12 +242,3 @@ def test_check_invalid():
     with mock.patch("zigpy.ota.validators.validate_ota_image") as m:
         m.side_effect = [ValidationError("error")]
         assert validators.check_invalid(image)
-
-
-def test_check_invalid_special():
-    image = mock.Mock()
-
-    # Unknown OTA image containers are not checked
-    with mock.patch("zigpy.ota.validators.validate_ota_image") as m:
-        assert not validators.check_invalid(image)
-        assert m.call_count == 0

--- a/zigpy/ota/validators.py
+++ b/zigpy/ota/validators.py
@@ -129,11 +129,14 @@ def validate_firmware(data: bytes) -> ValidationResult:
     return ValidationResult.VALID
 
 
-def validate_ota_image(image: OTAImage) -> ValidationResult:
+def validate_ota_image(image: BaseOTAImage) -> ValidationResult:
     """
     Validates a Zigbee OTA image's embedded firmwares and indicates if an image is
     valid, invalid, or of an unknown type.
     """
+
+    if not isinstance(image, OTAImage):
+        return ValidationResult.UNKNOWN
 
     results = []
 
@@ -151,9 +154,6 @@ def check_invalid(image: BaseOTAImage) -> bool:
     """
     Checks if an image is invalid or not. Unknown image types are considered valid.
     """
-
-    if not isinstance(image, OTAImage):
-        return False
 
     try:
         validate_ota_image(image)


### PR DESCRIPTION
Allows for `validate_ota_image` to be used to "validate" Hue OTA images.

The firmware itself is fully encrypted so it can't actually be validated.