### PR TITLE
Add release notes and image source to OTA metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,4 @@ ENV/
 .DS_Store
 
 # Don't keep track of downloaded OTA files
-tests/ota/files/remote/dl
+tests/ota/files/external/dl

--- a/tests/ota/files/remote_index.json
+++ b/tests/ota/files/remote_index.json
@@ -9,6 +9,7 @@
             "model_names": ["Test Model 1", "Test Model 2"],
             "manufacturer_id": 4454,
             "changelog": "A changelog",
+            "release_notes": "Long release notes",
             "checksum": "sha3-256:28d4883705ac932160b51f09d2c4697f288d5bb11174677c6e43247288f6c794",
             "min_hardware_version": 0,
             "max_hardware_version": 257,

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -278,7 +278,7 @@ async def test_ledvance_provider():
         assert isinstance(meta, providers.RemoteOtaImageMetadata)
         assert meta.image_type == obj["identity"]["product"]
         assert meta.checksum == "sha256:" + obj.pop("shA256")
-        assert meta.changelog == obj.pop("releaseNotes")
+        assert meta.release_notes == obj.pop("releaseNotes")
         assert meta.file_size == obj.pop("length")
         assert meta.manufacturer_id == obj["identity"]["company"]
         assert meta.model_names == (obj.pop("productName"),)
@@ -465,6 +465,7 @@ async def test_remote_provider():
         assert meta.model_names == tuple(obj.pop("model_names"))
         assert meta.manufacturer_id == obj.pop("manufacturer_id")
         assert meta.changelog == obj.pop("changelog")
+        assert meta.release_notes == obj.pop("release_notes")
         assert meta.checksum == obj.pop("checksum")
         assert meta.min_hardware_version == obj.pop("min_hardware_version")
         assert meta.max_hardware_version == obj.pop("max_hardware_version")

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -425,10 +425,6 @@ class Salus(BaseOtaProvider):
             yield SalusRemoteOtaImageMetadata(  # type: ignore[call-arg]
                 file_version=int(fw["version"], 16),
                 model_names=(fw["model"],),
-                manufacturer_id=None,
-                image_type=None,
-                checksum=None,
-                file_size=None,
                 # Upgrade HTTP to HTTPS, the server supports it
                 url=fw["url"].replace("http://", "https://", 1),
                 source="SALUS",
@@ -538,8 +534,6 @@ class Inovelli(BaseOtaProvider):
                     manufacturer_id=fw["manufacturer_id"],
                     image_type=fw["image_type"],
                     model_names=(model,),
-                    checksum=None,
-                    file_size=None,
                     url=fw["firmware"],
                     source="Inovelli",
                 )
@@ -594,8 +588,6 @@ class ThirdReality(BaseOtaProvider):
                 manufacturer_id=fw["manufacturerId"],
                 model_names=(fw["modelId"],),
                 image_type=fw["imageType"],
-                checksum=None,
-                file_size=None,
                 url=fw["url"],
                 source="ThirdReality",
             )
@@ -743,9 +735,6 @@ class AdvancedFileProvider(BaseOtaProvider):
                 image_type=image.header.image_type,
                 checksum="sha1:" + hasher.hexdigest(),
                 file_size=len(data),
-                manufacturer_names=(),
-                model_names=(),
-                changelog=None,
                 min_hardware_version=image.header.minimum_hardware_version,
                 max_hardware_version=image.header.maximum_hardware_version,
                 source=f"Advanced file provider ({self.image_dir})",

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -38,6 +38,7 @@ class BaseOtaImageMetadata(t.BaseDataclassMixin):
     model_names: tuple[str] = ()
 
     changelog: str | None = None
+    release_notes: str | None = None
 
     min_hardware_version: int | None = None
     max_hardware_version: int | None = None
@@ -374,7 +375,7 @@ class Ledvance(BaseOtaProvider):
                         }
                     )
                 ),
-                changelog=fw["releaseNotes"],
+                release_notes=fw["releaseNotes"],
                 source="Ledvance",
             )
 
@@ -687,6 +688,7 @@ class RemoteProvider(BaseOtaProvider):
                 min_current_file_version=fw.get("min_current_file_version"),
                 max_current_file_version=fw.get("max_current_file_version"),
                 changelog=fw.get("changelog"),
+                release_notes=fw.get("release_notes"),
                 specificity=fw.get("specificity"),
                 source=f"Remote provider ({self.url})",
             )

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -614,6 +614,7 @@ class RemoteProvider(BaseOtaProvider):
                         "model_names": {"type": "array", "items": {"type": "string"}},
                         "manufacturer_id": {"type": "integer"},
                         "changelog": {"type": "string"},
+                        "release_notes": {"type": "string"},
                         "checksum": {
                             "type": "string",
                             "pattern": "^sha3-256:[a-f0-9]{64}$",
@@ -638,6 +639,7 @@ class RemoteProvider(BaseOtaProvider):
                         # "max_hardware_version",
                         # "min_current_file_version",
                         # "max_current_file_version",
+                        # "release_notes",
                         # "specificity",
                     ],
                 },


### PR DESCRIPTION
`release_notes` is for long-form release notes while `changelog` will be reserved for short.

`source` is a user-friendly name of the OTA provider.