### PR TITLE
Fix `direction` field for replies and use correct definitions

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1193,7 +1193,7 @@ async def test_request_future_matching(app, make_initialized_device):
         command_id=ota.commands_by_name["query_next_image"].id,
         schema=ota.commands_by_name["query_next_image"].schema,
         disable_default_response=False,
-        direction=foundation.Direction.Server_to_Client,
+        direction=foundation.Direction.Client_to_Server,
         args=(),
         kwargs={
             "field_control": 0,
@@ -1256,7 +1256,7 @@ async def test_request_callback_matching(app, make_initialized_device):
         command_id=ota.commands_by_name["query_next_image"].id,
         schema=ota.commands_by_name["query_next_image"].schema,
         disable_default_response=False,
-        direction=foundation.Direction.Server_to_Client,
+        direction=foundation.Direction.Client_to_Server,
         args=(),
         kwargs={
             "field_control": 0,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -508,7 +508,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
             command_id=cluster.commands_by_name[cmd_name].id,
             schema=cluster.commands_by_name[cmd_name].schema,
             disable_default_response=False,
-            direction=foundation.Direction.Server_to_Client,
+            direction=foundation.Direction.Client_to_Server,
             args=(),
             kwargs=kwargs,
         )
@@ -797,7 +797,7 @@ async def test_request_exception_propagation(dev, event_loop):
                     frame_control=foundation.FrameControl(
                         frame_type=foundation.FrameType.CLUSTER_COMMAND,
                         is_manufacturer_specific=False,
-                        direction=foundation.Direction.Client_to_Server,
+                        direction=foundation.Direction.Server_to_Client,
                         disable_default_response=True,
                         reserved=0,
                     ),

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -28,7 +28,7 @@ def test_deserialize_general(endpoint):
     hdr, args = endpoint.deserialize(0, b"\x00\x01\x00")
     assert hdr.tsn == 1
     assert hdr.command_id == 0
-    assert hdr.direction == foundation.Direction.Server_to_Client
+    assert hdr.direction == foundation.Direction.Client_to_Server
 
 
 def test_deserialize_general_unknown(endpoint):
@@ -37,7 +37,7 @@ def test_deserialize_general_unknown(endpoint):
     assert hdr.frame_control.is_general is True
     assert hdr.frame_control.is_cluster is False
     assert hdr.command_id == 255
-    assert hdr.direction == foundation.Direction.Server_to_Client
+    assert hdr.direction == foundation.Direction.Client_to_Server
 
 
 def test_deserialize_cluster(endpoint):
@@ -46,7 +46,7 @@ def test_deserialize_cluster(endpoint):
     assert hdr.frame_control.is_general is False
     assert hdr.frame_control.is_cluster is True
     assert hdr.command_id == 0
-    assert hdr.direction == foundation.Direction.Server_to_Client
+    assert hdr.direction == foundation.Direction.Client_to_Server
 
 
 def test_deserialize_cluster_client(endpoint):
@@ -56,7 +56,7 @@ def test_deserialize_cluster_client(endpoint):
     assert hdr.frame_control.is_cluster is True
     assert hdr.command_id == 0
     assert list(args) == [0x4241]
-    assert hdr.direction == foundation.Direction.Client_to_Server
+    assert hdr.direction == foundation.Direction.Server_to_Client
 
 
 def test_deserialize_cluster_unknown(endpoint):
@@ -68,7 +68,7 @@ def test_deserialize_cluster_command_unknown(endpoint):
     hdr, args = endpoint.deserialize(0, b"\x01\x01\xff")
     assert hdr.tsn == 1
     assert hdr.command_id == 255
-    assert hdr.direction == foundation.Direction.Server_to_Client
+    assert hdr.direction == foundation.Direction.Client_to_Server
 
 
 def test_unknown_cluster():
@@ -1052,14 +1052,14 @@ async def test_zcl_request_direction():
     # Input cluster
     await ep.in_clusters[zcl.clusters.general.OnOff.cluster_id].on()
     hdr1, _ = foundation.ZCLHeader.deserialize(ep.request.mock_calls[0].args[2])
-    assert hdr1.direction == foundation.Direction.Server_to_Client
+    assert hdr1.direction == foundation.Direction.Client_to_Server
 
     ep.request.reset_mock()
 
     # Output cluster
     await ep.out_clusters[zcl.clusters.general.OnOff.cluster_id].on()
     hdr2, _ = foundation.ZCLHeader.deserialize(ep.request.mock_calls[0].args[2])
-    assert hdr2.direction == foundation.Direction.Client_to_Server
+    assert hdr2.direction == foundation.Direction.Server_to_Client
 
     # Color cluster that also uses `direction` as a kwarg
     await ep.light_color.move_to_hue(
@@ -1086,7 +1086,7 @@ async def test_zcl_reply_direction(app_mock):
         frame_control=foundation.FrameControl(
             frame_type=foundation.FrameType.GLOBAL_COMMAND,
             is_manufacturer_specific=0,
-            direction=foundation.Direction.Client_to_Server,
+            direction=foundation.Direction.Server_to_Client,
             disable_default_response=0,
             reserved=0,
         ),
@@ -1117,4 +1117,4 @@ async def test_zcl_reply_direction(app_mock):
 
     # The direction is correct
     packet_hdr, _ = foundation.ZCLHeader.deserialize(packet.data.serialize())
-    assert packet_hdr.direction == foundation.Direction.Server_to_Client
+    assert packet_hdr.direction == foundation.Direction.Client_to_Server

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -219,7 +219,7 @@ def test_frame_control():
 
 def test_frame_control_general():
     frc = foundation.FrameControl.general(
-        direction=foundation.Direction.Server_to_Client
+        direction=foundation.Direction.Client_to_Server
     )
     assert frc.is_cluster is False
     assert frc.is_general is True
@@ -233,21 +233,21 @@ def test_frame_control_general():
     assert frc.serialize() == b"\x04"
 
     frc = foundation.FrameControl.general(
-        direction=foundation.Direction.Server_to_Client
+        direction=foundation.Direction.Client_to_Server
     )
-    assert frc.direction == foundation.Direction.Server_to_Client
+    assert frc.direction == foundation.Direction.Client_to_Server
     assert frc.serialize() == b"\x00"
-    frc.direction = foundation.Direction.Client_to_Server
+    frc.direction = foundation.Direction.Server_to_Client
     assert frc.serialize() == b"\x08"
     assert (
         foundation.FrameControl.general(
-            direction=foundation.Direction.Client_to_Server
+            direction=foundation.Direction.Server_to_Client
         ).serialize()
         == b"\x18"
     )
 
     frc = foundation.FrameControl.general(
-        direction=foundation.Direction.Server_to_Client
+        direction=foundation.Direction.Client_to_Server
     )
     assert not frc.disable_default_response
     assert frc.serialize() == b"\x00"
@@ -259,7 +259,7 @@ def test_frame_control_general():
 
 def test_frame_control_cluster():
     frc = foundation.FrameControl.cluster(
-        direction=foundation.Direction.Server_to_Client
+        direction=foundation.Direction.Client_to_Server
     )
     assert frc.is_cluster is True
     assert frc.is_general is False
@@ -273,23 +273,23 @@ def test_frame_control_cluster():
     assert frc.serialize() == b"\x05"
 
     frc = foundation.FrameControl.cluster(
-        direction=foundation.Direction.Server_to_Client
+        direction=foundation.Direction.Client_to_Server
     )
-    assert frc.direction == foundation.Direction.Server_to_Client
-    assert frc.serialize() == b"\x01"
-    frc.direction = foundation.Direction.Server_to_Client
+    assert frc.direction == foundation.Direction.Client_to_Server
     assert frc.serialize() == b"\x01"
     frc.direction = foundation.Direction.Client_to_Server
+    assert frc.serialize() == b"\x01"
+    frc.direction = foundation.Direction.Server_to_Client
     assert frc.serialize() == b"\x09"
     assert (
         foundation.FrameControl.cluster(
-            direction=foundation.Direction.Client_to_Server
+            direction=foundation.Direction.Server_to_Client
         ).serialize()
         == b"\x19"
     )
 
     frc = foundation.FrameControl.cluster(
-        direction=foundation.Direction.Server_to_Client
+        direction=foundation.Direction.Client_to_Server
     )
     assert not frc.disable_default_response
     assert frc.serialize() == b"\x01"
@@ -307,7 +307,7 @@ def test_frame_header():
 
     assert rest == extra
     assert hdr.command_id == 0x0A
-    assert hdr.direction == foundation.Direction.Client_to_Server
+    assert hdr.direction == foundation.Direction.Server_to_Client
     assert hdr.manufacturer == 0x115F
     assert hdr.tsn == 0xC0
 
@@ -618,7 +618,7 @@ def test_schema():
         schema={
             "uh oh": t.uint16_t,
         },
-        direction=foundation.Direction.Server_to_Client,
+        direction=foundation.Direction.Client_to_Server,
     )
 
     with pytest.raises(ValueError):
@@ -632,7 +632,7 @@ def test_schema():
             "bar?": t.uint16_t,
             "baz?": t.uint8_t,
         },
