### PR TITLE
Typing improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         args: ["--toml", "pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.6.0
     hooks:
       - id: mypy
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,11 +172,11 @@ disable_error_code = [
 follow_imports = "silent"
 
 [[tool.mypy.overrides]]
-module = "zigpy.types.basic"
-disable_error_code = []
-
-[[tool.mypy.overrides]]
-module = "zigpy.appdb_schemas"
+module = [
+    "zigpy.appdb_schemas",
+    "zigpy.types.basic",
+    "zigpy.types.named",
+]
 disable_error_code = []
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,8 +155,29 @@ non_interactive = true
 show_error_codes = true
 show_error_context = true
 error_summary = true
+disable_error_code = [
+    # Only a few notifications left:
+    "type-arg",
+    # Only a few notifications left:
+    "return-value",
+    # operator breaks in CI (zigpy.types.basic), but not locally
+    "operator",
+    "valid-type",
+    "misc",
+    "attr-defined",
+    "assignment",
+    "arg-type"
+]
 # Only report on selected files
 follow_imports = "silent"
+
+[[tool.mypy.overrides]]
+module = "zigpy.types.basic"
+disable_error_code = []
+
+[[tool.mypy.overrides]]
+module = "zigpy.appdb_schemas"
+disable_error_code = []
 
 [tool.coverage.run]
 source = ["zigpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,19 +155,6 @@ non_interactive = true
 show_error_codes = true
 show_error_context = true
 error_summary = true
-disable_error_code = [
-    # Only a few notifications left:
-    "type-arg",
-    # Only a few notifications left:
-    "return-value",
-    # operator breaks in CI (zigpy.types.basic), but not locally
-    "operator",
-    "valid-type",
-    "misc",
-    "attr-defined",
-    "assignment",
-    "arg-type"
-]
 # Only report on selected files
 follow_imports = "silent"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,8 @@ disable_error_code = [
     "misc",
     "attr-defined",
     "assignment",
-    "arg-type"
+    "arg-type",
+    "has-type",
 ]
 # Only report on selected files
 follow_imports = "silent"

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -393,7 +393,7 @@ def test_ias_zone_type():
 
     zone, rest = sec.IasZone.ZoneType.deserialize(b"\x81\x81" + extra)
     assert rest == extra
-    assert zone.name.startswith("manufacturer_specific")
+    assert zone.name.startswith("undefined")
     assert zone.value == 0x8181
 
 
@@ -409,7 +409,7 @@ def test_ias_ace_audible_notification():
         b"\x81" + extra
     )
     assert rest == extra
-    assert notification_type.name.startswith("manufacturer_specific")
+    assert notification_type.name.startswith("undefined")
     assert notification_type.value == 0x81
 
 

--- a/zigpy/appdb_schemas/__init__.py
+++ b/zigpy/appdb_schemas/__init__.py
@@ -10,6 +10,7 @@ else:
 # Map each schema version to its SQL
 SCHEMAS = {}
 
-for file in importlib_resources.files(__name__).glob("schema_v*.sql"):
-    n = int(file.name.replace("schema_v", "").replace(".sql", ""), 10)
-    SCHEMAS[n] = file.read_text()
+with importlib_resources.as_file(importlib_resources.files(__name__)) as resources:
+    for file in resources.glob("schema_v*.sql"):
+        n = int(file.name.replace("schema_v", "").replace(".sql", ""), 10)
+        SCHEMAS[n] = file.read_text()

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -43,7 +43,7 @@ class Bits(list[int]):
         return bytes(serialized_bytes)
 
     @classmethod
-    def deserialize(cls, data) -> tuple[Bits, bytes]:
+    def deserialize(cls, data: bytes) -> tuple[Bits, bytes]:
         bits: list[int] = []
 
         for byte in data:
@@ -462,7 +462,7 @@ class AlwaysCreateEnumType(enum.EnumMeta):
 
 
 class _IntEnumMeta(AlwaysCreateEnumType):
-    def __call__(cls, value, names=None, *args, **kwargs):
+    def __call__(cls, value, names=None, *args, **kwargs) -> type[enum.Enum]:
         if isinstance(value, str):
             if value.startswith("0x"):
                 value = int(value, base=16)

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -11,6 +11,7 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Self
 
 
+@dataclasses.dataclass
 class BaseDataclassMixin:
     def replace(self, **kwargs) -> Self:
         return dataclasses.replace(self, **kwargs)
@@ -105,7 +106,7 @@ class Channels(basic.bitmap32):
     CHANNEL_26 = 0x04000000
 
     @classmethod
-    def from_channel_list(cls: Channels, channels: typing.Iterable[int]) -> Channels:
+    def from_channel_list(cls, channels: typing.Iterable[int]) -> Self:
         mask = cls.NO_CHANNELS
 
         for channel in channels:
@@ -114,14 +115,16 @@ class Channels(basic.bitmap32):
                     f"Invalid channel number {channel}. Must be between 11 and 26."
                 )
 
-            mask |= cls[f"CHANNEL_{channel}"]
+            mask |= getattr(cls, f"CHANNEL_{channel}")
 
         return mask
 
     def __iter__(self):
         cls = type(self)
 
-        channels = [c for c in range(11, 26 + 1) if self & cls[f"CHANNEL_{c}"]]
+        channels = [
+            c for c in range(11, 26 + 1) if self & getattr(self, f"CHANNEL_{c}")
+        ]
 
         if self != cls.from_channel_list(channels):
             raise ValueError(f"Channels bitmap has unexpected members: {self}")

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -7,7 +7,7 @@ import functools
 import itertools
 import logging
 import types
-from typing import TYPE_CHECKING, Any, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Sequence, cast
 import warnings
 
 from zigpy import util
@@ -132,7 +132,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
         # Create new definitions from the old-style definitions
         if cls.attributes and "AttributeDefs" not in cls.__dict__:
-            cls.AttributeDefs = types.new_class(
+            cls.AttributeDefs = types.new_class(  # type:ignore[misc]
                 name="AttributeDefs",
                 bases=(BaseAttributeDefs,),
             )
@@ -141,7 +141,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 setattr(cls.AttributeDefs, attr.name, attr)
 
         if cls.server_commands and "ServerCommandDefs" not in cls.__dict__:
-            cls.ServerCommandDefs = types.new_class(
+            cls.ServerCommandDefs = types.new_class(  # type:ignore[misc]
                 name="ServerCommandDefs",
                 bases=(BaseCommandDefs,),
             )
@@ -150,7 +150,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 setattr(cls.ServerCommandDefs, command.name, command)
 
         if cls.client_commands and "ClientCommandDefs" not in cls.__dict__:
-            cls.ClientCommandDefs = types.new_class(
+            cls.ClientCommandDefs = types.new_class(  # type:ignore[misc]
                 name="ClientCommandDefs",
                 bases=(BaseCommandDefs,),
             )
@@ -282,7 +282,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 self.warning("Unknown foundation command %s %s", hdr.command_id, data)
                 return hdr, data
 
-            command = foundation.GENERAL_COMMANDS[hdr.command_id]
+            command = foundation.GENERAL_COMMANDS[
+                cast(foundation.GeneralCommand, hdr.command_id)
+            ]
 
         hdr.frame_control.direction = command.direction
         response, data = command.schema.deserialize(data)
@@ -861,7 +863,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
     def general_command(
         self,
-        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        command_id: foundation.GeneralCommand,
         *args,
         manufacturer: int | t.uint16_t | None = None,
         expect_reply: bool = True,

--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -33,9 +33,9 @@ class Shade(Cluster):
     ShadeStatus: Final = ShadeStatus
     ShadeMode: Final = ShadeMode
 
-    cluster_id: Final = 0x0100
-    name: Final = "Shade Configuration"
-    ep_attribute: Final = "shade"
+    cluster_id = 0x0100
+    name = "Shade Configuration"
+    ep_attribute = "shade"
 
     class AttributeDefs(BaseAttributeDefs):
         # Shade Information
@@ -288,9 +288,9 @@ class DoorLock(Cluster):
     DayMask: Final = DayMask
     EventType: Final = EventType
 
-    cluster_id: Final = 0x0101
-    name: Final = "Door Lock"
-    ep_attribute: Final = "door_lock"
+    cluster_id = 0x0101
+    name = "Door Lock"
+    ep_attribute = "door_lock"
 
     class AttributeDefs(BaseAttributeDefs):
         lock_state: Final = ZCLAttributeDef(
@@ -730,9 +730,9 @@ class WindowCovering(Cluster):
     ConfigStatus: Final = ConfigStatus
     WindowCoveringMode: Final = WindowCoveringMode
 
-    cluster_id: Final = 0x0102
-    name: Final = "Window Covering"
-    ep_attribute: Final = "window_covering"
+    cluster_id = 0x0102
+    name = "Window Covering"
+    ep_attribute = "window_covering"
 
     class AttributeDefs(BaseAttributeDefs):
         # Window Covering Information

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Final
 
+from typing_extensions import Self
+
 import zigpy.types as t
 from zigpy.typing import AddressingMode
 from zigpy.zcl import Cluster, foundation
@@ -31,7 +33,7 @@ class PowerSource(t.enum8):
         self.battery_backup = False
 
     @classmethod
-    def deserialize(cls, data: bytes) -> tuple[bytes, bytes]:
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
         val, data = t.uint8_t.deserialize(data)
         r = cls(val & 0x7F)
         r.battery_backup = bool(val & 0x80)
@@ -214,8 +216,8 @@ class Basic(Cluster):
     GenericDeviceClass: Final = GenericDeviceClass
     GenericLightingDeviceType: Final = GenericLightingDeviceType
 
-    cluster_id: Final = 0x0000
-    ep_attribute: Final = "basic"
+    cluster_id = 0x0000
+    ep_attribute = "basic"
 
     class AttributeDefs(BaseAttributeDefs):
         # Basic Device Information
@@ -307,9 +309,9 @@ class PowerConfiguration(Cluster):
     MainsAlarmMask: Final = MainsAlarmMask
     BatterySize: Final = BatterySize
 
-    cluster_id: Final = 0x0001
-    name: Final = "Power Configuration"
-    ep_attribute: Final = "power"
+    cluster_id = 0x0001
+    name = "Power Configuration"
+    ep_attribute = "power"
 
     class AttributeDefs(BaseAttributeDefs):
         # Mains Information
@@ -502,9 +504,9 @@ class DeviceTemperature(Cluster):
 
     DeviceTempAlarmMask: Final = DeviceTempAlarmMask
 
-    cluster_id: Final = 0x0002
-    name: Final = "Device Temperature"
-    ep_attribute: Final = "device_temperature"
+    cluster_id = 0x0002
+    name = "Device Temperature"
+    ep_attribute = "device_temperature"
 
     class AttributeDefs(BaseAttributeDefs):
         # Device Temperature Information
@@ -557,8 +559,8 @@ class Identify(Cluster):
     EffectIdentifier: Final = EffectIdentifier
     EffectVariant: Final = EffectVariant
 
-    cluster_id: Final = 0x0003
-    ep_attribute: Final = "identify"
+    cluster_id = 0x0003
+    ep_attribute = "identify"
 
     class AttributeDefs(BaseAttributeDefs):
         identify_time: Final = ZCLAttributeDef(
@@ -597,8 +599,8 @@ class Groups(Cluster):
 
     NameSupport: Final = NameSupport
 
-    cluster_id: Final = 0x0004
-    ep_attribute: Final = "groups"
+    cluster_id = 0x0004
+    ep_attribute = "groups"
 
     class AttributeDefs(BaseAttributeDefs):
         name_support: Final = ZCLAttributeDef(
@@ -663,8 +665,8 @@ class Scenes(Cluster):
 
     NameSupport: Final = NameSupport
 
-    cluster_id: Final = 0x0005
-    ep_attribute: Final = "scenes"
+    cluster_id = 0x0005
+    ep_attribute = "scenes"
 
     class AttributeDefs(BaseAttributeDefs):
         # Scene Management Information
@@ -874,9 +876,9 @@ class OnOff(Cluster):
 
     DYING_LIGHT_DIM_UP_THEN_FADE_TO_OFF = 0x00
 
-    cluster_id: Final = 0x0006
-    name: Final = "On/Off"
-    ep_attribute: Final = "on_off"
+    cluster_id = 0x0006
+    name = "On/Off"
+    ep_attribute = "on_off"
 
     class AttributeDefs(BaseAttributeDefs):
         on_off: Final = ZCLAttributeDef(
@@ -934,9 +936,9 @@ class OnOffConfiguration(Cluster):
     SwitchType: Final = SwitchType
     SwitchActions: Final = SwitchActions
 
-    cluster_id: Final = 0x0007
-    name: Final = "On/Off Switch Configuration"
-    ep_attribute: Final = "on_off_config"
+    cluster_id = 0x0007
+    name = "On/Off Switch Configuration"
+    ep_attribute = "on_off_config"
 
     class AttributeDefs(BaseAttributeDefs):
         switch_type: Final = ZCLAttributeDef(
@@ -973,9 +975,9 @@ class LevelControl(Cluster):
     StepMode: Final = StepMode
     Options: Final = Options
 
-    cluster_id: Final = 0x0008
-    name: Final = "Level control"
-    ep_attribute: Final = "level"
+    cluster_id = 0x0008
+    name = "Level control"
+    ep_attribute = "level"
 
     class AttributeDefs(BaseAttributeDefs):
         current_level: Final = ZCLAttributeDef(
@@ -1079,8 +1081,8 @@ class Alarms(Cluster):
     configuring alarm functionality.
     """
 
-    cluster_id: Final = 0x0009
-    ep_attribute: Final = "alarms"
+    cluster_id = 0x0009
+    ep_attribute = "alarms"
 
     class AttributeDefs(BaseAttributeDefs):
         alarm_count: Final = ZCLAttributeDef(id=0x0000, type=t.uint16_t, access="r")
@@ -1131,8 +1133,8 @@ class Time(Cluster):
 
     TimeStatus: Final = TimeStatus
 
-    cluster_id: Final = 0x000A
-    ep_attribute: Final = "time"
+    cluster_id = 0x000A
+    ep_attribute = "time"
 
     class AttributeDefs(BaseAttributeDefs):
         time: Final = ZCLAttributeDef(
@@ -1211,8 +1213,8 @@ class RSSILocation(Cluster):
     LocationMethod: Final = LocationMethod
     NeighborInfo: Final = NeighborInfo
 
-    cluster_id: Final = 0x000B
-    ep_attribute: Final = "rssi_location"
+    cluster_id = 0x000B
+    ep_attribute = "rssi_location"
 
     class AttributeDefs(BaseAttributeDefs):
         # Location Information
@@ -1387,8 +1389,8 @@ class Reliability(t.enum8):
 class AnalogInput(Cluster):
     Reliability: Final = Reliability
 
-    cluster_id: Final = 0x000C
-    ep_attribute: Final = "analog_input"
+    cluster_id = 0x000C
+    ep_attribute = "analog_input"
 
     class AttributeDefs(BaseAttributeDefs):
         description: Final = ZCLAttributeDef(
@@ -1422,8 +1424,8 @@ class AnalogInput(Cluster):
 
 
 class AnalogOutput(Cluster):
-    cluster_id: Final = 0x000D
-    ep_attribute: Final = "analog_output"
+    cluster_id = 0x000D
+    ep_attribute = "analog_output"
 
     class AttributeDefs(BaseAttributeDefs):
         description: Final = ZCLAttributeDef(
@@ -1462,8 +1464,8 @@ class AnalogOutput(Cluster):
 
 
 class AnalogValue(Cluster):
-    cluster_id: Final = 0x000E
-    ep_attribute: Final = "analog_value"
+    cluster_id = 0x000E
+    ep_attribute = "analog_value"
 
     class AttributeDefs(BaseAttributeDefs):
         description: Final = ZCLAttributeDef(
@@ -1495,9 +1497,9 @@ class AnalogValue(Cluster):
 
 
 class BinaryInput(Cluster):
-    cluster_id: Final = 0x000F
-    name: Final = "Binary Input (Basic)"
-    ep_attribute: Final = "binary_input"
+    cluster_id = 0x000F
+    name = "Binary Input (Basic)"
+    ep_attribute = "binary_input"
 
     class AttributeDefs(BaseAttributeDefs):
         active_text: Final = ZCLAttributeDef(
@@ -1528,8 +1530,8 @@ class BinaryInput(Cluster):
 
 
 class BinaryOutput(Cluster):
-    cluster_id: Final = 0x0010
-    ep_attribute: Final = "binary_output"
+    cluster_id = 0x0010
+    ep_attribute = "binary_output"
 
     class AttributeDefs(BaseAttributeDefs):
         active_text: Final = ZCLAttributeDef(
@@ -1577,8 +1579,8 @@ class BinaryOutput(Cluster):
 
 
 class BinaryValue(Cluster):
-    cluster_id: Final = 0x0011
-    ep_attribute: Final = "binary_value"
+    cluster_id = 0x0011
+    ep_attribute = "binary_value"
 
     class AttributeDefs(BaseAttributeDefs):
         active_text: Final = ZCLAttributeDef(
@@ -1619,8 +1621,8 @@ class BinaryValue(Cluster):
 
 
 class MultistateInput(Cluster):
-    cluster_id: Final = 0x0012
-    ep_attribute: Final = "multistate_input"
+    cluster_id = 0x0012
+    ep_attribute = "multistate_input"
 
     class AttributeDefs(BaseAttributeDefs):
         state_text: Final = ZCLAttributeDef(
@@ -1652,8 +1654,8 @@ class MultistateInput(Cluster):
 
 
 class MultistateOutput(Cluster):
-    cluster_id: Final = 0x0013
-    ep_attribute: Final = "multistate_output"
+    cluster_id = 0x0013
+    ep_attribute = "multistate_output"
 
     class AttributeDefs(BaseAttributeDefs):
         state_text: Final = ZCLAttributeDef(
@@ -1688,8 +1690,8 @@ class MultistateOutput(Cluster):
 
 
 class MultistateValue(Cluster):
-    cluster_id: Final = 0x0014
-    ep_attribute: Final = "multistate_value"
+    cluster_id = 0x0014
+    ep_attribute = "multistate_value"
 
     class AttributeDefs(BaseAttributeDefs):
         state_text: Final = ZCLAttributeDef(
@@ -1742,8 +1744,8 @@ class Commissioning(Cluster):
     StartupControl: Final = StartupControl
     NetworkKeyType: Final = NetworkKeyType
 
-    cluster_id: Final = 0x0015
-    ep_attribute: Final = "commissioning"
+    cluster_id = 0x0015
+    ep_attribute = "commissioning"
 
     class AttributeDefs(BaseAttributeDefs):
         # Startup Parameters
@@ -1859,8 +1861,8 @@ class Commissioning(Cluster):
 
 
 class Partition(Cluster):
-    cluster_id: Final = 0x0016
-    ep_attribute: Final = "partition"
+    cluster_id = 0x0016
+    ep_attribute = "partition"
 
     class AttributeDefs(BaseAttributeDefs):
         maximum_incoming_transfer_size: Final = ZCLAttributeDef(
@@ -2043,8 +2045,8 @@ class Ota(Cluster):
     ImagePageCommand: Final = ImagePageCommand
     ImageBlockResponseCommand: Final = ImageBlockResponseCommand
 
-    cluster_id: Final = 0x0019
-    ep_attribute: Final = "ota"
+    cluster_id = 0x0019
+    ep_attribute = "ota"
 
     class AttributeDefs(BaseAttributeDefs):
         upgrade_server_id: Final = ZCLAttributeDef(
@@ -2364,8 +2366,8 @@ class PowerProfile(Cluster):
     PowerProfilePhase: Final = PowerProfilePhase
     PowerProfile: Final = PowerProfileType
 
-    cluster_id: Final = 0x001A
-    ep_attribute: Final = "power_profile"
+    cluster_id = 0x001A
+    ep_attribute = "power_profile"
 
     class AttributeDefs(BaseAttributeDefs):
         total_profile_num: Final = ZCLAttributeDef(
@@ -2535,8 +2537,8 @@ class PowerProfile(Cluster):
 
 
 class ApplianceControl(Cluster):
-    cluster_id: Final = 0x001B
-    ep_attribute: Final = "appliance_control"
+    cluster_id = 0x001B
+    ep_attribute = "appliance_control"
 
     class AttributeDefs(BaseAttributeDefs):
         start_time: Final = ZCLAttributeDef(
@@ -2551,9 +2553,9 @@ class ApplianceControl(Cluster):
 
 
 class PollControl(Cluster):
-    cluster_id: Final = 0x0020
-    name: Final = "Poll Control"
-    ep_attribute: Final = "poll_control"
+    cluster_id = 0x0020
+    name = "Poll Control"
+    ep_attribute = "poll_control"
 
     class AttributeDefs(BaseAttributeDefs):
         checkin_interval: Final = ZCLAttributeDef(
@@ -2601,5 +2603,5 @@ class PollControl(Cluster):
 
 
 class GreenPowerProxy(Cluster):
-    cluster_id: Final = 0x0021
-    ep_attribute: Final = "green_power"
+    cluster_id = 0x0021
+    ep_attribute = "green_power"

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -13,19 +13,19 @@ from zigpy.zcl.foundation import (
 
 
 class ApplianceIdentification(Cluster):
-    cluster_id: Final = 0x0B00
-    name: Final = "Appliance Identification"
-    ep_attribute: Final = "appliance_id"
+    cluster_id = 0x0B00
+    name = "Appliance Identification"
+    ep_attribute = "appliance_id"
 
     class AttributeDefs(BaseAttributeDefs):
         basic_identification: Final = ZCLAttributeDef(
             id=0x0000, type=t.uint56_t, access="r", mandatory=True
         )
-        company_name: Final = ZCLAttributeDef(
+        company_name = ZCLAttributeDef(
             id=0x0010, type=t.LimitedCharString(16), access="r"
         )
         company_id: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t, access="r")
-        brand_name: Final = ZCLAttributeDef(
+        brand_name = ZCLAttributeDef(
             id=0x0012, type=t.LimitedCharString(16), access="r"
         )
         brand_id: Final = ZCLAttributeDef(id=0x0013, type=t.uint16_t, access="r")
@@ -39,9 +39,7 @@ class ApplianceIdentification(Cluster):
         software_revision: Final = ZCLAttributeDef(
             id=0x0017, type=t.LimitedLVBytes(6), access="r"
         )
-        product_type_name: Final = ZCLAttributeDef(
-            id=0x0018, type=t.LVBytesSize2, access="r"
-        )
+        product_type_name = ZCLAttributeDef(id=0x0018, type=t.LVBytesSize2, access="r")
         product_type_id: Final = ZCLAttributeDef(id=0x0019, type=t.uint16_t, access="r")
         ceced_specification_version: Final = ZCLAttributeDef(
             id=0x001A, type=t.uint8_t, access="r"
@@ -51,12 +49,12 @@ class ApplianceIdentification(Cluster):
 
 
 class MeterIdentification(Cluster):
-    cluster_id: Final = 0x0B01
-    name: Final = "Meter Identification"
-    ep_attribute: Final = "meter_id"
+    cluster_id = 0x0B01
+    name = "Meter Identification"
+    ep_attribute = "meter_id"
 
     class AttributeDefs(BaseAttributeDefs):
-        company_name: Final = ZCLAttributeDef(
+        company_name = ZCLAttributeDef(
             id=0x0000, type=t.LimitedCharString(16), access="r", mandatory=True
         )
         meter_type_id: Final = ZCLAttributeDef(
@@ -65,7 +63,7 @@ class MeterIdentification(Cluster):
         data_quality_id: Final = ZCLAttributeDef(
             id=0x0004, type=t.uint16_t, access="r", mandatory=True
         )
-        customer_name: Final = ZCLAttributeDef(
+        customer_name = ZCLAttributeDef(
             id=0x0005, type=t.LimitedCharString(16), access="rw"
         )
         model: Final = ZCLAttributeDef(id=0x0006, type=t.LimitedLVBytes(16), access="r")
@@ -78,7 +76,7 @@ class MeterIdentification(Cluster):
         software_revision: Final = ZCLAttributeDef(
             id=0x000A, type=t.LimitedLVBytes(6), access="r"
         )
-        utility_name: Final = ZCLAttributeDef(
+        utility_name = ZCLAttributeDef(
             id=0x000B, type=t.LimitedCharString(16), access="r"
         )
         pod: Final = ZCLAttributeDef(
@@ -95,9 +93,9 @@ class MeterIdentification(Cluster):
 
 
 class ApplianceEventAlerts(Cluster):
-    cluster_id: Final = 0x0B02
-    name: Final = "Appliance Event Alerts"
-    ep_attribute: Final = "appliance_event"
+    cluster_id = 0x0B02
+    name = "Appliance Event Alerts"
+    ep_attribute = "appliance_event"
 
     class AttributeDefs(BaseAttributeDefs):
         cluster_revision: Final = foundation.ZCL_CLUSTER_REVISION_ATTR
@@ -113,9 +111,9 @@ class ApplianceEventAlerts(Cluster):
 
 
 class ApplianceStatistics(Cluster):
-    cluster_id: Final = 0x0B03
-    name: Final = "Appliance Statistics"
-    ep_attribute: Final = "appliance_stats"
+    cluster_id = 0x0B03
+    name = "Appliance Statistics"
+    ep_attribute = "appliance_stats"
 
     class AttributeDefs(BaseAttributeDefs):
         log_max_size: Final = ZCLAttributeDef(
@@ -169,9 +167,9 @@ class ACAlarmsMask(t.bitmap16):
 
 
 class ElectricalMeasurement(Cluster):
-    cluster_id: Final = 0x0B04
-    name: Final = "Electrical Measurement"
-    ep_attribute: Final = "electrical_measurement"
+    cluster_id = 0x0B04
+    name = "Electrical Measurement"
+    ep_attribute = "electrical_measurement"
 
     MeasurementType: Final = MeasurementType
     DCOverloadAlarmMark: Final = DCOverloadAlarmMark
@@ -543,8 +541,8 @@ class ElectricalMeasurement(Cluster):
 
 
 class Diagnostic(Cluster):
-    cluster_id: Final = 0x0B05
-    ep_attribute: Final = "diagnostic"
+    cluster_id = 0x0B05
+    ep_attribute = "diagnostic"
 
     class AttributeDefs(BaseAttributeDefs):
         # Hardware Information

--- a/zigpy/zcl/clusters/hvac.py
+++ b/zigpy/zcl/clusters/hvac.py
@@ -67,9 +67,9 @@ class Pump(Cluster):
     OperationMode: Final = OperationMode
     PumpStatus: Final = PumpStatus
 
-    cluster_id: Final = 0x0200
-    name: Final = "Pump Configuration and Control"
-    ep_attribute: Final = "pump"
+    cluster_id = 0x0200
+    name = "Pump Configuration and Control"
+    ep_attribute = "pump"
 
     class AttributeDefs(BaseAttributeDefs):
         # Pump Information
@@ -347,8 +347,8 @@ class Thermostat(Cluster):
     RunningMode: Final = RunningMode
     RunningState: Final = RunningState
 
-    cluster_id: Final = 0x0201
-    ep_attribute: Final = "thermostat"
+    cluster_id = 0x0201
+    ep_attribute = "thermostat"
 
     class AttributeDefs(BaseAttributeDefs):
         # Thermostat Information
@@ -571,9 +571,9 @@ class Fan(Cluster):
     FanMode: Final = FanMode
     FanModeSequence: Final = FanModeSequence
 
-    cluster_id: Final = 0x0202
-    name: Final = "Fan Control"
-    ep_attribute: Final = "fan"
+    cluster_id = 0x0202
+    name = "Fan Control"
+    ep_attribute = "fan"
 
     class AttributeDefs(BaseAttributeDefs):
         fan_mode: Final = ZCLAttributeDef(id=0x0000, type=FanMode, access="")
@@ -604,8 +604,8 @@ class Dehumidification(Cluster):
     DehumidificationLockout: Final = DehumidificationLockout
     RelativeHumidityDisplay: Final = RelativeHumidityDisplay
 
-    cluster_id: Final = 0x0203
-    ep_attribute: Final = "dehumidification"
+    cluster_id = 0x0203
+    ep_attribute = "dehumidification"
 
     class AttributeDefs(BaseAttributeDefs):
         # Dehumidification Information
@@ -665,9 +665,9 @@ class UserInterface(Cluster):
     KeypadLockout: Final = KeypadLockout
     ScheduleProgrammingVisibility: Final = ScheduleProgrammingVisibility
 
-    cluster_id: Final = 0x0204
-    name: Final = "Thermostat User Interface Configuration"
-    ep_attribute: Final = "thermostat_ui"
+    cluster_id = 0x0204
+    name = "Thermostat User Interface Configuration"
+    ep_attribute = "thermostat_ui"
 
     class AttributeDefs(BaseAttributeDefs):
         temperature_display_mode: Final = ZCLAttributeDef(

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -100,9 +100,9 @@ class Color(Cluster):
     DriftCompensation: Final = DriftCompensation
     Options: Final = Options
 
-    cluster_id: Final = 0x0300
-    name: Final = "Color Control"
-    ep_attribute: Final = "light_color"
+    cluster_id = 0x0300
+    name = "Color Control"
+    ep_attribute = "light_color"
 
     class AttributeDefs(BaseAttributeDefs):
         current_hue: Final = ZCLAttributeDef(id=0x0000, type=t.uint8_t, access="rp")
@@ -443,8 +443,8 @@ class Ballast(Cluster):
     BallastStatus: Final = BallastStatus
     LampAlarmMode: Final = LampAlarmMode
 
-    cluster_id: Final = 0x0301
-    ep_attribute: Final = "light_ballast"
+    cluster_id = 0x0301
+    ep_attribute = "light_ballast"
 
     class AttributeDefs(BaseAttributeDefs):
         physical_min_level: Final = ZCLAttributeDef(

--- a/zigpy/zcl/clusters/lightlink.py
+++ b/zigpy/zcl/clusters/lightlink.py
@@ -78,8 +78,8 @@ class EndpointInfoRecord(t.Struct):
 
 
 class LightLink(Cluster):
-    cluster_id: Final = 0x1000
-    ep_attribute: Final = "lightlink"
+    cluster_id = 0x1000
+    ep_attribute = "lightlink"
 
     class ServerCommandDefs(BaseCommandDefs):
         scan: Final = ZCLCommandDef(

--- a/zigpy/zcl/clusters/manufacturer_specific.py
+++ b/zigpy/zcl/clusters/manufacturer_specific.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from typing import Final
-
 from zigpy.zcl import Cluster
 
 
 class ManufacturerSpecificCluster(Cluster):
     cluster_id_range = (0xFC00, 0xFFFF)
-    ep_attribute: Final = "manufacturer_specific"
-    name: Final = "Manufacturer Specific"
+    ep_attribute = "manufacturer_specific"
+    name = "Manufacturer Specific"

--- a/zigpy/zcl/clusters/measurement.py
+++ b/zigpy/zcl/clusters/measurement.py
@@ -18,9 +18,9 @@ class LightSensorType(t.enum8):
 class IlluminanceMeasurement(Cluster):
     LightSensorType: Final = LightSensorType
 
-    cluster_id: Final = 0x0400
-    name: Final = "Illuminance Measurement"
-    ep_attribute: Final = "illuminance"
+    cluster_id = 0x0400
+    name = "Illuminance Measurement"
+    ep_attribute = "illuminance"
 
     class AttributeDefs(BaseAttributeDefs):
         measured_value: Final = ZCLAttributeDef(
@@ -50,9 +50,9 @@ class IlluminanceLevelSensing(Cluster):
     LevelStatus: Final = LevelStatus
     LightSensorType: Final = LightSensorType
 
-    cluster_id: Final = 0x0401
-    name: Final = "Illuminance Level Sensing"
-    ep_attribute: Final = "illuminance_level"
+    cluster_id = 0x0401
+    name = "Illuminance Level Sensing"
+    ep_attribute = "illuminance_level"
 
     class AttributeDefs(BaseAttributeDefs):
         level_status: Final = ZCLAttributeDef(
@@ -70,9 +70,9 @@ class IlluminanceLevelSensing(Cluster):
 
 
 class TemperatureMeasurement(Cluster):
-    cluster_id: Final = 0x0402
-    name: Final = "Temperature Measurement"
-    ep_attribute: Final = "temperature"
+    cluster_id = 0x0402
+    name = "Temperature Measurement"
+    ep_attribute = "temperature"
 
     class AttributeDefs(BaseAttributeDefs):
         # Temperature Measurement Information
@@ -93,9 +93,9 @@ class TemperatureMeasurement(Cluster):
 
 
 class PressureMeasurement(Cluster):
-    cluster_id: Final = 0x0403
-    name: Final = "Pressure Measurement"
-    ep_attribute: Final = "pressure"
+    cluster_id = 0x0403
+    name = "Pressure Measurement"
+    ep_attribute = "pressure"
 
     class AttributeDefs(BaseAttributeDefs):
         # Pressure Measurement Information
@@ -122,9 +122,9 @@ class PressureMeasurement(Cluster):
 
 
 class FlowMeasurement(Cluster):
-    cluster_id: Final = 0x0404
-    name: Final = "Flow Measurement"
-    ep_attribute: Final = "flow"
+    cluster_id = 0x0404
+    name = "Flow Measurement"
+    ep_attribute = "flow"
 
     class AttributeDefs(BaseAttributeDefs):
         measured_value: Final = ZCLAttributeDef(
@@ -142,9 +142,9 @@ class FlowMeasurement(Cluster):
 
 
 class RelativeHumidity(Cluster):
-    cluster_id: Final = 0x0405
-    name: Final = "Relative Humidity Measurement"
-    ep_attribute: Final = "humidity"
+    cluster_id = 0x0405
+    name = "Relative Humidity Measurement"
+    ep_attribute = "humidity"
 
     class AttributeDefs(BaseAttributeDefs):
         measured_value: Final = ZCLAttributeDef(
@@ -184,9 +184,9 @@ class OccupancySensing(Cluster):
     OccupancySensorType: Final = OccupancySensorType
     OccupancySensorTypeBitmap: Final = OccupancySensorTypeBitmap
 
-    cluster_id: Final = 0x0406
-    name: Final = "Occupancy Sensing"
-    ep_attribute: Final = "occupancy"
+    cluster_id = 0x0406
+    name = "Occupancy Sensing"
+    ep_attribute = "occupancy"
 
     class AttributeDefs(BaseAttributeDefs):
         # Occupancy Sensor Information
@@ -231,9 +231,9 @@ class OccupancySensing(Cluster):
 
 
 class LeafWetness(Cluster):
-    cluster_id: Final = 0x0407
-    name: Final = "Leaf Wetness Measurement"
-    ep_attribute: Final = "leaf_wetness"
+    cluster_id = 0x0407
+    name = "Leaf Wetness Measurement"
+    ep_attribute = "leaf_wetness"
 
     class AttributeDefs(BaseAttributeDefs):
         # Leaf Wetness Measurement Information
@@ -252,9 +252,9 @@ class LeafWetness(Cluster):
 
 
 class SoilMoisture(Cluster):
-    cluster_id: Final = 0x0408
-    name: Final = "Soil Moisture Measurement"
-    ep_attribute: Final = "soil_moisture"
+    cluster_id = 0x0408
+    name = "Soil Moisture Measurement"
+    ep_attribute = "soil_moisture"
 
     class AttributeDefs(BaseAttributeDefs):
         # Soil Moisture Measurement Information
@@ -273,9 +273,9 @@ class SoilMoisture(Cluster):
 
 
 class PH(Cluster):
-    cluster_id: Final = 0x0409
-    name: Final = "pH Measurement"
-    ep_attribute: Final = "ph"
+    cluster_id = 0x0409
+    name = "pH Measurement"
+    ep_attribute = "ph"
 
     class AttributeDefs(BaseAttributeDefs):
         # pH Measurement Information
@@ -294,9 +294,9 @@ class PH(Cluster):
 
 
 class ElectricalConductivity(Cluster):
-    cluster_id: Final = 0x040A
-    name: Final = "Electrical Conductivity"
-    ep_attribute: Final = "electrical_conductivity"
+    cluster_id = 0x040A
+    name = "Electrical Conductivity"
+    ep_attribute = "electrical_conductivity"
 
     class AttributeDefs(BaseAttributeDefs):
         measured_value: Final = ZCLAttributeDef(
@@ -314,9 +314,9 @@ class ElectricalConductivity(Cluster):
 
 
 class WindSpeed(Cluster):
-    cluster_id: Final = 0x040B
-    name: Final = "Wind Speed Measurement"
-    ep_attribute: Final = "wind_speed"
+    cluster_id = 0x040B
+    name = "Wind Speed Measurement"
+    ep_attribute = "wind_speed"
 
     class AttributeDefs(BaseAttributeDefs):
         # Wind Speed Measurement Information
@@ -353,200 +353,200 @@ class _ConcentrationMixin:
 
 
 class CarbonMonoxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x040C
-    name: Final = "Carbon Monoxide (CO) Concentration"
-    ep_attribute: Final = "carbon_monoxide_concentration"
+    cluster_id = 0x040C
+    name = "Carbon Monoxide (CO) Concentration"
+    ep_attribute = "carbon_monoxide_concentration"
 
 
 class CarbonDioxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x040D
-    name: Final = "Carbon Dioxide (CO₂) Concentration"
-    ep_attribute: Final = "carbon_dioxide_concentration"
+    cluster_id = 0x040D
+    name = "Carbon Dioxide (CO₂) Concentration"
+    ep_attribute = "carbon_dioxide_concentration"
 
 
 class EthyleneConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x040E
-    name: Final = "Ethylene (CH₂) Concentration"
-    ep_attribute: Final = "ethylene_concentration"
+    cluster_id = 0x040E
+    name = "Ethylene (CH₂) Concentration"
+    ep_attribute = "ethylene_concentration"
 
 
 class EthyleneOxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x040F
-    name: Final = "Ethylene Oxide (C₂H₄O) Concentration"
-    ep_attribute: Final = "ethylene_oxide_concentration"
+    cluster_id = 0x040F
+    name = "Ethylene Oxide (C₂H₄O) Concentration"
+    ep_attribute = "ethylene_oxide_concentration"
 
 
 class HydrogenConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0410
-    name: Final = "Hydrogen (H) Concentration"
-    ep_attribute: Final = "hydrogen_concentration"
+    cluster_id = 0x0410
+    name = "Hydrogen (H) Concentration"
+    ep_attribute = "hydrogen_concentration"
 
 
 class HydrogenSulfideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0411
-    name: Final = "Hydrogen Sulfide (H₂S) Concentration"
-    ep_attribute: Final = "hydrogen_sulfide_concentration"
+    cluster_id = 0x0411
+    name = "Hydrogen Sulfide (H₂S) Concentration"
+    ep_attribute = "hydrogen_sulfide_concentration"
 
 
 class NitricOxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0412
-    name: Final = "Nitric Oxide (NO) Concentration"
-    ep_attribute: Final = "nitric_oxide_concentration"
+    cluster_id = 0x0412
+    name = "Nitric Oxide (NO) Concentration"
+    ep_attribute = "nitric_oxide_concentration"
 
 
 class NitrogenDioxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0413
-    name: Final = "Nitrogen Dioxide (NO₂) Concentration"
-    ep_attribute: Final = "nitrogen_dioxide_concentration"
+    cluster_id = 0x0413
+    name = "Nitrogen Dioxide (NO₂) Concentration"
+    ep_attribute = "nitrogen_dioxide_concentration"
 
 
 class OxygenConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0414
-    name: Final = "Oxygen (O₂) Concentration"
-    ep_attribute: Final = "oxygen_concentration"
+    cluster_id = 0x0414
+    name = "Oxygen (O₂) Concentration"
+    ep_attribute = "oxygen_concentration"
 
 
 class OzoneConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0415
-    name: Final = "Ozone (O₃) Concentration"
-    ep_attribute: Final = "ozone_concentration"
+    cluster_id = 0x0415
+    name = "Ozone (O₃) Concentration"
+    ep_attribute = "ozone_concentration"
 
 
 class SulfurDioxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0416
-    name: Final = "Sulfur Dioxide (SO₂) Concentration"
-    ep_attribute: Final = "sulfur_dioxide_concentration"
+    cluster_id = 0x0416
+    name = "Sulfur Dioxide (SO₂) Concentration"
+    ep_attribute = "sulfur_dioxide_concentration"
 
 
 class DissolvedOxygenConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0417
-    name: Final = "Dissolved Oxygen (DO) Concentration"
-    ep_attribute: Final = "dissolved_oxygen_concentration"
+    cluster_id = 0x0417
+    name = "Dissolved Oxygen (DO) Concentration"
+    ep_attribute = "dissolved_oxygen_concentration"
 
 
 class BromateConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0418
-    name: Final = "Bromate Concentration"
-    ep_attribute: Final = "bromate_concentration"
+    cluster_id = 0x0418
+    name = "Bromate Concentration"
+    ep_attribute = "bromate_concentration"
 
 
 class ChloraminesConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0419
-    name: Final = "Chloramines Concentration"
-    ep_attribute: Final = "chloramines_concentration"
+    cluster_id = 0x0419
+    name = "Chloramines Concentration"
+    ep_attribute = "chloramines_concentration"
 
 
 class ChlorineConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041A
-    name: Final = "Chlorine Concentration"
-    ep_attribute: Final = "chlorine_concentration"
+    cluster_id = 0x041A
+    name = "Chlorine Concentration"
+    ep_attribute = "chlorine_concentration"
 
 
 class FecalColiformAndEColiFraction(_ConcentrationMixin, Cluster):
     """Percent of positive samples"""
 
-    cluster_id: Final = 0x041B
-    name: Final = "Fecal coliform & E. Coli Fraction"
-    ep_attribute: Final = "fecal_coliform_and_e_coli_fraction"
+    cluster_id = 0x041B
+    name = "Fecal coliform & E. Coli Fraction"
+    ep_attribute = "fecal_coliform_and_e_coli_fraction"
 
 
 class FluorideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041C  # XXX: spec repeats 0x041B but this seems like a mistake
-    name: Final = "Fluoride Concentration"
-    ep_attribute: Final = "fluoride_concentration"
+    cluster_id = 0x041C  # XXX: spec repeats 0x041B but this seems like a mistake
+    name = "Fluoride Concentration"
+    ep_attribute = "fluoride_concentration"
 
 
 class HaloaceticAcidsConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041D
-    name: Final = "Haloacetic Acids Concentration"
-    ep_attribute: Final = "haloacetic_acids_concentration"
+    cluster_id = 0x041D
+    name = "Haloacetic Acids Concentration"
+    ep_attribute = "haloacetic_acids_concentration"
 
 
 class TotalTrihalomethanesConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041E
-    name: Final = "Total Trihalomethanes Concentration"
-    ep_attribute: Final = "total_trihalomethanes_concentration"
+    cluster_id = 0x041E
+    name = "Total Trihalomethanes Concentration"
+    ep_attribute = "total_trihalomethanes_concentration"
 
 
 class TotalColiformBacteriaFraction(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041F
-    name: Final = "Total Coliform Bacteria Fraction"
-    ep_attribute: Final = "total_coliform_bacteria_fraction"
+    cluster_id = 0x041F
+    name = "Total Coliform Bacteria Fraction"
+    ep_attribute = "total_coliform_bacteria_fraction"
 
 
 # XXX: is this a concentration? What are the units?
 class Turbidity(_ConcentrationMixin, Cluster):
     """Cloudiness of particles in water where an average person would notice a 5 or higher"""
 
-    cluster_id: Final = 0x0420
-    name: Final = "Turbidity"
-    ep_attribute: Final = "turbidity"
+    cluster_id = 0x0420
+    name = "Turbidity"
+    ep_attribute = "turbidity"
 
 
 class CopperConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0421
-    name: Final = "Copper Concentration"
-    ep_attribute: Final = "copper_concentration"
+    cluster_id = 0x0421
+    name = "Copper Concentration"
+    ep_attribute = "copper_concentration"
 
 
 class LeadConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0422
-    name: Final = "Lead Concentration"
-    ep_attribute: Final = "lead_concentration"
+    cluster_id = 0x0422
+    name = "Lead Concentration"
+    ep_attribute = "lead_concentration"
 
 
 class ManganeseConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0423
-    name: Final = "Manganese Concentration"
-    ep_attribute: Final = "manganese_concentration"
+    cluster_id = 0x0423
+    name = "Manganese Concentration"
+    ep_attribute = "manganese_concentration"
 
 
 class SulfateConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0424
-    name: Final = "Sulfate Concentration"
-    ep_attribute: Final = "sulfate_concentration"
+    cluster_id = 0x0424
+    name = "Sulfate Concentration"
+    ep_attribute = "sulfate_concentration"
 
 
 class BromodichloromethaneConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0425
-    name: Final = "Bromodichloromethane Concentration"
-    ep_attribute: Final = "bromodichloromethane_concentration"
+    cluster_id = 0x0425
+    name = "Bromodichloromethane Concentration"
+    ep_attribute = "bromodichloromethane_concentration"
 
 
 class BromoformConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0426
-    name: Final = "Bromoform Concentration"
-    ep_attribute: Final = "bromoform_concentration"
+    cluster_id = 0x0426
+    name = "Bromoform Concentration"
+    ep_attribute = "bromoform_concentration"
 
 
 class ChlorodibromomethaneConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0427
-    name: Final = "Chlorodibromomethane Concentration"
-    ep_attribute: Final = "chlorodibromomethane_concentration"
+    cluster_id = 0x0427
+    name = "Chlorodibromomethane Concentration"
+    ep_attribute = "chlorodibromomethane_concentration"
 
 
 class ChloroformConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0428
-    name: Final = "Chloroform Concentration"
-    ep_attribute: Final = "chloroform_concentration"
+    cluster_id = 0x0428
+    name = "Chloroform Concentration"
+    ep_attribute = "chloroform_concentration"
 
 
 class SodiumConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0429
-    name: Final = "Sodium Concentration"
-    ep_attribute: Final = "sodium_concentration"
+    cluster_id = 0x0429
+    name = "Sodium Concentration"
+    ep_attribute = "sodium_concentration"
 
 
 # XXX: is this a concentration? What are the units?
 class PM25(_ConcentrationMixin, Cluster):
     """Particulate Matter 2.5 microns or less"""
 
-    cluster_id: Final = 0x042A
-    name: Final = "PM2.5"
-    ep_attribute: Final = "pm25"
+    cluster_id = 0x042A
+    name = "PM2.5"
+    ep_attribute = "pm25"
 
 
 class FormaldehydeConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x042B
-    name: Final = "Formaldehyde Concentration"
-    ep_attribute: Final = "formaldehyde_concentration"
+    cluster_id = 0x042B
+    name = "Formaldehyde Concentration"
+    ep_attribute = "formaldehyde_concentration"

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -20,8 +20,8 @@ class DateTime(t.Struct):
 
 
 class GenericTunnel(Cluster):
-    cluster_id: Final = 0x0600
-    ep_attribute: Final = "generic_tunnel"
+    cluster_id = 0x0600
+    ep_attribute = "generic_tunnel"
 
     class AttributeDefs(BaseAttributeDefs):
         max_income_trans_size: Final = ZCLAttributeDef(id=0x0001, type=t.uint16_t)
@@ -41,8 +41,8 @@ class GenericTunnel(Cluster):
 
 
 class BacnetProtocolTunnel(Cluster):
-    cluster_id: Final = 0x0601
-    ep_attribute: Final = "bacnet_tunnel"
+    cluster_id = 0x0601
+    ep_attribute = "bacnet_tunnel"
 
     class ServerCommandDefs(BaseCommandDefs):
         transfer_npdu: Final = ZCLCommandDef(
@@ -51,22 +51,22 @@ class BacnetProtocolTunnel(Cluster):
 
 
 class AnalogInputRegular(Cluster):
-    cluster_id: Final = 0x0602
-    ep_attribute: Final = "bacnet_regular_analog_input"
+    cluster_id = 0x0602
+    ep_attribute = "bacnet_regular_analog_input"
 
     class AttributeDefs(BaseAttributeDefs):
         cov_increment: Final = ZCLAttributeDef(id=0x0016, type=t.Single)
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
-        object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
+        object_name = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         update_interval: Final = ZCLAttributeDef(id=0x0076, type=t.uint8_t)
-        profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
+        profile_name = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
 class AnalogInputExtended(Cluster):
-    cluster_id: Final = 0x0603
-    ep_attribute: Final = "bacnet_extended_analog_input"
+    cluster_id = 0x0603
+    ep_attribute = "bacnet_extended_analog_input"
 
     class AttributeDefs(BaseAttributeDefs):
         acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
@@ -90,22 +90,22 @@ class AnalogInputExtended(Cluster):
 
 
 class AnalogOutputRegular(Cluster):
-    cluster_id: Final = 0x0604
-    ep_attribute: Final = "bacnet_regular_analog_output"
+    cluster_id = 0x0604
+    ep_attribute = "bacnet_regular_analog_output"
 
     class AttributeDefs(BaseAttributeDefs):
         cov_increment: Final = ZCLAttributeDef(id=0x0016, type=t.Single)
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
-        object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
+        object_name = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         update_interval: Final = ZCLAttributeDef(id=0x0076, type=t.uint8_t)
-        profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
+        profile_name = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
 class AnalogOutputExtended(Cluster):
-    cluster_id: Final = 0x0605
-    ep_attribute: Final = "bacnet_extended_analog_output"
+    cluster_id = 0x0605
+    ep_attribute = "bacnet_extended_analog_output"
 
     class AttributeDefs(BaseAttributeDefs):
         acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
@@ -123,20 +123,20 @@ class AnalogOutputExtended(Cluster):
 
 
 class AnalogValueRegular(Cluster):
-    cluster_id: Final = 0x0606
-    ep_attribute: Final = "bacnet_regular_analog_value"
+    cluster_id = 0x0606
+    ep_attribute = "bacnet_regular_analog_value"
 
     class AttributeDefs(BaseAttributeDefs):
         cov_increment: Final = ZCLAttributeDef(id=0x0016, type=t.Single)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
-        object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
+        object_name = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
-        profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
+        profile_name = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
 class AnalogValueExtended(Cluster):
-    cluster_id: Final = 0x0607
-    ep_attribute: Final = "bacnet_extended_analog_value"
+    cluster_id = 0x0607
+    ep_attribute = "bacnet_extended_analog_value"
 
     class AttributeDefs(BaseAttributeDefs):
         acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
@@ -152,8 +152,8 @@ class AnalogValueExtended(Cluster):
 
 
 class BinaryInputRegular(Cluster):
-    cluster_id: Final = 0x0608
-    ep_attribute: Final = "bacnet_regular_binary_input"
+    cluster_id = 0x0608
+    ep_attribute = "bacnet_regular_binary_input"
 
     class AttributeDefs(BaseAttributeDefs):
         change_of_state_count: Final = ZCLAttributeDef(id=0x000F, type=t.uint32_t)
@@ -161,16 +161,16 @@ class BinaryInputRegular(Cluster):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         elapsed_active_time: Final = ZCLAttributeDef(id=0x0021, type=t.uint32_t)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
-        object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
+        object_name = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         time_of_at_reset: Final = ZCLAttributeDef(id=0x0072, type=DateTime)
         time_of_sc_reset: Final = ZCLAttributeDef(id=0x0073, type=DateTime)
-        profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
+        profile_name = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
 class BinaryInputExtended(Cluster):
-    cluster_id: Final = 0x0609
-    ep_attribute: Final = "bacnet_extended_binary_input"
+    cluster_id = 0x0609
+    ep_attribute = "bacnet_extended_binary_input"
 
     class AttributeDefs(BaseAttributeDefs):
         acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
@@ -185,8 +185,8 @@ class BinaryInputExtended(Cluster):
 
 
 class BinaryOutputRegular(Cluster):
-    cluster_id: Final = 0x060A
-    ep_attribute: Final = "bacnet_regular_binary_output"
+    cluster_id = 0x060A
+    ep_attribute = "bacnet_regular_binary_output"
 
     class AttributeDefs(BaseAttributeDefs):
         change_of_state_count: Final = ZCLAttributeDef(id=0x000F, type=t.uint32_t)
@@ -195,16 +195,16 @@ class BinaryOutputRegular(Cluster):
         elapsed_active_time: Final = ZCLAttributeDef(id=0x0021, type=t.uint32_t)
         feed_back_value: Final = ZCLAttributeDef(id=0x0028, type=t.enum8)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
-        object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
+        object_name = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         time_of_at_reset: Final = ZCLAttributeDef(id=0x0072, type=DateTime)
         time_of_sc_reset: Final = ZCLAttributeDef(id=0x0073, type=DateTime)
-        profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
+        profile_name = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
 class BinaryOutputExtended(Cluster):
-    cluster_id: Final = 0x060B
-    ep_attribute: Final = "bacnet_extended_binary_output"
+    cluster_id = 0x060B
+    ep_attribute = "bacnet_extended_binary_output"
 
     class AttributeDefs(BaseAttributeDefs):
         acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
@@ -218,24 +218,24 @@ class BinaryOutputExtended(Cluster):
 
 
 class BinaryValueRegular(Cluster):
-    cluster_id: Final = 0x060C
-    ep_attribute: Final = "bacnet_regular_binary_value"
+    cluster_id = 0x060C
+    ep_attribute = "bacnet_regular_binary_value"
 
     class AttributeDefs(BaseAttributeDefs):
         change_of_state_count: Final = ZCLAttributeDef(id=0x000F, type=t.uint32_t)
         change_of_state_time: Final = ZCLAttributeDef(id=0x0010, type=DateTime)
         elapsed_active_time: Final = ZCLAttributeDef(id=0x0021, type=t.uint32_t)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
-        object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
+        object_name = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         time_of_at_reset: Final = ZCLAttributeDef(id=0x0072, type=DateTime)
         time_of_sc_reset: Final = ZCLAttributeDef(id=0x0073, type=DateTime)
-        profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
+        profile_name = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
 class BinaryValueExtended(Cluster):
-    cluster_id: Final = 0x060D
-    ep_attribute: Final = "bacnet_extended_binary_value"
+    cluster_id = 0x060D
+    ep_attribute = "bacnet_extended_binary_value"
 
     class AttributeDefs(BaseAttributeDefs):
         acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
@@ -250,20 +250,20 @@ class BinaryValueExtended(Cluster):
 
 
 class MultistateInputRegular(Cluster):
-    cluster_id: Final = 0x060E
-    ep_attribute: Final = "bacnet_regular_multistate_input"
+    cluster_id = 0x060E
+    ep_attribute = "bacnet_regular_multistate_input"
 
     class AttributeDefs(BaseAttributeDefs):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
-        object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
+        object_name = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
-        profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
+        profile_name = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
 class MultistateInputExtended(Cluster):
-    cluster_id: Final = 0x060F
-    ep_attribute: Final = "bacnet_extended_multistate_input"
+    cluster_id = 0x060F
+    ep_attribute = "bacnet_extended_multistate_input"
 
     class AttributeDefs(BaseAttributeDefs):
         acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
@@ -279,21 +279,21 @@ class MultistateInputExtended(Cluster):
 
 
 class MultistateOutputRegular(Cluster):
-    cluster_id: Final = 0x0610
-    ep_attribute: Final = "bacnet_regular_multistate_output"
+    cluster_id = 0x0610
+    ep_attribute = "bacnet_regular_multistate_output"
 
     class AttributeDefs(BaseAttributeDefs):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         feed_back_value: Final = ZCLAttributeDef(id=0x0028, type=t.enum8)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
-        object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
+        object_name = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
-        profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
+        profile_name = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
 class MultistateOutputExtended(Cluster):
-    cluster_id: Final = 0x0611
-    ep_attribute: Final = "bacnet_extended_multistate_output"
+    cluster_id = 0x0611
+    ep_attribute = "bacnet_extended_multistate_output"
 
     class AttributeDefs(BaseAttributeDefs):
         acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
@@ -307,19 +307,19 @@ class MultistateOutputExtended(Cluster):
 
 
 class MultistateValueRegular(Cluster):
-    cluster_id: Final = 0x0612
-    ep_attribute: Final = "bacnet_regular_multistate_value"
+    cluster_id = 0x0612
+    ep_attribute = "bacnet_regular_multistate_value"
 
     class AttributeDefs(BaseAttributeDefs):
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
-        object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
+        object_name = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
-        profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
+        profile_name = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
 class MultistateValueExtended(Cluster):
-    cluster_id: Final = 0x0613
-    ep_attribute: Final = "bacnet_extended_multistate_value"
+    cluster_id = 0x0613
+    ep_attribute = "bacnet_extended_multistate_value"
 
     class AttributeDefs(BaseAttributeDefs):
         acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -75,9 +75,9 @@ class IasZone(Cluster):
     ZoneStatus: Final = ZoneStatus
     EnrollResponse: Final = EnrollResponse
 
-    cluster_id: Final = 0x0500
-    name: Final = "IAS Zone"
-    ep_attribute: Final = "ias_zone"
+    cluster_id = 0x0500
+    name = "IAS Zone"
+    ep_attribute = "ias_zone"
 
     class AttributeDefs(BaseAttributeDefs):
         # Zone Information
@@ -241,9 +241,9 @@ class IasAce(Cluster):
     ZoneStatus: Final = IasZone.ZoneStatus
     ZoneStatusRsp: Final = ZoneStatusRsp
 
-    cluster_id: Final = 0x0501
-    name: Final = "IAS Ancillary Control Equipment"
-    ep_attribute: Final = "ias_ace"
+    cluster_id = 0x0501
+    name = "IAS Ancillary Control Equipment"
+    ep_attribute = "ias_ace"
 
     class AttributeDefs(BaseAttributeDefs):
         cluster_revision: Final = foundation.ZCL_CLUSTER_REVISION_ATTR
@@ -484,9 +484,9 @@ class IasWd(Cluster):
     Warning: Final = WarningType
     Squawk: Final = Squawk
 
-    cluster_id: Final = 0x0502
-    name: Final = "IAS Warning Device"
-    ep_attribute: Final = "ias_wd"
+    cluster_id = 0x0502
+    name = "IAS Warning Device"
+    ep_attribute = "ias_wd"
 
     class AttributeDefs(BaseAttributeDefs):
         max_duration: Final = ZCLAttributeDef(

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -20,7 +20,7 @@ class ZoneState(t.enum8):
     Enrolled = 0x01
 
 
-class ZoneType(t.enum_factory(t.uint16_t, "manufacturer_specific")):
+class ZoneType(t.enum16):
     """Zone type enum."""
 
     Standard_CIE = 0x0000
@@ -187,7 +187,7 @@ class ArmNotification(t.enum8):
     Already_Disarmed = 0x06
 
 
-class AudibleNotification(t.enum_factory(t.uint8_t, "manufacturer_specific")):
+class AudibleNotification(t.enum8):
     """IAS ACE audible notification enum."""
 
     Mute = 0x00

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -13,13 +13,13 @@ from zigpy.zcl.foundation import (
 
 
 class Price(Cluster):
-    cluster_id: Final = 0x0700
-    ep_attribute: Final = "smartenergy_price"
+    cluster_id = 0x0700
+    ep_attribute = "smartenergy_price"
 
 
 class Drlc(Cluster):
-    cluster_id: Final = 0x0701
-    ep_attribute: Final = "smartenergy_drlc"
+    cluster_id = 0x0701
+    ep_attribute = "smartenergy_drlc"
 
 
 class RegisteredTier(t.enum8):
@@ -44,8 +44,8 @@ class RegisteredTier(t.enum8):
 class Metering(Cluster):
     RegisteredTier: Final = RegisteredTier
 
-    cluster_id: Final = 0x0702
-    ep_attribute: Final = "smartenergy_metering"
+    cluster_id = 0x0702
+    ep_attribute = "smartenergy_metering"
 
     class AttributeDefs(BaseAttributeDefs):
         current_summ_delivered: Final = ZCLAttributeDef(
@@ -440,45 +440,45 @@ class Metering(Cluster):
 
 
 class Messaging(Cluster):
-    cluster_id: Final = 0x0703
-    ep_attribute: Final = "smartenergy_messaging"
+    cluster_id = 0x0703
+    ep_attribute = "smartenergy_messaging"
 
 
 class Tunneling(Cluster):
-    cluster_id: Final = 0x0704
-    ep_attribute: Final = "smartenergy_tunneling"
+    cluster_id = 0x0704
+    ep_attribute = "smartenergy_tunneling"
 
 
 class Prepayment(Cluster):
-    cluster_id: Final = 0x0705
-    ep_attribute: Final = "smartenergy_prepayment"
+    cluster_id = 0x0705
+    ep_attribute = "smartenergy_prepayment"
 
 
 class EnergyManagement(Cluster):
-    cluster_id: Final = 0x0706
-    ep_attribute: Final = "smartenergy_energy_management"
+    cluster_id = 0x0706
+    ep_attribute = "smartenergy_energy_management"
 
 
 class Calendar(Cluster):
-    cluster_id: Final = 0x0707
-    ep_attribute: Final = "smartenergy_calendar"
+    cluster_id = 0x0707
+    ep_attribute = "smartenergy_calendar"
 
 
 class DeviceManagement(Cluster):
-    cluster_id: Final = 0x0708
-    ep_attribute: Final = "smartenergy_device_management"
+    cluster_id = 0x0708
+    ep_attribute = "smartenergy_device_management"
 
 
 class Events(Cluster):
-    cluster_id: Final = 0x0709
-    ep_attribute: Final = "smartenergy_events"
+    cluster_id = 0x0709
+    ep_attribute = "smartenergy_events"
 
 
 class MduPairing(Cluster):
-    cluster_id: Final = 0x070A
-    ep_attribute: Final = "smartenergy_mdu_pairing"
+    cluster_id = 0x070A
+    ep_attribute = "smartenergy_mdu_pairing"
 
 
 class KeyEstablishment(Cluster):
-    cluster_id: Final = 0x0800
-    ep_attribute: Final = "smartenergy_key_establishment"
+    cluster_id = 0x0800
+    ep_attribute = "smartenergy_key_establishment"

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -452,7 +452,7 @@ class _CommandID(t.uint16_t, repr="hex"):
     pass
 
 
-class ZDOCmd(t.enum_factory(_CommandID)):
+class ZDOCmd(_CommandID, t.BaseEnum):
     # Device and Service Discovery Server Requests
     NWK_addr_req = 0x0000
     IEEE_addr_req = 0x0001


### PR DESCRIPTION
Our most major problem right now is `__init_subclass__`. A simple example:

```Python
class MyClass:
    always_a_str: str

    def __init_subclass__(cls):
        cls.always_a_str = str(cls.always_a_str)


class MySubclass(MyClass):
    always_a_str: str = 7


reveal_type(MySubclass.always_a_str)
```

We rely on the subclass hook to enforce types, which mypy seemingly does not check right now. This is accounting for the vast majority of typing errors.