### PR TITLE
Deprecate `handle_message` and migrate to `packet_received`

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1103,7 +1103,7 @@ async def test_bad_zdo_packet_received(app, device):
 
     app.packet_received(bogus_zdo_packet)
 
-    assert len(device.handle_message.mock_calls) == 1
+    assert len(device.packet_received.mock_calls) == 1
 
 
 def test_get_device_with_address_nwk(app, device):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -10,6 +10,7 @@ import zigpy.exceptions
 from zigpy.profiles import zha
 import zigpy.state
 import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic
 import zigpy.zcl.foundation as foundation
 from zigpy.zdo import types as zdo_t
 
@@ -35,7 +36,7 @@ async def test_initialize(monkeypatch, dev):
 
     async def mockepinit(self, *args, **kwargs):
         self.status = endpoint.Status.ZDO_INIT
-        self.add_input_cluster(0x0001)  # Basic
+        self.add_input_cluster(Basic.cluster_id)
 
     async def mock_ep_get_model_info(self):
         if self.endpoint_id == 1:
@@ -225,46 +226,6 @@ async def test_handle_message_read_report_conf(dev):
     assert cfg_sup2.serialize() == cfg_sup1.serialize()
 
 
-async def test_handle_message_reply(dev):
-    ep = dev.add_endpoint(3)
-    ep.handle_message = MagicMock()
-    tsn = int_sentinel.tsn
-    req_mock = MagicMock()
-    dev._pending[tsn] = req_mock
-    hdr_1 = MagicMock()
-    hdr_1.tsn = tsn
-    hdr_1.command_id = sentinel.command_id
-    hdr_1.direction = foundation.Direction.Client_to_Server
-    hdr_2 = MagicMock()
-    hdr_2.tsn = sentinel.another_tsn
-    hdr_2.command_id = sentinel.command_id
-    hdr_2.direction = foundation.Direction.Client_to_Server
-    dev.deserialize = MagicMock(
-        side_effect=(
-            (hdr_1, sentinel.args),
-            (hdr_2, sentinel.args),
-            (hdr_1, sentinel.args),
-        )
-    )
-    dev.handle_message(99, 98, 3, 3, b"abcd")
-    assert ep.handle_message.call_count == 0
-    assert req_mock.result.set_result.call_count == 1
-    assert req_mock.result.set_result.call_args[0][0] is sentinel.args
-
-    req_mock.reset_mock()
-    dev.handle_message(99, 98, 3, 3, b"abcd")
-    assert ep.handle_message.call_count == 1
-    assert ep.handle_message.call_args[0][-1] is sentinel.args
-    assert req_mock.result.set_result.call_count == 0
-
-    req_mock.reset_mock()
-    req_mock.result.set_result.side_effect = asyncio.InvalidStateError
-    ep.handle_message.reset_mock()
-    dev.handle_message(99, 98, 3, 3, b"abcd")
-    assert ep.handle_message.call_count == 0
-    assert req_mock.result.set_result.call_count == 1
-
-
 async def test_handle_message_deserialize_error(dev):
     ep = dev.add_endpoint(3)
     dev.deserialize = MagicMock(side_effect=ValueError)
@@ -435,3 +396,119 @@ def test_device_last_seen(dev, monkeypatch):
     dev.listener_event.assert_called_once_with("device_last_seen_updated", ANY)
     event_time = dev.listener_event.mock_calls[0].args[1]
     assert (event_time - datetime.now(timezone.utc)).total_seconds() < 0.1
