### PR TITLE
Fix saving attributes to db in short intervals

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -556,7 +556,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 SET value=excluded.value, last_updated=excluded.last_updated
                 WHERE
                     value != excluded.value
-                    AND :timestamp - last_updated > :min_update_delta
+                    OR :timestamp - last_updated > :min_update_delta
             """
         await self.execute(
             q,


### PR DESCRIPTION
Addresses the issues in:
- https://github.com/home-assistant/core/issues/97215
- https://github.com/home-assistant/core/issues/96737

Background information: https://github.com/home-assistant/core/issues/97215#issuecomment-1657208886

TL;DR is:
Attribute updates currently aren't saved to the DB if they're changed in under 30 seconds.
This is corrected by changing the `AND` to an `OR` in the SQL query to make sure a changed attribute is always written, but the "last updated" time is only written when the delta is greater than 30 seconds.

I've also added a quick (and dirty) test which checks:
- if the latter attribute write is saved to the DB (when written in a 10 second interval) (which is within 30 seconds delta)
- if the first last updated time is NOT overwritten when in the 30 seconds delta

I've used that test to "verify that it works". Not sure if such a test is good in that place though.
The sleep is needed, as `device_initialized` causes the attribute cache to be completely saved (and that's executed in a worker task we need to wait for complete).
This can probably be done better (but I also didn't want to mock out `_save_attribute_cache`, so open to suggestions on how to improve this, if we want to keep the test).