### PR TITLE
Log incompatible listeners

### DIFF
--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -34,8 +34,15 @@ class BaseRequestListener:
                 command, foundation.CommandSchema
             ):
                 match = command.matches(matcher)
-            else:
+            elif callable(matcher):
                 match = matcher(hdr, command)
+            else:
+                LOGGER.warning(
+                    "Matcher %r and command %r %r are incompatible",
+                    matcher,
+                    hdr,
+                    command,
+                )
 
             if match:
                 return self._resolve(hdr, command)

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -37,6 +37,7 @@ class BaseRequestListener:
             elif callable(matcher):
                 match = matcher(hdr, command)
             else:
+                match = None
                 LOGGER.warning(
                     "Matcher %r and command %r %r are incompatible",
                     matcher,


### PR DESCRIPTION
If a listener object isn't callable, it should not be called.

Should identify the issue @TheJulianJES noticed with OTA.