### PR TITLE
Rename input and output clusters to server and client

### DIFF
--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -420,7 +420,7 @@ async def test_v4_to_v6_migration_missing_endpoints(test_db, with_quirk_attribut
     def get_device(dev):
         if dev.ieee == t.EUI64.convert("00:0d:6f:ff:fe:a6:11:7a"):
             ep = dev.add_endpoint(123)
-            ep.add_input_cluster(456)
+            ep.add_server_cluster(456)
 
         return dev
 
@@ -430,7 +430,7 @@ async def test_v4_to_v6_migration_missing_endpoints(test_db, with_quirk_attribut
 
     if with_quirk_attribute:
         dev = app.get_device(ieee=t.EUI64.convert("00:0d:6f:ff:fe:a6:11:7a"))
-        assert dev.endpoints[123].in_clusters[456]._attr_cache[789] == "test"
+        assert dev.endpoints[123].server_clusters[456]._attr_cache[789] == "test"
 
     await app.shutdown()
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1186,7 +1186,7 @@ def test_get_device_with_address_nwk(app, device):
 
 async def test_request_future_matching(app, make_initialized_device):
     device = make_initialized_device(app)
-    ota = device.endpoints[1].add_output_cluster(clusters.general.Ota.cluster_id)
+    ota = device.endpoints[1].add_client_cluster(clusters.general.Ota.cluster_id)
 
     req_hdr, req_cmd = ota._create_request(
         general=False,
@@ -1249,7 +1249,7 @@ async def test_request_future_matching(app, make_initialized_device):
 
 async def test_request_callback_matching(app, make_initialized_device):
     device = make_initialized_device(app)
-    ota = device.endpoints[1].add_output_cluster(clusters.general.Ota.cluster_id)
+    ota = device.endpoints[1].add_client_cluster(clusters.general.Ota.cluster_id)
 
     req_hdr, req_cmd = ota._create_request(
         general=False,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -38,7 +38,7 @@ async def test_initialize(monkeypatch, dev):
 
     async def mockepinit(self, *args, **kwargs):
         self.status = endpoint.Status.ZDO_INIT
-        self.add_input_cluster(Basic.cluster_id)
+        self.add_server_cluster(Basic.cluster_id)
 
     async def mock_ep_get_model_info(self):
         if self.endpoint_id == 1:
@@ -174,7 +174,7 @@ def test_radio_details(dev):
 
 async def test_handle_message_read_report_conf(dev):
     ep = dev.add_endpoint(3)
-    ep.add_input_cluster(0x702)
+    ep.add_server_cluster(0x702)
     tsn = 0x56
     req_mock = MagicMock()
     dev._pending[tsn] = req_mock
@@ -465,7 +465,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     tsn = 0x12
     ep = dev.add_endpoint(1)
     cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
-    ep.add_output_cluster(Ota.cluster_id, cluster)
+    ep.add_client_cluster(Ota.cluster_id, cluster)
     dev.get_sequence = MagicMock(return_value=tsn)
 
     async def mockrequest(nwk, tries=None, delay=None):
@@ -473,7 +473,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
 
     async def mockepinit(self, *args, **kwargs):
         self.status = endpoint.Status.ZDO_INIT
-        self.add_input_cluster(Basic.cluster_id)
+        self.add_server_cluster(Basic.cluster_id)
 
     async def mock_ep_get_model_info(self):
         if self.endpoint_id == 1:
@@ -764,7 +764,7 @@ async def test_deserialize_backwards_compat(dev):
     )
 
     ep = dev.add_endpoint(1)
-    ep.add_input_cluster(Basic.cluster_id)
+    ep.add_server_cluster(Basic.cluster_id)
 
     dev.packet_received(packet)
 
@@ -780,7 +780,7 @@ async def test_request_exception_propagation(dev, event_loop):
     tsn = 0x12
 
     ep = dev.add_endpoint(1)
-    ep.add_input_cluster(Basic.cluster_id)
+    ep.add_server_cluster(Basic.cluster_id)
     ep.deserialize = MagicMock(side_effect=RuntimeError())
 
     dev.get_sequence = MagicMock(return_value=tsn)

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -55,8 +55,8 @@ def real_device(app_mock):
     real_device[1].device_type = 255
     real_device.model = "model"
     real_device.manufacturer = "manufacturer"
-    real_device[1].add_input_cluster(3)
-    real_device[1].add_output_cluster(6)
+    real_device[1].add_server_cluster(3)
+    real_device[1].add_client_cluster(6)
     return real_device
 
 
@@ -71,8 +71,8 @@ def real_device_2(app_mock):
     real_device[1].device_type = 255
     real_device.model = "model"
     real_device.manufacturer = "A different manufacturer"
-    real_device[1].add_input_cluster(3)
-    real_device[1].add_output_cluster(6)
+    real_device[1].add_server_cluster(3)
+    real_device[1].add_client_cluster(6)
     return real_device
 
 
@@ -281,13 +281,13 @@ def test_custom_device(app_mock):
     assert test_device[1].profile_id == sentinel.profile_id
     assert test_device[1].device_type == sentinel.device_type
 
-    assert 0x0000 in test_device[1].in_clusters
-    assert 0x8888 in test_device[1].in_clusters
-    assert isinstance(test_device[1].in_clusters[0x8888], Device.MyCluster)
+    assert 0x0000 in test_device[1].server_clusters
+    assert 0x8888 in test_device[1].server_clusters
+    assert isinstance(test_device[1].server_clusters[0x8888], Device.MyCluster)
 
-    assert 0x0001 in test_device[1].out_clusters
-    assert 0x8888 in test_device[1].out_clusters
-    assert isinstance(test_device[1].out_clusters[0x8888], Device.MyCluster)
+    assert 0x0001 in test_device[1].client_clusters
+    assert 0x8888 in test_device[1].client_clusters
+    assert isinstance(test_device[1].client_clusters[0x8888], Device.MyCluster)
 
     assert isinstance(test_device[2], Device.MyEndpoint)
 
@@ -942,7 +942,7 @@ async def test_manuf_id_disable(real_device):
     real_device.manufacturer_id_override = 0x1234
 
     ep = real_device.endpoints[1]
-    ep.add_input_cluster(TestCluster.cluster_id, TestCluster(ep))
+    ep.add_server_cluster(TestCluster.cluster_id, TestCluster(ep))
     assert isinstance(ep.just_a_cluster, TestCluster)
 
     assert ep.manufacturer_id == 0x1234

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -19,8 +19,8 @@ DEFAULT_TSN = 123
 @pytest.fixture
 def endpoint():
     ep = zigpy.endpoint.Endpoint(MagicMock(), 1)
-    ep.add_input_cluster(0)
-    ep.add_input_cluster(3)
+    ep.add_server_cluster(0)
+    ep.add_server_cluster(3)
     return ep
 
 
@@ -766,7 +766,7 @@ async def test_handle_cluster_general_request_disable_default_rsp(endpoint):
         b"\x06\x24\x02\x00\x05\x00\x00\x64\x29\xF8\x07\x65\x21\xD9\x0E\x66\x2B\x84\x87"
         b"\x01\x00\x0A\x21\x00\x00",
     )
-    cluster = endpoint.in_clusters[0]
+    cluster = endpoint.server_clusters[0]
     p1 = patch.object(cluster, "_update_attribute")
     p2 = patch.object(cluster, "general_command")
     with p1 as attr_lst_mock, p2 as general_cmd_mock:
@@ -1045,19 +1045,19 @@ async def test_zcl_request_direction():
     ep.device.get_sequence.return_value = DEFAULT_TSN
     ep.request = AsyncMock()
 
-    ep.add_input_cluster(zcl.clusters.general.OnOff.cluster_id)
-    ep.add_input_cluster(zcl.clusters.lighting.Color.cluster_id)
-    ep.add_output_cluster(zcl.clusters.general.OnOff.cluster_id)
+    ep.add_server_cluster(zcl.clusters.general.OnOff.cluster_id)
+    ep.add_server_cluster(zcl.clusters.lighting.Color.cluster_id)
+    ep.add_client_cluster(zcl.clusters.general.OnOff.cluster_id)
 
     # Input cluster
-    await ep.in_clusters[zcl.clusters.general.OnOff.cluster_id].on()
+    await ep.server_clusters[zcl.clusters.general.OnOff.cluster_id].on()
     hdr1, _ = foundation.ZCLHeader.deserialize(ep.request.mock_calls[0].args[2])
     assert hdr1.direction == foundation.Direction.Client_to_Server
 
     ep.request.reset_mock()
 
     # Output cluster
-    await ep.out_clusters[zcl.clusters.general.OnOff.cluster_id].on()
+    await ep.client_clusters[zcl.clusters.general.OnOff.cluster_id].on()
     hdr2, _ = foundation.ZCLHeader.deserialize(ep.request.mock_calls[0].args[2])
     assert hdr2.direction == foundation.Direction.Server_to_Client
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1327,7 +1327,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         return self.get_device(ieee=self.state.node_info.ieee)
 
     def _persist_coordinator_model_strings_in_db(self) -> None:
-        cluster = self._device.endpoints[1].add_input_cluster(
+        cluster = self._device.endpoints[1].add_server_cluster(
             zigpy.zcl.clusters.general.Basic.cluster_id
         )
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -398,8 +398,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         # TODO: this isn't actually necessary, we can parse most packets by cluster ID.
         if (
             packet.dst_ep != zdo.ZDO_ENDPOINT
-            and packet.cluster_id not in endpoint.in_clusters
-            and packet.cluster_id not in endpoint.out_clusters
+            and packet.cluster_id not in endpoint.server_clusters
+            and packet.cluster_id not in endpoint.client_clusters
         ):
             self.debug(
                 "Ignoring message on unknown cluster %s for endpoint %s",
@@ -615,13 +615,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             if endpoint_id == 0:  # ZDO
                 continue
             signature.setdefault(SIG_ENDPOINTS, {})
-            in_clusters = list(endpoint.in_clusters)
-            out_clusters = list(endpoint.out_clusters)
+            server_clusters = list(endpoint.server_clusters)
+            client_clusters = list(endpoint.client_clusters)
             signature[SIG_ENDPOINTS][endpoint_id] = {
                 SIG_EP_PROFILE: endpoint.profile_id,
                 SIG_EP_TYPE: endpoint.device_type,
-                SIG_EP_INPUT: in_clusters,
-                SIG_EP_OUTPUT: out_clusters,
+                SIG_EP_INPUT: server_clusters,
+                SIG_EP_OUTPUT: client_clusters,
             }
         return signature
 

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -93,6 +93,28 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def add_input_cluster(
         self, cluster_id: int, cluster: zigpy.zcl.Cluster | None = None
     ) -> zigpy.zcl.Cluster:
+        """Backwards-compatible method to add a server cluster."""
+        return self.add_server_cluster(cluster_id, cluster)
+
+    def add_output_cluster(
+        self, cluster_id: int, cluster: zigpy.zcl.Cluster | None = None
+    ) -> zigpy.zcl.Cluster:
+        """Backwards-compatible method to add a client cluster."""
+        return self.add_client_cluster(cluster_id, cluster)
+
+    @property
+    def in_clusters(self) -> dict:
+        """Backwards-compatible accessor for `server_clusters`."""
+        return self.server_clusters
+
+    @property
+    def out_clusters(self) -> dict:
+        """Backwards-compatible accessor for `client_clusters`."""
+        return self.client_clusters
+
+    def add_server_cluster(
+        self, cluster_id: int, cluster: zigpy.zcl.Cluster | None = None
+    ) -> zigpy.zcl.Cluster:
         """Adds an endpoint's input cluster
 
         (a server cluster supported by the device)

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -27,7 +27,7 @@ class OTAManager:
 
         for ep in device.non_zdo_endpoints:
             try:
-                self.ota_cluster = ep.out_clusters[Ota.cluster_id]
+                self.ota_cluster = ep.client_clusters[Ota.cluster_id]
                 break
             except KeyError:
                 pass

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -143,7 +143,7 @@ class CustomEndpoint(zigpy.endpoint.Endpoint):
             else:
                 cluster = c(self, is_server=True)
                 cluster_id = cluster.cluster_id
-            self.add_input_cluster(cluster_id, cluster)
+            self.add_server_cluster(cluster_id, cluster)
 
         for c in replacement_data.get(SIG_EP_OUTPUT, []):
             if isinstance(c, int):
@@ -152,7 +152,7 @@ class CustomEndpoint(zigpy.endpoint.Endpoint):
             else:
                 cluster = c(self, is_server=False)
                 cluster_id = cluster.cluster_id
-            self.add_output_cluster(cluster_id, cluster)
+            self.add_client_cluster(cluster_id, cluster)
 
 
 class CustomCluster(zigpy.zcl.Cluster):

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -120,7 +120,7 @@ class DeviceRegistry:
                 continue
 
             if not all(
-                self._match(device[eid].in_clusters, ep.get(SIG_EP_INPUT, []))
+                self._match(device[eid].server_clusters, ep.get(SIG_EP_INPUT, []))
                 for eid, ep in sig.items()
             ):
                 _LOGGER.debug(
@@ -129,7 +129,7 @@ class DeviceRegistry:
                 continue
 
             if not all(
-                self._match(device[eid].out_clusters, ep.get(SIG_EP_OUTPUT, []))
+                self._match(device[eid].client_clusters, ep.get(SIG_EP_OUTPUT, []))
                 for eid, ep in sig.items()
             ):
                 _LOGGER.debug(

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -167,7 +167,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         hdr: types.ZDOHeader,
         addr: t.NWK,
         profile: int,
-        in_clusters: list,
+        server_clusters: list,
         out_cluster: list,
         dst_addressing: AddressingMode | None = None,
     ):


### PR DESCRIPTION
This better matches the names given to the clusters in the Zigbee specifications.