### PR TITLE
Don't shut down the database when `startup` has been manually called

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -437,24 +437,6 @@ async def test_remove_parent_devices(app, make_initialized_device):
         assert parent.zdo.request.await_count == 1
 
 
-async def test_startup_log_on_uninitialized_device(ieee, caplog):
-    class TestApp(App):
-        async def _load_db(self):
-            dev = self.add_device(ieee, 1)
-            assert not dev.is_initialized
-
-    caplog.set_level(logging.WARNING)
-
-    await TestApp.new(
-        {
-            conf.CONF_DATABASE: "/dev/null",
-            conf.CONF_DEVICE: {conf.CONF_DEVICE_PATH: "/dev/null"},
-            conf.CONF_STARTUP_ENERGY_SCAN: False,
-        }
-    )
-    assert "Device is partially initialized" in caplog.text
-
-
 @patch("zigpy.device.Device.schedule_initialize", new_callable=MagicMock)
 @patch("zigpy.device.Device.schedule_group_membership_scan", new_callable=MagicMock)
 @patch("zigpy.device.Device.is_initialized", new_callable=PropertyMock)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1375,3 +1375,17 @@ async def test_move_network_to_new_channel_noop(app):
 
     assert app.state.network_info.channel == old_channel
     assert len(mock_broadcast.mock_calls) == 0
+
+
+async def test_startup_multiple_dblistener(app):
+    app._dblistener = AsyncMock()
+    app.connect = AsyncMock(side_effect=RuntimeError())
+
+    with pytest.raises(RuntimeError):
+        await app.startup()
+
+    with pytest.raises(RuntimeError):
+        await app.startup()
+
+    # The database listener will not be shut down automatically
+    assert len(app._dblistener.shutdown.mock_calls) == 0

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -52,6 +52,7 @@ def test_listenable():
     listen.remove_listener(listener)
     listen.remove_listener(listener)
     listen.remove_listener(broken_listener)
+    listen.remove_listener(context_listener)
     listen.listener_event("event", "test1")
     assert listener.event.call_count == 2
     assert context_listener.event.call_count == 1

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -48,6 +48,15 @@ def test_listenable():
     assert context_listener.event.call_count == 1
     assert broken_listener.event.call_count == 1
 
+    listen.remove_listener(object())
+    listen.remove_listener(listener)
+    listen.remove_listener(listener)
+    listen.remove_listener(broken_listener)
+    listen.listener_event("event", "test1")
+    assert listener.event.call_count == 2
+    assert context_listener.event.call_count == 1
+    assert broken_listener.event.call_count == 1
+
 
 class Logger(util.LocalLogMixin):
     log = MagicMock()

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -222,10 +222,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         await app.startup(auto_form=auto_form)
 
-        for device in app.devices.values():
-            if not device.is_initialized:
-                LOGGER.warning("Device is partially initialized: %s", device)
-
         return app
 
     async def energy_scan(

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -40,6 +40,12 @@ class ListenableMixin:
     def add_context_listener(self, listener: CatchingTaskMixin) -> int:
         return self._add_listener(listener, include_context=True)
 
+    def remove_listener(self, listener: typing.Any) -> None:
+        for id_, (attached_listener, _) in self._listeners.items():
+            if attached_listener is listener:
+                del self._listeners[id_]
+                break
+
     def listener_event(self, method_name: str, *args) -> list[typing.Any | None]:
         result = []
         for listener, include_context in self._listeners.values():


### PR DESCRIPTION
ZHA currently initializes the zigpy application before attempting to connect multiple times. The application database listener does not properly work after the second shutdown/reconnect attempt.

To work around this, `shutdown` must manually be called when disconnecting.