### PR TITLE
Validate the JSON of all OTA providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     'importlib_resources; python_version<"3.9"',
     'async-timeout; python_version<"3.11"',
     "voluptuous",
+    "jsonschema",
     'pyserial-asyncio; platform_system!="Windows"',
     'pyserial-asyncio!=0.5; platform_system=="Windows"',
     "typing_extensions",

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -248,19 +248,32 @@ async def test_ledvance_provider():
     for obj, meta in zip(index_obj["firmwares"], index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)
         assert meta.image_type == obj["identity"]["product"]
-        assert meta.checksum == "sha256:" + obj["shA256"]
-        assert meta.changelog == obj["releaseNotes"]
-        assert meta.file_size == obj["length"]
+        assert meta.checksum == "sha256:" + obj.pop("shA256")
+        assert meta.changelog == obj.pop("releaseNotes")
+        assert meta.file_size == obj.pop("length")
         assert meta.manufacturer_id == obj["identity"]["company"]
+        assert meta.model_names == (obj.pop("productName"),)
         assert meta.url == (
             f"https://api.update.ledvance.com/v1/zigbee/firmwares/download"
-            f"?Company={obj['identity']['company']}"
-            f"&Product={obj['identity']['product']}"
-            f"&Version={obj['identity']['version']['major']}"
-            f".{obj['identity']['version']['minor']}"
-            f".{obj['identity']['version']['build']}"
-            f".{obj['identity']['version']['revision']}"
+            f"?Company={obj['identity'].pop('company')}"
+            f"&Product={obj['identity'].pop('product')}"
+            f"&Version={obj['identity']['version'].pop('major')}"
+            f".{obj['identity']['version'].pop('minor')}"
+            f".{obj['identity']['version'].pop('build')}"
+            f".{obj['identity']['version'].pop('revision')}"
         )
+
+        assert not obj["identity"].pop("version")
+        assert not obj.pop("identity")
+
+        obj.pop("blob")
+        obj.pop("extension")
+        obj.pop("fullName")
+        obj.pop("name")
+        obj.pop("released")
+        obj.pop("salesRegion")
+
+        assert not obj
 
 
 async def test_salus_provider():

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -295,9 +295,10 @@ async def test_salus_provider():
 
     for obj, meta in zip(filtered_firmware_obj, index):
         assert isinstance(meta, providers.SalusRemoteOtaImageMetadata)
-        assert meta.url == obj["url"].replace("http://", "https://")
-        assert meta.file_version == int(obj["version"], 16)
-        assert meta.model_names == (obj["model"],)
+        assert meta.url == obj.pop("url").replace("http://", "https://")
+        assert meta.file_version == int(obj.pop("version"), 16)
+        assert meta.model_names == (obj.pop("model"),)
+        assert not obj
 
 
 async def test_sonoff_provider():
@@ -318,12 +319,13 @@ async def test_sonoff_provider():
 
     for obj, meta in zip(index_obj, index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)
-        assert meta.url == obj["fw_binary_url"]
-        assert meta.file_version == obj["fw_file_version"]
-        assert meta.file_size == obj["fw_filesize"]
-        assert meta.image_type == obj["fw_image_type"]
-        assert meta.manufacturer_id == obj["fw_manufacturer_id"]
-        assert meta.model_names == (obj["model_id"],)
+        assert meta.url == obj.pop("fw_binary_url")
+        assert meta.file_version == obj.pop("fw_file_version")
+        assert meta.file_size == obj.pop("fw_filesize")
+        assert meta.image_type == obj.pop("fw_image_type")
+        assert meta.manufacturer_id == obj.pop("fw_manufacturer_id")
+        assert meta.model_names == (obj.pop("model_id"),)
+        assert not obj
 
 
 async def test_inovelli_provider():
@@ -351,10 +353,15 @@ async def test_inovelli_provider():
         else:
             assert meta.file_version == int(obj["version"])
 
-        assert meta.url == obj["firmware"]
-        assert meta.manufacturer_id == obj["manufacturer_id"]
-        assert meta.image_type == obj["image_type"]
+        obj.pop("version")
+
+        assert meta.url == obj.pop("firmware")
+        assert meta.manufacturer_id == obj.pop("manufacturer_id")
+        assert meta.image_type == obj.pop("image_type")
         assert meta.model_names == (model,)
