### PR TITLE
Persist coordinator model info in the database

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,8 @@ class App(zigpy.application.ControllerApplication):
         dev = add_initialized_device(
             app=self, nwk=self.state.node_info.nwk, ieee=self.state.node_info.ieee
         )
+        dev.model = "Coordinator Model"
+        dev.manufacturer = "Coordinator Manufacturer"
 
         dev.zdo.Mgmt_NWK_Update_req = AsyncMock(
             return_value=[

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -25,7 +25,7 @@ import zigpy.zcl
 from zigpy.zcl.foundation import Status as ZCLStatus
 from zigpy.zdo import types as zdo_t
 
-from tests.async_mock import AsyncMock, MagicMock, patch
+from tests.async_mock import AsyncMock, MagicMock, call, patch
 from tests.conftest import make_app, make_ieee
 from tests.test_backups import backup_factory  # noqa: F401
 
@@ -1023,3 +1023,17 @@ async def test_appdb_network_backups(tmp_path, backup_factory):  # noqa: F811
     assert app3.backups.backups[0] == new_backup
     assert app3.backups.backups[0] != backup
     await app3.shutdown()
+
+
+async def test_appdb_persist_coordinator_info(tmp_path):  # noqa: F811
+    db = tmp_path / "test.db"
+
+    with patch(
+        "zigpy.appdb.PersistingListener._save_attribute_cache",
+        wraps=zigpy.appdb.PersistingListener._save_attribute_cache,
+    ) as mock_save_attr_cache:
+        app = await make_app_with_db(db)
+        await app.initialize()
+        await app.shutdown()
+
+    assert mock_save_attr_cache.mock_calls == [call(app._device.endpoints[1])]

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -602,7 +602,7 @@ async def test_form_network_find_best_channel(app):
 
 async def test_startup_formed():
     app = make_app({conf.CONF_STARTUP_ENERGY_SCAN: False})
-    app.start_network = AsyncMock()
+    app.start_network = AsyncMock(wraps=app.start_network)
     app.form_network = AsyncMock()
     app.permit = AsyncMock()
 
@@ -615,7 +615,7 @@ async def test_startup_formed():
 
 async def test_startup_not_formed():
     app = make_app({conf.CONF_STARTUP_ENERGY_SCAN: False})
-    app.start_network = AsyncMock()
+    app.start_network = AsyncMock(wraps=app.start_network)
     app.form_network = AsyncMock()
     app.load_network_info = AsyncMock(
         side_effect=[NetworkNotFormed(), NetworkNotFormed(), None]
@@ -642,7 +642,7 @@ async def test_startup_not_formed():
 
 async def test_startup_not_formed_with_backup():
     app = make_app({conf.CONF_STARTUP_ENERGY_SCAN: False})
-    app.start_network = AsyncMock()
+    app.start_network = AsyncMock(wraps=app.start_network)
     app.load_network_info = AsyncMock(side_effect=[NetworkNotFormed(), None])
     app.permit = AsyncMock()
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1219,16 +1219,17 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         return self.get_device(ieee=self.state.node_info.ieee)
 
     def _persist_coordinator_model_strings_in_db(self) -> None:
-        # Emit an `attribute_updated` event from a fake cluster to persist the attribute
-        fake_ep = zigpy.endpoint.Endpoint(device=self._device, endpoint_id=1)
-        fake_cluster = fake_ep.add_input_cluster(
+        cluster = self._device.endpoints[1].add_input_cluster(
             zigpy.zcl.clusters.general.Basic.cluster_id
         )
-        fake_cluster.update_attribute(
+
+        cluster.update_attribute(
             attrid=zigpy.zcl.clusters.general.Basic.AttributeDefs.model.id,
             value=self._device.model,
         )
-        fake_cluster.update_attribute(
+        cluster.update_attribute(
             attrid=zigpy.zcl.clusters.general.Basic.AttributeDefs.manufacturer.id,
             value=self._device.manufacturer,
         )
+
+        self.device_initialized(self._device)


### PR DESCRIPTION
This PR is required to split ZHA initialization (https://github.com/home-assistant/core/pull/98082) into two phases:

 - Database loading and entity creation
 - Radio communication

ZHA group entities are attached to the coordinator device, whose model info is loaded dynamically by communicating with the adapter. We need this info to be able to fully initialize ZHA entities (TODO: detach groups from the coordinator device).

This will hopefully fix all the existing race conditions where ZHA startup was limiting the creation of device automation triggers, since we will be able to set all of this up long before needing to try to communicating with the radio.