### PR TITLE
Remove unnecessary or incorrect uses of `hasattr`

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -409,13 +409,6 @@ def test_optional_struct_special_case():
     )
 
 
-def test_old_style_struct():
-    with pytest.raises(TypeError):
-        # `_fields` would typically be ignored but this would be very bad
-        class OldStruct(t.Struct):
-            _fields = [("foo", t.uint8_t)]
-
-
 def test_conflicting_types():
     class GoodStruct(t.Struct):
         foo: t.uint8_t = t.StructField(type=t.uint8_t)

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -104,10 +104,10 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         self.in_clusters[cluster_id] = cluster
 
-        if hasattr(cluster, "ep_attribute"):
+        if cluster.ep_attribute is not None:
             self._cluster_attr[cluster.ep_attribute] = cluster
 
-        if hasattr(self._device.application, "_dblistener"):
+        if self._device.application._dblistener is not None:
             listener = zigpy.zcl.ClusterPersistingListener(
                 self._device.application._dblistener, cluster
             )

--- a/zigpy/group.py
+++ b/zigpy/group.py
@@ -195,7 +195,7 @@ class GroupCluster(zigpy.zcl.Cluster):
         """Instantiate by Cluster name."""
 
         for cluster in cls._registry.values():
-            if hasattr(cluster, "ep_attribute") and cluster.ep_attribute == ep_name:
+            if cluster.ep_attribute == ep_name:
                 return cluster(group_endpoint, is_server=True)
         raise AttributeError(f"Unsupported {ep_name} group cluster")
 

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -57,13 +57,6 @@ class Struct:
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
 
-        # Explicitly check for old-style structs
-        if hasattr(cls, "_fields"):
-            raise TypeError(
-                "Struct subclasses do not use `_fields` anymore."
-                " Use class attributes with type annotations."
-            )
-
         # We generate fields up here to fail early and cache it
         cls.fields = cls._real_cls()._get_fields()
 


### PR DESCRIPTION
`hasattr(self._device.application, "_dblistener")` is not enough to check if a DB listener is attached (since the attribute will always exist, it can just be `None`).