### PR TITLE
Fix ZDO command logging warnings when OTA is active

### DIFF
--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -30,10 +30,12 @@ class BaseRequestListener:
         """
 
         for matcher in self.matchers:
-            if isinstance(matcher, foundation.CommandSchema) and isinstance(
-                command, foundation.CommandSchema
-            ):
-                match = command.matches(matcher)
+            if isinstance(matcher, foundation.CommandSchema):
+                if isinstance(hdr, zdo_t.ZDOHeader):
+                    # FIXME: ZDO does not use command schemas and cannot be matched
+                    continue
+                elif isinstance(command, foundation.CommandSchema):
+                    match = command.matches(matcher)
             elif callable(matcher):
                 match = matcher(hdr, command)
             else:


### PR DESCRIPTION
ZDO commands were causing the matching logic to trip up and treat the `CommandSchema` as a callable. 

Fixes the problem #1330 identified.