### PR TITLE
Opportunistically use pyserial-asyncio-fast

### DIFF
--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -7,11 +7,17 @@ import urllib.parse
 
 import async_timeout
 import serial as pyserial
-import serial_asyncio as pyserial_asyncio
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_SOCKET_PORT = 6638
 SOCKET_CONNECT_TIMEOUT = 5
+
+try:
+    import serial_asyncio_fast as pyserial_asyncio
+
+    LOGGER.info("Using pyserial-asyncio-fast in place of pyserial-asyncio")
+except ImportError:
+    import serial_asyncio as pyserial_asyncio
 
 
 async def create_serial_connection(


### PR DESCRIPTION
Use [`pyserial-asyncio-fast`](https://github.com/home-assistant-libs/pyserial-asyncio-fast) if it is available. I'm intentionally not adding this package to zigpy's dependencies yet, that will be done within ZHA's manifest.

Since every zigpy radio library uses `zigpy.serial` instead of pyserial directly, this change will be global once ZHA is updated.