### PR TITLE
Use `asyncio.timeout` instead of `asyncio.wait_for`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ REQUIRES = [
     "crccheck",
     "cryptography",
     'importlib_resources; python_version<"3.9"',
+    'async-timeout; python_version<"3.11"',
     "voluptuous",
     'pyserial-asyncio; platform_system!="Windows"',
     'pyserial-asyncio!=0.5; platform_system=="Windows"',


### PR DESCRIPTION
The cancellation semantics of `asyncio.wait_for` are probably the root cause of the task cancellation bug (#809). zigpy-znp has always used `asyncio.timeout` internally without any problems so we may as well migrate zigpy as well. Plus, the context manager syntax is usually clearer.

https://github.com/python/cpython/pull/98518