### PR TITLE
Always store a reference to task objects

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -47,7 +47,6 @@ ignore = [
     "E731",   # do not assign a lambda expression, use a def
     "B007",   # Loop control variable `id_` not used within loop body
     "PGH004", # Use specific rule codes when using `noqa`
-    "RUF006", # Store a reference to the return value of `asyncio.create_task`
     "TRY004", # Prefer `TypeError` exception for invalid type
 ]
 

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -119,7 +119,7 @@ async def test_callback_listener():
     ]
 
 
-async def test_callback_listener_async(app):
+async def test_callback_listener_async():
     listener = listeners.CallbackListener(
         device=mock.Mock(spec_set=zigpy.device.Device),
         matchers=[

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -119,7 +119,7 @@ async def test_callback_listener():
     ]
 
 
-async def test_callback_listener_async():
+async def test_callback_listener_async(app):
     listener = listeners.CallbackListener(
         device=mock.Mock(spec_set=zigpy.device.Device),
         matchers=[
@@ -134,7 +134,7 @@ async def test_callback_listener_async():
     await asyncio.sleep(0.1)
 
     assert listener.callback.mock_calls == [mock.call(make_hdr(on()), on())]
-    assert listener.callback.await_count == 1
+    assert listener.device.application.create_task.call_count == 1
 
 
 async def test_callback_listener_error(caplog):

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -99,7 +99,7 @@ class CallbackListener(BaseRequestListener):
 
             # Run coroutines in the background
             if asyncio.iscoroutine(result):
-                asyncio.create_task(result)
+                self.device.application.create_task(result)
         except Exception:
             LOGGER.warning(
                 "Caught an exception while executing callback", exc_info=True


### PR DESCRIPTION
RUF006: Store a reference to the return value of asyncio.create_task

Ref: https://beta.ruff.rs/docs/rules/asyncio-dangling-task/