### PR TITLE
Implement packet debouncing

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1144,6 +1144,8 @@ def test_get_device_with_address_nwk(app, device):
 
 async def test_request_future_matching(app, make_initialized_device):
     device = make_initialized_device(app)
+    device._packet_debouncer.filter = MagicMock(return_value=False)
+
     ota = device.endpoints[1].add_output_cluster(clusters.general.Ota.cluster_id)
 
     req_hdr, req_cmd = ota._create_request(
@@ -1207,6 +1209,7 @@ async def test_request_future_matching(app, make_initialized_device):
 
 async def test_request_callback_matching(app, make_initialized_device):
     device = make_initialized_device(app)
+    device._packet_debouncer.filter = MagicMock(return_value=False)
     ota = device.endpoints[1].add_output_cluster(clusters.general.Ota.cluster_id)
 
     req_hdr, req_cmd = ota._create_request(

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -290,6 +290,9 @@ async def test_debouncer():
     """ "Test debouncer."""
 
     debouncer = datastructures.Debouncer()
+    debouncer.clean()
+    assert repr(debouncer) == "<Debouncer [tracked:0]>"
+
     obj1 = object()
     assert not debouncer.is_filtered(obj1)
     assert not debouncer.filter(obj1, expire_in=0.1)
@@ -299,7 +302,7 @@ async def test_debouncer():
     assert debouncer.filter(obj1, expire_in=0.1)
     assert debouncer.filter(obj1, expire_in=1)
     assert debouncer.is_filtered(obj1)
-    assert len(debouncer._queue) == 1
+    assert repr(debouncer) == "<Debouncer [tracked:1]>"
 
     obj2 = object()
     assert not debouncer.is_filtered(obj2)
@@ -311,14 +314,14 @@ async def test_debouncer():
 
     assert debouncer.is_filtered(obj1)
     assert debouncer.is_filtered(obj2)
-    assert len(debouncer._queue) == 2
+    assert repr(debouncer) == "<Debouncer [tracked:2]>"
 
     await asyncio.sleep(0.1)
     assert not debouncer.is_filtered(obj1)
     assert debouncer.is_filtered(obj2)
-    assert len(debouncer._queue) == 1
+    assert repr(debouncer) == "<Debouncer [tracked:1]>"
 
     await asyncio.sleep(0.1)
     assert not debouncer.is_filtered(obj1)
     assert not debouncer.is_filtered(obj2)
-    assert len(debouncer._queue) == 0
+    assert repr(debouncer) == "<Debouncer [tracked:0]>"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -462,11 +462,9 @@ async def test_update_device_firmware_already_in_progress(dev, caplog):
 
 async def test_update_device_firmware(monkeypatch, dev, caplog):
     """Test that device firmware updates execute the expected calls."""
-    tsn = 0x12
     ep = dev.add_endpoint(1)
     cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
     ep.add_output_cluster(Ota.cluster_id, cluster)
-    dev.get_sequence = MagicMock(return_value=tsn)
 
     async def mockrequest(nwk, tries=None, delay=None):
         return [0, None, [0, 1, 2, 3, 4]]
@@ -782,6 +780,8 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
 
 async def test_deserialize_backwards_compat(dev):
     """Test that deserialization uses the method if it is overloaded."""
+    dev._packet_debouncer.filter = MagicMock(return_value=False)
+
     packet = t.ZigbeePacket(
         profile_id=260,
         cluster_id=Basic.cluster_id,

--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -217,3 +217,54 @@ class ReschedulableTimeout:
         if self._timer is not None:
             self._timer.cancel()
             self._timer = None
+
+
+class Debouncer:
+    """Generic debouncer supporting per-invocation expiration."""
+
+    def __init__(self):
+        self._times: dict[typing.Any, float] = {}
+        self._queue: list[tuple[float, typing.Any]] = []
+
+    @functools.cached_property
+    def _loop(self) -> asyncio.BaseEventLoop:
+        return asyncio.get_running_loop()
+
+    def clean(self, now: float | None = None) -> None:
+        """Clean up stale timers."""
+        if now is None:
+            now = self._loop.time()
+
+        # We store the negative expiration time to ensure we can pop expiring objects
+        while self._queue and -self._queue[-1][0] < now:
+            _, obj = self._queue.pop()
+            self._times.pop(obj)
+
+    def is_filtered(self, obj: typing.Any, now: float | None = None) -> bool:
+        """Check if an object will be filtered."""
+        if now is None:
+            now = self._loop.time()
+
+        # Clean up stale timers
+        self.clean(now)
+
+        # If an object still exists after cleaning, it won't be expired
+        return obj in self._times
+
+    def filter(self, obj: typing.Any, expire_in: float) -> bool:
+        """Check if an object should be filtered. If not, store it."""
+        now = self._loop.time()
+
+        # If the object is filtered, do nothing
+        if self.is_filtered(obj, now=now):
+            return True
+
+        # Otherwise, queue it
+        self._times[obj] = now + expire_in
+        heapq.heappush(self._queue, (-(now + expire_in), obj))
+
+        return False
+
+    def __repr__(self) -> str:
+        """String representation of the debouncer."""
+        return f"<{self.__class__.__name__} [tracked:{len(self._queue)}]>"

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -391,8 +391,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.rssi = packet.rssi
 
         if self._packet_debouncer.filter(
-            # Be conservative with deduplication and only ignore the timestamp
-            obj=packet.replace(timestamp=None),
+            # Be conservative with deduplication
+            obj=packet.replace(timestamp=None, lqi=None, rssi=None),
             expire_in=PACKET_DEBOUNCE_WINDOW,
         ):
             self.debug("Filtering duplicate packet")

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -27,6 +27,7 @@ from zigpy.const import (
     SIG_MODEL,
     SIG_NODE_DESC,
 )
+import zigpy.datastructures
 import zigpy.endpoint
 import zigpy.exceptions
 import zigpy.listeners
@@ -41,9 +42,12 @@ if typing.TYPE_CHECKING:
     from zigpy.application import ControllerApplication
     from zigpy.ota.providers import OtaImageWithMetadata
 
+
+LOGGER = logging.getLogger(__name__)
+
 APS_REPLY_TIMEOUT = 5
 APS_REPLY_TIMEOUT_EXTENDED = 28
-LOGGER = logging.getLogger(__name__)
+PACKET_DEBOUNCE_WINDOW = 10
 
 
 class Status(enum.IntEnum):
@@ -82,6 +86,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._relays: t.Relays | None = None
         self._skip_configuration: bool = False
         self._send_sequence: int = 0
+
+        self._packet_debouncer = zigpy.datastructures.Debouncer()
 
         # Retained for backwards compatibility, will be removed in a future release
         self.status = Status.NEW
@@ -383,6 +389,14 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         if packet.rssi is not None:
             self.rssi = packet.rssi
+
+        if self._packet_debouncer.filter(
+            # Be conservative with deduplication and only ignore the timestamp
+            obj=packet.replace(timestamp=None),
+            expire_in=PACKET_DEBOUNCE_WINDOW,
+        ):
+            self.debug("Filtering duplicate packet")
+            return
 
         # Filter out packets that refer to unknown endpoints or clusters
         if packet.src_ep not in self.endpoints:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -392,7 +392,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         if self._packet_debouncer.filter(
             # Be conservative with deduplication
-            obj=packet.replace(timestamp=None, lqi=None, rssi=None),
+            obj=packet.replace(timestamp=None, tsn=None, lqi=None, rssi=None),
             expire_in=PACKET_DEBOUNCE_WINDOW,
         ):
             self.debug("Filtering duplicate packet")

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -71,6 +71,9 @@ class SerializableBytes:
     def __repr__(self) -> str:
         return f"Serialized[{self.value!r}]"
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 NOT_SET = object()
 

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -556,6 +556,9 @@ class AddrModeAddress(BaseDataclassMixin):
                 AddrMode.Broadcast: BroadcastAddress,
             }[self.addr_mode](self.address)
 
+    def __hash__(self) -> int:
+        return hash((self.addr_mode, self.address))
+
 
 class TransmitOptions(enum.Flag):
     NONE = 0
@@ -605,3 +608,25 @@ class ZigbeePacket(BaseDataclassMixin):
     # Options for incoming packets
     lqi: basic.uint8_t | None = dataclasses.field(default=None)
     rssi: basic.int8s | None = dataclasses.field(default=None)
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.timestamp,
+                self.src,
+                self.src_ep,
+                self.dst,
+                self.dst_ep,
+                self.source_route,
+                self.extended_timeout,
+                self.tsn,
+                self.profile_id,
+                self.cluster_id,
+                self.data,
+                self.tx_options,
+                self.radius,
+                self.non_member_radius,
+                self.lqi,
+                self.rssi,
+            )
+        )


### PR DESCRIPTION
Duplicate Zigbee packets received within a 10s window (picked arbitrarily) will be ignored and only the first one will be handled.

Packets are considered duplicates if *everything* about them is the same: same addressing mode, source, destination, payload, etc. This is lower-level than filtering based on TSN alone and should be safer. We can investigate deduplicating based on TSN if this is not enough.