### PR TITLE
Handle invalid commands within listeners without throwing an exception

### DIFF
--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -151,7 +151,7 @@ async def test_listener_callback_no_matches():
     assert listener.callback.mock_calls == []
 
 
-async def test_listener_callback_invalid(caplog):
+async def test_listener_callback_invalid_matcher(caplog):
     listener = listeners.CallbackListener(
         matchers=[object()],
         callback=mock.Mock(),
@@ -159,6 +159,19 @@ async def test_listener_callback_invalid(caplog):
 
     with caplog.at_level(logging.WARNING):
         assert not listener.resolve(make_hdr(off()), off())
+
+    assert listener.callback.mock_calls == []
+    assert f"Matcher {listener.matchers[0]!r} and command" in caplog.text
+
+
+async def test_listener_callback_invalid_call(caplog):
+    listener = listeners.CallbackListener(
+        matchers=[on()],
+        callback=mock.Mock(),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert not listener.resolve(make_hdr(on()), b"data")
 
     assert listener.callback.mock_calls == []
     assert f"Matcher {listener.matchers[0]!r} and command" in caplog.text

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -30,16 +30,17 @@ class BaseRequestListener:
         """
 
         for matcher in self.matchers:
-            if isinstance(matcher, foundation.CommandSchema):
-                if isinstance(hdr, zdo_t.ZDOHeader):
-                    # FIXME: ZDO does not use command schemas and cannot be matched
-                    continue
-                elif isinstance(command, foundation.CommandSchema):
-                    match = command.matches(matcher)
+            match = None
+            is_matcher_cmd = isinstance(matcher, foundation.CommandSchema)
+
+            if is_matcher_cmd and isinstance(command, foundation.CommandSchema):
+                match = command.matches(matcher)
+            elif is_matcher_cmd and isinstance(hdr, zdo_t.ZDOHeader):
+                # FIXME: ZDO does not use command schemas and cannot be matched
+                pass
             elif callable(matcher):
                 match = matcher(hdr, command)
             else:
-                match = None
                 LOGGER.warning(
                     "Matcher %r and command %r %r are incompatible",
                     matcher,


### PR DESCRIPTION
If a command fails to deserialize, we currently pass it as raw bytes. This will change in the future once we start passing `ZigbeePacket` structures around with deserialized packet data within the payload.

Until then, we should handle theses cases better.