### PR TITLE
Include the old and new settings in `NetworkSettingsInconsistent` errors

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -717,11 +717,14 @@ async def test_initialize_incompatible_backup(
     app = make_app({conf.CONF_NWK_VALIDATE_SETTINGS: True})
     mock_backup_from_state.return_value.is_compatible_with.return_value = False
 
-    with pytest.raises(NetworkSettingsInconsistent):
+    with pytest.raises(NetworkSettingsInconsistent) as exc:
         await app.initialize()
 
     mock_backup_from_state.return_value.is_compatible_with.assert_called_once()
     mock_most_recent_backup.assert_called_once()
+
+    assert exc.value.old_state is mock_most_recent_backup()
+    assert exc.value.new_state is mock_backup_from_state.return_value
 
 
 async def test_relays_received_device_exists(app):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -142,7 +142,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             raise zigpy.exceptions.NetworkSettingsInconsistent(
                 f"Radio network settings are not compatible with most recent backup!\n"
                 f"Current settings: {new_state!r}\n"
-                f"Last backup: {last_backup!r}"
+                f"Last backup: {last_backup!r}",
+                old_state=last_backup,
+                new_state=new_state,
             )
 
         await self.start_network()

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import zigpy.backups
+
 
 class ZigbeeException(Exception):
     """Base exception class"""
@@ -43,6 +45,16 @@ class FormationFailure(RadioException):
 
 class NetworkSettingsInconsistent(ZigbeeException):
     """Loaded network settings are different from what is in the database"""
+
+    def __init__(
+        self,
+        message: str,
+        new_state: zigpy.backups.NetworkBackup,
+        old_state: zigpy.backups.NetworkBackup,
+    ) -> None:
+        super().__init__(message)
+        self.new_state = new_state
+        self.old_state = old_state
 
 
 class CorruptDatabase(ZigbeeException):


### PR DESCRIPTION
This allows for applications (i.e. ZHA) catching `NetworkSettingsInconsistent` to be able to diff the settings and display an error on startup.