### PR TITLE
Handle `UNSUP_CLUSTER_COMMAND` when scanning groups

### DIFF
--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -12,6 +12,7 @@ from zigpy.typing import AddressingMode, DeviceType
 import zigpy.util
 import zigpy.zcl
 from zigpy.zcl.foundation import (
+    GENERAL_COMMANDS,
     CommandSchema,
     GeneralCommand,
     Status as ZCLStatus,
@@ -164,11 +165,15 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     async def group_membership_scan(self) -> None:
         """Sync up group membership."""
         try:
-            res = await self.groups.get_membership([])
+            res = await self.groups.get_membership(groups=[])
         except AttributeError:
             return
         except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
             self.debug("Failed to sync-up group membership")
+            return
+
+        if isinstance(res, GENERAL_COMMANDS[GeneralCommand.Default_Response].schema):
+            self.debug("Device does not support group commands: %s", res)
             return
 
         groups = set(res[1])


### PR DESCRIPTION
Looks like some devices erroneously have a `Groups` cluster (0x0004) but do not actually support any commands.

Maybe we should raise a `zigpy.exceptions.UnsupportedCommand` error instead of returning the response?

Fixes #1210