### PR TITLE
Allow custom cluster to override default manufacturer

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -964,9 +964,10 @@ async def test_manuf_id_disable(real_device):
         hdr, _ = zcl.foundation.ZCLHeader.deserialize(data)
         assert hdr.manufacturer == 0x1234
 
-    # But it can be disabled by passing NO_MANUFACTURER_ID
     with patch.object(ep, "request", AsyncMock()) as request_mock:
         request_mock.return_value = (zcl.foundation.Status.SUCCESS, "done")
+
+        # That it can be disabled by passing NO_MANUFACTURER_ID
         await ep.just_a_cluster.command(
             ep.just_a_cluster.commands_by_name["server_cmd0"].id,
             manufacturer=zcl.foundation.ZCLHeader.NO_MANUFACTURER_ID,
@@ -978,9 +979,7 @@ async def test_manuf_id_disable(real_device):
             {"attr0": 1}, manufacturer=zcl.foundation.ZCLHeader.NO_MANUFACTURER_ID
         )
 
-    # And it can be disabled by defaulting to NO_MANUFACTURER_ID
-    with patch.object(ep, "request", AsyncMock()) as request_mock:
-        request_mock.return_value = (zcl.foundation.Status.SUCCESS, "done")
+        # That it can be disabled by defaulting to NO_MANUFACTURER_ID
         ep.just_a_cluster.manufacturer_id_override = (
             zcl.foundation.ZCLHeader.NO_MANUFACTURER_ID
         )

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -978,7 +978,19 @@ async def test_manuf_id_disable(real_device):
             {"attr0": 1}, manufacturer=zcl.foundation.ZCLHeader.NO_MANUFACTURER_ID
         )
 
-    assert len(request_mock.mock_calls) == 3
+    # And it can be disabled by defaulting to NO_MANUFACTURER_ID
+    with patch.object(ep, "request", AsyncMock()) as request_mock:
+        request_mock.return_value = (zcl.foundation.Status.SUCCESS, "done")
+        ep.just_a_cluster.manufacturer_id_override = (
+            zcl.foundation.ZCLHeader.NO_MANUFACTURER_ID
+        )
+        await ep.just_a_cluster.command(
+            ep.just_a_cluster.commands_by_name["server_cmd0"].id
+        )
+        await ep.just_a_cluster.read_attributes(["attr0"])
+        await ep.just_a_cluster.write_attributes({"attr0": 1})
+
+    assert len(request_mock.mock_calls) == 6
 
     for mock_call in request_mock.mock_calls:
         data = mock_call.args[2]

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -191,6 +191,9 @@ class CustomCluster(zigpy.zcl.Cluster):
     ) -> typing.Coroutine:
         command = self.server_commands[command_id]
 
+        if manufacturer is None:
+            manufacturer = self.manufacturer_id_override
+
         if manufacturer is None and (
             self._is_manuf_specific or command.is_manufacturer_specific
         ):
@@ -216,6 +219,9 @@ class CustomCluster(zigpy.zcl.Cluster):
         **kwargs: typing.Any,
     ):
         command = self.client_commands[command_id]
+
+        if manufacturer is None:
+            manufacturer = self.manufacturer_id_override
 
         if manufacturer is None and (
             self._is_manuf_specific or command.is_manufacturer_specific
@@ -281,6 +287,9 @@ class CustomCluster(zigpy.zcl.Cluster):
         **kwargs,
     ):
         """Configure reporting ZCL foundation command."""
+        if manufacturer is None:
+            manufacturer = self.manufacturer_id_override
+
         if manufacturer is None and self._has_manuf_attr(
             [a.attrid for a in config_records]
         ):
@@ -300,6 +309,9 @@ class CustomCluster(zigpy.zcl.Cluster):
         **kwargs,
     ):
         """Read attributes ZCL foundation command."""
+        if manufacturer is None:
+            manufacturer = self.manufacturer_id_override
+
         if manufacturer is None and self._has_manuf_attr(attribute_ids):
             manufacturer = self.endpoint.manufacturer_id
         return await super()._read_attributes(
@@ -314,6 +326,9 @@ class CustomCluster(zigpy.zcl.Cluster):
         **kwargs,
     ):
         """Write attribute ZCL foundation command."""
+        if manufacturer is None:
+            manufacturer = self.manufacturer_id_override
+
         if manufacturer is None and self._has_manuf_attr(
             [a.attrid for a in attributes]
         ):
@@ -330,6 +345,9 @@ class CustomCluster(zigpy.zcl.Cluster):
         **kwargs,
     ):
         """Write attribute undivided ZCL foundation command."""
+        if manufacturer is None:
+            manufacturer = self.manufacturer_id_override
+
         if manufacturer is None and self._has_manuf_attr(
             [a.attrid for a in attributes]
         ):


### PR DESCRIPTION
Allow a custom cluster to define what manufacturer identifier should be used on calls. This avoids complex solutions needed in quirks like:

- https://github.com/zigpy/zha-device-handlers/pull/2831
- https://github.com/zigpy/zha-device-handlers/pull/2916/files#diff-26ece3bfac018bd040ddcad810ff6049fa91c0a552ef6b2aa01d8edbb9eabf98R71
- https://github.com/zigpy/zha-device-handlers/blob/a014ef5969045bf3e3be8664d2778c7a5ed8c2a5/zhaquirks/tuya/ts0601_valve.py#L374
- https://github.com/zigpy/zha-device-handlers/blob/a014ef5969045bf3e3be8664d2778c7a5ed8c2a5/zhaquirks/tuya/ts0001_fingerbot.py#L51
- https://github.com/zigpy/zha-device-handlers/blob/a014ef5969045bf3e3be8664d2778c7a5ed8c2a5/zhaquirks/tuya/ts0601_siren.py#L275