### PR TITLE
Only create pending requests if we are expecting a reply

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -116,13 +116,12 @@ async def test_request(dev):
 async def test_request_without_reply(dev):
     seq = int_sentinel.tsn
 
-    async def mock_req(*args, **kwargs):
-        dev._pending[seq].result.set_result(sentinel.result)
-
-    dev.application.send_packet = AsyncMock(side_effect=mock_req)
+    dev._pending.new = MagicMock()
+    dev.application.send_packet = AsyncMock()
     r = await dev.request(1, 2, 3, 3, seq, b"", expect_reply=False)
     assert r is None
     assert dev._application.send_packet.call_count == 1
+    assert len(dev._pending.new.mock_calls) == 0
 
 
 async def test_failed_request(dev):


### PR DESCRIPTION
@dmulcahey noticed a race condition with attribute reports: if a device expects a default reply to its attribute report *and* our reply takes a while to send, the device may send a duplicate attribute report while retrying. This duplicate will require us to reply with the same TSN, which is currently locked by the current request, causing it to never send.

We should not create a `Request` context if we do not expect a reply.