### PR TITLE
Add the `py.typed` marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 exclude = ["tests", "tests.*"]
 
 [tool.setuptools.package-data]
-"*" = ["appdb_schemas/schema_v*.sql"]
+"*" = ["appdb_schemas/schema_v*.sql", "py.typed"]
 
 [project.optional-dependencies]
 testing = [


### PR DESCRIPTION
This allows for mypy to use zigpy's type annotations when included in other modules.