### PR TITLE
Use the new IKEA OTA URL

### DIFF
--- a/tests/test_ota_provider.py
+++ b/tests/test_ota_provider.py
@@ -286,6 +286,17 @@ async def test_ikea_refresh_list(mock_get, ikea_prov):
     assert not ikea_prov.expired
 
 
+def test_ikea_bad_version():
+    image = ota_p.IKEAImage(
+        image_type=4552,
+        binary_url="https://fw.ota.homesmart.ikea.com/files/DIRIGERA_release_prod_v2.453.1_348f0dce-3c34-49a2-b64c-a1caa202104c.raucb",
+        sha3_256_sum="1b5fbea79c5b41864352a938a90ad25d9a0118054bf1cdc0314ef9636a60143a",
+    )
+
+    with pytest.raises(ValueError):
+        image.version
+
+
 @patch("aiohttp.ClientSession.get")
 async def test_ikea_refresh_list_locked(mock_get, ikea_prov):
     await ikea_prov._locks[ota_p.LOCK_REFRESH].acquire()

--- a/tests/test_ota_provider.py
+++ b/tests/test_ota_provider.py
@@ -1,3 +1,4 @@
+import hashlib
 import os.path
 from unittest import mock
 import uuid
@@ -58,9 +59,11 @@ def file_image_with_version(file_image_name):
 
 @pytest.fixture
 def ikea_image_with_version():
-    def img(version=100, image_type=IMAGE_TYPE):
+    def img(image_type=IMAGE_TYPE):
         img = zigpy.ota.provider.IKEAImage(
-            MANUFACTURER_ID, image_type, version, 66, mock.sentinel.url
+            image_type=image_type,
+            binary_url=mock.sentinel.url,
+            sha3_256_sum=mock.sentinel.sha3_256_sum,
         )
         return img
 
@@ -186,7 +189,10 @@ async def test_ikea_get_image_no_cache(ikea_prov, ikea_image):
     ikea_prov._cache.__getitem__.side_effect = KeyError()
     ikea_prov.refresh_firmware_list = AsyncMock()
 
-    non_ikea = zigpy.ota.image.ImageKey(mock.sentinel.manufacturer, IMAGE_TYPE)
+    non_ikea = zigpy.ota.image.ImageKey(
+        ota_p.Trådfri.MANUFACTURER_ID + 1,
+        IMAGE_TYPE,
+    )
 
     # Non IKEA manufacturer_id, don't bother doing anything at all
     r = await ikea_prov.get_image(non_ikea)
@@ -218,68 +224,70 @@ async def test_ikea_get_image(ikea_prov, key, ikea_image):
 
 
 @patch("aiohttp.ClientSession.get")
