### PR TITLE
Ignore endpoint `0` when present in `Active_EP_rsp`

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -32,7 +32,7 @@ def dev(monkeypatch, app_mock):
 
 async def test_initialize(monkeypatch, dev):
     async def mockrequest(nwk, tries=None, delay=None):
-        return [0, None, [1, 2, 3, 4]]
+        return [0, None, [0, 1, 2, 3, 4]]
 
     async def mockepinit(self, *args, **kwargs):
         self.status = endpoint.Status.ZDO_INIT
@@ -53,6 +53,7 @@ async def test_initialize(monkeypatch, dev):
     dev.zdo.Active_EP_req = mockrequest
     await dev.initialize()
 
+    assert dev.endpoints[0] is dev.zdo
     assert 1 in dev.endpoints
     assert 2 in dev.endpoints
     assert 3 in dev.endpoints

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -219,7 +219,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.info("Discovered endpoints: %s", endpoints)
 
             for endpoint_id in endpoints:
-                self.add_endpoint(endpoint_id)
+                if endpoint_id != 0:
+                    self.add_endpoint(endpoint_id)
 
         self.status = Status.ZDO_INIT
 


### PR DESCRIPTION
The ZDO endpoint should not be included in this response. If it is, we can't use this endpoint anyways as it conflicts with ZDO and thus should be filtered out.