### PR TITLE
Do not load OTA providers until the radio has started

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -73,7 +73,7 @@ async def test_new_exception(ota_mock):
             )
     assert db_mck.call_count == 2
     assert db_mck.await_count == 2
-    assert ota_mock.return_value.initialize.call_count == 2
+    assert ota_mock.return_value.initialize.call_count == 1
     assert load_nwk_info_mck.call_count == 2
     assert load_nwk_info_mck.await_count == 2
     assert shut_mck.call_count == 1

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -206,6 +206,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 period=(60 * self.config[zigpy.config.CONF_TOPO_SCAN_PERIOD])
             )
 
+        # Only initialize OTA after we've fully loaded
+        await self.ota.initialize()
+
     async def startup(self, *, auto_form: bool = False) -> None:
         """Starts a network, optionally forming one with random settings if necessary."""
 
@@ -230,7 +233,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         app = cls(config)
 
         await app._load_db()
-        await app.ota.initialize()
 
         if start_radio:
             await app.startup(auto_form=auto_form)


### PR DESCRIPTION
If ZHA cannot load due to a missing USB stick, we should not continuously send requests to the OTA providers.