+
+        obj.pop("channel")
+        assert not obj
 
 
 async def test_third_reality_provider():
@@ -376,11 +383,14 @@ async def test_third_reality_provider():
 
     for obj, meta in zip(index_obj["versions"], index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)
-        assert meta.model_names == (obj["modelId"],)
-        assert meta.url == obj["url"]
-        assert meta.image_type == obj["imageType"]
-        assert meta.manufacturer_id == obj["manufacturerId"]
-        assert meta.file_version == obj["fileVersion"]
+        assert meta.model_names == (obj.pop("modelId"),)
+        assert meta.url == obj.pop("url")
+        assert meta.image_type == obj.pop("imageType")
+        assert meta.manufacturer_id == obj.pop("manufacturerId")
+        assert meta.file_version == obj.pop("fileVersion")
+
+        obj.pop("version")
+        assert not obj
 
 
 async def test_remote_provider():
@@ -418,20 +428,21 @@ async def test_remote_provider():
 
     for obj, meta in zip(index_obj["firmwares"], index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)
-        assert meta.url == obj["binary_url"]
-        assert meta.file_version == obj["file_version"]
-        assert meta.file_size == obj["file_size"]
-        assert meta.image_type == obj["image_type"]
-        assert meta.manufacturer_names == tuple(obj["manufacturer_names"])
-        assert meta.model_names == tuple(obj["model_names"])
-        assert meta.manufacturer_id == obj["manufacturer_id"]
-        assert meta.changelog == obj["changelog"]
-        assert meta.checksum == obj["checksum"]
-        assert meta.min_hardware_version == obj["min_hardware_version"]
-        assert meta.max_hardware_version == obj["max_hardware_version"]
-        assert meta.min_current_file_version == obj["min_current_file_version"]
-        assert meta.max_current_file_version == obj["max_current_file_version"]
-        assert meta.specificity == obj["specificity"]
+        assert meta.url == obj.pop("binary_url")
+        assert meta.file_version == obj.pop("file_version")
+        assert meta.file_size == obj.pop("file_size")
+        assert meta.image_type == obj.pop("image_type")
+        assert meta.manufacturer_names == tuple(obj.pop("manufacturer_names"))
+        assert meta.model_names == tuple(obj.pop("model_names"))
+        assert meta.manufacturer_id == obj.pop("manufacturer_id")
+        assert meta.changelog == obj.pop("changelog")
+        assert meta.checksum == obj.pop("checksum")
+        assert meta.min_hardware_version == obj.pop("min_hardware_version")
+        assert meta.max_hardware_version == obj.pop("max_hardware_version")
+        assert meta.min_current_file_version == obj.pop("min_current_file_version")
+        assert meta.max_current_file_version == obj.pop("max_current_file_version")
+        assert meta.specificity == obj.pop("specificity")
+        assert not obj
 
         # An unknown manufacturer ID will still be used
         assert meta.manufacturer_id in provider.manufacturer_ids

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -357,6 +357,7 @@ class Ledvance(BaseOtaProvider):
                 image_type=identity["product"],
                 checksum="sha256:" + fw["shA256"],
                 file_size=fw["length"],