-        direction=foundation.Direction.Server_to_Client,
+        direction=foundation.Direction.Client_to_Server,
     )
     s = s.with_compiled_schema()
 
@@ -647,7 +647,7 @@ def test_schema():
     assert s.schema.baz.type is t.uint8_t
     assert s.schema.baz.optional
 
-    assert "test" in str(s) and "direction=<Direction.Server_to_Client" in str(s)
+    assert "test" in str(s) and "direction=<Direction.Client_to_Server" in str(s)
 
     for kwargs, value in [
         ({"foo": 1}, b"\x01"),
@@ -668,7 +668,7 @@ def test_command_schema_error_on_tuple():
         id=0x12,
         name="test",
         schema=(t.uint16_t,),
-        direction=foundation.Direction.Server_to_Client,
+        direction=foundation.Direction.Client_to_Server,
     )
 
     with pytest.raises(ValueError):
@@ -704,7 +704,7 @@ def test_invalid_command_def_name():
         schema={
             "foo": t.uint8_t,
         },
-        direction=foundation.Direction.Server_to_Client,
+        direction=foundation.Direction.Client_to_Server,
     )
 
     with pytest.raises(ValueError):
@@ -754,7 +754,7 @@ def test_attribute_command_iteration():
             schema={
                 "foo": t.uint8_t,
             },
