### PR TITLE
Keep coordinator model and manufacturer info in node state

### DIFF
--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -21,6 +21,9 @@ def backup_factory():
                 nwk=t.NWK(0x0000),
                 ieee=t.EUI64.convert("93:2C:A9:34:D9:D0:5D:12"),
                 logical_type=zdo_t.LogicalType.Coordinator,
+                model="Coordinator Model",
+                manufacturer="Coordinator Manufacturer",
+                version="1.2.3.4",
             ),
             network_info=app_state.NetworkInfo(
                 extended_pan_id=t.ExtendedPanId.convert("0D:49:91:99:AE:CD:3C:35"),
@@ -226,6 +229,9 @@ def test_state_backup_as_open_coordinator(backup):
 def test_z2m_backup_parsing(z2m_backup_json, backup):
     backup.network_info.metadata = None
     backup.network_info.source = None
+    backup.node_info.manufacturer = None
+    backup.node_info.model = None
+    backup.node_info.version = None
     backup.network_info.tc_link_key.tx_counter = 0
 
     for key in backup.network_info.key_table:

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import dataclasses
 from datetime import datetime, timezone
 import logging
@@ -17,10 +18,12 @@ if TYPE_CHECKING:
     import zigpy.application
 
 LOGGER = logging.getLogger(__name__)
+BACKUP_FORMAT_VERSION = 1
 
 
 @dataclasses.dataclass
 class NetworkBackup(t.BaseDataclassMixin):
+    version: int = dataclasses.field(default=BACKUP_FORMAT_VERSION)
     backup_time: datetime = dataclasses.field(
         default_factory=lambda: datetime.now(timezone.utc)
     )
@@ -73,6 +76,7 @@ class NetworkBackup(t.BaseDataclassMixin):
 
     def as_dict(self) -> dict[str, Any]:
         return {
+            "version": self.version,
             "backup_time": self.backup_time.isoformat(),
             "network_info": self.network_info.as_dict(),
             "node_info": self.node_info.as_dict(),
@@ -83,7 +87,21 @@ class NetworkBackup(t.BaseDataclassMixin):
         if "metadata" in obj:
             return cls.from_open_coordinator_json(obj)
         elif "network_info" in obj:
+            version = obj.get("version", 0)
+
+            # Version 1 introduced the `model`, `manufacturer`, and `version` fields
+            if version == 0:
+                obj = copy.deepcopy(obj)
+
+                obj["node_info"]["model"] = None
+                obj["node_info"]["manufacturer"] = None
+                obj["node_info"]["version"] = None
+                version = 1
+
+            assert version == BACKUP_FORMAT_VERSION
+
             return cls(
+                version=BACKUP_FORMAT_VERSION,
                 backup_time=datetime.fromisoformat(obj["backup_time"]),
                 network_info=zigpy.state.NetworkInfo.from_dict(obj["network_info"]),
                 node_info=zigpy.state.NodeInfo.from_dict(obj["node_info"]),
@@ -258,6 +276,9 @@ def _network_backup_to_open_coordinator_backup(backup: NetworkBackup) -> dict[st
                     "ieee": node_info.ieee.serialize()[::-1].hex(),
                     "nwk": node_info.nwk.serialize()[::-1].hex(),
                     "type": zigpy.state.LOGICAL_TYPE_TO_JSON[node_info.logical_type],
+                    "model": node_info.model,
+                    "manufacturer": node_info.manufacturer,
+                    "version": node_info.version,
                 },
                 "network": {
                     "tc_link_key": {
@@ -314,6 +335,9 @@ def _open_coordinator_backup_to_network_backup(obj: dict[str, Any]) -> NetworkBa
     node_info.ieee, _ = t.EUI64.deserialize(
         bytes.fromhex(obj["coordinator_ieee"])[::-1]
     )
+    node_info.model = node_meta.get("model")
+    node_info.manufacturer = node_meta.get("manufacturer")
+    node_info.version = node_meta.get("version")
 
     network_info = zigpy.state.NetworkInfo()
     network_info.source = obj["metadata"]["source"]
@@ -412,6 +436,7 @@ def _open_coordinator_backup_to_network_backup(obj: dict[str, Any]) -> NetworkBa
         creation_time = internal.get("creation_time", "1970-01-01T00:00:00+00:00")
 
     return NetworkBackup(
+        version=BACKUP_FORMAT_VERSION,
         backup_time=datetime.fromisoformat(creation_time),
         network_info=network_info,
         node_info=node_info,

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -40,7 +40,9 @@ class NetworkBackup(t.BaseDataclassMixin):
         """
 
         return (
-            self.node_info == backup.node_info
+            self.node_info.nwk == backup.node_info.nwk
+            and self.node_info.logical_type == backup.node_info.logical_type
+            and self.node_info.ieee == backup.node_info.ieee
             and self.network_info.extended_pan_id == backup.network_info.extended_pan_id
             and self.network_info.pan_id == backup.network_info.pan_id
             and self.network_info.nwk_update_id == backup.network_info.nwk_update_id

--- a/zigpy/state.py
+++ b/zigpy/state.py
@@ -61,11 +61,19 @@ class NodeInfo(t.BaseDataclassMixin):
     ieee: t.EUI64 = dataclasses.field(default_factory=lambda: t.EUI64.UNKNOWN)
     logical_type: zdo_t.LogicalType = zdo_t.LogicalType.EndDevice
 
+    # Device information
+    model: str | None = None
+    manufacturer: str | None = None
+    version: str | None = None
+
     def as_dict(self) -> dict[str, Any]:
         return {
             "nwk": str(self.nwk)[2:],
             "ieee": str(self.ieee),
             "logical_type": LOGICAL_TYPE_TO_JSON[self.logical_type],
+            "model": self.model,
+            "manufacturer": self.manufacturer,
+            "version": self.version,
         }
 
     @classmethod
@@ -74,6 +82,9 @@ class NodeInfo(t.BaseDataclassMixin):
             nwk=t.NWK.convert(obj["nwk"]),
             ieee=t.EUI64.convert(obj["ieee"]),
             logical_type=JSON_TO_LOGICAL_TYPE[obj["logical_type"]],
+            model=obj["model"],
+            manufacturer=obj["manufacturer"],
+            version=obj["version"],
         )
 
 


### PR DESCRIPTION
This splits out the coordinator version string from the model and will allow for more structured coordinator info to be displayed in ZHA. This will also help with the eventual migration away from attaching ZHA group entities to the coordinator device.