### PR TITLE
Implement an API to change channels

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1373,4 +1373,4 @@ async def test_move_network_to_new_channel(app):
         await app.move_network_to_channel(new_channel=26, num_broadcasts=10)
 
     assert app.state.network_info.channel == 26
-    assert len(mock_broadcast.mock_calls) == 1 + 10
+    assert len(mock_broadcast.mock_calls) == 10

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -250,7 +250,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     ) -> None:
         """Broadcasts the channel migration update request."""
         # Default implementation for radios that migrate via a loopback ZDO request
-        await self._zigpy_device.zdo.Mgmt_NWK_Update_req(
+        await self._device.zdo.Mgmt_NWK_Update_req(
             zigpy.zdo.types.NwkUpdate(
                 ScanChannels=zigpy.types.Channels.from_channel_list([new_channel]),
                 ScanDuration=zigpy.zdo.types.NwkUpdate.CHANNEL_CHANGE_REQ,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -259,7 +259,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         )
 
     async def move_network_to_channel(
-        self, new_channel: int, *, num_broadcasts: int = 10
+        self, new_channel: int, *, num_broadcasts: int = 5
     ) -> None:
         """Moves the network to a new channel."""
         if self.state.network_info.channel == new_channel:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -48,6 +48,9 @@ TRANSIENT_CONNECTION_ERRORS = {
 ENERGY_SCAN_WARN_THRESHOLD = 0.75 * 255
 _R = TypeVar("_R")
 
+CHANNEL_CHANGE_BROADCAST_DELAY_S = 1.0
+CHANNEL_CHANGE_SETTINGS_RELOAD_DELAY_S = 1.0
+
 
 class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     SCHEMA = conf.CONFIG_SCHEMA
@@ -241,6 +244,64 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             _, scanned_channels, _, _, energy_values = rsp
 
         return dict(zip(scanned_channels, energy_values))
+
+    async def _move_network_to_channel(
+        self, new_channel: int, new_nwk_update_id: int
+    ) -> None:
+        """Broadcasts the channel migration update request."""
+        # Default implementation for radios that migrate via a loopback ZDO request
+        await self._zigpy_device.zdo.Mgmt_NWK_Update_req(
+            zigpy.zdo.types.NwkUpdate(
+                ScanChannels=zigpy.types.Channels.from_channel_list([new_channel]),
+                ScanDuration=zigpy.zdo.types.NwkUpdate.CHANNEL_CHANGE_REQ,
+                nwkUpdateId=new_nwk_update_id,
+            )
+        )
+
+    async def move_network_to_channel(
+        self, new_channel: int, *, num_broadcasts: int = 10
+    ) -> None:
+        """Moves the network to a new channel."""
+        if self.state.network_info.channel == new_channel:
+            return
+
+        new_nwk_update_id = (self.state.network_info.nwk_update_id + 1) % 0xFF
+
+        for attempt in range(num_broadcasts):
+            LOGGER.info(
+                "Broadcasting migration to channel %s (%s of %s)",
+                new_channel,
+                attempt + 1,
+                num_broadcasts,
+            )
+
+            await zigpy.zdo.broadcast(
+                app=self,
+                command=zigpy.zdo.types.ZDOCmd.Mgmt_NWK_Update_req,
+                grpid=None,
+                radius=30,  # Explicitly set the maximum radius
+                broadcast_address=zigpy.types.BroadcastAddress.ALL_DEVICES,
+                NwkUpdate=zigpy.zdo.types.NwkUpdate(
+                    ScanChannels=zigpy.types.Channels.from_channel_list([new_channel]),
+                    ScanDuration=zigpy.zdo.types.NwkUpdate.CHANNEL_CHANGE_REQ,
+                    nwkUpdateId=new_nwk_update_id,
+                ),
+            )
+
+            await asyncio.sleep(CHANNEL_CHANGE_BROADCAST_DELAY_S)
+
+        # Move the coordinator itself, if supported
+        await self._move_network_to_channel(
+            new_channel=new_channel, new_nwk_update_id=new_nwk_update_id
+        )
+
+        # Wait for settings to update
+        while self.state.network_info.channel != new_channel:
+            LOGGER.info("Waiting for channel change to take effect")
+            await self.load_network_info(load_devices=False)
+            await asyncio.sleep(CHANNEL_CHANGE_SETTINGS_RELOAD_DELAY_S)
+
+        LOGGER.info("Successfully migrated to channel %d", new_channel)
 
     async def form_network(self, *, fast: bool = False) -> None:
         """Writes random network settings to the coordinator."""


### PR DESCRIPTION
See #1185 (@dumpfheimer).

Currently, ZNP implements the best version of this API because it allows the coordinator to change channels after having a few chances to send out the broadcast. Other coordinators (EZSP and deCONZ) directly react to the loopback request and migrate almost immediately.

This rudimentary version has been implemented in zigpy-cli for some time and has been used by a few people to migrate their networks. From what I can tell, if an end device does not react to the channel change broadcast, it definitely won't with a unicast request. But it still might find the network again after detecting that it has been orphaned.

Thoughts?