### PR TITLE
Use shared PyPi release workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish distributions to PyPI
 on:
   release:
     types:
-      - released
+      - published
 
 jobs:
   shared-build-and-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,7 +8,5 @@ on:
 jobs:
   shared-build-and-publish:
     uses: zigpy/workflows/.github/workflows/publish-to-pypi.yml@main
-    with:
-      PYTHON_VERSION_DEFAULT: 3.9.15
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,26 +1,14 @@
-name: Publish distributions to PyPI and TestPyPI
+name: Publish distributions to PyPI
+
 on:
   release:
     types:
       - released
 
 jobs:
-  build-and-publish:
-    name: Build and publish distributions to PyPI and TestPyPI
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-    - name: Install wheel
-      run: >-
-        pip install wheel build
-    - name: Build
-      run: >-
-        python3 -m build
-    - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}
+  shared-build-and-publish:
+    uses: zigpy/workflows/.github/workflows/publish-to-pypi.yml@main
+    with:
+      PYTHON_VERSION_DEFAULT: 3.9.15
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Changes:
- Migrates the PyPi publishing workflow to the shared workflow (with providing the token as a secret).
- Thus also fixes the [warning for using the master branch of the action](https://github.com/zigpy/zigpy/actions/runs/5672371193), as the shared workflow is using v1 correctly.
- Also removes "TestPyPi" from the action title, as both the old and the new actions do not actually publish to TestPyPi.

This is untested, but it *should* work, as it's the same workflow as in the quirks repo.
I'll follow-up with the same PR for the other zigpy repos.

Related PRs from the zha-quirks repo:
- https://github.com/zigpy/zha-device-handlers/pull/2501
- https://github.com/zigpy/zha-device-handlers/pull/2502
- https://github.com/zigpy/zha-device-handlers/pull/2505