### PR TITLE
Bump pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
 
-  - repo: https://github.com/fsouza/autoflake8
-    rev: v0.3.2
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.0.1
     hooks:
-      - id: autoflake8
+      - id: autoflake
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
       - id: black
         args:
@@ -18,22 +18,22 @@ repos:
           - --quiet
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v0.991
     hooks:
       - id: mypy
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: codespell
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v0.982
     hooks:
       - id: mypy
         additional_dependencies:

--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -44,7 +44,7 @@ class _IntSentinelObject(int):
     __str__ = __reduce__ = __repr__
 
 
-class _IntSentinel(object):
+class _IntSentinel:
     def __init__(self):
         self._sentinels = {}
 

--- a/tests/ota_providers/test_ota_provider_inovelli.py
+++ b/tests/ota_providers/test_ota_provider_inovelli.py
@@ -201,7 +201,6 @@ async def test_inovelli_refresh_list_locked(
 
 @patch("aiohttp.ClientSession.get")
 async def test_inovelli_refresh_list_failed(mock_get, inovelli_prov):
-
     mock_get.return_value.__aenter__.return_value.json = AsyncMock(side_effect=[[]])
     mock_get.return_value.__aenter__.return_value.status = 434
     mock_get.return_value.__aenter__.return_value.reason = "UNK"

--- a/tests/ota_providers/test_ota_provider_ledvance.py
+++ b/tests/ota_providers/test_ota_provider_ledvance.py
@@ -202,7 +202,6 @@ async def test_ledvance_refresh_list_locked(
 
 @patch("aiohttp.ClientSession.get")
 async def test_ledvance_refresh_list_failed(mock_get, ledvance_prov):
-
     mock_get.return_value.__aenter__.return_value.json = AsyncMock(side_effect=[[]])
     mock_get.return_value.__aenter__.return_value.status = 434
     mock_get.return_value.__aenter__.return_value.reason = "UNK"

--- a/tests/ota_providers/test_ota_provider_salus.py
+++ b/tests/ota_providers/test_ota_provider_salus.py
@@ -145,7 +145,6 @@ async def test_salus_refresh_list_locked(
 
 @patch("aiohttp.ClientSession.get")
 async def test_salus_refresh_list_failed(mock_get, salus_prov):
-
     mock_get.return_value.__aenter__.return_value.json = AsyncMock(side_effect=[[]])
     mock_get.return_value.__aenter__.return_value.status = 434
     mock_get.return_value.__aenter__.return_value.reason = "UNK"

--- a/tests/ota_providers/test_ota_provider_sonoff.py
+++ b/tests/ota_providers/test_ota_provider_sonoff.py
@@ -130,7 +130,6 @@ async def test_sonoff_refresh_list_locked(
 
 @patch("aiohttp.ClientSession.get")
 async def test_sonoff_refresh_list_failed(mock_get, sonoff_prov):
-
     mock_get.return_value.__aenter__.return_value.json = AsyncMock(side_effect=[[]])
     mock_get.return_value.__aenter__.return_value.status = 434
     mock_get.return_value.__aenter__.return_value.reason = "UNK"

--- a/tests/ota_providers/test_ota_provider_thirdreality.py
+++ b/tests/ota_providers/test_ota_provider_thirdreality.py
@@ -122,7 +122,6 @@ async def test_thirdreality_refresh_list_locked(mock_get, thirdreality_prov):
 
 @patch("aiohttp.ClientSession.get")
 async def test_thirdreality_refresh_list_failed(mock_get, thirdreality_prov):
-
     mock_get.return_value.__aenter__.return_value.json = AsyncMock(side_effect=[[]])
     mock_get.return_value.__aenter__.return_value.status = 434
     mock_get.return_value.__aenter__.return_value.reason = "UNK"

--- a/tests/test_app_state.py
+++ b/tests/test_app_state.py
@@ -156,7 +156,7 @@ def test_counters_reset(counters):
 
 
 def test_counter_incr():
-    """Test counter incement."""
+    """Test counter increment."""
 
     counter = app_state.Counter("counter_name", 42)
     assert counter == 42

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -869,7 +869,6 @@ def test_build_source_route_no_relays(app):
 
 
 async def test_send_mrequest(app, packet):
-
     status, msg = await app.mrequest(
         group_id=0xABCD,
         profile=0x1234,
@@ -895,7 +894,6 @@ async def test_send_mrequest(app, packet):
 
 
 async def test_send_broadcast(app, packet):
-
     status, msg = await app.broadcast(
         profile=0x1234,
         cluster=0x0006,

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -172,7 +172,6 @@ def test_group_remove_member(group, endpoint):
 
 
 def test_group_magic_methods(group, endpoint):
-
     group.add_member(endpoint, suppress_event=True)
 
     assert endpoint.unique_id in group.members

--- a/tests/test_ota_provider.py
+++ b/tests/test_ota_provider.py
@@ -292,7 +292,6 @@ async def test_ikea_refresh_list_locked(mock_get, ikea_prov, ikea_image_with_ver
 
 @patch("aiohttp.ClientSession.get")
 async def test_ikea_refresh_list_failed(mock_get, ikea_prov):
-
     mock_get.return_value.__aenter__.return_value.json = AsyncMock(side_effect=[[]])
 
     mock_get.return_value.__aenter__.return_value.status = 434

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -63,7 +63,7 @@ def test_struct_subclass_creation():
     assert TestStruct3._private2 == 4567
     assert TestStruct3._PRIVATE_CONST is mock.sentinel.priv_const
     assert TestStruct3()._PRIVATE_CONST is mock.sentinel.priv_const
-    assert TestStruct3.Test
+    assert TestStruct3.Test  # type: ignore[truthy-function]
     assert TestStruct3().Test
     assert "Test" not in TestStruct3().as_dict()
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -271,7 +271,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def attribute_updated(
         self, cluster: zigpy.typing.ClusterType, attrid: int, value: Any
     ) -> None:
-
         self.enqueue(
             "_save_attribute",
             cluster.endpoint.device.ieee,
@@ -284,7 +283,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def unsupported_attribute_added(
         self, cluster: zigpy.typing.ClusterType, attrid: int
     ) -> None:
-
         self.enqueue(
             "_unsupported_attribute_added",
             cluster.endpoint.device.ieee,
@@ -305,7 +303,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def unsupported_attribute_removed(
         self, cluster: zigpy.typing.ClusterType, attrid: int
     ) -> None:
-
         self.enqueue(
             "_unsupported_attribute_removed",
             cluster.endpoint.device.ieee,

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -23,7 +23,7 @@ TYPE_MANUF_QUIRKS_DICT = Dict[Optional[str], TYPE_MODEL_QUIRKS_LIST]
 
 
 class DeviceRegistry:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self._registry: TYPE_MANUF_QUIRKS_DICT = collections.defaultdict(
             lambda: collections.defaultdict(list)
         )

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -23,7 +23,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ListenableMixin:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._listeners: dict[int, tuple[typing.Callable, bool]] = {}
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -75,7 +75,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
     attributes_by_name: dict[str, foundation.ZCLAttributeDef] = {}
     commands_by_name: dict[str, foundation.ZCLCommandDef] = {}
 
-    def __init_subclass__(cls):
+    def __init_subclass__(cls) -> None:
         # Fail on deprecated attribute presence
         for a in ("attributes", "client_commands", "server_commands"):
             if not hasattr(cls, f"manufacturer_{a}"):


### PR DESCRIPTION
`isort` is breaking CI.

MyPy v0.990 introduced a change that causes it to fail to discover the type of `Basic.cluster_id` so we can't seem to use the most recent version.