### PR TITLE
Fix manufacturer name filter in OTAs from a Z2M index

### DIFF
--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -67,8 +67,8 @@ def _test_z2m_index_entry(obj: dict, meta: providers.BaseOtaImageMetadata) -> bo
     else:
         assert meta.model_names == ()
 
-    if "manufacturerNames" in obj:
-        assert meta.manufacturer_names == tuple(obj["manufacturerNames"])
+    if "manufacturerName" in obj:
+        assert meta.manufacturer_names == tuple(obj["manufacturerName"])
     else:
         assert meta.manufacturer_names == ()
 

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -467,7 +467,7 @@ def _load_z2m_index(index: dict, *, index_root: pathlib.Path | None = None):
             "image_type": obj["imageType"],
             "checksum": "sha512:" + obj["sha512"],
             "file_size": obj["fileSize"],
-            "manufacturer_names": tuple(obj.get("manufacturerNames", [])),
+            "manufacturer_names": tuple(obj.get("manufacturerName", [])),
             "model_names": tuple([obj["modelId"]] if "modelId" in obj else []),
             "min_current_file_version": obj.get("minFileVersion"),
             "max_current_file_version": obj.get("maxFileVersion"),


### PR DESCRIPTION
Fix the manufacturer name filter when using a Z2M index for OTAs.

Fixes #1351