### PR TITLE
Bypass `enum`'s functional creation API in 3.11+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   shared-ci:
-    uses: zigpy/workflows/.github/workflows/ci.yml@main
+    runs-on: ubuntu-latest
+    uses: zigpy/workflows/.github/workflows/ci.yml@puddly/pre-commit
     with:
       CODE_FOLDER: zigpy
       CACHE_VERSION: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,6 @@ jobs:
     with:
       CODE_FOLDER: zigpy
       CACHE_VERSION: 2
+      PRE_COMMIT_CACHE_PATH:  ~/.cache/pre-commit
       PYTHON_VERSION_DEFAULT: 3.9.15
       MINIMUM_COVERAGE_PERCENTAGE: 99

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   shared-ci:
-    runs-on: ubuntu-latest
     uses: zigpy/workflows/.github/workflows/ci.yml@puddly/pre-commit
     with:
       CODE_FOLDER: zigpy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   shared-ci:
-    uses: zigpy/workflows/.github/workflows/ci.yml@puddly/pre-commit
+    uses: zigpy/workflows/.github/workflows/ci.yml@main
     with:
       CODE_FOLDER: zigpy
       CACHE_VERSION: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,4 @@ jobs:
       CODE_FOLDER: zigpy
       CACHE_VERSION: 2
       PYTHON_VERSION_DEFAULT: 3.9.15
-      PRE_COMMIT_CACHE_PATH:  ~/.cache/pre-commit
       MINIMUM_COVERAGE_PERCENTAGE: 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ testing = [
     "pytest-timeout",
     "freezegun",
     "ruff==0.0.261",
-    'pysqlite3-binary; platform_system=="Linux"',
+    'pysqlite3-binary; platform_system=="Linux" and python_version<"3.12"',
 ]
 
 [tool.setuptools-git-versioning]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,4 +11,4 @@ freezegun
 ruff==0.0.261
 tomli
 
-pysqlite3-binary; platform_system=="Linux"
+pysqlite3-binary; platform_system=="Linux" and python_version<"3.12"

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -361,7 +361,14 @@ class uint64_t_be(uint_t_be, bits=64):
     pass
 
 
-class _IntEnumMeta(enum.EnumMeta):
+class AlwaysCreateEnumType(enum.EnumMeta):
+    """Enum metaclass that skips the functional creation API."""
+
+    def __call__(cls, value, names=None, *values) -> type[enum.Enum]:  # type: ignore
+        return cls.__new__(cls, value)  # type: ignore
+
+
+class _IntEnumMeta(AlwaysCreateEnumType):
     def __call__(cls, value, names=None, *args, **kwargs):
         if isinstance(value, str):
             if value.startswith("0x"):
@@ -382,7 +389,13 @@ def bitmap_factory(int_type: CALLABLE_T) -> CALLABLE_T:
 
     if sys.version_info >= (3, 11):
 
-        class _NewEnum(int_type, enum.ReprEnum, enum.Flag, boundary=enum.KEEP):
+        class _NewEnum(
+            int_type,
+            enum.ReprEnum,
+            enum.Flag,
+            boundary=enum.KEEP,
+            metaclass=AlwaysCreateEnumType,
+        ):
             pass
 
     else:


### PR DESCRIPTION
Our use of enums is a little nonstandard. To avoid future problems with the functional creation API, it is easier to disable it. This completes preliminary Python 3.12 support in zigpy.

Fixes #1233.