### PR TITLE
Allow clearing attributes from the cache

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1147,7 +1147,12 @@ async def test_appdb_attribute_clear(tmp_path):
         dev2.endpoints[1].basic._attr_cache[Basic.AttributeDefs.zcl_version.id] == 0x12
     )
 
+    # This attribute exists
     dev2.endpoints[1].basic.update_attribute(Basic.AttributeDefs.zcl_version.id, None)
+
+    # This attribute won't exist
+    dev2.endpoints[1].basic.update_attribute(Basic.AttributeDefs.manufacturer.id, None)
+
     assert Basic.AttributeDefs.zcl_version.id not in dev2.endpoints[1].basic._attr_cache
     await app2.shutdown()
 

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -22,11 +22,12 @@ import zigpy.ota
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
 import zigpy.zcl
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import Status as ZCLStatus
 from zigpy.zdo import types as zdo_t
 
 from tests.async_mock import AsyncMock, MagicMock, call, patch
-from tests.conftest import make_app, make_ieee
+from tests.conftest import make_app, make_ieee, make_node_desc
 from tests.test_backups import backup_factory  # noqa: F401
 
 
@@ -1118,3 +1119,40 @@ async def test_appdb_persist_coordinator_info(tmp_path):  # noqa: F811
         await app.shutdown()
 
     assert mock_save_attr_cache.mock_calls == [call(app._device.endpoints[1])]
+
+
+async def test_appdb_attribute_clear(tmp_path):
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+    dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+
+    basic = ep.add_input_cluster(Basic.cluster_id)
+    app.device_initialized(dev)
+
+    basic.update_attribute(Basic.AttributeDefs.zcl_version.id, 0x12)
+
+    await app.shutdown()
+
+    # Upon reload, the attribute is cleared
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(ieee=dev.ieee)
+    assert (
+        dev2.endpoints[1].basic._attr_cache[Basic.AttributeDefs.zcl_version.id] == 0x12
+    )
+
+    dev2.endpoints[1].basic.update_attribute(Basic.AttributeDefs.zcl_version.id, None)
+    assert Basic.AttributeDefs.zcl_version.id not in dev2.endpoints[1].basic._attr_cache
+    await app2.shutdown()
+
+    # The attribute has been removed from the database
+    app3 = await make_app_with_db(db)
+    app3.get_device(ieee=dev.ieee)
+    assert Basic.AttributeDefs.zcl_version.id not in dev2.endpoints[1].basic._attr_cache
+    await app3.shutdown()

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1140,24 +1140,25 @@ async def test_appdb_attribute_clear(tmp_path):
 
     await app.shutdown()
 
-    # Upon reload, the attribute is cleared
+    # Upon reload, the attribute exists and is in the cache
     app2 = await make_app_with_db(db)
     dev2 = app2.get_device(ieee=dev.ieee)
     assert (
         dev2.endpoints[1].basic._attr_cache[Basic.AttributeDefs.zcl_version.id] == 0x12
     )
 
-    # This attribute exists
+    # Clear an existing attribute
     dev2.endpoints[1].basic.update_attribute(Basic.AttributeDefs.zcl_version.id, None)
 
-    # This attribute won't exist
+    # Clear an attribute not in the cache
     dev2.endpoints[1].basic.update_attribute(Basic.AttributeDefs.manufacturer.id, None)
 
     assert Basic.AttributeDefs.zcl_version.id not in dev2.endpoints[1].basic._attr_cache
+    await asyncio.sleep(0.1)
     await app2.shutdown()
 
     # The attribute has been removed from the database
     app3 = await make_app_with_db(db)
-    app3.get_device(ieee=dev.ieee)
-    assert Basic.AttributeDefs.zcl_version.id not in dev2.endpoints[1].basic._attr_cache
+    dev3 = app3.get_device(ieee=dev.ieee)
+    assert Basic.AttributeDefs.zcl_version.id not in dev3.endpoints[1].basic._attr_cache
     await app3.shutdown()

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -593,7 +593,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             WHERE
                 ieee = :ieee
                 AND endpoint_id = :endpoint_id
-                AND cluster = :cluster
+                AND cluster = :cluster_id
                 AND attrid = :attrid
             """
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -284,6 +284,15 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             timestamp,
         )
 
+    def attribute_cleared(self, cluster: zigpy.typing.ClusterType, attrid: int) -> None:
+        self.enqueue(
+            "_clear_attribute",
+            cluster.endpoint.device.ieee,
+            cluster.endpoint.endpoint_id,
+            cluster.cluster_id,
+            attrid,
+        )
+
     def unsupported_attribute_added(
         self, cluster: zigpy.typing.ClusterType, attrid: int
     ) -> None:
@@ -568,6 +577,33 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 "value": value,
                 "timestamp": timestamp.timestamp(),
                 "min_update_delta": MIN_UPDATE_DELTA,
+            },
+        )
+        await self._db.commit()
+
+    async def _clear_attribute(
+        self,
+        ieee: t.EUI64,
+        endpoint_id: int,
+        cluster_id: int,
+        attrid: int,
+    ) -> None:
+        q = f"""
+            DELETE FROM attributes_cache{DB_V}
+            WHERE
+                ieee = :ieee
+                AND endpoint_id = :endpoint_id
+                AND cluster = :cluster
+                AND attrid = :attrid
+            """
+
+        await self.execute(
+            q,
+            {
+                "ieee": ieee,
+                "endpoint_id": endpoint_id,
+                "cluster_id": cluster_id,
+                "attrid": attrid,
             },
         )
         await self._db.commit()

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -816,6 +816,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
     def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
         if value is None:
+            if attrid not in self._attr_cache:
+                return
+
             self._attr_cache.pop(attrid)
             self._attr_last_updated.pop(attrid)
             self.listener_event("attribute_cleared", attrid)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1003,6 +1003,9 @@ class ClusterPersistingListener:
     ) -> None:
         self._applistener.attribute_updated(self._cluster, attrid, value, timestamp)
 
+    def attribute_cleared(self, attrid: int | t.uint16_t) -> None:
+        self._applistener.attribute_cleared(self._cluster, attrid)
+
     def cluster_command(self, *args, **kwargs) -> None:
         pass
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -815,12 +815,15 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         self._update_attribute(attrid, value)
 
     def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
-        now = datetime.now(timezone.utc)
-
-        self._attr_cache[attrid] = value
-        self._attr_last_updated[attrid] = now
-
-        self.listener_event("attribute_updated", attrid, value, now)
+        if value is None:
+            self._attr_cache.pop(attrid)
+            self._attr_last_updated.pop(attrid)
+            self.listener_event("attribute_cleared", attrid)
+        else:
+            now = datetime.now(timezone.utc)
+            self._attr_cache[attrid] = value
+            self._attr_last_updated[attrid] = now
+            self.listener_event("attribute_updated", attrid, value, now)
 
     def log(self, lvl: int, msg: str, *args, **kwargs) -> None:
         msg = "[%s:%s:0x%04x] " + msg


### PR DESCRIPTION
This PR introduces an `attribute_cleared` event (perhaps there's a more suitable name?) which indicates that an attribute has been cleared from cache. You trigger it setting the attribute value to `None`:

```python
ep.basic.update_attribute(Basic.AttributeDefs.zcl_version.id, None)
```

The purpose of this PR is to clear the OTA cluster's `current_file_version` attribute upon completing an OTA update. I think it would also be useful to fully re-initialize a device after OTA by purging its attributes from cache and reading them anew. (This would also be good default behavior for the "Reconfigure" button in ZHA).