### PR TITLE
Keep track of the last updated time of attributes

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -144,9 +144,9 @@ async def test_database(tmp_path):
     ep.profile_id = 49246
     ep.device_type = profiles.zll.DeviceType.COLOR_LIGHT
     app.device_initialized(dev)
-    clus._update_attribute(0, 99)
-    clus._update_attribute(4, bytes("Custom", "ascii"))
-    clus._update_attribute(5, bytes("Model", "ascii"))
+    clus.update_attribute(0, 99)
+    clus.update_attribute(4, bytes("Custom", "ascii"))
+    clus.update_attribute(5, bytes("Model", "ascii"))
     clus.listener_event("cluster_command", 0)
     clus.listener_event("general_command")
     dev.relays = relays_1
@@ -181,8 +181,8 @@ async def test_database(tmp_path):
     dev = app.get_device(custom_ieee)
     app.device_initialized(dev)
     dev.relays = relays_2
-    dev.endpoints[1].level._update_attribute(0x0011, 17)
-    dev.endpoints[99].level._update_attribute(0x0011, 17)
+    dev.endpoints[1].level.update_attribute(0x0011, 17)
+    dev.endpoints[99].level.update_attribute(0x0011, 17)
     assert dev.endpoints[1].in_clusters[0x0008]._attr_cache[0x0011] == 17
     assert dev.endpoints[99].in_clusters[0x0008]._attr_cache[0x0011] == 17
     custom_dev_last_seen = dev.last_seen
@@ -259,8 +259,8 @@ async def _test_null_padded(tmp_path, test_manufacturer=None, test_model=None):
     clus = ep.add_input_cluster(0)
     ep.add_output_cluster(1)
     app.device_initialized(dev)
-    clus._update_attribute(4, test_manufacturer)
-    clus._update_attribute(5, test_model)
+    clus.update_attribute(4, test_manufacturer)
+    clus.update_attribute(5, test_model)
     clus.listener_event("cluster_command", 0)
     clus.listener_event("zdo_command")
     await app.shutdown()
@@ -435,8 +435,8 @@ async def test_attribute_update(tmp_path, dev_init):
     ep.device_type = profiles.zha.DeviceType.PUMP
     clus = ep.add_input_cluster(0)
     ep.add_output_cluster(1)
-    clus._update_attribute(4, test_manufacturer)
-    clus._update_attribute(5, test_model)
+    clus.update_attribute(4, test_manufacturer)
+    clus.update_attribute(5, test_model)
     app.device_initialized(dev)
     await app.shutdown()
 
@@ -593,8 +593,8 @@ async def test_device_rejoin(tmp_path):
     clus = ep.add_input_cluster(0)
     ep.add_output_cluster(1)
     app.device_initialized(dev)
-    clus._update_attribute(4, "Custom")
-    clus._update_attribute(5, "Model")
+    clus.update_attribute(4, "Custom")
+    clus.update_attribute(5, "Model")
     await app.shutdown()
 
     # Everything should've been saved - check that it re-loads
@@ -641,13 +641,13 @@ async def test_stopped_appdb_listener(tmp_path):
     app.device_initialized(dev)
 
     with patch("zigpy.appdb.PersistingListener._save_attribute") as mock_attr_save:
-        clus._update_attribute(0, 99)
-        clus._update_attribute(4, bytes("Custom", "ascii"))
-        clus._update_attribute(5, bytes("Model", "ascii"))
+        clus.update_attribute(0, 99)
+        clus.update_attribute(4, bytes("Custom", "ascii"))
+        clus.update_attribute(5, bytes("Model", "ascii"))
         await app.shutdown()
         assert mock_attr_save.call_count == 3
 
-        clus._update_attribute(0, 100)
+        clus.update_attribute(0, 100)
         for i in range(100):
             await asyncio.sleep(0)
         assert mock_attr_save.call_count == 3
@@ -732,8 +732,8 @@ async def test_unsupported_attribute(tmp_path, dev_init):
     ep.device_type = profiles.zha.DeviceType.PUMP
     clus = ep.add_input_cluster(0)
     ep.add_output_cluster(1)
-    clus._update_attribute(4, "Custom")
-    clus._update_attribute(5, "Model")
+    clus.update_attribute(4, "Custom")
+    clus.update_attribute(5, "Model")
     app.device_initialized(dev)
     clus.add_unsupported_attribute(0x0010)
     clus.add_unsupported_attribute("physical_env")
