### PR TITLE
Support separate update of lqi and rssi

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -144,6 +144,14 @@ def test_radio_details(dev):
     assert dev.lqi == 1
     assert dev.rssi == 2
 
+    dev.radio_details(lqi=3)
+    assert dev.lqi == 3
+    assert dev.rssi == 2
+
+    dev.radio_details(rssi=4)
+    assert dev.lqi == 3
+    assert dev.rssi == 4
+
 
 def test_deserialize(dev):
     ep = dev.add_endpoint(3)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -389,9 +389,11 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             use_ieee=use_ieee,
         )
 
-    def radio_details(self, lqi, rssi) -> None:
-        self.lqi = lqi
-        self.rssi = rssi
+    def radio_details(self, lqi=None, rssi=None) -> None:
+        if lqi is not None:
+            self.lqi = lqi
+        if rssi is not None:
+            self.rssi = rssi
 
     def log(self, lvl, msg, *args, **kwargs) -> None:
         msg = "[0x%04x] " + msg


### PR DESCRIPTION
When calling `device.radio_details`, only update lqi and rssi if the argument is not None.
This has two purpuses:
1. Don't reset `rssi` and `lqi` on every `ControllerApplication.package_received()` when rssi and lqi was set by other means.
2. Support setting `rssi` and `lqi` separately without updating the other.