### PR TITLE
OTA reliability improvements

### DIFF
--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 # Devices often ask for bigger blocks than radios can send
 MAXIMUM_IMAGE_BLOCK_SIZE = 40
-MAX_TIME_WITHOUT_PROGRESS = 10
+MAX_TIME_WITHOUT_PROGRESS = 30
 
 
 def find_ota_cluster(device: Device) -> Ota:
@@ -94,7 +94,9 @@ class OTAManager:
     def _finish(self, status: foundation.Status) -> None:
         """Finish the OTA process."""
         self._stall_timer.cancel()
-        self._upgrade_end_future.set_result(status)
+
+        if not self._upgrade_end_future.done():
+            self._upgrade_end_future.set_result(status)
 
     async def _image_query_req(
         self, hdr: foundation.ZCLHeader, command: Ota.QueryNextImageCommand

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -161,7 +161,12 @@ class OTAManager:
 
             self._stall_timer.reschedule(MAX_TIME_WITHOUT_PROGRESS)
 
-            if self.progress_callback is not None:
+            # Image block requests can sometimes succeed after the device aborts the
+            # update. We should not allow the progress callback to be called.
+            if (
+                self.progress_callback is not None
+                and not self._upgrade_end_future.done()
+            ):
                 self.progress_callback(
                     command.file_offset + len(block), len(self._image_data)
                 )


### PR DESCRIPTION
Changes required to get OTA working reliably on a few more real devices:

1. Increase the "max time without progress" timeout from 10s to 30s: Hue bulbs can stall for 20s during OTA.
2. Do not send OTA progress if the upgrade has failed: if a battery-powered sensor rejects the image before we get an ACK for the last block, OTA can fail and then emit progress, confusing ZHA.
3. Read the current file version after OTA concludes.

3 is a little hacky but it works. In the future, we should read the software version and other basic information during a join/rejoin and fully re-initialize the device if this information changes. This would require some sort of method to "clear" a device from the database without fully removing it.