### PR TITLE
Ensure ZCL command schemas do not directly use tuples

### DIFF
--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -675,6 +675,20 @@ def test_schema():
     assert issubclass(s.schema, tuple)
 
 
+def test_command_schema_error_on_tuple():
+    """Test schema throwing an exception when a tuple is passed instead of a dict."""
+
+    cmd_def = foundation.ZCLCommandDef(
+        id=0x12,
+        name="test",
+        schema=(t.uint16_t,),
+        direction=foundation.Direction.Server_to_Client,
+    )
+
+    with pytest.raises(ValueError):
+        cmd_def.with_compiled_schema()
+
+
 def test_zcl_attribute_definition():
     a = foundation.ZCLAttributeDef(
         id=0x1234,

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -680,8 +680,13 @@ class ZCLCommandDef:
         schema converted into a `CommandSchema` subclass.
         """
 
-        # If the schema is already a struct, do nothing
-        if not isinstance(self.schema, dict):
+        if isinstance(self.schema, tuple):
+            raise ValueError(
+                f"Tuple schemas are deprecated: {self.schema!r}. Use a dictionary or a"
+                f" Struct subclass."
+            )
+        elif not isinstance(self.schema, dict):
+            # If the schema is already a struct, do nothing
             self.schema.command = self
             return self
 


### PR DESCRIPTION
This catches `ZCLCommandDef` definitions that use tuples. This isn't supported.