### PR TITLE
Raise a useful exception on transient connection errors

### DIFF
--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -26,6 +26,10 @@ class RadioException(Exception):
     """Base exception class for radio exceptions"""
 
 
+class TransientConnectionError(RadioException):
+    """Connection to the radio failed but will likely succeed in the near future"""
+
+
 class NetworkNotFormed(RadioException):
     """A network cannot be started because the radio has no stored network info"""
 


### PR DESCRIPTION
Raises `TransientConnectionError` for errors that likely will resolve themselves after retrying (currently just `ENETUNREACH`). 

https://github.com/home-assistant/core/pull/84615