### PR TITLE
List experimental Espressif and ZBOSS radio libraries in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Note! Zigbee 3.0 support or not in zigpy depends primarily on your Zigbee coordi
 - **Texas Instruments** based Zigbee radios with all compatible Z-Stack firmware via the [zigpy-znp](https://github.com/zha-ng/zigpy-znp) library for zigpy.
 - **ZiGate** based ZigBee radios via the [zigpy-zigate](https://github.com/zigpy/zigpy-zigate) library for zigpy.
 
+### Experimental and unofficial zigpy radio libraries from third parties
+
+- **Espressif Zigbee NCP Serial Protocol (ESP ZNSP)** based ESP32-C6/ESP32-H2 Zigbee radios via the [zigpy-espzb](https://github.com/lhespress/zigpy-espzb) library for zigpy.
+- **ZOI (ZBOSS Open Initiative)** based Zigbee radios compatible with ZBOSS NCP firmware via the [zigpy-zboss](https://github.com/kardia-as/zigpy-zboss) library for zigpy.
+
 ### Legacy or obsolete zigpy radio libraries
 
 - Texas Instruments with Z-Stack legacy firmware via the [zigpy-cc](https://github.com/zigpy/zigpy-cc) library for zigpy.


### PR DESCRIPTION
Add listing of experimental and unofficial zigpy radio libraries from third parties to README.md for reference:

- **Espressif Zigbee NCP Serial Protocol (ESP ZNSP)** based ESP32-C6/ESP32-H2 Zigbee radios via [zigpy-espzb](https://github.com/lhespress/zigpy-espzb) library for zigpy.
- **ZOI (ZBOSS Open Initiative)** based Zigbee radios compatible with ZBOSS NCP firmware via [zigpy-zboss](https://github.com/kardia-as/zigpy-zboss) library for zigpy.

PS: This is related to https://github.com/zigpy/zigpy/issues/394 but should not close that issue unless the [zigpy-zboss](https://github.com/kardia-as/zigpy-zboss) repo is also moved to the [zigpy ](https://github.com/zigpy) organization.