### PR TITLE
Fail when an unknown attribute is read with `.get()`

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -390,7 +390,9 @@ async def test_read_attributes_uncached():
         return [[rar0, rar99, rar199]]
 
     # Unknown attribute read passes through
-    assert cluster.get("unknown_attribute", 123) == 123
+    with pytest.raises(KeyError):
+        cluster.get("unknown_attribute", 123)
+
     assert "unknown_attribute" not in cluster._attr_cache
 
     # Constant attribute can be read with `get`

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -377,7 +377,8 @@ async def test_item_access_attributes(cluster):
         cluster.get(None)
 
     # Test access to cached attribute via wrong attr name
-    assert cluster.get("no_such_attribute", mock.sentinel.attr) is mock.sentinel.attr
+    with pytest.raises(KeyError):
+        cluster.get("no_such_attribute")
 
 
 async def test_item_set_attributes(cluster):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -791,11 +791,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
     def get(self, key: int | str, default: Any | None = None) -> Any:
         """Get cached attribute."""
-        try:
-            attr_def = self.find_attribute(key)
-        except KeyError:
-            return default
-
+        attr_def = self.find_attribute(key)
         return self._attr_cache.get(attr_def.id, default)
 
     def __getitem__(self, key: int | str) -> Any:


### PR DESCRIPTION
This will break a few of ZHA's unit tests but it exposes a bunch of bugs, including https://github.com/puddly/core/commit/4de50036f364380ec5d9745d5e1c1cf4de026b7d#r110865576.