### PR TITLE
Demote common warnings to debug logging

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -196,7 +196,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def enqueue(self, cb_name: str, *args) -> None:
         """Enqueue an async callback handler action."""
         if not self.running:
-            LOGGER.warning("Discarding %s event", cb_name)
+            LOGGER.debug("Discarding %s event", cb_name)
             return
         self._callback_handlers.put_nowait((cb_name, args))
 

--- a/zigpy/topology.py
+++ b/zigpy/topology.py
@@ -81,7 +81,7 @@ class Topology(zigpy.util.ListenableMixin):
                 # not be interrupted if a manual scan is initiated
                 LOGGER.debug("Topology scan cancelled")
             except (Exception, asyncio.CancelledError):
-                LOGGER.warning("Topology scan failed", exc_info=True)
+                LOGGER.debug("Topology scan failed", exc_info=True)
 
     async def scan(
         self, devices: typing.Iterable[zigpy.device.Device] | None = None

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -59,9 +59,6 @@ class ListenableMixin:
                 else:
                     result.append(method(*args))
             except Exception as e:
-                LOGGER.warning(
-                    "Error calling listener %r with args %r: %r", method, args, e
-                )
                 LOGGER.debug(
                     "Error calling listener %r with args %r", method, args, exc_info=e
                 )
@@ -83,9 +80,6 @@ class ListenableMixin:
         results = []
         for result in await asyncio.gather(*tasks, return_exceptions=True):
             if isinstance(result, Exception):
-                LOGGER.warning(
-                    "Error calling listener %r with args %r: %r", method, args, result
-                )
                 LOGGER.debug(
                     "Error calling listener %r with args %r",
                     method,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -272,14 +272,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 commands = self.server_commands
 
             if hdr.command_id not in commands:
-                self.warning("Unknown cluster command %s %s", hdr.command_id, data)
+                self.debug("Unknown cluster command %s %s", hdr.command_id, data)
                 return hdr, data
 
             command = commands[hdr.command_id]
         else:
             # General command
             if hdr.command_id not in foundation.GENERAL_COMMANDS:
-                self.warning("Unknown foundation command %s %s", hdr.command_id, data)
+                self.debug("Unknown foundation command %s %s", hdr.command_id, data)
                 return hdr, data
 
             command = foundation.GENERAL_COMMANDS[hdr.command_id]
@@ -290,7 +290,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         self.debug("Decoded ZCL frame: %s:%r", type(self).__name__, response)
 
         if data:
-            self.warning("Data remains after deserializing ZCL frame: %r", data)
+            self.debug("Data remains after deserializing ZCL frame: %r", data)
 
         return hdr, response
 


### PR DESCRIPTION
A lot of these warnings shouldn't be logged at the warning log level, especially `Unknown cluster command`.