### PR TITLE
0.53.1 Release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ REQUIRES = [
     "voluptuous",
     'pyserial-asyncio; platform_system!="Windows"',
     'pyserial-asyncio!=0.5; platform_system=="Windows"',
-    "yarl",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import find_packages, setup
 import zigpy
 
 REQUIRES = [
+    "attrs",
     "aiohttp",
     "aiosqlite>=0.16.0",
     "async_timeout",

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -39,5 +39,7 @@ async def test_serial_socket(event_loop):
         )
 
         assert len(event_loop.create_connection.mock_calls) == 2
-        assert event_loop.create_connection.mock_calls[0].args[1:] == ("1.2.3.4", 5678)
-        assert event_loop.create_connection.mock_calls[1].args[1:] == ("1.2.3.4", 6638)
+        assert event_loop.create_connection.mock_calls[0].kwargs["host"] == "1.2.3.4"
+        assert event_loop.create_connection.mock_calls[0].kwargs["port"] == 5678
+        assert event_loop.create_connection.mock_calls[1].kwargs["host"] == "1.2.3.4"
+        assert event_loop.create_connection.mock_calls[1].kwargs["port"] == 6638

--- a/zigpy/__init__.py
+++ b/zigpy/__init__.py
@@ -1,5 +1,5 @@
 MAJOR_VERSION = 0
-MINOR_VERSION = 53
+MINOR_VERSION = 54
 PATCH_VERSION = "0.dev0"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"

--- a/zigpy/__init__.py
+++ b/zigpy/__init__.py
@@ -1,5 +1,5 @@
 MAJOR_VERSION = 0
-MINOR_VERSION = 54
-PATCH_VERSION = "0.dev0"
+MINOR_VERSION = 53
+PATCH_VERSION = "1"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"


### PR DESCRIPTION
0.53.1 release

This release significantly simplifies packaging for https://github.com/NabuCasa/universal-silabs-flasher/pull/4, as yarl and aiohttp and its dependencies had no pure-Python wheels on PyPI. aiohttp isn't technically required to run zigpy but yarl was.