### PR TITLE
Fix invalid relay lists

### DIFF
--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import sys

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -467,3 +467,16 @@ def test_singleton():
     obj = {}
     obj[singleton] = 5
     assert obj[singleton] == 5
+
+
+@pytest.mark.parametrize(
+    "input_relays, expected_relays",
+    [
+        ([0x0000, 0x0000, 0x0001, 0x0001, 0x0002], [0x0001, 0x0002]),
+        ([0x0001, 0x0002], [0x0001, 0x0002]),
+        ([], []),
+        ([0x0000], []),
+    ],
+)
+def test_relay_filtering(input_relays: list[int], expected_relays: list[int]):
+    assert util.filter_relays(input_relays) == expected_relays

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -745,7 +745,8 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         async with self.execute(f"SELECT * FROM relays{DB_V}") as cursor:
             async for (ieee, value) in cursor:
                 dev = self._application.get_device(ieee)
-                dev.relays, _ = t.Relays.deserialize(value)
+                relays, _ = t.Relays.deserialize(value)
+                dev.relays = zigpy.util.filter_relays(relays)
 
     async def _load_neighbors(self) -> None:
         async with self.execute(f"SELECT * FROM neighbors{DB_V}") as cursor:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -598,8 +598,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 f"discover_unknown_device_from_relays-nwk={nwk!r}",
             )
         else:
-            # `relays` is a property with a setter that emits an event
-            device.relays = relays
+            device.relays = zigpy.util.filter_relays(relays)
 
     @classmethod
     async def probe(cls, device_config: dict[str, Any]) -> bool | dict[str, Any]:

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -450,3 +450,15 @@ class Singleton:
 
     def __hash__(self) -> int:
         return hash(self.name)
+
+
+def filter_relays(relays: list[int]) -> list[int]:
+    """Filter out invalid relays."""
+    filtered_relays = []
+
+    # BUG: relays sometimes include 0x0000 or duplicate entries
+    for relay in relays:
+        if relay != 0x0000 and relay not in filtered_relays:
+            filtered_relays.append(relay)
+
+    return filtered_relays


### PR DESCRIPTION
It seems that older EmberZNet stacks incorrectly report relays by including `0x0000` or having duplicate entries. These break source routing when enabled with these old stacks.