### PR TITLE
Use first existing endpoint for basic cluster instead of hardcoded number

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1221,6 +1221,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         return self.get_device(ieee=self.state.node_info.ieee)
 
     def _persist_coordinator_model_strings_in_db(self) -> None:
+        if 1 not in self._device.endpoints:
+            self._device.add_endpoint(1)
+
         cluster = self._device.endpoints[1].add_input_cluster(
             zigpy.zcl.clusters.general.Basic.cluster_id
         )

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1221,10 +1221,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         return self.get_device(ieee=self.state.node_info.ieee)
 
     def _persist_coordinator_model_strings_in_db(self) -> None:
-        if 1 not in self._device.endpoints:
-            self._device.add_endpoint(1)
-
-        cluster = self._device.endpoints[1].add_input_cluster(
+        cluster = self._device.non_zdo_endpoints[0].add_input_cluster(
             zigpy.zcl.clusters.general.Basic.cluster_id
         )
 


### PR DESCRIPTION
On #1238 we add Basic cluster to endpoint 1.
This PR makes sure that that endpoint actually exists.

Mostly applicable to xbee coordinators: https://github.com/zigpy/zigpy-xbee/blob/dev/zigpy_xbee/zigbee/application.py#L381