### PR TITLE
Update GitHub stale action to v8

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,7 @@ jobs:
           operations-per-run: 150
           remove-stale-when-updated: true
           stale-issue-label: "stale"
-          exempt-issue-labels: "no-stale,help-wanted"
+          exempt-issue-labels: "no stale,help wanted"
           stale-issue-message: >
             There hasn't been any activity on this issue recently. Due to the
             high number of incoming GitHub notifications, we have to clean some
@@ -36,13 +36,13 @@ jobs:
             This issue has now been marked as stale and will be closed if no
             further activity occurs. Thank you for your contributions.
           stale-pr-label: "stale"
-          exempt-pr-labels: "no-stale"
+          exempt-pr-labels: "no stale"
           stale-pr-message: >
             There hasn't been any activity on this pull request recently. This
             pull request has been automatically marked as stale because of that
             and will be closed if no further activity occurs within 7 days.
             Thank you for your contributions.
-            
+
       # The 60 day stale policy for issues
       # Used for:
       # - Issues that are pending more information (incomplete issues)
@@ -52,14 +52,14 @@ jobs:
         uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          only-labels: "needs-more-information"
+          only-labels: "needs more information"
           days-before-stale: 60
           days-before-close: 7
           days-before-pr-close: -1
           operations-per-run: 50
           remove-stale-when-updated: true
           stale-issue-label: "stale"
-          exempt-issue-labels: "no-stale,help-wanted"
+          exempt-issue-labels: "no stale,help wanted"
           stale-issue-message: >
             There hasn't been any activity on this issue recently. Due to the
             high number of incoming GitHub notifications, we have to clean some

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
       # - No PRs marked as no-stale
       # - No issues marked as no-stale or help-wanted
       - name: 180 days stale issues & PRs policy
-        uses: actions/stale@v4
+        uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 180
@@ -49,7 +49,7 @@ jobs:
       # - No Issues marked as no-stale or help-wanted
       # - No PRs (-1)
       - name: Needs more information stale issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           only-labels: "needs-more-information"


### PR DESCRIPTION
## Main change: new version

This updates the GitHub "stale" action to v8. Releases: https://github.com/actions/stale/releases (check v4 to v8 notes) 
(Viewing the [individual commits](https://github.com/actions/stale/compare/v4.0.0...v8.0.0) likely won't help)

### Version changes:

v5 fixes this warning for every stale run:
_from [zigpy stale run: #17590](https://github.com/zigpy/zigpy/actions/runs/6594931811)_
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/stale@v4. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

v6: The main new feature is that **stale issues are closed as "not planned" (grey) rather than "completed" (purple).** (!)
v7 and v8 don't contain any changes that should affect us, since we don't use any of the more "advanced options".


## Second change: labels

Furthermore, this PR also updates the labels to check for which are either processed sooner ("needs more information") or never ("help wanted" and "no stale") to remove the dashes.

The current "help wanted" label for the zigpy repo doesn't actually contain any dashes: https://github.com/zigpy/zigpy/labels
The other labels do not exist (yet). This does not cause any issues.

Creating and assigning the "no stale" label to [some issues](https://github.com/zigpy/zigpy/issues/948) might be good a good idea though.


## Additional information

The same "stale file" has been used for the quirks repo with v7 and has been working as expected.
The action [was just updated from v7 to v8](https://github.com/zigpy/zha-device-handlers/pull/2671) and I'll be monitoring [the next run](https://github.com/zigpy/zha-device-handlers/actions/workflows/stale.yml) to see if the new version works as expected.
If stale run 18368 or later succeed and do not cause any issues, this PR is good-to-go too IMO.
EDIT: Seems to be good.