### PR TITLE
Remove unnecessary `yarl` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ REQUIRES = [
     "voluptuous",
     'pyserial-asyncio; platform_system!="Windows"',
     'pyserial-asyncio!=0.5; platform_system=="Windows"',
-    "yarl",
 ]
 
 setup(

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -39,5 +39,7 @@ async def test_serial_socket(event_loop):
         )
 
         assert len(event_loop.create_connection.mock_calls) == 2
-        assert event_loop.create_connection.mock_calls[0].args[1:] == ("1.2.3.4", 5678)
-        assert event_loop.create_connection.mock_calls[1].args[1:] == ("1.2.3.4", 6638)
+        assert event_loop.create_connection.mock_calls[0].kwargs["host"] == "1.2.3.4"
+        assert event_loop.create_connection.mock_calls[0].kwargs["port"] == 5678
+        assert event_loop.create_connection.mock_calls[1].kwargs["host"] == "1.2.3.4"
+        assert event_loop.create_connection.mock_calls[1].kwargs["port"] == 6638


### PR DESCRIPTION
We can just use `urllib.parse.urlparse`.