+
+
+async def test_ignore_unknown_endpoint(dev, caplog):
+    """Test that unknown endpoints are ignored."""
+    dev.add_endpoint(1)
+
+    with caplog.at_level(logging.DEBUG):
+        dev.packet_received(
+            t.ZigbeePacket(
+                profile_id=260,
+                cluster_id=1,
+                src_ep=2,
+                dst_ep=3,
+                data=t.SerializableBytes(b"data"),
+                src=t.AddrModeAddress(
+                    addr_mode=t.AddrMode.NWK,
+                    address=dev.nwk,
+                ),
+                dst=t.AddrModeAddress(
+                    addr_mode=t.AddrMode.NWK,
+                    address=0x0000,
+                ),
+            )
+        )
+
+    assert "Ignoring message on unknown endpoint" in caplog.text
+
+
+async def test_deserialize_backwards_compat(dev):
+    """Test that deserialization uses the method if it is overloaded."""
+    packet = t.ZigbeePacket(
+        profile_id=260,
+        cluster_id=Basic.cluster_id,
+        src_ep=1,
+        dst_ep=1,
+        data=t.SerializableBytes(
+            b"\x18\x56\x09\x00\x00\x00\x00\x25\x1e\x00\x84\x03\x01\x02\x03\x04\x05\x06"
+        ),
+        src=t.AddrModeAddress(
+            addr_mode=t.AddrMode.NWK,
+            address=dev.nwk,
+        ),
+        dst=t.AddrModeAddress(
+            addr_mode=t.AddrMode.NWK,
+            address=0x0000,
+        ),
+    )
+
+    ep = dev.add_endpoint(1)
+    ep.add_input_cluster(Basic.cluster_id)
+
+    dev.packet_received(packet)
+
+    # Replace the method
+    dev.deserialize = MagicMock(side_effect=dev.deserialize)
+    dev.packet_received(packet)
+
+    assert dev.deserialize.call_count == 1
+
+
+async def test_request_exception_propagation(dev, event_loop):
+    """Test that exceptions are propagated to the caller."""
+    tsn = 0x12
+
+    ep = dev.add_endpoint(1)
+    ep.add_input_cluster(Basic.cluster_id)
+    ep.deserialize = MagicMock(side_effect=RuntimeError())
+
+    dev.application.get_sequence = MagicMock(return_value=tsn)
+
+    event_loop.call_soon(
+        dev.packet_received,
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=Basic.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(
+                foundation.ZCLHeader(
+                    frame_control=foundation.FrameControl(
+                        frame_type=foundation.FrameType.CLUSTER_COMMAND,
+                        is_manufacturer_specific=False,
+                        direction=foundation.Direction.Client_to_Server,
+                        disable_default_response=True,
+                        reserved=0,
+                    ),
+                    tsn=tsn,
+                    command_id=foundation.GeneralCommand.Default_Response,
+                    manufacturer=None,
+                ).serialize()
+                + (
+                    foundation.GENERAL_COMMANDS[
+                        foundation.GeneralCommand.Default_Response
+                    ]
+                    .schema(
+                        command_id=Basic.ServerCommandDefs.reset_fact_default.id,
+                        status=foundation.Status.SUCCESS,
+                    )
+                    .serialize()
+                )
+            ),
+            src=t.AddrModeAddress(
+                addr_mode=t.AddrMode.NWK,
+                address=dev.nwk,
+            ),
+            dst=t.AddrModeAddress(
+                addr_mode=t.AddrMode.NWK,
+                address=0x0000,
+            ),
+        ),
+    )
+
+    with pytest.raises(zigpy.exceptions.ParsingError) as exc:
+        await ep.basic.reset_fact_default()
+
+    assert type(exc.value.__cause__) is RuntimeError

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -153,25 +153,6 @@ def test_radio_details(dev):
     assert dev.rssi == 4
 
 
-async def test_handle_message_no_endpoint(dev):
-    dev.handle_message(99, 98, 97, 97, b"aabbcc")
-
-
-async def test_handle_message(dev):
-    ep = dev.add_endpoint(3)
-    hdr = MagicMock()
-    hdr.tsn = int_sentinel.tsn
-    hdr.direction = sentinel.direction
-    dev.deserialize = MagicMock(return_value=[hdr, sentinel.args])
-    ep.handle_message = MagicMock()
-
-    assert dev.last_seen is None
-    dev.handle_message(99, 98, 3, 3, b"abcd")
-    assert dev.last_seen is not None
-
-    assert ep.handle_message.call_count == 1
-
-
 async def test_handle_message_read_report_conf(dev):
     ep = dev.add_endpoint(3)
     ep.add_input_cluster(0x702)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -153,13 +153,6 @@ def test_radio_details(dev):
     assert dev.rssi == 4
 
 