-async def test_ikea_refresh_list(mock_get, ikea_prov, ikea_image_with_version):
-    ver1, img_type1 = (0x12345678, mock.sentinel.img_type_1)
-    ver2, img_type2 = (0x23456789, mock.sentinel.img_type_2)
-    img1 = ikea_image_with_version(version=ver1, image_type=img_type1)
-    img2 = ikea_image_with_version(version=ver2, image_type=img_type2)
-
+async def test_ikea_refresh_list(mock_get, ikea_prov):
     mock_get.return_value.__aenter__.return_value.json = AsyncMock(
         side_effect=[
             [
                 {
-                    "fw_binary_url": "http://localhost/ota.ota.signed",
-                    "fw_build_version": 123,
-                    "fw_filesize": 128,
+                    "fw_image_type": 4557,
+                    "fw_type": 2,
+                    "fw_sha3_256": "896edfb0a9d8314fb49d44fb11dc91fb5bb55e2ee1f793d53189cb13f884e13c",
+                    "fw_binary_url": "https://fw.ota.homesmart.ikea.com/files/rodret-dimmer-soc_release_prod_v16777287_9812b73c-b02e-4678-b737-d21251a34fd2.ota",
+                },
+                {
+                    "fw_update_prio": 5,
+                    "fw_filesize": 242071587,
+                    "fw_type": 3,
                     "fw_hotfix_version": 1,
-                    "fw_image_type": 2,
-                    "fw_major_version": 3,
-                    "fw_manufacturer_id": MANUFACTURER_ID,
-                    "fw_minor_version": 4,
-                    "fw_type": 2,
+                    "fw_major_version": 2,
+                    "fw_binary_checksum": "8c17b203bede63ea53e36d345b628cc7f2faecc18d4406458a12f8f25e54718a24495d30a03fe3244799bfaa50de72d99e6c0d2f7553a8465e37c10c22ba75fc",
+                    "fw_minor_version": 453,
+                    "fw_sha3_256": "657ed8fd0f6e5e6700acdc6afd64829cebacb1dd03b3f5453258b4bd77b674ed",
+                    "fw_binary_url": "https://fw.ota.homesmart.ikea.com/files/DIRIGERA_release_prod_v2.453.1_348f0dce-3c34-49a2-b64c-a1caa202104c.raucb",
                 },
                 {
-                    "fw_binary_url": "http://localhost/ota1.ota.signed",
-                    "fw_file_version_MSB": img1.version >> 16,
-                    "fw_file_version_LSB": img1.version & 0xFFFF,
-                    "fw_filesize": 129,
-                    "fw_image_type": img1.image_type,
-                    "fw_manufacturer_id": MANUFACTURER_ID,
+                    "fw_image_type": 4552,
                     "fw_type": 2,
-                },
-                {
-                    "fw_binary_url": "http://localhost/ota2.ota.signed",
-                    "fw_file_version_MSB": img2.version >> 16,
-                    "fw_file_version_LSB": img2.version & 0xFFFF,
-                    "fw_filesize": 130,
-                    "fw_image_type": img2.image_type,
-                    "fw_manufacturer_id": MANUFACTURER_ID,
-                    "fw_type": 2,
+                    "fw_sha3_256": "1b5fbea79c5b41864352a938a90ad25d9a0118054bf1cdc0314ef9636a60143a",
+                    "fw_binary_url": "https://fw.ota.homesmart.ikea.com/files/tradfri-motion-sensor2_release_prod_v604241925_8afa2f7c-19c3-4ddf-a96c-233714179022.ota",
                 },
             ]
         ]
     )
-    mock_get.return_value.__aenter__.return_value.status = 202
+    mock_get.return_value.__aenter__.return_value.status = 200
     mock_get.return_value.__aenter__.return_value.reason = "OK"
 
     await ikea_prov.refresh_firmware_list()
     assert mock_get.call_count == 1
     assert len(ikea_prov._cache) == 2
-    assert img1.key in ikea_prov._cache
-    assert img2.key in ikea_prov._cache
-    cached_1 = ikea_prov._cache[img1.key]
-    assert cached_1.image_type == img1.image_type
-    assert cached_1.url == "http://localhost/ota1.ota.signed"
 
-    cached_2 = ikea_prov._cache[img2.key]
-    assert cached_2.image_type == img2.image_type
-    assert cached_2.url == "http://localhost/ota2.ota.signed"
+    image1 = ikea_prov._cache[
+        zigpy.ota.image.ImageKey(ota_p.Trådfri.MANUFACTURER_ID, 4557)
+    ]
+    image2 = ikea_prov._cache[
+        zigpy.ota.image.ImageKey(ota_p.Trådfri.MANUFACTURER_ID, 4552)
+    ]
+
+    assert image1 == ota_p.IKEAImage(
+        image_type=4557,
+        binary_url="https://fw.ota.homesmart.ikea.com/files/rodret-dimmer-soc_release_prod_v16777287_9812b73c-b02e-4678-b737-d21251a34fd2.ota",
+        sha3_256_sum="896edfb0a9d8314fb49d44fb11dc91fb5bb55e2ee1f793d53189cb13f884e13c",
+    )
+
+    assert image1.version == 16777287
+
+    assert image2 == ota_p.IKEAImage(
+        image_type=4552,
+        binary_url="https://fw.ota.homesmart.ikea.com/files/tradfri-motion-sensor2_release_prod_v604241925_8afa2f7c-19c3-4ddf-a96c-233714179022.ota",
+        sha3_256_sum="1b5fbea79c5b41864352a938a90ad25d9a0118054bf1cdc0314ef9636a60143a",
+    )
+    assert image2.version == 604241925
 
     assert not ikea_prov.expired
 
 
 @patch("aiohttp.ClientSession.get")
