### PR TITLE
Allow enum to parse enum value

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -32,6 +32,21 @@ def expose_global():
         del globals()[obj.__name__]
 
 
+def test_enum_fields():
+    class EnumNamed(t.enum8):
+        NAME1 = 0x01
+        NAME2 = 0x10
+
+    assert EnumNamed("0x01") == EnumNamed.NAME1
+    assert EnumNamed("1") == EnumNamed.NAME1
+    assert EnumNamed("0x10") == EnumNamed.NAME2
+    assert EnumNamed("16") == EnumNamed.NAME2
+    assert EnumNamed("NAME1") == EnumNamed.NAME1
+    assert EnumNamed("NAME2") == EnumNamed.NAME2
+    assert EnumNamed("EnumNamed.NAME1") == EnumNamed.NAME1
+    assert EnumNamed("EnumNamed.NAME2") == EnumNamed.NAME2
+
+
 def test_struct_fields():
     class TestStruct(t.Struct):
         a: t.uint8_t

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -366,7 +366,7 @@ class _IntEnumMeta(enum.EnumMeta):
             elif value.isnumeric():
                 value = int(value)
             elif value.startswith(cls.__name__ + "."):
-                value = cls[value[len(cls.__name__)+1:]].value
+                value = cls[value[len(cls.__name__) + 1 :]].value
             else:
                 value = cls[value].value
         return super().__call__(value, names, *args, **kwargs)

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -363,8 +363,12 @@ class _IntEnumMeta(enum.EnumMeta):
         if isinstance(value, str):
             if value.startswith("0x"):
                 value = int(value, base=16)
-            elif value.isnumeric()
+            elif value.isnumeric():
                 value = int(value)
+            elif value.startswith(cls.__name__ + "."):
+                value = cls[value[len(cls.__name__)+1:]].value
+            else:
+                value = cls[value].value
         return super().__call__(value, names, *args, **kwargs)
 
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -360,10 +360,11 @@ class uint64_t_be(uint_t_be, bits=64):
 
 class _IntEnumMeta(enum.EnumMeta):
     def __call__(cls, value, names=None, *args, **kwargs):
-        if isinstance(value, str) and value.startswith("0x"):
-            value = int(value, base=16)
-        else:
-            value = int(value)
+        if isinstance(value, str):
+            if value.startswith("0x"):
+                value = int(value, base=16)
+            elif value.isnumeric()
+                value = int(value)
         return super().__call__(value, names, *args, **kwargs)
 
 


### PR DESCRIPTION
Allow enum parsers to parse the string value of the enum name not only int value.

When enum entries are displayed in HA UI, it will display the stringified version of the enum. The enum should be possible to reproduce from the given name.

This was changed in https://github.com/zigpy/zigpy/pull/352