### PR TITLE
Remove `tries` from topology function calls

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -50,7 +50,7 @@ def patch_device_tables(
     neighbors: list | BaseException | zdo_t.Status,
     routes: list | BaseException | zdo_t.Status,
 ):
-    def mgmt_lqi_req(StartIndex: t.uint8_t, **kwargs):
+    def mgmt_lqi_req(StartIndex: t.uint8_t):
         status = zdo_t.Status.SUCCESS
         entries = 0
         start_index = 0
@@ -76,7 +76,7 @@ def patch_device_tables(
             ).values()
         )
 
-    def mgmt_rtg_req(StartIndex: t.uint8_t, **kwargs):
+    def mgmt_rtg_req(StartIndex: t.uint8_t):
         status = zdo_t.Status.SUCCESS
         entries = 0
         start_index = 0

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -103,10 +103,14 @@ def patch_device_tables(
         )
 
     lqi_req_patch = mock.patch.object(
-        device.zdo, "Mgmt_Lqi_req", mock.AsyncMock(side_effect=mgmt_lqi_req)
+        device.zdo,
+        "Mgmt_Lqi_req",
+        mock.AsyncMock(side_effect=mgmt_lqi_req, spec_set=device.zdo.Mgmt_Lqi_req),
     )
     rtg_req_patch = mock.patch.object(
-        device.zdo, "Mgmt_Rtg_req", mock.AsyncMock(side_effect=mgmt_rtg_req)
+        device.zdo,
+        "Mgmt_Rtg_req",
+        mock.AsyncMock(side_effect=mgmt_rtg_req, spec_set=device.zdo.Mgmt_Rtg_req),
     )
 
     with lqi_req_patch, rtg_req_patch:
@@ -136,8 +140,8 @@ async def test_scan_failures(
     with patch_device_tables(dev, neighbors=neighbors, routes=routes):
         await topology.scan()
 
-        assert len(dev.zdo.Mgmt_Lqi_req.mock_calls) == 1
-        assert len(dev.zdo.Mgmt_Rtg_req.mock_calls) == 1
+        assert len(dev.zdo.Mgmt_Lqi_req.mock_calls) == 1 if not neighbors else 3
+        assert len(dev.zdo.Mgmt_Rtg_req.mock_calls) == 1 if not routes else 3
 
     assert not topology.neighbors[dev.ieee]
     assert not topology.routes[dev.ieee]

--- a/zigpy/topology.py
+++ b/zigpy/topology.py
@@ -22,6 +22,9 @@ if typing.TYPE_CHECKING:
     import zigpy.application
 
 
+RETRY_SLOW = zigpy.util.retryable_request(tries=3, delay=1)
+
+
 class ScanNotSupported(Exception):
     pass
 
@@ -101,7 +104,7 @@ class Topology(zigpy.util.ListenableMixin):
         table = []
 
         while True:
-            status, rsp = await scan_request(index, tries=3, delay=1)
+            status, rsp = await RETRY_SLOW(scan_request)(index)
 
             if status != zdo_t.Status.SUCCESS:
                 raise ScanNotSupported()


### PR DESCRIPTION
Apparently unit tests have again too many mocks and allowed this typo to sneak in.