### PR TITLE
Fix Inovelli JSON version format

### DIFF
--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -322,7 +322,12 @@ async def test_inovelli_provider():
 
     for (model, obj), meta in zip(unpacked_objs, index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)
-        assert meta.file_version == int(obj["version"], 16)
+
+        if obj["version"] == "0000000B":
+            assert meta.file_version == 0x0000000B
+        else:
+            assert meta.file_version == int(obj["version"])
+
         assert meta.url == obj["firmware"]
         assert meta.manufacturer_id == obj["manufacturer_id"]
         assert meta.image_type == obj["image_type"]

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -327,8 +327,14 @@ class Inovelli(BaseOtaProvider):
 
         for model, firmwares in fw_lst.items():
             for fw in firmwares:
+                version = int(fw["version"], 16)
+
+                if version > 0x0000000B:
+                    # Only the first firmware was in hex, all others are decimal
+                    version = int(fw["version"])
+
                 yield RemoteOtaImageMetadata(  # type: ignore[call-arg]
-                    file_version=int(fw["version"], 16),
+                    file_version=version,
                     manufacturer_id=fw["manufacturer_id"],
                     image_type=fw["image_type"],
                     model_names=(model,),


### PR DESCRIPTION
The JSON version numbers switch from hexadecimal to decimal after the first firmware. Old OTA provider fixed this, new one after the rewrite did not.