-            direction=foundation.Direction.Server_to_Client,
+            direction=foundation.Direction.Client_to_Server,
         )
 
     class Commands2(Commands1):
@@ -764,7 +764,7 @@ def test_attribute_command_iteration():
             schema={
                 "foo": t.uint8_t,
             },
-            direction=foundation.Direction.Server_to_Client,
+            direction=foundation.Direction.Client_to_Server,
         )
 
     assert list(Commands1) == [Commands1.command1]

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -437,7 +437,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         # Resolve the future if this is a response to a request
         if hdr.tsn in self._pending and (
-            hdr.direction == foundation.Direction.Client_to_Server
+            hdr.direction == foundation.Direction.Server_to_Client
             if isinstance(hdr, foundation.ZCLHeader)
             else hdr.is_reply
         ):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -266,7 +266,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
         if hdr.frame_control.frame_type == foundation.FrameType.CLUSTER_COMMAND:
             # Cluster command
-            if hdr.direction == foundation.Direction.Client_to_Server:
+            if hdr.direction == foundation.Direction.Server_to_Client:
                 commands = self.client_commands
             else:
                 commands = self.server_commands
@@ -313,7 +313,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             schema = convert_list_schema(
                 command_id=command_id,
                 schema=schema,
-                direction=foundation.Direction.Server_to_Client,
+                direction=foundation.Direction.Client_to_Server,
             )
 
         request = schema(*args, **kwargs)  # type:ignore[operator]