-async def test_ikea_refresh_list_locked(mock_get, ikea_prov, ikea_image_with_version):
+async def test_ikea_refresh_list_locked(mock_get, ikea_prov):
     await ikea_prov._locks[ota_p.LOCK_REFRESH].acquire()
 
     mock_get.return_value.__aenter__.return_value.json = AsyncMock(side_effect=[[]])
@@ -319,6 +327,7 @@ async def test_ikea_fetch_image(mock_get, ikea_image_with_version):
 
     img = ikea_image_with_version(image_type=0x2101)
     img.url = mock.sentinel.url
+    img.sha3_256_sum = hashlib.sha3_256(container).hexdigest()
 
     mock_get.return_value.__aenter__.return_value.read = AsyncMock(
         side_effect=[container]

--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -10,6 +10,8 @@ import io
 import logging
 import os
 import os.path
+import re
+import ssl
 import tarfile
 import typing
 import urllib.parse
@@ -101,50 +103,70 @@ class Basic(zigpy.util.LocalLogMixin, ABC):
 
 @attr.s
 class IKEAImage:
-    manufacturer_id = attr.ib()
-    image_type = attr.ib()
-    version = attr.ib(default=None)
-    image_size = attr.ib(default=None)
-    url = attr.ib(default=None)
+    image_type: int = attr.ib()
+    binary_url: str = attr.ib()
+    sha3_256_sum: str = attr.ib()
 
     @classmethod
     def new(cls, data: dict[str, str | int]) -> IKEAImage:
-        res = cls(data["fw_manufacturer_id"], data["fw_image_type"])
-        res.file_version = data["fw_file_version_MSB"] << 16
-        res.file_version |= data["fw_file_version_LSB"]
-        res.image_size = data["fw_filesize"]
-        res.url = data["fw_binary_url"]
-        return res
+        return cls(
+            image_type=data["fw_image_type"],
+            sha3_256_sum=data["fw_sha3_256"],
+            binary_url=data["fw_binary_url"],
+        )
+
+    @property
+    def version(self) -> int:
+        file_version_match = re.match(r".*_v(?P<v>\d+)_.*", self.binary_url)
+        if file_version_match is None:
+            raise ValueError(f"Couldn't parse firmware version from {self}")
+
+        return int(file_version_match.group("v"), 10)
 
     @property
     def key(self) -> ImageKey:
-        return ImageKey(self.manufacturer_id, self.image_type)
+        return ImageKey(Trådfri.MANUFACTURER_ID, self.image_type)
 
     async def fetch_image(self) -> BaseOTAImage | None:
         async with aiohttp.ClientSession() as req:
-            LOGGER.debug("Downloading %s for %s", self.url, self.key)
-            async with req.get(self.url) as rsp:
+            LOGGER.debug("Downloading %s for %s", self.binary_url, self.key)
+            async with req.get(self.binary_url, ssl=Trådfri.SSL_CTX) as rsp:
                 data = await rsp.read()
+
+        assert hashlib.sha3_256(data).hexdigest() == self.sha3_256_sum
 
         ota_image, _ = parse_ota_image(data)
         assert ota_image.header.key == self.key
 
-        LOGGER.debug(
-            "Finished downloading %s bytes from %s for %s ver %s",
-            self.image_size,
-            self.url,
-            self.key,
-            self.version,
-        )
+        LOGGER.debug("Finished downloading %s", self)
         return ota_image
 
 
 class Trådfri(Basic):
     """IKEA OTA Firmware provider."""
 
-    UPDATE_URL = "http://fw.ota.homesmart.ikea.net/feed/version_info.json"
+    UPDATE_URL = "https://fw.ota.homesmart.ikea.com/check/update/prod"
     MANUFACTURER_ID = 4476
     HEADERS = {"accept": "application/json;q=0.9,*/*;q=0.8"}
+
+    # `openssl s_client -connect fw.ota.homesmart.ikea.com:443 -showcerts`
+    SSL_CTX = ssl.create_default_context(
+        cadata="""\
+-----BEGIN CERTIFICATE-----
+MIICGDCCAZ+gAwIBAgIUdfH0KDnENv/dEcxH8iVqGGGDqrowCgYIKoZIzj0EAwMw
+SzELMAkGA1UEBhMCU0UxGjAYBgNVBAoMEUlLRUEgb2YgU3dlZGVuIEFCMSAwHgYD
+VQQDDBdJS0VBIEhvbWUgc21hcnQgUm9vdCBDQTAgFw0yMTA1MjYxOTAxMDlaGA8y
+MDcxMDUxNDE5MDEwOFowSzELMAkGA1UEBhMCU0UxGjAYBgNVBAoMEUlLRUEgb2Yg
+U3dlZGVuIEFCMSAwHgYDVQQDDBdJS0VBIEhvbWUgc21hcnQgUm9vdCBDQTB2MBAG
+ByqGSM49AgEGBSuBBAAiA2IABIDRUvKGFMUu2zIhTdgfrfNcPULwMlc0TGSrDLBA
+oTr0SMMV4044CRZQbl81N4qiuHGhFzCnXapZogkiVuFu7ZqSslsFuELFjc6ZxBjk
+Kmud+pQM6QQdsKTE/cS06dA+P6NCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4E
+FgQUcdlEnfX0MyZA4zAdY6CLOye9wfwwDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49
+BAMDA2cAMGQCMG6mFIeB2GCFch3r0Gre4xRH+f5pn/bwLr9yGKywpeWvnUPsQ1KW
+ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
+2kVHW/Mz9/xwpy4u
+-----END CERTIFICATE-----"""
+    )
 
     async def initialize_provider(self, ota_config: dict) -> None:
         self.info("OTA provider enabled")
@@ -158,7 +180,7 @@ class Trådfri(Basic):
 
         async with self._locks[LOCK_REFRESH]:
             async with aiohttp.ClientSession(headers=self.HEADERS) as req:
-                async with req.get(self.UPDATE_URL) as rsp:
+                async with req.get(self.UPDATE_URL, ssl=self.SSL_CTX) as rsp:
                     # IKEA does not always respond with an appropriate Content-Type
                     # but the response is always JSON
                     if not (200 <= rsp.status <= 299):
@@ -173,7 +195,7 @@ class Trådfri(Basic):
         self.debug("Finished downloading firmware update list")
         self._cache.clear()
         for fw in fw_lst:
-            if "fw_file_version_MSB" not in fw:
+            if "fw_image_type" not in fw:
                 continue
             img = IKEAImage.new(fw)
             self._cache[img.key] = img

--- a/zigpy/ota/provider.py
+++ b/zigpy/ota/provider.py
@@ -145,7 +145,7 @@ class IKEAImage:
 class Trådfri(Basic):
     """IKEA OTA Firmware provider."""
 
-    UPDATE_URL = "https://fw.ota.homesmart.ikea.com/check/update/prod"
+    UPDATE_URL = "https://fw.ota.homesmart.ikea.com/DIRIGERA/version_info.json"
     MANUFACTURER_ID = 4476
     HEADERS = {"accept": "application/json;q=0.9,*/*;q=0.8"}
 


### PR DESCRIPTION
The new IKEA OTA URL uses a self-signed certificate. For security, I've hardcoded the IKEA root CA.
The new IKEA images are also distributed normally, without the IKEA wrapping container, and all validate.

CC @mattwestb