### PR TITLE
Per-device TSNs

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -465,7 +465,7 @@ async def test_request_exception_propagation(dev, event_loop):
     ep.add_input_cluster(Basic.cluster_id)
     ep.deserialize = MagicMock(side_effect=RuntimeError())
 
-    dev.application.get_sequence = MagicMock(return_value=tsn)
+    dev.get_sequence = MagicMock(return_value=tsn)
 
     event_loop.call_soon(
         dev.packet_received,

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -386,8 +386,8 @@ async def test_read_attributes_uncached():
             )
 
     epmock = MagicMock()
-    epmock._device.application.get_sequence.return_value = 123
-    epmock.device.application.get_sequence.return_value = 123
+    epmock._device.get_sequence.return_value = 123
+    epmock.device.get_sequence.return_value = 123
     cluster = TestCluster(epmock, True)
     cluster2 = TestCluster2(epmock, True)
 
@@ -478,8 +478,8 @@ async def test_read_attributes_default_response():
             )
 
     epmock = MagicMock()
-    epmock._device.application.get_sequence.return_value = 123
-    epmock.device.application.get_sequence.return_value = 123
+    epmock._device.get_sequence.return_value = 123
+    epmock.device.get_sequence.return_value = 123
     cluster = TestCluster(epmock, True)
 
     async def mockrequest(
@@ -1023,6 +1023,8 @@ async def test_request_with_kwargs(real_device):
     ep = quirked.endpoints[1]
 
     with patch.object(ep, "request", AsyncMock()) as request_mock:
+        ep.device.get_sequence = MagicMock(return_value=1)
+
         await ep.level.move_to_level(0x00, 123)
         await ep.level.move_to_level(0x00, transition_time=123)
         await ep.level.move_to_level(level=0x00, transition_time=123)

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -91,8 +91,8 @@ def test_manufacturer_specific_cluster():
 def cluster_by_id():
     def _cluster(cluster_id=0):
         epmock = MagicMock()
-        epmock._device.application.get_sequence.return_value = DEFAULT_TSN
-        epmock.device.application.get_sequence.return_value = DEFAULT_TSN
+        epmock._device.get_sequence.return_value = DEFAULT_TSN
+        epmock.device.get_sequence.return_value = DEFAULT_TSN
         epmock.request = AsyncMock()
         epmock.reply = AsyncMock()
         return zcl.Cluster.from_id(epmock, cluster_id)
@@ -108,7 +108,7 @@ def cluster(cluster_by_id):
 @pytest.fixture
 def client_cluster():
     epmock = AsyncMock()
-    epmock.device.application.get_sequence = MagicMock(return_value=DEFAULT_TSN)
+    epmock.device.get_sequence = MagicMock(return_value=DEFAULT_TSN)
     return zcl.Cluster.from_id(epmock, 3)
 
 
@@ -1040,8 +1040,8 @@ async def test_zcl_request_direction():
     dev = MagicMock()
 
     ep = zigpy.endpoint.Endpoint(dev, 1)
-    ep._device.application.get_sequence.return_value = DEFAULT_TSN
-    ep.device.application.get_sequence.return_value = DEFAULT_TSN
+    ep._device.get_sequence.return_value = DEFAULT_TSN
+    ep.device.get_sequence.return_value = DEFAULT_TSN
     ep.request = AsyncMock()
 
     ep.add_input_cluster(zcl.clusters.general.OnOff.cluster_id)

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -44,10 +44,12 @@ def test_deserialize_unknown(zdo_f):
 
 
 async def test_request(zdo_f):
-    await zdo_f.request(2, 65535)
-    app = zdo_f._device._application
-    assert zdo_f.device.request.call_count == 1
-    assert app.get_sequence.call_count == 1
+    with patch.object(
+        zdo_f._device, "get_sequence", wraps=zdo_f._device.get_sequence
+    ) as get_sequence:
+        await zdo_f.request(2, 65535)
+        assert zdo_f.device.request.call_count == 1
+        assert get_sequence.call_count == 1
 
 
 async def test_bind(zdo_f):
@@ -217,8 +219,8 @@ async def test_reply_tsn_override(zdo_f, monkeypatch):
     await zdo_f.reply(sentinel.cmd, sentinel.arg1, sentinel.arg2)
     seq = zdo_f.device.request.call_args[0][4]
     data = zdo_f.device.request.call_args[0][5]
-    assert seq == 123
-    assert data[0] == 123
+    assert seq == 1
+    assert data[0] == 1
     assert data[1:3] == b"\xaa\x55"
 
     # override tsn

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -73,7 +73,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._manufacturer: str | None = None
         self._model: str | None = None
         self.node_desc: zdo_t.NodeDescriptor | None = None
-        self._pending: zigpy.util.Requests = zigpy.util.Requests()
+        self._pending: zigpy.util.Requests[t.uint8_t] = zigpy.util.Requests()
         self._relays: t.Relays | None = None
         self._skip_configuration: bool = False
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -76,9 +76,14 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._pending: zigpy.util.Requests[t.uint8_t] = zigpy.util.Requests()
         self._relays: t.Relays | None = None
         self._skip_configuration: bool = False
+        self._send_sequence: int = 0
 
         # Retained for backwards compatibility, will be removed in a future release
         self.status = Status.NEW
+
+    def get_sequence(self) -> t.uint8_t:
+        self._send_sequence = (self._send_sequence + 1) % 256
+        return self._send_sequence
 
     @property
     def name(self) -> str:

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -253,12 +253,14 @@ def convert_install_code(code: bytes) -> t.KeyData:
     return aes_mmo_hash(code)
 
 
-class Request:
+T = typing.TypeVar("T")
+
+
+class Request(typing.Generic[T]):
     """Request context manager."""
 
-    def __init__(self, pending: dict, sequence: t.uint8_t) -> None:
+    def __init__(self, pending: dict, sequence: T) -> None:
         """Init context manager for requests."""
-        assert sequence not in pending
         self._pending = pending
         self._result: asyncio.Future = asyncio.Future()
         self._sequence = sequence
@@ -268,8 +270,8 @@ class Request:
         return self._result
 
     @property
-    def sequence(self) -> t.uint8_t:
-        """Send Future."""
+    def sequence(self) -> T:
+        """Request sequence."""
         return self._sequence
 
     def __enter__(self) -> Request:
@@ -286,14 +288,14 @@ class Request:
         return not exc_type
 
 
-class Requests(dict):
-    def new(self, sequence: t.uint8_t) -> Request:
+class Requests(dict, typing.Generic[T]):
+    def new(self, sequence: T) -> Request:
         """Wrap new request into a context manager."""
-        try:
-            return Request(self, sequence)
-        except AssertionError:
-            LOGGER.debug("Duplicate %s TSN", sequence)
-            raise ControllerException(f"duplicate {sequence} TSN") from AssertionError
+        if sequence in self:
+            LOGGER.debug("Duplicate %s TSN: pending %s", self)
+            raise ControllerException(f"Duplicate TSN: {sequence}")
+
+        return Request(self, sequence)
 
 
 class CatchingTaskMixin(LocalLogMixin):

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -289,10 +289,10 @@ class Request(typing.Generic[T]):
 
 
 class Requests(dict, typing.Generic[T]):
-    def new(self, sequence: T) -> Request:
+    def new(self, sequence: T) -> Request[T]:
         """Wrap new request into a context manager."""
         if sequence in self:
-            LOGGER.debug("Duplicate %s TSN: pending %s", self)
+            LOGGER.debug("Duplicate %s TSN: pending %s", sequence, self)
             raise ControllerException(f"Duplicate TSN: {sequence}")
 
         return Request(self, sequence)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -320,7 +320,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         request.serialize()  # Throw an error before generating a new TSN
 
         if tsn is None:
-            tsn = self._endpoint.device.application.get_sequence()
+            tsn = self._endpoint.device.get_sequence()
 
         frame_control = foundation.FrameControl(
             frame_type=(

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -51,14 +51,14 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
 
     def request(self, command, *args, use_ieee=False):
         data = self._serialize(command, *args)
-        tsn = self.device.application.get_sequence()
+        tsn = self.device.get_sequence()
         data = t.uint8_t(tsn).serialize() + data
         return self._device.request(0, command, 0, 0, tsn, data, use_ieee=use_ieee)
 
     def reply(self, command, *args, tsn=None, use_ieee=False):
         data = self._serialize(command, *args)
         if tsn is None:
-            tsn = self.device.application.get_sequence()
+            tsn = self.device.get_sequence()
         data = t.uint8_t(tsn).serialize() + data
         return self._device.reply(0, command, 0, 0, tsn, data, use_ieee=use_ieee)
 


### PR DESCRIPTION
Instead of a global, per-application TSN, we instead should use per-device TSNs. This should prevent duplicate TSN issues when hundreds of requests are issued.