### PR TITLE
Treat all connection errors as transient

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -667,11 +667,22 @@ async def test_startup_no_backup():
     p.assert_not_called()
 
 
-async def test_startup_failure_transient_error():
-    app = make_app({conf.CONF_NWK_BACKUP_ENABLED: False})
+def with_attributes(obj, **attrs):
+    for k, v in attrs.items():
+        setattr(obj, k, v)
 
-    err = OSError("Network is unreachable")
-    err.errno = errno.ENETUNREACH
+    return obj
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        with_attributes(OSError("Network is unreachable"), errno=errno.ENETUNREACH),
+        ConnectionRefusedError(),
+    ],
+)
+async def test_startup_failure_transient_error(err):
+    app = make_app({conf.CONF_NWK_BACKUP_ENABLED: False})
 
     with patch.object(app, "connect", side_effect=[err]):
         with pytest.raises(TransientConnectionError):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -681,10 +681,10 @@ def with_attributes(obj, **attrs):
         ConnectionRefusedError(),
     ],
 )
-async def test_startup_failure_transient_error(err):
+async def test_startup_failure_transient_error(error):
     app = make_app({conf.CONF_NWK_BACKUP_ENABLED: False})
 
-    with patch.object(app, "connect", side_effect=[err]):
+    with patch.object(app, "connect", side_effect=[error]):
         with pytest.raises(TransientConnectionError):
             await app.startup()
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -174,7 +174,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             LOGGER.error("Couldn't start application", exc_info=e)
             await self.shutdown()
 
-            if isinstance(e, ConnectionRefusedError) or (
+            if isinstance(e, ConnectionError) or (
                 isinstance(e, OSError) and e.errno in TRANSIENT_CONNECTION_ERRORS
             ):
                 raise zigpy.exceptions.TransientConnectionError() from e


### PR DESCRIPTION
There are a few other types of connection errors that we don't handle:

```
      │    ├── ConnectionError
      │    │    ├── BrokenPipeError
      │    │    ├── ConnectionAbortedError
      │    │    ├── ConnectionRefusedError
      │    │    └── ConnectionResetError
```