### PR TITLE
Remove retryable and `tries` + `delay`

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -629,7 +629,6 @@ async def test_configure_reporting_manuf():
         mock.ANY,
         expect_reply=True,
         manufacturer=None,
-        tries=1,
         tsn=mock.ANY,
     )
 
@@ -643,7 +642,6 @@ async def test_configure_reporting_manuf():
         mock.ANY,
         expect_reply=True,
         manufacturer=manufacturer_id,
-        tries=1,
         tsn=mock.ANY,
     )
     assert cluster.request.call_count == 1
@@ -728,7 +726,6 @@ def test_general_command(cluster):
         sentinel.items,
         expect_reply=True,
         manufacturer=0x4567,
-        tries=1,
         tsn=mock.ANY,
     )
 

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -135,7 +135,7 @@ async def test_retry_once():
 async def _test_retryable(exception, retry_exceptions, n, tries=3, delay=0.001):
     counter = 0
 
-    @util.retryable(retry_exceptions)
+    @util.retryable(retry_exceptions, tries=tries, delay=delay)
     async def count(x, y, z):
         assert x == y == z == 9
         nonlocal counter
@@ -145,7 +145,7 @@ async def _test_retryable(exception, retry_exceptions, n, tries=3, delay=0.001):
             exc._counter = counter
             raise exc
 
-    await count(9, 9, 9, tries=tries, delay=delay)
+    await count(9, 9, 9)
     return counter
 
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -773,7 +773,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # TODO: utilize topology scanner information
         return dest.relays[::-1]
 
-    @zigpy.util.retryable_request
     async def request(
         self,
         device: zigpy.device.Device,

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -61,7 +61,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.info("Endpoint descriptor already queried")
         else:
             status, _, sd = await self._device.zdo.Simple_Desc_req(
-                self._device.nwk, self._endpoint_id, tries=3, delay=2
+                self._device.nwk, self._endpoint_id
             )
 
             if status == ZDOStatus.NOT_ACTIVE:

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -186,7 +186,6 @@ class CustomCluster(zigpy.zcl.Cluster):
         *args,
         manufacturer: int | t.uint16_t | None = None,
         expect_reply: bool = True,
-        tries: int = 1,
         tsn: int | t.uint8_t | None = None,
         **kwargs: typing.Any,
     ) -> typing.Coroutine:
@@ -204,7 +203,6 @@ class CustomCluster(zigpy.zcl.Cluster):
             *args,
             manufacturer=manufacturer,
             expect_reply=expect_reply,
-            tries=tries,
             tsn=tsn,
             **kwargs,
         )

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -140,10 +140,8 @@ async def retry(
 def retryable(
     retry_exceptions: typing.Iterable[BaseException], tries: int = 1, delay: float = 0.1
 ) -> typing.Callable:
-    """Return a decorator which makes a function able to be retried
-
-    This adds "tries" and "delay" keyword arguments to the function. Only
-    exceptions in `retry_exceptions` will be retried.
+    """Return a decorator which makes a function able to be retried.
+    Only exceptions in `retry_exceptions` will be retried.
     """
 
     def decorator(func: typing.Callable) -> typing.Callable:

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -150,7 +150,7 @@ def retryable(
         nonlocal tries, delay
 
         @functools.wraps(func)
-        def wrapper(*args, tries=tries, delay=delay, **kwargs):
+        def wrapper(*args, **kwargs):
             if tries <= 1:
                 return func(*args, **kwargs)
             return retry(
@@ -165,7 +165,9 @@ def retryable(
     return decorator
 
 
-retryable_request = retryable((ZigbeeException, asyncio.TimeoutError))
+retryable_request = functools.partial(
+    retryable, (ZigbeeException, asyncio.TimeoutError)
+)
 
 
 def aes_mmo_hash_update(length: int, result: bytes, data: bytes) -> tuple[int, bytes]:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -341,7 +341,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
         return hdr, request
 
-    @util.retryable_request
     async def request(
         self,
         general: bool,
@@ -747,7 +746,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         *args,
         manufacturer: int | t.uint16_t | None = None,
         expect_reply: bool = True,
-        tries: int = 1,
         tsn: int | t.uint8_t | None = None,
         **kwargs,
     ):
@@ -760,7 +758,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             *args,
             manufacturer=manufacturer,
             expect_reply=expect_reply,
-            tries=tries,
             tsn=tsn,
             **kwargs,
         )
@@ -866,7 +863,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         *args,
         manufacturer: int | t.uint16_t | None = None,
         expect_reply: bool = True,
-        tries: int = 1,
         tsn: int | t.uint8_t | None = None,
         **kwargs,
     ):
@@ -891,7 +887,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             *args,
             manufacturer=manufacturer,
             expect_reply=expect_reply,
-            tries=tries,
             tsn=tsn,
             **kwargs,
         )

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -49,7 +49,6 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
 
         return hdr, args
 
-    @zigpy.util.retryable_request
     def request(self, command, *args, use_ieee=False):
         data = self._serialize(command, *args)
         tsn = self.device.application.get_sequence()


### PR DESCRIPTION
The decorator-added keyword arguments are pretty confusing and break with inheritance. It's more straightforward for the downstream application to handle these kinds of retries on its own in one spot.

One side effect of this change is a consolidation of retries: the only place they are done in zigpy is during device initialization, which is now retried five times instead of three. This is because during each retry, the node descriptor request also was retried a few times implicitly.

Related: https://github.com/home-assistant/core/issues/93955