### PR TITLE
Allow wildcard listener subscriptions

### DIFF
--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -119,24 +119,6 @@ async def test_callback_listener():
     ]
 
 
-async def test_callback_listener_async():
-    listener = listeners.CallbackListener(
-        device=mock.Mock(spec_set=zigpy.device.Device),
-        matchers=[
-            on(),
-        ],
-        callback=mock.AsyncMock(),
-    )
-
-    assert not listener.resolve(make_hdr(off()), off())
-    assert listener.resolve(make_hdr(on()), on())
-
-    await asyncio.sleep(0.1)
-
-    assert listener.callback.mock_calls == [mock.call(make_hdr(on()), on())]
-    assert listener.device.application.create_task.call_count == 1
-
-
 async def test_callback_listener_error(caplog):
     listener = listeners.CallbackListener(
         device=mock.Mock(spec_set=zigpy.device.Device),

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 
 from zigpy import listeners
-import zigpy.device
 from zigpy.zcl import foundation
 import zigpy.zcl.clusters.general
 
@@ -24,7 +23,6 @@ toggle = zigpy.zcl.clusters.general.OnOff.commands_by_name["toggle"].schema
 
 async def test_future_listener():
     listener = listeners.FutureListener(
-        device=mock.Mock(spec_set=zigpy.device.Device),
         matchers=[
             query_next_image(manufacturer_code=0x1234),
             on(),
@@ -72,7 +70,6 @@ async def test_future_listener():
 
 async def test_future_listener_cancellation():
     listener = listeners.FutureListener(
-        device=mock.Mock(spec_set=zigpy.device.Device),
         matchers=[],
         future=asyncio.get_running_loop().create_future(),
     )
@@ -87,7 +84,6 @@ async def test_future_listener_cancellation():
 
 async def test_callback_listener():
     listener = listeners.CallbackListener(
-        device=mock.Mock(spec_set=zigpy.device.Device),
         matchers=[
             query_next_image(manufacturer_code=0x1234),
             on(),
@@ -121,7 +117,6 @@ async def test_callback_listener():
 
 async def test_callback_listener_error(caplog):
     listener = listeners.CallbackListener(
-        device=mock.Mock(spec_set=zigpy.device.Device),
         matchers=[
             on(),
         ],

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -636,3 +636,14 @@ def test_picking_optimal_channel(plot):
     }
 
     assert util.pick_optimal_channel(channel_energy) == expected_channel
+
+
+def test_singleton():
+    singleton = util.Singleton("NAME")
+
+    assert str(singleton) == repr(singleton) == "<Singleton 'NAME'>"
+    assert singleton == singleton
+
+    obj = {}
+    obj[singleton] = 5
+    assert obj[singleton] == 5

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1074,7 +1074,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Context manager to create a callback that is passed Zigbee responses."""
 
         listener = zigpy.listeners.CallbackListener(
-            device=src,
             matchers=tuple(filters),
             callback=callback,
         )
@@ -1095,7 +1094,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Context manager to wait for a Zigbee response."""
 
         listener = zigpy.listeners.FutureListener(
-            device=src,
             matchers=tuple(filters),
             future=asyncio.get_running_loop().create_future(),
         )

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1061,7 +1061,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     @contextlib.contextmanager
     def _callback_for_response(
         self,
-        src: zigpy.device.Device,
+        src: zigpy.device.Device | zigpy.listeners.ANY_DEVICE,
         filters: list[zigpy.listeners.MatcherType],
         callback: typing.Callable[
             [
@@ -1088,7 +1088,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     @contextlib.contextmanager
     def _wait_for_response(
         self,
-        src: zigpy.device.Device,
+        src: zigpy.device.Device | zigpy.listeners.ANY_DEVICE,
         filters: list[zigpy.listeners.MatcherType],
     ) -> typing.Any:
         """Context manager to wait for a Zigbee response."""

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 import enum
+import itertools
 import logging
 import sys
 import typing
@@ -448,7 +449,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             return
 
         # Pass the request off to a listener, if one is registered
-        for listener in self._application._req_listeners[self]:
+        for listener in itertools.chain(
+            self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
+            self._application._req_listeners[self],
+        ):
             # Resolve only until the first future listener
             if listener.resolve(hdr, args) and isinstance(
                 listener, zigpy.listeners.FutureListener

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -95,11 +95,7 @@ class CallbackListener(BaseRequestListener):
         command: foundation.CommandSchema,
     ) -> bool:
         try:
-            result = self.callback(hdr, command)
-
-            # Run coroutines in the background
-            if asyncio.iscoroutine(result):
-                self.device.application.create_task(result)
+            self.callback(hdr, command)
         except Exception:
             LOGGER.warning(
                 "Caught an exception while executing callback", exc_info=True

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -5,10 +5,14 @@ import dataclasses
 import logging
 import typing
 
+from zigpy.util import Singleton
 from zigpy.zcl import foundation
 import zigpy.zdo.types as zdo_t
 
 LOGGER = logging.getLogger(__name__)
+
+
+ANY_DEVICE = Singleton("ANY_DEVICE")
 
 
 @dataclasses.dataclass(frozen=True)

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -8,15 +8,11 @@ import typing
 from zigpy.zcl import foundation
 import zigpy.zdo.types as zdo_t
 
-if typing.TYPE_CHECKING:
-    import zigpy.device
-
 LOGGER = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass(frozen=True)
 class BaseRequestListener:
-    device: zigpy.device.Device
     matchers: tuple[MatcherType]
 
     def resolve(

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -556,3 +556,16 @@ def pick_optimal_channel(
     LOGGER.debug("Channel scores: %s", scores)
 
     return optimal_channel
+
+
+class Singleton:
+    """Singleton class."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __repr__(self) -> str:
+        return f"<Singleton {self.name!r}>"
+
+    def __hash__(self) -> int:
+        return hash(self.name)


### PR DESCRIPTION
Passing `zigpy.listeners.ANY_DEVICE` as the `src` for any callback or future handler will allow listeners to be created that listen for ZCL data coming from all devices.

CC https://github.com/zigpy/zigpy/pull/1282