### PR TITLE
Don't assume all endpoints will exist when loading unsupported attrs

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -627,7 +627,11 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         ) as cursor:
             async for (ieee, endpoint_id, cluster_id, attrid) in cursor:
                 dev = self._application.get_device(ieee)
-                ep = dev.endpoints[endpoint_id]
+
+                try:
+                    ep = dev.endpoints[endpoint_id]
+                except KeyError:
+                    continue
 
                 try:
                     cluster = ep.in_clusters[cluster_id]


### PR DESCRIPTION
The quirk for the affected Tuya device removes an endpoint but the attribute cache must have been built with an earlier revision of the quirk (or an unquirked device), causing a startup error.

Related to https://github.com/home-assistant/core/issues/89245#issuecomment-1465290171, fixes a few more issues of this type.