### PR TITLE
Ensure `zigpy.exceptions` does not have circular imports

### DIFF
--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-import zigpy.backups
+import typing
+
+if typing.TYPE_CHECKING:
+    import zigpy.backups
 
 
 class ZigbeeException(Exception):


### PR DESCRIPTION
#1249 introduced a circular import if `zigpy.backups` is imported *after* `zigpy.exceptions`, at runtime.