### PR TITLE
Wait for aiosqlite connection thread to join before shutting down

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,7 +245,9 @@ def verify_cleanup(
     tasks_before = asyncio.all_tasks(event_loop)
     yield
 
-    event_loop.run_until_complete(event_loop.shutdown_default_executor())
+    # Introduced in Python 3.9
+    if hasattr(event_loop, "shutdown_default_executor"):
+        event_loop.run_until_complete(event_loop.shutdown_default_executor())
 
     # Warn and clean-up lingering tasks and timers
     # before moving on to the next test.

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -193,6 +193,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         await self._db.close()
 
+        # FIXME: aiosqlite's thread won't always be closed immediately
+        await asyncio.get_running_loop().run_in_executor(None, self._db.join)
+
     def enqueue(self, cb_name: str, *args) -> None:
         """Enqueue an async callback handler action."""
         if not self.running:


### PR DESCRIPTION
`aiosqlite.Connection.close` doesn't actually close the thread immediately. I've copied Home Assistant's global thread-leaking detection test to ensure this is caught in the future.