### PR TITLE
Inovelli OTA URL Changes

### DIFF
--- a/zigpy/ota/OTA_URLs.md
+++ b/zigpy/ota/OTA_URLs.md
@@ -6,9 +6,9 @@ Collection of external Zigbee OTA firmware images from official and unofficial O
 
 Manufacturer ID = 4655
 
-Inovelli Zigbee OTA firmware images are made publicly available by Inovelli (first-party) at the following URLs:
+Inovelli Zigbee OTA firmware images for zigpy are made publicly available by Inovelli (first-party) at the following URLs:
 
-https://files.inovelli.com/firmware/firmware.json
+https://files.inovelli.com/firmware/firmware-zha.json
 
 https://files.inovelli.com/firmware
 

--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -666,7 +666,7 @@ class INOVELLIImage:
 class Inovelli(Basic):
     """Inovelli OTA Firmware provider."""
 
-    UPDATE_URL = "https://files.inovelli.com/firmware/firmware.json"
+    UPDATE_URL = "https://files.inovelli.com/firmware/firmware-zha.json"
     MANUFACTURER_ID = 4655
     HEADERS = {"accept": "application/json"}
 


### PR DESCRIPTION
Inovelli requested to update their OTA URL for zigpy. These changes are to update to the new json while they work on changing how they handle Zigbee OTA image update releases.