### PR TITLE
Fail loading the database when table suffixes aren't consistent with `user_version`

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -859,7 +859,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                             pass
                         else:
                             raise ValueError(
-                                f"Invalid value for `errors`: {errors}!r"
+                                f"Invalid value for `errors`: {errors!r}"
                             )  # noqa
 
     async def _migrate_to_v4(self):

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -733,7 +733,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         for dev in self._application.devices.values():
             dev.add_context_listener(self)
 
-    async def _get_table_versions(self) -> dict[str, str]:
+    async def _get_table_versions(self) -> dict[str, int]:
         tables = {}
 
         async with self.execute(
@@ -748,7 +748,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 match = DB_V_REGEX.search(name)
                 assert match is not None
 
-                tables[name] = match.group(0)
+                tables[name] = int(match.group(0)[2:] or "0")
 
         return tables
 

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -40,3 +40,7 @@ class FormationFailure(RadioException):
 
 class NetworkSettingsInconsistent(ZigbeeException):
     """Loaded network settings are different from what is in the database"""
+
+
+class CorruptDatabase(ZigbeeException):
+    """The SQLite database is corrupt or otherwise inconsistent"""


### PR DESCRIPTION
Basically, we now enforce `PRAGMA user_version = 12` and `devices_v12`. If they don't sync up, something is broken and we shouldn't let zigpy start up and break the database further.

There is a small chance of data loss if `user_version` is ever cleared. To ensure this doesn't happen, I think it is best to explicitly fail on startup when the versions are inconsistent.

Downgrades are still permitted so this will be a breaking change only for people using very corrupted databases.

---

Side note: should we similarly fail to start up when `PRAGMA integrity_check` fails? We currently log an error but I'm sure many people still run HA and ignore it. We would need a way to fix the database, though, and the method in https://github.com/zigpy/zigpy-cli#database isn't guaranteed to work (though has for everyone that has reported broken databases). I think this would be a useful thing to include as [a repair](https://www.home-assistant.io/integrations/repairs/).