-def test_deserialize(dev):
-    ep = dev.add_endpoint(3)
-    ep.deserialize = MagicMock()
-    dev.deserialize(3, 1, b"")
-    assert ep.deserialize.call_count == 1
-
-
 async def test_handle_message_no_endpoint(dev):
     dev.handle_message(99, 98, 97, 97, b"aabbcc")
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -370,8 +370,11 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         endpoint = self.endpoints[packet.src_ep]
 
-        if packet.src_ep != zdo.ZDO_ENDPOINT and (
-            packet.cluster_id not in endpoint.in_clusters
+        # Ignore packets that do not match the endpoint's clusters.
+        # TODO: this isn't actually necessary, we can parse most packets by cluster ID.
+        if (
+            packet.dst_ep != zdo.ZDO_ENDPOINT
+            and packet.cluster_id not in endpoint.in_clusters
             and packet.cluster_id not in endpoint.out_clusters
         ):
             self.debug(
@@ -384,7 +387,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         # Parse the ZCL/ZDO header first. This should never fail.
         data = packet.data.serialize()
 
-        if packet.dst_ep == zdo_t.ZDO_ENDPOINT:
+        if packet.dst_ep == zdo.ZDO_ENDPOINT:
             hdr, _ = zdo_t.ZDOHeader.deserialize(packet.cluster_id, data)
         else:
             hdr, _ = foundation.ZCLHeader.deserialize(data)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -401,7 +401,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             hdr, _ = foundation.ZCLHeader.deserialize(data)
 
         try:
-            if type(self).deserialize is not Device.deserialize:
+            if (
+                type(self).deserialize is not Device.deserialize
+                or getattr(self.deserialize, "__func__", None) is not Device.deserialize
+            ):
                 # XXX: support for custom deserialization will be removed
                 hdr, args = self.deserialize(packet.src_ep, packet.cluster_id, data)
             else:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -393,8 +393,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             hdr, _ = foundation.ZCLHeader.deserialize(data)
 
         try:
-            # Next, parse the ZCl/ZDO payload
-            _, args = endpoint.deserialize(packet.cluster_id, data)
+            # Next, parse the ZCL/ZDO payload
+            # FIXME: ZCL deserialization mutates the header!
+            hdr, args = endpoint.deserialize(packet.cluster_id, data)
         except Exception as exc:
             error = zigpy.exceptions.ParsingError()
             error.__cause__ = exc

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -391,7 +391,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             error.__cause__ = exc
 
             self.debug("Failed to parse packet %r", packet, exc_info=error)
-            return
 
         # Resolve the future if this is a response to a request
         if hdr.tsn in self._pending and (
@@ -415,6 +414,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     hdr.tsn,
                 )
 
+            return
+
+        if error is not None:
             return
 
         # Pass the request off to a listener, if one is registered

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -10,6 +10,10 @@ class ZigbeeException(Exception):
     """Base exception class"""
 
 
+class ParsingError(ZigbeeException):
+    """Failed to parse a frame"""
+
+
 class ControllerException(ZigbeeException):
     """Application controller failed in some way."""
 

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+from datetime import datetime, timezone
 import enum
 import typing
 
@@ -565,6 +566,10 @@ class ZigbeePacket(BaseDataclassMixin):
     The radio library is expected to fill this object in with all received data and pass
     it to zigpy for every type of packet.
     """
+
+    timestamp: datetime = dataclasses.field(
+        compare=False, default_factory=lambda: datetime.now(timezone.utc)
+    )
 
     # Set to `None` when the packet is outgoing
     src: AddrModeAddress | None = dataclasses.field(default=None)


### PR DESCRIPTION
Passing around encapsulated packet objects and centralizing parsing will allow for simpler device-specific overrides. This also fixes the logging issue that hid #1266.