### PR TITLE
Fix integer `Struct` comparisons

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -851,3 +851,30 @@ def test_dynamic_type():
 
     assert TestStruct(foo=0x00, baz=b"test").serialize() == b"\x00\x04test"
     assert TestStruct(foo=0x01, baz=0x04).serialize() == b"\x01\x04"
+
+
+def test_int_comparison(expose_global):
+    @expose_global
+    class FirmwarePlatform(t.enum8):
+        Conbee = 0x05
+        Conbee_II = 0x07
+        Conbee_III = 0x09
+
+    class FirmwareVersion(t.Struct, t.uint32_t):
+        reserved: t.uint8_t
+        platform: FirmwarePlatform
+        minor: t.uint8_t
+        major: t.uint8_t
+
+    fw_ver = FirmwareVersion(0x264F0900)
+    assert fw_ver == FirmwareVersion(
+        reserved=0, platform=FirmwarePlatform.Conbee_III, minor=79, major=38
+    )
+    assert fw_ver == 0x264F0900
+    assert int(fw_ver) == 0x264F0900
+
+    assert int(fw_ver) <= fw_ver
+    assert fw_ver <= int(fw_ver)
+
+    assert int(fw_ver) - 1 < fw_ver
+    assert fw_ver < int(fw_ver) + 1

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -885,3 +885,34 @@ def test_int_comparison(expose_global):
 
     assert int(fw_ver) + 1 > fw_ver
     assert fw_ver > int(fw_ver) - 1
+
+
+def test_int_comparison_non_int(expose_global):
+    @expose_global
+    class FirmwarePlatform(t.enum8):
+        Conbee = 0x05
+        Conbee_II = 0x07
+        Conbee_III = 0x09
+
+    # This isn't an integer
+    class FirmwareVersion(t.Struct):
+        reserved: t.uint8_t
+        platform: FirmwarePlatform
+        minor: t.uint8_t
+        major: t.uint8_t
+
+    fw_ver = FirmwareVersion(
+        reserved=0, platform=FirmwarePlatform.Conbee_III, minor=79, major=38
+    )
+
+    with pytest.raises(TypeError):
+        fw_ver < 0
+
+    with pytest.raises(TypeError):
+        fw_ver <= 0
+
+    with pytest.raises(TypeError):
+        fw_ver > 0
+
+    with pytest.raises(TypeError):
+        fw_ver >= 0

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -879,3 +879,9 @@ def test_int_comparison(expose_global):
 
     assert int(fw_ver) - 1 < fw_ver
     assert fw_ver < int(fw_ver) + 1
+
+    assert int(fw_ver) >= fw_ver
+    assert fw_ver >= int(fw_ver)
+
+    assert int(fw_ver) + 1 > fw_ver
+    assert fw_ver > int(fw_ver) - 1

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -872,6 +872,7 @@ def test_int_comparison(expose_global):
     )
     assert fw_ver == 0x264F0900
     assert int(fw_ver) == 0x264F0900
+    assert "0x264F0900" in str(fw_ver)
 
     assert int(fw_ver) <= fw_ver
     assert fw_ver <= int(fw_ver)

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -90,7 +90,8 @@ class FixedIntType(int):
 
         n = super().__new__(cls, *args, **kwargs)
 
-        if not cls.min_value <= n <= cls.max_value:
+        # We use `n + 0` to convert `n` into an integer without calling `int()`
+        if not cls.min_value <= n + 0 <= cls.max_value:
             raise ValueError(
                 f"{int(n)} is not an {'un' if not cls._signed else ''}signed"
                 f" {cls._bits} bit integer"

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -347,6 +347,30 @@ class Struct:
 
         return int(n)
 
+    def __lt__(self, other: object) -> bool:
+        if self._int_type is None or not isinstance(other, int):
+            return NotImplemented
+
+        return int(self) < int(other)
+
+    def __le__(self, other: object) -> bool:
+        if self._int_type is None or not isinstance(other, int):
+            return NotImplemented
+
+        return int(self) <= int(other)
+
+    def __gt__(self, other: object) -> bool:
+        if self._int_type is None or not isinstance(other, int):
+            return NotImplemented
+
+        return int(self) > int(other)
+
+    def __ge__(self, other: object) -> bool:
+        if self._int_type is None or not isinstance(other, int):
+            return NotImplemented
+
+        return int(self) >= int(other)
+
     def __repr__(self) -> str:
         fields = []
 

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -392,7 +392,12 @@ class Struct:
             if value is not None:
                 fields.append(f"*{attr}={value!r}")
 
-        return f"{type(self).__name__}({', '.join(fields)})"
+        extra = ""
+
+        if self._int_type is not None:
+            extra = f"<{self._int_type(int(self))._hex_repr()}>"
+
+        return f"{type(self).__name__}{extra}({', '.join(fields)})"
 
     @property
     def is_valid(self) -> bool:


### PR DESCRIPTION
Integer structs have seemingly undefined semantics with comparisons to real integers. Some comparisons work, others don't. This is causing issues with zigpy-deconz where the firmware version struct is returning the wrong value on comparison.