### PR TITLE
Remove `py.typed`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 exclude = ["tests", "tests.*"]
 
 [tool.setuptools.package-data]
-"*" = ["appdb_schemas/schema_v*.sql", "py.typed"]
+"*" = ["appdb_schemas/schema_v*.sql"]
 
 [project.optional-dependencies]
 testing = [


### PR DESCRIPTION
Our current type annotations aren't enough to work with Home Assistant, especially the cryptic one related to `cluster_id` having an unknown type for any concrete subclass of `Cluster`.

Type annotations will be added back in once these problems are fixed.