@@ -804,8 +804,8 @@ async def test_load_unsupp_attr_wrong_cluster(tmp_path):
     ep.device_type = profiles.zha.DeviceType.PUMP
     clus = ep.add_input_cluster(0)
     ep.add_output_cluster(1)
-    clus._update_attribute(4, "Custom")
-    clus._update_attribute(5, "Model")
+    clus.update_attribute(4, "Custom")
+    clus.update_attribute(5, "Model")
     app.device_initialized(dev)
     await app.shutdown()
     del clus
@@ -846,8 +846,8 @@ async def test_load_unsupp_attr_missing_endpoint(tmp_path):
     ep.device_type = profiles.zha.DeviceType.PUMP
     clus = ep.add_input_cluster(0x0000)
     ep.add_output_cluster(0x0001)
-    clus._update_attribute(0x0004, "Custom")
-    clus._update_attribute(0x0005, "Model")
+    clus.update_attribute(0x0004, "Custom")
+    clus.update_attribute(0x0005, "Model")
 
     ep = dev.add_endpoint(4)
     ep.status = zigpy.endpoint.Status.ZDO_INIT
@@ -892,8 +892,8 @@ async def test_last_seen(tmp_path):
     ep.device_type = profiles.zha.DeviceType.PUMP
     clus = ep.add_input_cluster(0)
     ep.add_output_cluster(1)
-    clus._update_attribute(4, "Custom")
-    clus._update_attribute(5, "Model")
+    clus.update_attribute(4, "Custom")
+    clus.update_attribute(5, "Model")
     app.device_initialized(dev)
 
     old_last_seen = dev.last_seen

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -483,7 +483,9 @@ async def test_write_attributes_cache_success(cluster, attributes, result):
         assert cluster._write_attributes.call_count == 1
         for attr_id in attributes:
             assert cluster._attr_cache[attr_id] == attributes[attr_id]
