### PR TITLE
Explicitly include `attrs` as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import find_packages, setup
 import zigpy
 
 REQUIRES = [
+    "attrs",
     "aiohttp",
     "aiosqlite>=0.16.0",
     "async_timeout",


### PR DESCRIPTION
It's currently only included implicitly by `aiohttp`, even though we directly import it.