+                model_names=(fw["productName"],),
                 url=(
                     "https://api.update.ledvance.com/v1/zigbee/firmwares/download?"
                     + urllib.parse.urlencode(

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -16,6 +16,7 @@ import urllib.parse
 
 import aiohttp
 import attrs
+import jsonschema
 
 from zigpy.ota.image import BaseOTAImage, parse_ota_image
 import zigpy.types as t
@@ -192,6 +193,57 @@ ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
 -----END CERTIFICATE-----"""
     )
 
+    JSON_SCHEMA = {
+        "type": "array",
+        "items": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "fw_image_type": {"type": "integer"},
+                        "fw_type": {"type": "integer"},
+                        "fw_sha3_256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+                        "fw_binary_url": {"type": "string", "format": "uri"},
+                    },
+                    "required": [
+                        "fw_image_type",
+                        "fw_type",
+                        "fw_sha3_256",
+                        "fw_binary_url",
+                    ],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fw_update_prio": {"type": "integer"},
+                        "fw_filesize": {"type": "integer"},
+                        "fw_type": {"type": "integer"},
+                        "fw_hotfix_version": {"type": "integer"},
+                        "fw_major_version": {"type": "integer"},
+                        "fw_binary_checksum": {
+                            "type": "string",
+                            "pattern": "^[a-f0-9]{128}$",
+                        },
+                        "fw_minor_version": {"type": "integer"},
+                        "fw_sha3_256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+                        "fw_binary_url": {"type": "string", "format": "uri"},
+                    },
+                    "required": [
+                        "fw_update_prio",
+                        "fw_filesize",
+                        "fw_type",
+                        "fw_hotfix_version",
+                        "fw_major_version",
+                        "fw_binary_checksum",
+                        "fw_minor_version",
+                        "fw_sha3_256",
+                        "fw_binary_url",
+                    ],
+                },
+            ]
+        },
+    }
+
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
@@ -202,6 +254,8 @@ ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
             # IKEA does not always respond with an appropriate Content-Type but the
             # response is always JSON
             fw_lst = await rsp.json(content_type=None)
+
+        jsonschema.validate(fw_lst, self.JSON_SCHEMA)
 
         for fw in fw_lst:
             # Skip the gateway image
@@ -227,6 +281,62 @@ class Ledvance(BaseOtaProvider):
     # This isn't static but no more than these two have ever existed
     MANUFACTURER_IDS = [4489, 4364]
 
+    JSON_SCHEMA = {
+        "type": "object",
+        "properties": {
+            "firmwares": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "blob": {"type": ["null", "string"]},
+                        "identity": {
+                            "type": "object",
+                            "properties": {
+                                "company": {"type": "integer"},
+                                "product": {"type": "integer"},
+                                "version": {
+                                    "type": "object",
+                                    "properties": {
+                                        "major": {"type": "integer"},
+                                        "minor": {"type": "integer"},
+                                        "build": {"type": "integer"},
+                                        "revision": {"type": "integer"},
+                                    },
+                                    "required": ["major", "minor", "build", "revision"],
+                                },
+                            },
+                            "required": ["company", "product", "version"],
+                        },
+                        "releaseNotes": {"type": "string"},
+                        "shA256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+                        "name": {"type": "string"},
+                        "productName": {"type": "string"},
+                        "fullName": {"type": "string"},
+                        "extension": {"type": "string"},
+                        "released": {"type": "string", "format": "date-time"},
+                        "salesRegion": {"type": ["string", "null"]},
+                        "length": {"type": "integer"},
+                    },
+                    "required": [
+                        "blob",
+                        "identity",
+                        "releaseNotes",
+                        "shA256",
+                        "name",
+                        "productName",
+                        "fullName",
+                        "extension",
+                        "released",
+                        "salesRegion",
+                        "length",
+                    ],
+                },
+            }
+        },
+        "required": ["firmwares"],
+    }
+
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
@@ -234,6 +344,8 @@ class Ledvance(BaseOtaProvider):
             "https://api.update.ledvance.com/v1/zigbee/firmwares"
         ) as rsp:
             fw_lst = await rsp.json()
+
+        jsonschema.validate(fw_lst, self.JSON_SCHEMA)
 
         for fw in fw_lst["firmwares"]:
             identity = fw["identity"]
@@ -265,6 +377,28 @@ class Ledvance(BaseOtaProvider):
 class Salus(BaseOtaProvider):
     MANUFACTURER_IDS = [4216, 43981]
 
+    JSON_SCHEMA = {
+        "type": "object",
+        "properties": {
+            "versions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "model": {"type": "string"},
+                        "version": {
+                            "type": "string",
+                            "pattern": "^(|[0-9A-F]{8}|[0-9A-F]{12})$",
+                        },
+                        "url": {"type": "string", "format": "uri"},
+                    },
+                    "required": ["model", "version", "url"],
+                },
+            }
+        },
+        "required": ["versions"],
+    }
+
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
@@ -272,6 +406,8 @@ class Salus(BaseOtaProvider):
             "https://eu.salusconnect.io/demo/default/status/firmware"
         ) as rsp:
             fw_lst = await rsp.json()
+
+        jsonschema.validate(fw_lst, self.JSON_SCHEMA)
 
         for fw in fw_lst["versions"]:
             # A plain text file is present in the firmware list, ignore it
@@ -295,6 +431,29 @@ class Salus(BaseOtaProvider):
 class Sonoff(BaseOtaProvider):
     MANUFACTURER_IDS = [4742]
 
+    JSON_SCHEMA = {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "fw_binary_url": {"type": "string", "format": "uri"},
+                "fw_file_version": {"type": "integer"},
+                "fw_filesize": {"type": "integer"},
+                "fw_image_type": {"type": "integer"},
+                "fw_manufacturer_id": {"type": "integer"},
+                "model_id": {"type": "string"},
+            },
+            "required": [
+                "fw_binary_url",
+                "fw_file_version",
+                "fw_filesize",
+                "fw_image_type",
+                "fw_manufacturer_id",
+                "model_id",
+            ],
+        },
+    }
+
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
@@ -302,6 +461,8 @@ class Sonoff(BaseOtaProvider):
             "https://zigbee-ota.sonoff.tech/releases/upgrade.json"
         ) as rsp:
             fw_lst = await rsp.json()
+
+        jsonschema.validate(fw_lst, self.JSON_SCHEMA)
 
         for fw in fw_lst:
             yield RemoteOtaImageMetadata(  # type: ignore[call-arg]
@@ -317,6 +478,35 @@ class Sonoff(BaseOtaProvider):
 class Inovelli(BaseOtaProvider):
     MANUFACTURER_IDS = [4655]
 
+    JSON_SCHEMA = {
+        "type": "object",
+        "patternProperties": {
+            "^[A-Z0-9_-]+$": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "type": "string",
+                            "pattern": "^(?:[0-9A-F]{8}|[0-9]+)$",
+                        },
+                        "channel": {"type": "string"},
+                        "firmware": {"type": "string", "format": "uri"},
+                        "manufacturer_id": {"type": "integer"},
+                        "image_type": {"type": "integer"},
+                    },
+                    "required": [
+                        "version",
+                        "channel",
+                        "firmware",
+                        "manufacturer_id",
+                        "image_type",
+                    ],
+                },
+            }
+        },
+    }
+
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
@@ -324,6 +514,8 @@ class Inovelli(BaseOtaProvider):
             "https://files.inovelli.com/firmware/firmware-zha.json"
         ) as rsp:
             fw_lst = await rsp.json()
+
+        jsonschema.validate(fw_lst, self.JSON_SCHEMA)
 
         for model, firmwares in fw_lst.items():
             for fw in firmwares:
@@ -347,11 +539,45 @@ class Inovelli(BaseOtaProvider):
 class ThirdReality(BaseOtaProvider):
     MANUFACTURER_IDS = [4659, 4877]
 
+    JSON_SCHEMA = {
+        "type": "object",
+        "properties": {
+            "versions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "modelId": {"type": "string"},
+                        "url": {"type": "string", "format": "uri"},
+                        "version": {
+                            "type": "string",
+                            "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                        },
+                        "imageType": {"type": "integer"},
+                        "manufacturerId": {"type": "integer"},
+                        "fileVersion": {"type": "integer"},
+                    },
+                    "required": [
+                        "modelId",
+                        "url",
+                        "version",
+                        "imageType",
+                        "manufacturerId",
+                        "fileVersion",
+                    ],
+                },
+            }
+        },
+        "required": ["versions"],
+    }
+
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
         async with session.get("https://tr-zha.s3.amazonaws.com/firmware.json") as rsp:
             fw_lst = await rsp.json()
+
+        jsonschema.validate(fw_lst, self.JSON_SCHEMA)
 
         for fw in fw_lst["versions"]:
             yield RemoteOtaImageMetadata(  # type: ignore[call-arg]
@@ -366,6 +592,58 @@ class ThirdReality(BaseOtaProvider):
 
 
 class RemoteProvider(BaseOtaProvider):
+    JSON_SCHEMA = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "firmwares": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "binary_url": {"type": "string", "format": "uri"},
+                        "file_version": {"type": "integer"},
+                        "file_size": {"type": "integer"},
+                        "image_type": {"type": "integer"},
+                        "manufacturer_names": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "model_names": {"type": "array", "items": {"type": "string"}},
+                        "manufacturer_id": {"type": "integer"},
+                        "changelog": {"type": "string"},
+                        "checksum": {
+                            "type": "string",
+                            "pattern": "^sha3-256:[a-f0-9]{64}$",
+                        },
+                        "min_hardware_version": {"type": "integer"},
+                        "max_hardware_version": {"type": "integer"},
+                        "min_current_file_version": {"type": "integer"},
+                        "max_current_file_version": {"type": "integer"},
+                        "specificity": {"type": "integer"},
+                    },
+                    "required": [
+                        "binary_url",
+                        "file_version",
+                        "file_size",
+                        "image_type",
+                        # "manufacturer_names",
+                        # "model_names",
+                        "manufacturer_id",
+                        # "changelog",
+                        "checksum",
+                        # "min_hardware_version",
+                        # "max_hardware_version",
+                        # "min_current_file_version",
+                        # "max_current_file_version",
+                        # "specificity",
+                    ],
+                },
+            }
+        },
+        "required": ["firmwares"],
+    }
+
     def __init__(self, url: str, manufacturer_ids: list[int] | None = None):
         super().__init__()
         self.url = url
@@ -382,6 +660,8 @@ class RemoteProvider(BaseOtaProvider):
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
         async with session.get(self.url) as rsp:
             index = await rsp.json()
+
+        jsonschema.validate(index, self.JSON_SCHEMA)
 
         for fw in index["firmwares"]:
             meta = RemoteOtaImageMetadata(  # type: ignore[call-arg]
@@ -479,13 +759,43 @@ def _load_z2m_index(index: dict, *, index_root: pathlib.Path | None = None):
             yield RemoteOtaImageMetadata(**shared_kwargs, url=obj["url"])  # type: ignore[call-arg]
 
 
-class LocalZ2MProvider(BaseOtaProvider):
-    def __init__(self, index_file: pathlib.Path):
-        super().__init__()
-        self.index_file = index_file
+class BaseZ2MProvider(BaseOtaProvider):
+    JSON_SCHEMA = {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "fileVersion": {"type": "integer"},
+                "fileSize": {"type": "integer"},
+                "manufacturerCode": {"type": "integer"},
+                "imageType": {"type": "integer"},
+                "sha512": {"type": "string", "pattern": "^[a-f0-9]{128}$"},
+                "url": {"type": "string", "format": "uri"},
+                "path": {"type": "string"},
+                "minFileVersion": {"type": "integer"},
+                "maxFileVersion": {"type": "integer"},
+                "manufacturerName": {"type": "array", "items": {"type": "string"}},
+                "modelId": {"type": "string"},
+            },
+            "required": [
+                "fileVersion",
+                "fileSize",
+                "manufacturerCode",
+                "imageType",
+                "sha512",
+                "url",
+            ],
+        },
+    }
 
     def compatible_with_device(self, device: zigpy.device.Device) -> bool:
         return True
+
+
+class LocalZ2MProvider(BaseZ2MProvider):
+    def __init__(self, index_file: pathlib.Path):
+        super().__init__()
+        self.index_file = index_file
 
     async def _load_index(
         self, session: aiohttp.ClientSession
@@ -495,23 +805,24 @@ class LocalZ2MProvider(BaseOtaProvider):
         )
         index = json.loads(index_text)
 
+        jsonschema.validate(index, self.JSON_SCHEMA)
+
         for img in _load_z2m_index(index, index_root=self.index_file.parent):
             yield img
 
 
-class RemoteZ2MProvider(BaseOtaProvider):
+class RemoteZ2MProvider(BaseZ2MProvider):
     def __init__(self, url: str):
         super().__init__()
         self.url = url
-
-    def compatible_with_device(self, device: zigpy.device.Device) -> bool:
-        return True
 
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
         async with session.get(self.url) as rsp:
             fw_lst = await rsp.json(content_type=None)
+
+        jsonschema.validate(fw_lst, self.JSON_SCHEMA)
 
         for img in _load_z2m_index(fw_lst):
             yield img


### PR DESCRIPTION
Uses `jsonschema` to validate all JSON. I've disabled `additionalProperties` to allow the JSON to be extended in the future.