### PR TITLE
Feed the watchdog before doing anything else

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1464,7 +1464,8 @@ async def test_watchdog(app):
     await app.startup()
     assert app._watchdog_task is not None
 
-    assert app._watchdog_feed.mock_calls == []
+    # We call it once during startup synchronously
+    assert app._watchdog_feed.mock_calls == [call()]
     assert app.connection_lost.mock_calls == []
 
     await asyncio.sleep(0.5)


### PR DESCRIPTION
If the radio is still within a watchdog period, the watchdog can trigger during zigpy init and crash. We should extend the watchdog period before doing anything else.