### PR TITLE
More type annotations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ disable_error_code =
     operator,
     valid-type,
     misc,
-    dict-item,
     attr-defined,
     assignment,
     arg-type

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ REQUIRES = [
     "voluptuous",
     'pyserial-asyncio; platform_system!="Windows"',
     'pyserial-asyncio!=0.5; platform_system=="Windows"',
+    "typing_extensions",
 ]
 
 setup(

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -474,8 +474,8 @@ class ManufacturerSpecificCluster(zigpy.quirks.CustomCluster):
     cluster_id = 0x2222
     ep_attribute = "just_a_cluster"
     attributes = {
-        0: ("attr0", t.uint8_t),
-        1: ("attr1", t.uint16_t, True),
+        0: zcl.foundation.ZCLAttributeDef("attr0", t.uint8_t),
+        1: zcl.foundation.ZCLAttributeDef("attr1", t.uint16_t, True),
     }
 
     client_commands = {

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -474,20 +474,22 @@ class ManufacturerSpecificCluster(zigpy.quirks.CustomCluster):
     cluster_id = 0x2222
     ep_attribute = "just_a_cluster"
     attributes = {
-        0: zcl.foundation.ZCLAttributeDef("attr0", t.uint8_t),
-        1: zcl.foundation.ZCLAttributeDef("attr1", t.uint16_t, True),
+        0x0000: zcl.foundation.ZCLAttributeDef("attr0", t.uint8_t),
+        0x0001: zcl.foundation.ZCLAttributeDef(
+            "attr1", t.uint16_t, is_manufacturer_specific=True
+        ),
     }
 
     client_commands = {
-        0: zcl.foundation.ZCLCommandDef("client_cmd0", {}, False),
-        1: zcl.foundation.ZCLCommandDef(
+        0x00: zcl.foundation.ZCLCommandDef("client_cmd0", {}, False),
+        0x01: zcl.foundation.ZCLCommandDef(
             "client_cmd1", {}, False, is_manufacturer_specific=True
         ),
     }
 
     server_commands = {
-        0: zcl.foundation.ZCLCommandDef("server_cmd0", {}, False),
-        1: zcl.foundation.ZCLCommandDef(
+        0x00: zcl.foundation.ZCLCommandDef("server_cmd0", {}, False),
+        0x01: zcl.foundation.ZCLCommandDef(
             "server_cmd1", {}, False, is_manufacturer_specific=True
         ),
     }

--- a/zigpy/__init__.py
+++ b/zigpy/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 MAJOR_VERSION = 0
 MINOR_VERSION = 55
 PATCH_VERSION = "0.dev0"

--- a/zigpy/appdb_schemas/__init__.py
+++ b/zigpy/appdb_schemas/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 if sys.version_info >= (3, 9):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -56,7 +56,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     SCHEMA = conf.CONFIG_SCHEMA
     SCHEMA_DEVICE = conf.SCHEMA_DEVICE
 
-    def __init__(self, config: dict):
+    def __init__(self, config: dict) -> None:
         self.devices: dict[t.EUI64, zigpy.device.Device] = {}
         self.state: zigpy.state.State = zigpy.state.State()
         self._listeners = {}
@@ -105,7 +105,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.topology.add_listener(self._dblistener)
         await self._dblistener.load()
 
-    async def initialize(self, *, auto_form: bool = False):
+    async def initialize(self, *, auto_form: bool = False) -> None:
         """Starts the network on a connected radio, optionally forming one with random
         settings if necessary.
         """
@@ -186,7 +186,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 period=(60 * self.config[zigpy.config.CONF_TOPO_SCAN_PERIOD])
             )
 
-    async def startup(self, *, auto_form: bool = False):
+    async def startup(self, *, auto_form: bool = False) -> None:
         """Starts a network, optionally forming one with random settings if necessary."""
 
         try:
@@ -403,7 +403,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         await self.disconnect()
 
-    def add_device(self, ieee: t.EUI64, nwk: t.NWK):
+    def add_device(self, ieee: t.EUI64, nwk: t.NWK) -> zigpy.device.Device:
         """Creates a zigpy `Device` object with the provided IEEE and NWK addresses."""
 
         assert isinstance(ieee, t.EUI64)
@@ -413,7 +413,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.devices[ieee] = dev
         return dev
 
-    def device_initialized(self, device):
+    def device_initialized(self, device: zigpy.device.Device) -> None:
         """Used by a device to signal that it is initialized"""
         LOGGER.debug("Device is initialized %s", device)
 
@@ -694,7 +694,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """
         raise NotImplementedError()  # pragma: no cover
 
-    async def register_endpoints(self):
+    async def register_endpoints(self) -> None:
         """Registers all necessary endpoints.
         The exact order in which this method is called depends on the radio module.
         """
@@ -787,7 +787,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         expect_reply: bool = True,
         use_ieee: bool = False,
         extended_timeout: bool = False,
-    ):
+    ) -> tuple[zigpy.zcl.foundation.Status, str]:
         """Submit and send data out as an unicast transmission.
         :param device: destination device
         :param profile: Zigbee Profile ID to use for outgoing message
@@ -896,7 +896,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         sequence: t.uint8_t,
         data: bytes,
         broadcast_address: t.BroadcastAddress = t.BroadcastAddress.RX_ON_WHEN_IDLE,
-    ):
+    ) -> tuple[zigpy.zcl.foundation.Status, str]:
         """Submit and send data out as an unicast transmission.
         :param profile: Zigbee Profile ID to use for outgoing message
         :param cluster: cluster id where the message is being sent
@@ -1076,7 +1076,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             self._req_listeners[src].remove(listener)
 
     @abc.abstractmethod
-    async def permit_ncp(self, time_s: int = 60):
+    async def permit_ncp(self, time_s: int = 60) -> None:
         """Permit joining on NCP.
         Not all radios will require this method.
         """
@@ -1115,7 +1115,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         raise NotImplementedError()  # pragma: no cover
 
-    async def permit(self, time_s: int = 60, node: t.EUI64 | str | None = None):
+    async def permit(self, time_s: int = 60, node: t.EUI64 | str | None = None) -> None:
         """Permit joining on a specific node or all router nodes."""
         assert 0 <= time_s <= 254
         if node is not None:
@@ -1143,7 +1143,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             0,
             broadcast_address=t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
         )
-        return await self.permit_ncp(time_s)
+        await self.permit_ncp(time_s)
 
     def get_sequence(self) -> t.uint8_t:
         self._send_sequence = (self._send_sequence + 1) % 256
@@ -1176,7 +1176,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Returns coordinator endpoint id for specified cluster id."""
         return DEFAULT_ENDPOINT_ID
 
-    def get_dst_address(self, cluster) -> zdo_types.MultiAddress:
+    def get_dst_address(self, cluster: zigpy.zcl.Cluster) -> zdo_types.MultiAddress:
         """Helper to get a dst address for bind/unbind operations.
 
         Allows radios to provide correct information especially for radios which listen
@@ -1205,11 +1205,11 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._config = self.SCHEMA(new_config)
 
     @property
-    def groups(self):
+    def groups(self) -> zigpy.group.Groups:
         return self._groups
 
     @property
-    def ota(self):
+    def ota(self) -> zigpy.ota.OTA:
         return self._ota
 
     @property

--- a/zigpy/config/__init__.py
+++ b/zigpy/config/__init__.py
@@ -1,5 +1,7 @@
 """Config schemas and validation."""
 
+from __future__ import annotations
+
 import voluptuous as vol
 
 from zigpy.config.defaults import (

--- a/zigpy/config/defaults.py
+++ b/zigpy/config/defaults.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import zigpy.types as t
 
 CONF_STARTUP_ENERGY_SCAN_DEFAULT = True

--- a/zigpy/const.py
+++ b/zigpy/const.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Zigpy Constants."""
 
 SIG_ENDPOINTS = "endpoints"

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -61,7 +61,13 @@ class CachedImage:
     def version(self) -> int:
         return self.image.header.file_version
 
-    def should_update(self, manufacturer_id, img_type, ver, hw_ver=None) -> bool:
+    def should_update(
+        self,
+        manufacturer_id: t.uint16_t,
+        img_type: t.uint16_t,
+        ver: t.uint32_t,
+        hw_ver: None = None,
+    ) -> bool:
         """Check if it should upgrade"""
 
         if self.key != ImageKey(manufacturer_id, img_type):
@@ -83,7 +89,7 @@ class CachedImage:
 
         return True
 
-    def get_image_block(self, offset: t.uint32_t, size: t.uint8_t) -> bytes:
+    def get_image_block(self, offset: t.t.uint32_t, size: t.uint8_t) -> bytes:
         if (
             self.expires_on is not None
             and self.expires_on - datetime.datetime.now() < DELAY_EXPIRATION
@@ -102,7 +108,7 @@ class CachedImage:
 class OTA(zigpy.util.ListenableMixin):
     """OTA Manager."""
 
-    def __init__(self, app: ControllerApplicationType, *args, **kwargs):
+    def __init__(self, app: ControllerApplicationType, *args, **kwargs) -> None:
         self._app: ControllerApplicationType = app
         self._image_cache: dict[ImageKey, CachedImage] = {}
         self._not_initialized = True
@@ -128,7 +134,10 @@ class OTA(zigpy.util.ListenableMixin):
         self._not_initialized = False
 
     async def get_ota_image(
-        self, manufacturer_id, image_type, model=None
+        self,
+        manufacturer_id: t.uint16_t,
+        image_type: t.uint16_t,
+        model: str | None = None,
     ) -> CachedImage | None:
         if manufacturer_id in (
             zigpy.ota.provider.Salus.MANUFACTURER_ID,

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -1,7 +1,8 @@
 """OTA support for Zigbee devices."""
+from __future__ import annotations
+
 import datetime
 import logging
-from typing import Optional
 
 import attr
 
@@ -38,7 +39,7 @@ class CachedImage:
     cached_data = attr.ib(default=None)
 
     @classmethod
-    def new(cls, img: BaseOTAImage) -> "CachedImage":
+    def new(cls, img: BaseOTAImage) -> CachedImage:
         expiration = datetime.datetime.now() + cls.DEFAULT_EXPIRATION
         return cls(img, expiration)
 
@@ -128,7 +129,7 @@ class OTA(zigpy.util.ListenableMixin):
 
     async def get_ota_image(
         self, manufacturer_id, image_type, model=None
-    ) -> Optional[CachedImage]:
+    ) -> CachedImage | None:
         if manufacturer_id in (
             zigpy.ota.provider.Salus.MANUFACTURER_ID,
         ):  # Salus/computime do not pass a useful image_type

--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -34,11 +34,11 @@ class Basic(zigpy.util.LocalLogMixin, ABC):
 
     REFRESH = datetime.timedelta(hours=12)
 
-    def __init__(self):
-        self.config = {}
-        self._cache = {}
+    def __init__(self) -> None:
+        self.config: dict[str, str | int] = {}
+        self._cache: dict[ImageKey, BaseOTAImage] = {}
         self._is_enabled = False
-        self._locks = defaultdict(asyncio.Semaphore)
+        self._locks: defaultdict[asyncio.Semaphore] = defaultdict(asyncio.Semaphore)
         self._last_refresh = None
 
     @abstractmethod
@@ -77,7 +77,7 @@ class Basic(zigpy.util.LocalLogMixin, ABC):
     def enable(self) -> None:
         self._is_enabled = True
 
-    def update_expiration(self):
+    def update_expiration(self) -> None:
         self._last_refresh = datetime.datetime.now()
 
     @property
@@ -92,7 +92,7 @@ class Basic(zigpy.util.LocalLogMixin, ABC):
 
         return datetime.datetime.now() - self._last_refresh > self.REFRESH
 
-    def log(self, lvl, msg, *args, **kwargs):
+    def log(self, lvl: int, msg: str, *args, **kwargs) -> None:
         """Log a message"""
         msg = f"{self.__class__.__name__}: {msg}"
         return LOGGER.log(lvl, msg, *args, **kwargs)
@@ -107,7 +107,7 @@ class IKEAImage:
     url = attr.ib(default=None)
 
     @classmethod
-    def new(cls, data):
+    def new(cls, data: dict[str, str | int]) -> IKEAImage:
         res = cls(data["fw_manufacturer_id"], data["fw_image_type"])
         res.file_version = data["fw_file_version_MSB"] << 16
         res.file_version |= data["fw_file_version_LSB"]
@@ -116,7 +116,7 @@ class IKEAImage:
         return res
 
     @property
-    def key(self):
+    def key(self) -> ImageKey:
         return ImageKey(self.manufacturer_id, self.image_type)
 
     async def fetch_image(self) -> BaseOTAImage | None:
@@ -549,7 +549,7 @@ class FileImage:
 
 
 class FileStore(Basic):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._ota_dir = None
 
@@ -627,7 +627,7 @@ class INOVELLIImage:
     url = attr.ib()
 
     @classmethod
-    def from_json(cls, obj):
+    def from_json(cls, obj: dict[str, str | int]) -> INOVELLIImage:
         version = int(obj["version"], 16)
 
         # Old Inovelli OTA JSON versions were in hex, they then switched back to decimal
@@ -642,7 +642,7 @@ class INOVELLIImage:
         )
 
     @property
-    def key(self):
+    def key(self) -> ImageKey:
         return ImageKey(self.manufacturer_id, self.image_type)
 
     async def fetch_image(self) -> BaseOTAImage | None:

--- a/zigpy/profiles/__init__.py
+++ b/zigpy/profiles/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from . import zha, zll
 
 PROFILES = {zha.PROFILE_ID: zha, zll.PROFILE_ID: zll}

--- a/zigpy/profiles/zha.py
+++ b/zigpy/profiles/zha.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import zigpy.types as t
 
 PROFILE_ID = 260

--- a/zigpy/profiles/zll.py
+++ b/zigpy/profiles/zll.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import zigpy.types as t
 
 PROFILE_ID = 49246

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Coroutine, Iterable
+import typing
 
 from zigpy.const import (  # noqa: F401
     SIG_ENDPOINTS,
@@ -19,8 +19,12 @@ import zigpy.device
 import zigpy.endpoint
 from zigpy.quirks.registry import DeviceRegistry  # noqa: F401
 import zigpy.types as t
+from zigpy.types.basic import uint16_t
 import zigpy.zcl
 import zigpy.zcl.foundation as foundation
+
+if typing.TYPE_CHECKING:
+    from zigpy.application import ControllerApplication
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +32,9 @@ _DEVICE_REGISTRY = DeviceRegistry()
 _uninitialized_device_message_handlers = []
 
 
-def get_device(device: zigpy.device.Device, registry: DeviceRegistry | None = None):
+def get_device(
+    device: zigpy.device.Device, registry: DeviceRegistry | None = None
+) -> zigpy.device.Device:
     """Get a CustomDevice object, if one is available"""
     if registry is None:
         return _DEVICE_REGISTRY.get_device(device)
@@ -46,7 +52,7 @@ def get_quirk_list(
     return registry.registry[manufacturer][model]
 
 
-def register_uninitialized_device_message_handler(handler: Callable) -> None:
+def register_uninitialized_device_message_handler(handler: typing.Callable) -> None:
     """Register an handler for messages received by uninitialized devices.
 
     each handler is passed same parameters as
@@ -57,14 +63,20 @@ def register_uninitialized_device_message_handler(handler: Callable) -> None:
 
 
 class CustomDevice(zigpy.device.Device):
-    replacement: dict[str, Any] = {}
+    replacement: dict[str, typing.Any] = {}
     signature = None
 
-    def __init_subclass__(cls):
+    def __init_subclass__(cls) -> None:
         if getattr(cls, "signature", None) is not None:
             _DEVICE_REGISTRY.add_to_registry(cls)
 
-    def __init__(self, application, ieee, nwk, replaces):
+    def __init__(
+        self,
+        application: ControllerApplication,
+        ieee: t.EUI64,
+        nwk: t.NWK,
+        replaces: zigpy.device.Device,
+    ) -> None:
         super().__init__(application, ieee, nwk)
 
         def set_device_attr(attr):
@@ -84,7 +96,9 @@ class CustomDevice(zigpy.device.Device):
         for endpoint_id, endpoint in self.replacement.get(SIG_ENDPOINTS, {}).items():
             self.add_endpoint(endpoint_id, replace_device=replaces)
 
-    def add_endpoint(self, endpoint_id, replace_device=None) -> zigpy.endpoint.Endpoint:
+    def add_endpoint(
+        self, endpoint_id: int, replace_device: zigpy.device.Device | None = None
+    ) -> zigpy.endpoint.Endpoint:
         if endpoint_id not in self.replacement.get(SIG_ENDPOINTS, {}):
             return super().add_endpoint(endpoint_id)
 
@@ -103,7 +117,13 @@ class CustomDevice(zigpy.device.Device):
 
 
 class CustomEndpoint(zigpy.endpoint.Endpoint):
-    def __init__(self, device, endpoint_id, replacement_data, replace_device):
+    def __init__(
+        self,
+        device: CustomDevice,
+        endpoint_id: int,
+        replacement_data: dict[str, typing.Any],
+        replace_device: zigpy.device.Device,
+    ) -> None:
         super().__init__(device, endpoint_id)
 
         def set_device_attr(attr):
@@ -137,7 +157,7 @@ class CustomEndpoint(zigpy.endpoint.Endpoint):
 
 class CustomCluster(zigpy.zcl.Cluster):
     _skip_registry = True
-    _CONSTANT_ATTRIBUTES: dict[int, Any] | None = None
+    _CONSTANT_ATTRIBUTES: dict[int, typing.Any] | None = None
 
     manufacturer_id_override: t.uint16_t | None = None
 
@@ -146,7 +166,7 @@ class CustomCluster(zigpy.zcl.Cluster):
         """Return True if cluster_id is within manufacturer specific range."""
         return 0xFC00 <= self.cluster_id <= 0xFFFF
 
-    def _has_manuf_attr(self, attrs_to_process: Iterable | list | dict) -> bool:
+    def _has_manuf_attr(self, attrs_to_process: typing.Iterable | list | dict) -> bool:
         """Return True if contains a manufacturer specific attribute."""
         if self._is_manuf_specific:
             return True
@@ -168,8 +188,8 @@ class CustomCluster(zigpy.zcl.Cluster):
         expect_reply: bool = True,
         tries: int = 1,
         tsn: int | t.uint8_t | None = None,
-        **kwargs: Any,
-    ) -> Coroutine:
+        **kwargs: typing.Any,
+    ) -> typing.Coroutine:
         command = self.server_commands[command_id]
 
         if manufacturer is None and (
@@ -195,8 +215,8 @@ class CustomCluster(zigpy.zcl.Cluster):
         *args,
         manufacturer: int | t.uint16_t | None = None,
         tsn: int | t.uint8_t | None = None,
-        **kwargs: Any,
-    ) -> Coroutine:
+        **kwargs: typing.Any,
+    ):
         command = self.client_commands[command_id]
 
         if manufacturer is None and (
@@ -214,7 +234,9 @@ class CustomCluster(zigpy.zcl.Cluster):
             **kwargs,
         )
 
-    async def read_attributes_raw(self, attributes, manufacturer=None):
+    async def read_attributes_raw(
+        self, attributes: list[uint16_t], manufacturer: uint16_t | None = None
+    ):
         if not self._CONSTANT_ATTRIBUTES:
             return await super().read_attributes_raw(
                 attributes, manufacturer=manufacturer

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import itertools
 import logging
-from typing import Dict, List, Optional
+import typing
 
 from zigpy.const import (
     SIG_ENDPOINTS,
@@ -20,8 +20,10 @@ from zigpy.typing import CustomDeviceType, DeviceType
 
 _LOGGER = logging.getLogger(__name__)
 
-TYPE_MODEL_QUIRKS_LIST = Dict[Optional[str], List["zigpy.quirks.CustomDevice"]]
-TYPE_MANUF_QUIRKS_DICT = Dict[Optional[str], TYPE_MODEL_QUIRKS_LIST]
+TYPE_MANUF_QUIRKS_DICT = typing.Dict[
+    typing.Optional[str],
+    typing.Dict[typing.Optional[str], typing.List["zigpy.quirks.CustomDevice"]],
+]
 
 
 class DeviceRegistry:
@@ -152,11 +154,11 @@ class DeviceRegistry:
         return device
 
     @staticmethod
-    def _match(a, b):
+    def _match(a: dict | typing.Iterable, b: dict | typing.Iterable) -> bool:
         return set(a) == set(b)
 
     @property
-    def registry(self):
+    def registry(self) -> TYPE_MANUF_QUIRKS_DICT:
         return self._registry
 
     def __contains__(self, device: CustomDeviceType) -> bool:

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import collections
 import itertools
 import logging
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from zigpy.const import (
     SIG_ENDPOINTS,
@@ -51,7 +53,7 @@ class DeviceRegistry:
             model = custom_device.signature.get(SIG_MODEL)
             self.registry[manufacturer][model].remove(custom_device)
 
-    def get_device(self, device: DeviceType) -> Union[CustomDeviceType, DeviceType]:
+    def get_device(self, device: DeviceType) -> CustomDeviceType | DeviceType:
         """Get a CustomDevice object, if one is available"""
         if isinstance(device, zigpy.quirks.CustomDevice):
             return device

--- a/zigpy/state.py
+++ b/zigpy/state.py
@@ -186,7 +186,7 @@ class Counter(t.BaseDataclassMixin):
         """Return int of the current value."""
         return self.value
 
-    def __post_init__(self, initial_value) -> None:
+    def __post_init__(self, initial_value: int) -> None:
         """Initialize instance."""
         self._raw_value = initial_value
 

--- a/zigpy/topology.py
+++ b/zigpy/topology.py
@@ -35,7 +35,7 @@ INVALID_NEIGHBOR_IEEES = {
 class Topology(zigpy.util.ListenableMixin):
     """Topology scanner."""
 
-    def __init__(self, app: zigpy.application.ControllerApplication):
+    def __init__(self, app: zigpy.application.ControllerApplication) -> None:
         """Instantiate."""
         self._app: zigpy.application.ControllerApplication = app
         self._listeners: dict = {}
@@ -55,7 +55,7 @@ class Topology(zigpy.util.ListenableMixin):
         self.stop_periodic_scans()
         self._scan_loop_task = asyncio.create_task(self._scan_loop(period))
 
-    def stop_periodic_scans(self):
+    def stop_periodic_scans(self) -> None:
         if self._scan_loop_task is not None:
             self._scan_loop_task.cancel()
 

--- a/zigpy/types/__init__.py
+++ b/zigpy/types/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .basic import *  # noqa: F401,F403
 from .named import *  # noqa: F401,F403
 from .struct import *  # noqa: F401,F403

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import dataclasses
 import enum
-from typing import Iterable
+import typing
 
 from . import basic
 from .struct import Struct
 
+if typing.TYPE_CHECKING:
+    from typing_extensions import Self
+
 
 class BaseDataclassMixin:
-    def replace(self, **kwargs):
+    def replace(self, **kwargs) -> Self:
         return dataclasses.replace(self, **kwargs)
 
 
@@ -37,7 +40,7 @@ class EUI64(basic.FixedList, item_type=basic.uint8_t, length=8):
     def __repr__(self) -> str:
         return ":".join("%02x" % i for i in self[::-1])
 
-    def __hash__(self):
+    def __hash__(self) -> int:  # type: ignore
         return hash(repr(self))
 
     @classmethod
@@ -102,7 +105,7 @@ class Channels(basic.bitmap32):
     CHANNEL_26 = 0x04000000
 
     @classmethod
-    def from_channel_list(cls: Channels, channels: Iterable[int]) -> Channels:
+    def from_channel_list(cls: Channels, channels: typing.Iterable[int]) -> Channels:
         mask = cls.NO_CHANNELS
 
         for channel in channels:
@@ -538,7 +541,7 @@ class AddrModeAddress(BaseDataclassMixin):
     addr_mode: AddrMode
     address: NWK | Group | EUI64 | BroadcastAddress | None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.addr_mode is not None and self.address is not None:
             self.address = {
                 AddrMode.Group: Group,

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -54,7 +54,7 @@ class Struct:
         # We have to use a little introspection to find our real class.
         return next(c for c in cls.__mro__ if c.__name__ != "Optional")
 
-    def __init_subclass__(cls):
+    def __init_subclass__(cls) -> None:
         super().__init_subclass__()
 
         # Explicitly check for old-style structs

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -98,11 +98,11 @@ class TypeValue:
         self.type = type
         self.value = value
 
-    def serialize(self):
+    def serialize(self) -> bytes:
         return self.type.to_bytes(1, "little") + self.value.serialize()
 
     @classmethod
-    def deserialize(cls, data):
+    def deserialize(cls, data: bytes) -> tuple[TypeValue, bytes]:
         type, data = t.uint8_t.deserialize(data)
         python_type = DATA_TYPES[type][1]
         value, data = python_type.deserialize(data)
@@ -142,13 +142,13 @@ class Set(TypedCollection):
 class DataTypes(dict):
     """DataTypes container."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._idx_by_class = {
             _type: type_id for type_id, (name, _type, ad) in self.items()
         }
 
-    def pytype_to_datatype_id(self, python_type) -> int:
+    def pytype_to_datatype_id(self, python_type: typing.Any) -> int:
         """Return Zigbee Datatype ID for a give python type."""
 
         # We return the most specific parent class
@@ -394,7 +394,7 @@ class ConfigureReportingResponseRecord(t.Struct):
     attrid: t.uint16_t = t.StructField(repr=_hex_uint16_repr)
 
     @classmethod
-    def deserialize(cls, data):
+    def deserialize(cls, data: bytes) -> tuple[ConfigureReportingResponseRecord, bytes]:
         r = cls()
         r.status, data = Status.deserialize(data)
         if r.status == Status.SUCCESS:
@@ -415,7 +415,7 @@ class ConfigureReportingResponseRecord(t.Struct):
             r += t.uint16_t(self.attrid).serialize()
         return r
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         r = f"{self.__class__.__name__}(status={self.status}"
         if self.status != Status.SUCCESS:
             r += f", direction={self.direction}, attrid={self.attrid}"
@@ -547,7 +547,11 @@ class ZCLHeader(t.Struct):
     command_id: t.uint8_t
 
     def __new__(
-        cls, frame_control=None, manufacturer=None, tsn=None, command_id=None
+        cls: type[ZCLHeader],
+        frame_control: FrameControl | None = None,
+        manufacturer: t.uint16_t | None = None,
+        tsn: int | t.uint8_t | None = None,
+        command_id: int | GeneralCommand | None = None,
     ) -> ZCLHeader:
         # Allow "auto manufacturer ID" to be disabled in higher layers
         if manufacturer is cls.NO_MANUFACTURER_ID:
@@ -563,7 +567,11 @@ class ZCLHeader(t.Struct):
         """Return direction of Frame Control."""
         return self.frame_control.direction
 
-    def __setattr__(self, name, value) -> None:
+    def __setattr__(
+        self,
+        name: str,
+        value: t.uint16_t | FrameControl | t.uint8_t | GeneralCommand | None,
+    ) -> None:
         if name == "manufacturer" and value is self.NO_MANUFACTURER_ID:
             value = None
 
@@ -617,7 +625,7 @@ class ZCLCommandDef(t.BaseDataclassMixin):
     id: t.uint8_t = None
     is_manufacturer_specific: bool = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         ensure_valid_name(self.name)
 
         if isinstance(self.direction, bool):
@@ -625,7 +633,7 @@ class ZCLCommandDef(t.BaseDataclassMixin):
                 self, "direction", Direction._from_is_reply(self.direction)
             )
 
-    def with_compiled_schema(self):
+    def with_compiled_schema(self) -> ZCLCommandDef:
         """Return a copy of the ZCL command definition object with its dictionary command
         schema converted into a `CommandSchema` subclass.
         """
@@ -687,7 +695,9 @@ class CommandSchema(t.Struct, tuple):
     def __iter__(self):
         return iter(self.as_tuple())
 
-    def __getitem__(self, item):
+    def __getitem__(
+        self, item: slice | typing.SupportsIndex
+    ) -> typing.Any | tuple[typing.Any, ...]:
         return self.as_tuple()[item]
 
     def __len__(self) -> int:
@@ -754,7 +764,7 @@ class ZCLAttributeDef(t.BaseDataclassMixin):
     # The ID will be specified later
     id: t.uint16_t = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.id is not None and not isinstance(self.id, t.uint16_t):
             object.__setattr__(self, "id", t.uint16_t(self.id))
 

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -142,8 +142,21 @@ class Set(TypedCollection):
 class DataTypes(dict):
     """DataTypes container."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        data_types: dict[
+            int,
+            tuple[
+                str,
+                typing.Any,
+                typing.Literal[Null]
+                | typing.Literal[Discrete]
+                | typing.Literal[Analog]
+                | typing.Literal[None],
+            ],
+        ],
+    ) -> None:
+        super().__init__(data_types)
         self._idx_by_class = {
             _type: type_id for type_id, (name, _type, ad) in self.items()
         }


### PR DESCRIPTION
Uses https://github.com/Instagram/MonkeyType to dynamically collect type annotations at runtime. We use the new union syntax, so you'll need to install an updated version of the code parsing library used by MonkeyType:

```bash
pip install MonkeyType
pip install git+https://github.com/hauntsaninja/LibCST@pep604apply
```

Then, run Home Assistant with the modules you want to trace:

```bash
MONKEYTYPE_TRACE_MODULES=zigpy,bellows,zhaquirks,homeassistant monkeytype run -m homeassistant
```

After you use Home Assistant (it will be extremely slow!) and run through all of the codepaths, cleanly quit Home Assistant. It will take about 10-20 minutes to generate a multi-gigabyte `monkeytype.sqlite` file in the current folder.

You can then apply annotations to a specific module:

```bash
LIBCST_PARSER_TYPE=native monkeytype apply zigpy.ota
```

Note that recursive `apply` isn't supported yet but you can read the database to help:

```bash
sqlite3 monkeytype.sqlite3 'SELECT DISTINCT module FROM monkeytype_call_traces' | grep zigpy
```