### PR TITLE
Log serial connection attempts

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -499,7 +499,9 @@ async def test_attribute_update_short_interval(tmp_path):
     assert clus._attr_cache[0x4000] == "2.0"  # verify second attribute update was saved
 
     # verify the first update attribute time was not overwritten, as it was within the short interval
-    assert (attr_update_time_first - clus._attr_last_updated[0x0004]) < timedelta(seconds=0.1)
+    assert (attr_update_time_first - clus._attr_last_updated[0x0004]) < timedelta(
+        seconds=0.1
+    )
 
     await app2.shutdown()
 

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import typing
 import urllib.parse
 
@@ -8,6 +9,7 @@ import async_timeout
 import serial as pyserial
 import serial_asyncio as pyserial_asyncio
 
+LOGGER = logging.getLogger(__name__)
 DEFAULT_SOCKET_PORT = 6638
 SOCKET_CONNECT_TIMEOUT = 5
 
@@ -24,6 +26,9 @@ async def create_serial_connection(
     """Wrapper around pyserial-asyncio that transparently substitutes a normal TCP
     transport and protocol when a `socket` connection URI is provided.
     """
+    baudrate: int | None = kwargs.get("baudrate")
+    LOGGER.debug("Opening a serial connection to %r (%s baudrate)", url, baudrate)
+
     parsed_url = urllib.parse.urlparse(url)
 
     if parsed_url.scheme in ("socket", "tcp"):


### PR DESCRIPTION
This will help with debugging connection attempts for libraries that don't log this info (e.g. bellows).