-            listener.attribute_updated.assert_any_call(attr_id, attributes[attr_id])
+            listener.attribute_updated.assert_any_call(
+                attr_id, attributes[attr_id], mock.ANY
+            )
 
 
 @pytest.mark.parametrize(
@@ -530,7 +532,9 @@ async def test_write_attributes_cache_failure(cluster, attributes, result, faile
                     )
             else:
                 assert cluster._attr_cache[attr_id] == attributes[attr_id]
-                listener.attribute_updated.assert_any_call(attr_id, attributes[attr_id])
+                listener.attribute_updated.assert_any_call(
+                    attr_id, attributes[attr_id], mock.ANY
+                )
 
 
 async def test_read_attributes_response(cluster):

--- a/zigpy/appdb_schemas/schema_v12.sql
+++ b/zigpy/appdb_schemas/schema_v12.sql
@@ -1,0 +1,227 @@
+PRAGMA user_version = 12;
+
+-- devices
+DROP TABLE IF EXISTS devices_v12;
+CREATE TABLE devices_v12 (
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+    last_seen REAL NOT NULL
+);
+
+CREATE UNIQUE INDEX devices_idx_v12
+    ON devices_v12(ieee);
+
+
+-- endpoints
+DROP TABLE IF EXISTS endpoints_v12;
+CREATE TABLE endpoints_v12 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    profile_id INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v12(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX endpoint_idx_v12
+    ON endpoints_v12(ieee, endpoint_id);
+
+
+-- clusters
+DROP TABLE IF EXISTS in_clusters_v12;
+CREATE TABLE in_clusters_v12 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v12(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX in_clusters_idx_v12
+    ON in_clusters_v12(ieee, endpoint_id, cluster);
+
+
+-- neighbors
+DROP TABLE IF EXISTS neighbors_v12;
+CREATE TABLE neighbors_v12 (
+    device_ieee ieee NOT NULL,
+    extended_pan_id ieee NOT NULL,
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    rx_on_when_idle INTEGER NOT NULL,
+    relationship INTEGER NOT NULL,
+    reserved1 INTEGER NOT NULL,
+    permit_joining INTEGER NOT NULL,
+    reserved2 INTEGER NOT NULL,
+    depth INTEGER NOT NULL,
+    lqi INTEGER NOT NULL,
+
+    FOREIGN KEY(device_ieee)
+        REFERENCES devices_v12(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX neighbors_idx_v12
+    ON neighbors_v12(device_ieee);
+
+
+-- routes
+DROP TABLE IF EXISTS routes_v12;
+CREATE TABLE routes_v12 (
+    device_ieee ieee NOT NULL,
+    dst_nwk INTEGER NOT NULL,
+    route_status INTEGER NOT NULL,
+    memory_constrained INTEGER NOT NULL,
+    many_to_one INTEGER NOT NULL,
+    route_record_required INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    next_hop INTEGER NOT NULL
+);
+
+CREATE INDEX routes_idx_v12
+    ON routes_v12(device_ieee);
+
+
+-- node descriptors
+DROP TABLE IF EXISTS node_descriptors_v12;
+CREATE TABLE node_descriptors_v12 (
+    ieee ieee NOT NULL,
+
+    logical_type INTEGER NOT NULL,
+    complex_descriptor_available INTEGER NOT NULL,
+    user_descriptor_available INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    aps_flags INTEGER NOT NULL,
+    frequency_band INTEGER NOT NULL,
+    mac_capability_flags INTEGER NOT NULL,
+    manufacturer_code INTEGER NOT NULL,
+    maximum_buffer_size INTEGER NOT NULL,
+    maximum_incoming_transfer_size INTEGER NOT NULL,
+    server_mask INTEGER NOT NULL,
+    maximum_outgoing_transfer_size INTEGER NOT NULL,
+    descriptor_capability_field INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v12(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX node_descriptors_idx_v12
+    ON node_descriptors_v12(ieee);
+
+
+-- output clusters
+DROP TABLE IF EXISTS out_clusters_v12;
+CREATE TABLE out_clusters_v12 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v12(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX out_clusters_idx_v12
+    ON out_clusters_v12(ieee, endpoint_id, cluster);
+
+
+-- attributes
+DROP TABLE IF EXISTS attributes_cache_v12;
+CREATE TABLE attributes_cache_v12 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+    attrid INTEGER NOT NULL,
+    value BLOB NOT NULL,
+    last_updated REAL NOT NULL,
+
+    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
+    -- DB but whose values still need to be cached
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v12(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX attributes_idx_v12
+    ON attributes_cache_v12(ieee, endpoint_id, cluster, attrid);
+
+
+-- groups
+DROP TABLE IF EXISTS groups_v12;
+CREATE TABLE groups_v12 (
+    group_id INTEGER NOT NULL,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX groups_idx_v12
+    ON groups_v12(group_id);
+
+
+-- group members
+DROP TABLE IF EXISTS group_members_v12;
+CREATE TABLE group_members_v12 (
+    group_id INTEGER NOT NULL,
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+
+    FOREIGN KEY(group_id)
+        REFERENCES groups_v12(group_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v12(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX group_members_idx_v12
+    ON group_members_v12(group_id, ieee, endpoint_id);
+
+
+-- relays
+DROP TABLE IF EXISTS relays_v12;
+CREATE TABLE relays_v12 (
+    ieee ieee NOT NULL,
+    relays BLOB NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v12(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX relays_idx_v12
+    ON relays_v12(ieee);
+
+
+-- unsupported attributes
+DROP TABLE IF EXISTS unsupported_attributes_v12;
+CREATE TABLE unsupported_attributes_v12 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster INTEGER NOT NULL,
+    attrid INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v12(ieee)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id, cluster)
+        REFERENCES in_clusters_v12(ieee, endpoint_id, cluster)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX unsupported_attributes_idx_v12
+    ON unsupported_attributes_v12(ieee, endpoint_id, cluster, attrid);
+
+
+-- network backups
+DROP TABLE IF EXISTS network_backups_v12;
+CREATE TABLE network_backups_v12 (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    backup_json TEXT NOT NULL
+);


### PR DESCRIPTION
This will allow ZHA to more intelligently decide which devices need to be polled on startup. I would like to make the default behavior not overload the network with requests, with an optional setting to re-enable the old behavior for people who turn off bulbs.

Exposing this information will require some sort of new attribute API, since accessing private dictionaries is not a good one.

---

In the future, I think it would be useful to have some sort of unified proxy for attribute polling/subscriptions:

```Python
await self.subscribe_to_attribute("attr_name", min=5, max=30, delta=1, callback=self.attr_updated)
```

This can then automatically setup attribute reporting (if necessary) and resort to polling when a device does not report in the expected time period.