### PR TITLE
Start up even when the `permit(0)` broadcast fails due to interference

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1339,3 +1339,9 @@ async def test_startup_broadcast_failure_due_to_interference(app, caplog):
     # The application will still start up, however
     assert "Failed to deliver startup broadcast" in caplog.text
     assert "interference" in caplog.text
+
+
+async def test_startup_broadcast_failure_other(app, caplog):
+    with mock.patch.object(app, "permit", side_effect=DeliveryError("Error", 123)):
+        with pytest.raises(DeliveryError, match="^Error$"):
+            await app.startup()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1325,3 +1325,17 @@ async def test_startup_energy_scan(app, caplog, scan, message_present):
         assert "Zigbee channel 15 utilization is 100.00%" in caplog.text
     else:
         assert "Zigbee channel" not in caplog.text
+
+
+async def test_startup_broadcast_failure_due_to_interference(app, caplog):
+    err = DeliveryError(
+        "Failed to deliver packet: <TXStatus.MAC_CHANNEL_ACCESS_FAILURE: 225>", 225
+    )
+
+    with mock.patch.object(app, "permit", side_effect=err):
+        with caplog.at_level(logging.WARNING):
+            await app.startup()
+
+    # The application will still start up, however
+    assert "Failed to deliver startup broadcast" in caplog.text
+    assert "interference" in caplog.text

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1337,7 +1337,7 @@ async def test_startup_broadcast_failure_due_to_interference(app, caplog):
             await app.startup()
 
     # The application will still start up, however
-    assert "Failed to deliver startup broadcast" in caplog.text
+    assert "Failed to send startup broadcast" in caplog.text
     assert "interference" in caplog.text
 
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -152,7 +152,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
             # Some radios (like the Conbee) can fail to deliver the startup broadcast
             # due to interference
-            LOGGER.warning("Failed to deliver startup broadcast")
+            LOGGER.warning("Failed to send startup broadcast with error: %s", e)
             LOGGER.warning(const.INTERFERENCE_MESSAGE)
 
         if self.config[conf.CONF_NWK_BACKUP_ENABLED]:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -152,7 +152,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
             # Some radios (like the Conbee) can fail to deliver the startup broadcast
             # due to interference
-            LOGGER.warning("Failed to send startup broadcast with error: %s", e)
+            LOGGER.warning("Failed to send startup broadcast: %s", e)
             LOGGER.warning(const.INTERFERENCE_MESSAGE)
 
         if self.config[conf.CONF_NWK_BACKUP_ENABLED]:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -21,6 +21,7 @@ else:
 import zigpy.appdb
 import zigpy.backups
 import zigpy.config as conf
+import zigpy.const as const
 import zigpy.device
 import zigpy.exceptions
 import zigpy.group
@@ -143,7 +144,16 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         await self.start_network()
 
         # Some radios erroneously permit joins on startup
-        await self.permit(0)
+        try:
+            await self.permit(0)
+        except zigpy.exceptions.DeliveryError as e:
+            if e.status != t.MACStatus.MAC_CHANNEL_ACCESS_FAILURE:
+                raise
+
+            # Some radios (like the Conbee) can fail to deliver the startup broadcast
+            # due to interference
+            LOGGER.warning("Failed to deliver startup broadcast")
+            LOGGER.warning(const.INTERFERENCE_MESSAGE)
 
         if self.config[conf.CONF_NWK_BACKUP_ENABLED]:
             self.backups.start_periodic_backups(
@@ -171,12 +181,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                     self.state.network_info.channel,
                     100 * results[self.state.network_info.channel] / 255,
                 )
-                LOGGER.warning(
-                    "If you are having problems joining new devices, are missing sensor"
-                    " updates, or have issues keeping devices joined, ensure your"
-                    " coordinator is away from interference sources such as USB 3.0"
-                    " devices, SSDs, WiFi routers, etc."
-                )
+                LOGGER.warning(const.INTERFERENCE_MESSAGE)
 
     async def startup(self, *, auto_form: bool = False):
         """Starts a network, optionally forming one with random settings if necessary."""

--- a/zigpy/const.py
+++ b/zigpy/const.py
@@ -10,3 +10,10 @@ SIG_MODEL = "model"
 SIG_MODELS_INFO = "models_info"
 SIG_NODE_DESC = "node_desc"
 SIG_SKIP_CONFIG = "skip_configuration"
+
+INTERFERENCE_MESSAGE = (
+    "If you are having problems joining new devices, are missing sensor"
+    " updates, or have issues keeping devices joined, ensure your"
+    " coordinator is away from interference sources such as USB 3.0"
+    " devices, SSDs, WiFi routers, etc."
+)

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -13,7 +13,7 @@ class APIException(ZigbeeException):
 class DeliveryError(ZigbeeException):
     """Message delivery failed in some way"""
 
-    def __init__(self, message: str, status=None):
+    def __init__(self, message: str, status: int | None = None):
         super().__init__(message)
         self.status = status
 

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class ZigbeeException(Exception):
     """Base exception class"""
 


### PR DESCRIPTION
Mostly for the Conbee. Currently, what happens is this:

```Python
2023-04-10 18:52:58.538 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry ConBee II for zha
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 383, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/zha/__init__.py", line 122, in async_setup_entry
    await zha_gateway.async_initialize()
  File "/usr/src/homeassistant/homeassistant/components/zha/core/gateway.py", line 220, in async_initialize
    raise exc
  File "/usr/src/homeassistant/homeassistant/components/zha/core/gateway.py", line 205, in async_initialize
    self.application_controller = await app_controller_cls.new(
  File "/usr/local/lib/python3.10/site-packages/zigpy/application.py", line 191, in new
    await app.startup(auto_form=auto_form)
  File "/usr/local/lib/python3.10/site-packages/zigpy/application.py", line 166, in startup
    await self.initialize(auto_form=auto_form)
  File "/usr/local/lib/python3.10/site-packages/zigpy/application.py", line 126, in initialize
    await self.permit(0)
  File "/usr/local/lib/python3.10/site-packages/zigpy/application.py", line 1043, in permit
    await zigpy.zdo.broadcast(
  File "/usr/local/lib/python3.10/site-packages/zigpy/device.py", line 519, in broadcast
    return await app.broadcast(
  File "/usr/local/lib/python3.10/site-packages/zigpy/application.py", line 822, in broadcast
    await self.send_packet(
  File "/usr/local/lib/python3.10/site-packages/zigpy_deconz/zigbee/application.py", line 441, in send_packet
    raise zigpy.exceptions.DeliveryError(
zigpy.exceptions.DeliveryError: Failed to deliver packet: <TXStatus.MAC_CHANNEL_ACCESS_FAILURE: 225>
```

It's nicer to let the integration start up but log a bunch of warnings on startup (to become repairs in the future).