### PR TITLE
Deprecate `permit_with_key` in favor of `permit_with_link_key`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ class App(zigpy.application.ControllerApplication):
     async def permit_ncp(self, time_s=60):
         pass
 
-    async def permit_with_key(self, node, code, time_s=60):
+    async def permit_with_link_key(self, node, link_key, time_s=60):
         pass
 
     async def reset_network_info(self):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1155,11 +1155,21 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """
         raise NotImplementedError()  # pragma: no cover
 
-    @abc.abstractmethod
     async def permit_with_key(self, node: t.EUI64, code: bytes, time_s: int = 60):
         """Permit a node to join with the provided install code bytes."""
-        raise NotImplementedError()  # pragma: no cover
+        warnings.warn(
+            "`permit_with_key` is deprecated, use `permit_with_link_key`",
+            DeprecationWarning,
+        )
 
+        key = zigpy.util.convert_install_code(code)
+
+        if key is None:
+            raise ValueError(f"Invalid install code: {code!r}")
+
+        await self.permit_with_link_key(node=node, link_key=key, time_s=time_s)
+
+    @abc.abstractmethod
     async def permit_with_link_key(
         self, node: t.EUI64, link_key: t.KeyData, time_s: int = 60
     ) -> None:


### PR DESCRIPTION
`permit_with_link_key` accepts a link key directly, without hashing, allowing applications to perform the hashing themselves or to directly use an unhashed key.

A compatibility shim will be used until `permit_with_key` is removed.