@@ -362,9 +362,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             tsn=tsn,
             disable_default_response=self.is_client,
             direction=(
-                foundation.Direction.Client_to_Server
+                foundation.Direction.Server_to_Client
                 if self.is_client
-                else foundation.Direction.Server_to_Client
+                else foundation.Direction.Client_to_Server
             ),
             args=args,
             kwargs=kwargs,
@@ -400,9 +400,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             tsn=tsn,
             disable_default_response=True,
             direction=(
-                foundation.Direction.Client_to_Server
+                foundation.Direction.Server_to_Client
                 if self.is_client
-                else foundation.Direction.Server_to_Client
+                else foundation.Direction.Client_to_Server
             ),
             args=args,
             kwargs=kwargs,
@@ -874,7 +874,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
     ):
         command = foundation.GENERAL_COMMANDS[command_id]
 
-        if command.direction == foundation.Direction.Client_to_Server:
+        if command.direction == foundation.Direction.Server_to_Client:
             # should reply be retryable?
             return self.reply(
                 True,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -399,7 +399,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             manufacturer=manufacturer,
             tsn=tsn,
             disable_default_response=True,
-            direction=foundation.Direction.Client_to_Server,
+            direction=(
+                foundation.Direction.Server_to_Client
+                if self.is_client
+                else foundation.Direction.Client_to_Server
+            ),
             args=args,
             kwargs=kwargs,
         )

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -400,9 +400,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             tsn=tsn,
             disable_default_response=True,
             direction=(
-                foundation.Direction.Server_to_Client
+                foundation.Direction.Client_to_Server
                 if self.is_client
-                else foundation.Direction.Client_to_Server
+                else foundation.Direction.Server_to_Client
             ),
             args=args,
             kwargs=kwargs,

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -491,12 +491,12 @@ class FrameType(t.enum2):
 class Direction(t.enum1):
     """ZCL frame control direction."""
 
-    Server_to_Client = 0
-    Client_to_Server = 1
+    Client_to_Server = 0
+    Server_to_Client = 1
 
     @classmethod
     def _from_is_reply(cls, is_reply: bool) -> Direction:
-        return cls.Client_to_Server if is_reply else cls.Server_to_Client
+        return cls.Server_to_Client if is_reply else cls.Client_to_Server
 
 
 class FrameControl(t.Struct, t.uint8_t):
@@ -513,28 +513,28 @@ class FrameControl(t.Struct, t.uint8_t):
     @classmethod
     def cluster(
         cls,
-        direction: Direction = Direction.Server_to_Client,
+        direction: Direction = Direction.Client_to_Server,
         is_manufacturer_specific: bool = False,
     ):
         return cls(
             frame_type=FrameType.CLUSTER_COMMAND,
             is_manufacturer_specific=is_manufacturer_specific,
             direction=direction,
-            disable_default_response=(direction == Direction.Client_to_Server),
+            disable_default_response=(direction == Direction.Server_to_Client),
             reserved=0b000,
         )
 
     @classmethod
     def general(
         cls,
-        direction: Direction = Direction.Server_to_Client,
+        direction: Direction = Direction.Client_to_Server,
         is_manufacturer_specific: bool = False,
     ):
         return cls(
             frame_type=FrameType.GLOBAL_COMMAND,
             is_manufacturer_specific=is_manufacturer_specific,
             direction=direction,
-            disable_default_response=(direction == Direction.Client_to_Server),
+            disable_default_response=(direction == Direction.Server_to_Client),
             reserved=0b000,
         )
 
@@ -599,7 +599,7 @@ class ZCLHeader(t.Struct):
         tsn: int | t.uint8_t,
         command_id: int | t.uint8_t,
         manufacturer: int | t.uint16_t | None = None,
