### PR TITLE
Add greenpower cluster enumerations

### DIFF
--- a/zigpy/profiles/__init__.py
+++ b/zigpy/profiles/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from . import zha, zll, zgp
+from . import zgp, zha, zll
 
 PROFILES = {zha.PROFILE_ID: zha, zll.PROFILE_ID: zll, zgp.PROFILE_ID: zgp}

--- a/zigpy/profiles/__init__.py
+++ b/zigpy/profiles/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from . import zha, zll
+from . import zha, zll, zgp
 
-PROFILES = {zha.PROFILE_ID: zha, zll.PROFILE_ID: zll}
+PROFILES = {zha.PROFILE_ID: zha, zll.PROFILE_ID: zll, zgp.PROFILE_ID: zgp}

--- a/zigpy/profiles/zgp.py
+++ b/zigpy/profiles/zgp.py
@@ -7,12 +7,12 @@ PROFILE_ID = 41440
 
 class DeviceType(t.enum16):
     PROXY = 0x0060
-    PROXY_MIN = 0x0061
+    PROXY_BASIC = 0x0061
     TARGET_PLUS = 0x0062
     TARGET = 0x0063
     COMM_TOOL = 0x0064
     COMBO = 0x0065
-    COMBO_MIN = 0x0066
+    COMBO_BASIC = 0x0066
 
 
 CLUSTERS = {

--- a/zigpy/profiles/zgp.py
+++ b/zigpy/profiles/zgp.py
@@ -4,6 +4,7 @@ import zigpy.types as t
 
 PROFILE_ID = 41440
 
+
 class DeviceType(t.enum16):
     PROXY = 0x0060
     PROXY_MIN = 0x0061

--- a/zigpy/profiles/zgp.py
+++ b/zigpy/profiles/zgp.py
@@ -16,5 +16,5 @@ class DeviceType(t.enum16):
 
 
 CLUSTERS = {
-    DeviceType.PROXY_MIN: ([0x0021], []),
+    DeviceType.PROXY_BASIC: ([0x0021], []),
 }

--- a/zigpy/profiles/zgp.py
+++ b/zigpy/profiles/zgp.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import zigpy.types as t
+
+PROFILE_ID = 41440
+
+class DeviceType(t.enum16):
+    PROXY = 0x0060
+    PROXY_MIN = 0x0061
+    TARGET_PLUS = 0x0062
+    TARGET = 0x0063
+    COMM_TOOL = 0x0064
+    COMBO = 0x0065
+    COMBO_MIN = 0x0066
+
+CLUSTERS = {
+    DeviceType.PROXY_MIN: ([0x0021], []),
+}

--- a/zigpy/profiles/zgp.py
+++ b/zigpy/profiles/zgp.py
@@ -13,6 +13,7 @@ class DeviceType(t.enum16):
     COMBO = 0x0065
     COMBO_MIN = 0x0066
 
+
 CLUSTERS = {
     DeviceType.PROXY_MIN: ([0x0021], []),
 }

--- a/zigpy/profiles/zgp.py
+++ b/zigpy/profiles/zgp.py
@@ -16,5 +16,11 @@ class DeviceType(t.enum16):
 
 
 CLUSTERS = {
-    DeviceType.PROXY_BASIC: ([0x0021], []),
+    DeviceType.PROXY: ([0x0021], [0x0021]),
+    DeviceType.PROXY_BASIC: ([], [0x0021]),
+    DeviceType.TARGET_PLUS: ([0x0021], [0x0021]),
+    DeviceType.TARGET: ([0x0021], [0x0021]),
+    DeviceType.COMM_TOOL: ([0x0021], []),
+    DeviceType.COMBO: ([0x0021], [0x0021]),
+    DeviceType.COMBO_BASIC: ([0x0021], [0x0021]),
 }

--- a/zigpy/profiles/zha.py
+++ b/zigpy/profiles/zha.py
@@ -25,6 +25,14 @@ class DeviceType(t.enum16):
     SMART_PLUG = 0x0051
     WHITE_GOODS = 0x0052
     METER_INTERFACE = 0x0053
+    # Greenpower
+    GP_PROXY = 0x0060
+    GP_PROXY_MIN = 0x0061
+    GP_TARGET_PLUS = 0x0062
+    GP_TARGET = 0x0063
+    GP_COMM_TOOL = 0x0064
+    GP_COMBO = 0x0065
+    GP_COMBO_MIN = 0x0066
     # Lighting
     ON_OFF_LIGHT = 0x0100
     DIMMABLE_LIGHT = 0x0101

--- a/zigpy/profiles/zha.py
+++ b/zigpy/profiles/zha.py
@@ -25,14 +25,6 @@ class DeviceType(t.enum16):
     SMART_PLUG = 0x0051
     WHITE_GOODS = 0x0052
     METER_INTERFACE = 0x0053
-    # Greenpower
-    GP_PROXY = 0x0060
-    GP_PROXY_MIN = 0x0061
-    GP_TARGET_PLUS = 0x0062
-    GP_TARGET = 0x0063
-    GP_COMM_TOOL = 0x0064
-    GP_COMBO = 0x0065
-    GP_COMBO_MIN = 0x0066
     # Lighting
     ON_OFF_LIGHT = 0x0100
     DIMMABLE_LIGHT = 0x0101


### PR DESCRIPTION
This will allow enumerations of greenpower clusters in ZHA quirks.

Ref: https://zigbeealliance.org/wp-content/uploads/2019/11/docs-09-5499-26-batt-zigbee-green-power-specification.pdf (page 73)
