### PR TITLE
Fix group requests

### DIFF
--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -6,7 +6,7 @@ import zigpy.group
 import zigpy.types as t
 import zigpy.zcl
 
-from .async_mock import AsyncMock, MagicMock, sentinel
+from .async_mock import AsyncMock, MagicMock, call, sentinel
 
 FIXTURE_GRP_ID = 0x1001
 FIXTURE_GRP_NAME = "fixture group"
@@ -212,19 +212,17 @@ def test_group_cluster_from_cluster_name():
 
 
 async def test_group_ep_request(group_endpoint):
-    assert group_endpoint.device is not None
-    await group_endpoint.request(
-        sentinel.cluster,
-        sentinel.seq,
-        sentinel.data,
-        sentinel.extra_arg,
-        extra_kwarg=sentinel.extra_kwarg,
-    )
-    assert group_endpoint.device.request.call_count == 1
-    assert group_endpoint.device.request.await_count == 1
-    assert group_endpoint.device.request.call_args[0][1] is sentinel.cluster
-    assert group_endpoint.device.request.call_args[0][2] is sentinel.seq
-    assert group_endpoint.device.request.call_args[0][3] is sentinel.data
+    on_off = zigpy.group.GroupCluster.from_attr(group_endpoint, "on_off")
+    await on_off.on()
+
+    assert group_endpoint.device.request.mock_calls == [
+        call(
+            260,  # profile
+            0x0006,  # cluster
+            1,  # sequence
+            b"\x01\x01\x01",  # data
+        )
+    ]
 
 
 def test_group_ep_reply(group_endpoint):

--- a/zigpy/group.py
+++ b/zigpy/group.py
@@ -31,8 +31,14 @@ class Group(ListenableMixin, dict):
         self._group_id: t.Group = t.Group(group_id)
         self._name: str = name
         self._endpoint: GroupEndpoint = GroupEndpoint(self)
+        self._send_sequence = 0
+
         if groups is not None:
             self.add_listener(groups)
+
+    def get_sequence(self) -> t.uint8_t:
+        self._send_sequence = (self._send_sequence + 1) % 256
+        return self._send_sequence
 
     def add_member(self, ep: Endpoint, suppress_event: bool = False) -> Group:
         if not isinstance(ep, Endpoint):


### PR DESCRIPTION
Multicast is currently broken due to `get_sequence` not being implemented. I've added a unit test to ensure this is caught in the future.