### PR TITLE
Fix old-style `ZCLAttributeDef` conversion

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -499,7 +499,9 @@ async def test_attribute_update_short_interval(tmp_path):
     assert clus._attr_cache[0x4000] == "2.0"  # verify second attribute update was saved
 
     # verify the first update attribute time was not overwritten, as it was within the short interval
-    assert (attr_update_time_first - clus._attr_last_updated[0x0004]) < timedelta(seconds=0.1)
+    assert (attr_update_time_first - clus._attr_last_updated[0x0004]) < timedelta(
+        seconds=0.1
+    )
 
     await app2.shutdown()
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -125,6 +125,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                     type=attr_type,
                     is_manufacturer_specific=attr_manuf_specific,
                 )
+            else:
+                attr = attr.replace(id=attr_id)
 
             cls.attributes[attr.id] = attr.replace(id=attr_id)
 


### PR DESCRIPTION
This fixes an issue where `ZCLAttributeDef`s that are defined the "old dict way" aren't correctly converted.
This is done by adding the `id` to the `ZCLAttributeDef` dataclass when they're defined in the `attributes` value.
For context, see: https://github.com/zigpy/zha-device-handlers/pull/2315#issuecomment-1685351542

(It also runs pre-commit on `test_appdb.py` which I apparently missed previously, as the hook wasn't installed and CI didn't check for it.)

Note: This PR is only somewhat tested:
- the original issue seems to be fixed (quirk now loads)
- everything else still to works
- no regression tests have been added

I didn't explicitly test if other stuff still works correctly (but it should).