### PR TITLE
Add a `permit_with_link_key` method, in preparation for removing `permit_with_key`

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1090,6 +1090,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Permit a node to join with the provided install code bytes."""
         raise NotImplementedError()  # pragma: no cover
 
+    async def permit_with_link_key(
+        self, node: t.EUI64, link_key: t.KeyData, time_s: int = 60
+    ) -> None:
+        """Permit a node to join with the provided link key."""
+        raise NotImplementedError()  # pragma: no cover
+
     @abc.abstractmethod
     async def write_network_info(
         self,


### PR DESCRIPTION
All radio libraries currently convert install codes internally, which is unnecessary duplication and also prevents us from directly supplying the link key in an unhashed form (e.g. not as an install code). Once radio libraries migrate to `permit_with_link_key`, a default implementation of `permit_with_key` will be made possible (or the function will be removed).