-        direction: Direction = Direction.Server_to_Client,
+        direction: Direction = Direction.Client_to_Server,
     ) -> ZCLHeader:
         return cls(
             frame_control=FrameControl.general(
@@ -617,7 +617,7 @@ class ZCLHeader(t.Struct):
         tsn: int | t.uint8_t,
         command_id: int | t.uint8_t,
         manufacturer: int | t.uint16_t | None = None,
-        direction: Direction = Direction.Server_to_Client,
+        direction: Direction = Direction.Client_to_Server,
     ) -> ZCLHeader:
         return cls(
             frame_control=FrameControl.cluster(
@@ -857,89 +857,89 @@ class GeneralCommand(t.enum8):
 GENERAL_COMMANDS = COMMANDS = {
     GeneralCommand.Read_Attributes: ZCLCommandDef(
         schema={"attribute_ids": t.List[t.uint16_t]},
-        direction=Direction.Server_to_Client,
+        direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Read_Attributes_rsp: ZCLCommandDef(
         schema={"status_records": t.List[ReadAttributeRecord]},
-        direction=Direction.Client_to_Server,
+        direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Write_Attributes: ZCLCommandDef(
-        schema={"attributes": t.List[Attribute]}, direction=Direction.Server_to_Client
+        schema={"attributes": t.List[Attribute]}, direction=Direction.Client_to_Server
     ),
     GeneralCommand.Write_Attributes_Undivided: ZCLCommandDef(
-        schema={"attributes": t.List[Attribute]}, direction=Direction.Server_to_Client
+        schema={"attributes": t.List[Attribute]}, direction=Direction.Client_to_Server
     ),
     GeneralCommand.Write_Attributes_rsp: ZCLCommandDef(
         schema={"status_records": WriteAttributesResponse},
-        direction=Direction.Client_to_Server,
+        direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Write_Attributes_No_Response: ZCLCommandDef(
-        schema={"attributes": t.List[Attribute]}, direction=Direction.Server_to_Client
+        schema={"attributes": t.List[Attribute]}, direction=Direction.Client_to_Server
     ),
     GeneralCommand.Configure_Reporting: ZCLCommandDef(
         schema={"config_records": t.List[AttributeReportingConfig]},
-        direction=Direction.Server_to_Client,
+        direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Configure_Reporting_rsp: ZCLCommandDef(
         schema={"status_records": ConfigureReportingResponse},
-        direction=Direction.Client_to_Server,
+        direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Read_Reporting_Configuration: ZCLCommandDef(
         schema={"attribute_records": t.List[ReadReportingConfigRecord]},
-        direction=Direction.Server_to_Client,
+        direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Read_Reporting_Configuration_rsp: ZCLCommandDef(
         schema={"attribute_configs": t.List[AttributeReportingConfigWithStatus]},
-        direction=Direction.Client_to_Server,
+        direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Report_Attributes: ZCLCommandDef(
         schema={"attribute_reports": t.List[Attribute]},
-        direction=Direction.Server_to_Client,
+        direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Default_Response: ZCLCommandDef(
         schema={"command_id": t.uint8_t, "status": Status},
-        direction=Direction.Client_to_Server,
+        direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Discover_Attributes: ZCLCommandDef(
         schema={"start_attribute_id": t.uint16_t, "max_attribute_ids": t.uint8_t},
-        direction=Direction.Server_to_Client,
+        direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Discover_Attributes_rsp: ZCLCommandDef(
         schema={
             "discovery_complete": t.Bool,
             "attribute_info": t.List[DiscoverAttributesResponseRecord],
         },
-        direction=Direction.Client_to_Server,
+        direction=Direction.Server_to_Client,
     ),
-    # Command.Read_Attributes_Structured: ZCLCommandDef(schema=(, ), direction=Direction.Server_to_Client),
-    # Command.Write_Attributes_Structured: ZCLCommandDef(schema=(, ), direction=Direction.Server_to_Client),
-    # Command.Write_Attributes_Structured_rsp: ZCLCommandDef(schema=(, ), direction=Direction.Client_to_Server),
+    # Command.Read_Attributes_Structured: ZCLCommandDef(schema=(, ), direction=Direction.Client_to_Server),
+    # Command.Write_Attributes_Structured: ZCLCommandDef(schema=(, ), direction=Direction.Client_to_Server),
+    # Command.Write_Attributes_Structured_rsp: ZCLCommandDef(schema=(, ), direction=Direction.Server_to_Client),
     GeneralCommand.Discover_Commands_Received: ZCLCommandDef(
         schema={"start_command_id": t.uint8_t, "max_command_ids": t.uint8_t},
-        direction=Direction.Server_to_Client,
+        direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Discover_Commands_Received_rsp: ZCLCommandDef(
         schema={"discovery_complete": t.Bool, "command_ids": t.List[t.uint8_t]},
-        direction=Direction.Client_to_Server,
+        direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Discover_Commands_Generated: ZCLCommandDef(
         schema={"start_command_id": t.uint8_t, "max_command_ids": t.uint8_t},
-        direction=Direction.Server_to_Client,
+        direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Discover_Commands_Generated_rsp: ZCLCommandDef(
         schema={"discovery_complete": t.Bool, "command_ids": t.List[t.uint8_t]},
-        direction=Direction.Client_to_Server,
+        direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Discover_Attribute_Extended: ZCLCommandDef(
         schema={"start_attribute_id": t.uint16_t, "max_attribute_ids": t.uint8_t},
-        direction=Direction.Server_to_Client,
+        direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Discover_Attribute_Extended_rsp: ZCLCommandDef(
         schema={
             "discovery_complete": t.Bool,
             "extended_attr_info": t.List[DiscoverAttributesExtendedResponseRecord],
         },
-        direction=Direction.Client_to_Server,
+        direction=Direction.Server_to_Client,
     ),
 }
 


### PR DESCRIPTION
@dmulcahey and I look at some logs when diagnosing Tuya mmWave issues and noticed something odd:

```python
2024-01-31 13:41:12.617 DEBUG (MainThread) [zigpy_znp.api] Received command: AF.IncomingMsg.Callback(GroupId=0x0000, ClusterId=1794, SrcAddr=0x69DE, SrcEndpoint=1, DstEndpoint=1, WasBroadcast=<Bool.false: 0>, LQI=51, SecurityUse=<Bool.false: 0>, TimeStamp=15336323, TSN=0, Data=b'\x08\x57\x0A\x00\x00\x25\xA7\x00\x00\x00\x00\x00', MacSrcAddr=0xA107, MsgResultRadius=28)
...
2024-01-31 13:41:12.619 DEBUG (MainThread) [zigpy.zcl] [0x69DE:1:0x0702] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 1>, disable_default_response=0, reserved=0, *is_cluster=False, *is_general=True), tsn=87, command_id=10, *direction=<Direction.Client_to_Server: 1>)
...
2024-01-31 13:41:12.621 DEBUG (MainThread) [zigpy.zcl] [0x69DE:1:0x0702] Received command 0x0A (TSN 87): Report_Attributes(attribute_reports=[Attribute(attrid=0x0000, value=TypeValue(type=uint48_t, value=167))])
2024-01-31 13:41:12.622 DEBUG (MainThread) [zigpy.zcl] [0x69DE:1:0x0702] Sending reply header: ZCLHeader(frame_control=FrameControl(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=False, direction=<Direction.Client_to_Server: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), tsn=87, command_id=<GeneralCommand.Default_Response: 11>, *direction=<Direction.Client_to_Server: 1>)
2024-01-31 13:41:12.623 DEBUG (MainThread) [zigpy.zcl] [0x69DE:1:0x0702] Sending reply: Default_Response(command_id=10, status=<Status.SUCCESS: 0>)
```

Specifically:

```python
2024-01-31 13:41:12.619 DEBUG (MainThread) [zigpy.zcl] [0x69DE:1:0x0702] Decoded ZCL frame header: ... direction=<Direction.Client_to_Server: 1> ...
...
2024-01-31 13:41:12.622 DEBUG (MainThread) [zigpy.zcl] [0x69DE:1:0x0702] Sending reply header: ... direction=<Direction.Client_to_Server: 1> ...
```

The `direction` field appears to be incorrect!

Rationale:

1. If we define a device with `SomeCluster` being a `client` cluster, this means that the device assumes the coordinator has a corresponding `server` cluster.
2. Any data coming in from that device, from that cluster, will be `Client_to_Server`.
3. When we send a reply, it should be a `Server_to_Client` command.