### PR TITLE
Clean up pre commit and update types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   shared-ci:
-    uses: zigpy/workflows/.github/workflows/ci.yml@main
+    uses: zigpy/workflows/.github/workflows/ci.yml@dm/update-ci
     with:
       CODE_FOLDER: zigpy
-      CACHE_VERSION: 2
-      PRE_COMMIT_CACHE_PATH:  ~/.cache/pre-commit
-      PYTHON_VERSION_DEFAULT: 3.9.15
+      CACHE_VERSION: 3
+      PRE_COMMIT_CACHE_PATH: ~/.cache/pre-commit
+      PYTHON_VERSION_DEFAULT: 3.9.18
       MINIMUM_COVERAGE_PERCENTAGE: 99

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   shared-ci:
-    uses: zigpy/workflows/.github/workflows/ci.yml@dm/update-ci
+    uses: zigpy/workflows/.github/workflows/ci.yml@main
     with:
       CODE_FOLDER: zigpy
       CACHE_VERSION: 3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,35 +1,3 @@
-repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.0
-    hooks:
-      - id: autoflake
-
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-        args:
-          - --quiet
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        entry: pflake8
-        additional_dependencies: 
-          - pyproject-flake8==6.0.0.post1
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:
@@ -38,14 +6,12 @@ repos:
         args: ["--toml", "pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.9.0
     hooks:
       - id: mypy
-        additional_dependencies:
-          - pydantic
   
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.277
+    rev: v0.3.2
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix", "--config", "pyproject.toml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ line-length = 88
 "zigpy/ota/provider.py" = ["SIM117"]
 
 [tool.pyupgrade]
-py37plus = true
+py38plus = true
 
 [tool.autoflake8]
 in-place = true
@@ -149,7 +149,6 @@ skip = "./.*,tests/*,pyproject.toml"
 quiet-level = 2
 
 [tool.mypy]
-plugins = ["pydantic.mypy"]
 ignore_missing_imports = true
 install_types = true
 non_interactive = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ testing = [
     "pytest-cov",
     "pytest-timeout",
     "freezegun",
-    "ruff==0.0.261",
     'pysqlite3-binary; platform_system=="Linux" and python_version<"3.12"',
 ]
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,7 +8,6 @@ pytest-asyncio
 pytest-cov
 pytest-timeout
 freezegun
-ruff==0.0.261
 tomli
 aioresponses
 

--- a/zigpy/group.py
+++ b/zigpy/group.py
@@ -85,9 +85,7 @@ class Group(ListenableMixin, dict):
         )
 
     def __repr__(self) -> str:
-        return "<{} group_id={} name='{}' members={}>".format(
-            self.__class__.__name__, self.group_id, self.name, super().__repr__()
-        )
+        return f"<{self.__class__.__name__} group_id={self.group_id} name='{self.name}' members={super().__repr__()}>"
 
     @property
     def application(self) -> ControllerApplication:

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -155,7 +155,6 @@ class SubElement(t.Struct):
         )
 
 
-@attr.s(kw_only=True)
 class BaseOTAImage:
     """Base OTA image container type. Not all images are valid Zigbee OTA images but are
     nonetheless accepted by devices. Only requirement is that the image contains a valid
@@ -172,7 +171,6 @@ class BaseOTAImage:
         raise NotImplementedError()  # pragma: no cover
 
 
-@attr.s(kw_only=True)
 class OTAImage(t.Struct, BaseOTAImage):
     """Zigbee OTA image according to 11.4 of the ZCL specification."""
 
@@ -208,7 +206,7 @@ class OTAImage(t.Struct, BaseOTAImage):
         return res
 
 
-@attr.s(kw_only=True)
+@attr.s
 class HueSBLOTAImage(BaseOTAImage):
     """Unique OTA image format for certain Hue devices. Starts with a valid header but does
     not contain any valid subelements beyond that point.

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -22,9 +22,7 @@ class HWVersion(t.uint16_t):
         return self & 0x00FF
 
     def __repr__(self):
-        return "<{} version={} revision={}>".format(
-            self.__class__.__name__, self.version, self.revision
-        )
+        return f"<{self.__class__.__name__} version={self.version} revision={self.revision}>"
 
 
 class HeaderString(bytes):
@@ -157,6 +155,7 @@ class SubElement(t.Struct):
         )
 
 
+@attr.s(kw_only=True)
 class BaseOTAImage:
     """Base OTA image container type. Not all images are valid Zigbee OTA images but are
     nonetheless accepted by devices. Only requirement is that the image contains a valid
@@ -173,6 +172,7 @@ class BaseOTAImage:
         raise NotImplementedError()  # pragma: no cover
 
 
+@attr.s(kw_only=True)
 class OTAImage(t.Struct, BaseOTAImage):
     """Zigbee OTA image according to 11.4 of the ZCL specification."""
 
@@ -208,13 +208,13 @@ class OTAImage(t.Struct, BaseOTAImage):
         return res
 
 
-@attr.s
+@attr.s(kw_only=True)
 class HueSBLOTAImage(BaseOTAImage):
     """Unique OTA image format for certain Hue devices. Starts with a valid header but does
     not contain any valid subelements beyond that point.
     """
 
-    SUBELEMENTS_MAGIC = b"\x2A\x00\x01"
+    SUBELEMENTS_MAGIC = b"\x2a\x00\x01"
 
     header = attr.ib(default=None)
     data = attr.ib(default=None)
@@ -242,7 +242,7 @@ class HueSBLOTAImage(BaseOTAImage):
                 f"Only Hue images are expected. Got: {header.manufacturer_id}"
             )
 
-        return cls(header=header, data=firmware), data[header.image_size :]
+        return cls(header=header, data=firmware), data[header.image_size :]  # type: ignore
 
 
 def parse_ota_image(data: bytes) -> tuple[BaseOTAImage, bytes]:

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -53,7 +53,7 @@ class SerializableBytes:
 
     def __init__(self, value: bytes = b"") -> None:
         if isinstance(value, type(self)):
-            value = value.value
+            value = value.value  # type: ignore
         elif not isinstance(value, (bytes, bytearray)):
             raise ValueError(f"Object is not bytes: {value!r}")  # noqa: TRY004
 
@@ -460,7 +460,7 @@ def bitmap_factory(int_type: CALLABLE_T) -> CALLABLE_T:
         class _NewEnum(int_type, enum.Flag):
             # Rebind classmethods to our own class
             _missing_ = classmethod(enum.IntFlag._missing_.__func__)
-            _create_pseudo_member_ = classmethod(
+            _create_pseudo_member_ = classmethod(  # type: ignore
                 enum.IntFlag._create_pseudo_member_.__func__
             )
 

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -17,7 +17,7 @@ if typing.TYPE_CHECKING:
 class BaseDataclassMixin:
     def replace(self, **kwargs) -> Self:
         if dataclasses.is_dataclass(self):
-            return dataclasses.replace(self, **kwargs)
+            return dataclasses.replace(self, **kwargs)  # type: ignore
         else:
             return attrs.evolve(self, **kwargs)
 

--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -33,7 +33,7 @@ class Shade(Cluster):
     ShadeStatus: Final = ShadeStatus
     ShadeMode: Final = ShadeMode
 
-    cluster_id: Final = 0x0100
+    cluster_id: Final[t.uint16_t] = 0x0100
     name: Final = "Shade Configuration"
     ep_attribute: Final = "shade"
 
@@ -288,7 +288,7 @@ class DoorLock(Cluster):
     DayMask: Final = DayMask
     EventType: Final = EventType
 
-    cluster_id: Final = 0x0101
+    cluster_id: Final[t.uint16_t] = 0x0101
     name: Final = "Door Lock"
     ep_attribute: Final = "door_lock"
 
@@ -730,7 +730,7 @@ class WindowCovering(Cluster):
     ConfigStatus: Final = ConfigStatus
     WindowCoveringMode: Final = WindowCoveringMode
 
-    cluster_id: Final = 0x0102
+    cluster_id: Final[t.uint16_t] = 0x0102
     name: Final = "Window Covering"
     ep_attribute: Final = "window_covering"
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -214,7 +214,7 @@ class Basic(Cluster):
     GenericDeviceClass: Final = GenericDeviceClass
     GenericLightingDeviceType: Final = GenericLightingDeviceType
 
-    cluster_id: Final = 0x0000
+    cluster_id: Final[t.uint16_t] = 0x0000
     ep_attribute: Final = "basic"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -307,7 +307,7 @@ class PowerConfiguration(Cluster):
     MainsAlarmMask: Final = MainsAlarmMask
     BatterySize: Final = BatterySize
 
-    cluster_id: Final = 0x0001
+    cluster_id: Final[t.uint16_t] = 0x0001
     name: Final = "Power Configuration"
     ep_attribute: Final = "power"
 
@@ -502,7 +502,7 @@ class DeviceTemperature(Cluster):
 
     DeviceTempAlarmMask: Final = DeviceTempAlarmMask
 
-    cluster_id: Final = 0x0002
+    cluster_id: Final[t.uint16_t] = 0x0002
     name: Final = "Device Temperature"
     ep_attribute: Final = "device_temperature"
 
@@ -557,7 +557,7 @@ class Identify(Cluster):
     EffectIdentifier: Final = EffectIdentifier
     EffectVariant: Final = EffectVariant
 
-    cluster_id: Final = 0x0003
+    cluster_id: Final[t.uint16_t] = 0x0003
     ep_attribute: Final = "identify"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -597,7 +597,7 @@ class Groups(Cluster):
 
     NameSupport: Final = NameSupport
 
-    cluster_id: Final = 0x0004
+    cluster_id: Final[t.uint16_t] = 0x0004
     ep_attribute: Final = "groups"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -663,7 +663,7 @@ class Scenes(Cluster):
 
     NameSupport: Final = NameSupport
 
-    cluster_id: Final = 0x0005
+    cluster_id: Final[t.uint16_t] = 0x0005
     ep_attribute: Final = "scenes"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -874,7 +874,7 @@ class OnOff(Cluster):
 
     DYING_LIGHT_DIM_UP_THEN_FADE_TO_OFF = 0x00
 
-    cluster_id: Final = 0x0006
+    cluster_id: Final[t.uint16_t] = 0x0006
     name: Final = "On/Off"
     ep_attribute: Final = "on_off"
 
@@ -934,7 +934,7 @@ class OnOffConfiguration(Cluster):
     SwitchType: Final = SwitchType
     SwitchActions: Final = SwitchActions
 
-    cluster_id: Final = 0x0007
+    cluster_id: Final[t.uint16_t] = 0x0007
     name: Final = "On/Off Switch Configuration"
     ep_attribute: Final = "on_off_config"
 
@@ -973,7 +973,7 @@ class LevelControl(Cluster):
     StepMode: Final = StepMode
     Options: Final = Options
 
-    cluster_id: Final = 0x0008
+    cluster_id: Final[t.uint16_t] = 0x0008
     name: Final = "Level control"
     ep_attribute: Final = "level"
 
@@ -1079,7 +1079,7 @@ class Alarms(Cluster):
     configuring alarm functionality.
     """
 
-    cluster_id: Final = 0x0009
+    cluster_id: Final[t.uint16_t] = 0x0009
     ep_attribute: Final = "alarms"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1131,7 +1131,7 @@ class Time(Cluster):
 
     TimeStatus: Final = TimeStatus
 
-    cluster_id: Final = 0x000A
+    cluster_id: Final[t.uint16_t] = 0x000A
     ep_attribute: Final = "time"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1211,7 +1211,7 @@ class RSSILocation(Cluster):
     LocationMethod: Final = LocationMethod
     NeighborInfo: Final = NeighborInfo
 
-    cluster_id: Final = 0x000B
+    cluster_id: Final[t.uint16_t] = 0x000B
     ep_attribute: Final = "rssi_location"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1387,7 +1387,7 @@ class Reliability(t.enum8):
 class AnalogInput(Cluster):
     Reliability: Final = Reliability
 
-    cluster_id: Final = 0x000C
+    cluster_id: Final[t.uint16_t] = 0x000C
     ep_attribute: Final = "analog_input"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1422,7 +1422,7 @@ class AnalogInput(Cluster):
 
 
 class AnalogOutput(Cluster):
-    cluster_id: Final = 0x000D
+    cluster_id: Final[t.uint16_t] = 0x000D
     ep_attribute: Final = "analog_output"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1462,7 +1462,7 @@ class AnalogOutput(Cluster):
 
 
 class AnalogValue(Cluster):
-    cluster_id: Final = 0x000E
+    cluster_id: Final[t.uint16_t] = 0x000E
     ep_attribute: Final = "analog_value"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1495,7 +1495,7 @@ class AnalogValue(Cluster):
 
 
 class BinaryInput(Cluster):
-    cluster_id: Final = 0x000F
+    cluster_id: Final[t.uint16_t] = 0x000F
     name: Final = "Binary Input (Basic)"
     ep_attribute: Final = "binary_input"
 
@@ -1528,7 +1528,7 @@ class BinaryInput(Cluster):
 
 
 class BinaryOutput(Cluster):
-    cluster_id: Final = 0x0010
+    cluster_id: Final[t.uint16_t] = 0x0010
     ep_attribute: Final = "binary_output"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1577,7 +1577,7 @@ class BinaryOutput(Cluster):
 
 
 class BinaryValue(Cluster):
-    cluster_id: Final = 0x0011
+    cluster_id: Final[t.uint16_t] = 0x0011
     ep_attribute: Final = "binary_value"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1619,7 +1619,7 @@ class BinaryValue(Cluster):
 
 
 class MultistateInput(Cluster):
-    cluster_id: Final = 0x0012
+    cluster_id: Final[t.uint16_t] = 0x0012
     ep_attribute: Final = "multistate_input"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1652,7 +1652,7 @@ class MultistateInput(Cluster):
 
 
 class MultistateOutput(Cluster):
-    cluster_id: Final = 0x0013
+    cluster_id: Final[t.uint16_t] = 0x0013
     ep_attribute: Final = "multistate_output"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1688,7 +1688,7 @@ class MultistateOutput(Cluster):
 
 
 class MultistateValue(Cluster):
-    cluster_id: Final = 0x0014
+    cluster_id: Final[t.uint16_t] = 0x0014
     ep_attribute: Final = "multistate_value"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1742,7 +1742,7 @@ class Commissioning(Cluster):
     StartupControl: Final = StartupControl
     NetworkKeyType: Final = NetworkKeyType
 
-    cluster_id: Final = 0x0015
+    cluster_id: Final[t.uint16_t] = 0x0015
     ep_attribute: Final = "commissioning"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -1859,7 +1859,7 @@ class Commissioning(Cluster):
 
 
 class Partition(Cluster):
-    cluster_id: Final = 0x0016
+    cluster_id: Final[t.uint16_t] = 0x0016
     ep_attribute: Final = "partition"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -2043,7 +2043,7 @@ class Ota(Cluster):
     ImagePageCommand: Final = ImagePageCommand
     ImageBlockResponseCommand: Final = ImageBlockResponseCommand
 
-    cluster_id: Final = 0x0019
+    cluster_id: Final[t.uint16_t] = 0x0019
     ep_attribute: Final = "ota"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -2234,7 +2234,7 @@ class PowerProfile(Cluster):
     PowerProfilePhase: Final = PowerProfilePhase
     PowerProfile: Final = PowerProfileType
 
-    cluster_id: Final = 0x001A
+    cluster_id: Final[t.uint16_t] = 0x001A
     ep_attribute: Final = "power_profile"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -2405,7 +2405,7 @@ class PowerProfile(Cluster):
 
 
 class ApplianceControl(Cluster):
-    cluster_id: Final = 0x001B
+    cluster_id: Final[t.uint16_t] = 0x001B
     ep_attribute: Final = "appliance_control"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -2421,7 +2421,7 @@ class ApplianceControl(Cluster):
 
 
 class PollControl(Cluster):
-    cluster_id: Final = 0x0020
+    cluster_id: Final[t.uint16_t] = 0x0020
     name: Final = "Poll Control"
     ep_attribute: Final = "poll_control"
 
@@ -2471,14 +2471,14 @@ class PollControl(Cluster):
 
 
 class GreenPowerProxy(Cluster):
-    cluster_id: Final = 0x0021
+    cluster_id: Final[t.uint16_t] = 0x0021
     ep_attribute: Final = "green_power"
 
 
 class KeepAlive(Cluster):
     """Keep Alive cluster definition."""
 
-    cluster_id: Final = 0x0025
+    cluster_id: Final[t.uint16_t] = 0x0025
     ep_attribute: Final = "keep_alive"
 
     class AttributeDefs(BaseAttributeDefs):

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -13,7 +13,7 @@ from zigpy.zcl.foundation import (
 
 
 class ApplianceIdentification(Cluster):
-    cluster_id: Final = 0x0B00
+    cluster_id: Final[t.uint16_t] = 0x0B00
     name: Final = "Appliance Identification"
     ep_attribute: Final = "appliance_id"
 
@@ -51,7 +51,7 @@ class ApplianceIdentification(Cluster):
 
 
 class MeterIdentification(Cluster):
-    cluster_id: Final = 0x0B01
+    cluster_id: Final[t.uint16_t] = 0x0B01
     name: Final = "Meter Identification"
     ep_attribute: Final = "meter_id"
 
@@ -95,7 +95,7 @@ class MeterIdentification(Cluster):
 
 
 class ApplianceEventAlerts(Cluster):
-    cluster_id: Final = 0x0B02
+    cluster_id: Final[t.uint16_t] = 0x0B02
     name: Final = "Appliance Event Alerts"
     ep_attribute: Final = "appliance_event"
 
@@ -113,7 +113,7 @@ class ApplianceEventAlerts(Cluster):
 
 
 class ApplianceStatistics(Cluster):
-    cluster_id: Final = 0x0B03
+    cluster_id: Final[t.uint16_t] = 0x0B03
     name: Final = "Appliance Statistics"
     ep_attribute: Final = "appliance_stats"
 
@@ -169,7 +169,7 @@ class ACAlarmsMask(t.bitmap16):
 
 
 class ElectricalMeasurement(Cluster):
-    cluster_id: Final = 0x0B04
+    cluster_id: Final[t.uint16_t] = 0x0B04
     name: Final = "Electrical Measurement"
     ep_attribute: Final = "electrical_measurement"
 
@@ -543,7 +543,7 @@ class ElectricalMeasurement(Cluster):
 
 
 class Diagnostic(Cluster):
-    cluster_id: Final = 0x0B05
+    cluster_id: Final[t.uint16_t] = 0x0B05
     ep_attribute: Final = "diagnostic"
 
     class AttributeDefs(BaseAttributeDefs):

--- a/zigpy/zcl/clusters/hvac.py
+++ b/zigpy/zcl/clusters/hvac.py
@@ -67,7 +67,7 @@ class Pump(Cluster):
     OperationMode: Final = OperationMode
     PumpStatus: Final = PumpStatus
 
-    cluster_id: Final = 0x0200
+    cluster_id: Final[t.uint16_t] = 0x0200
     name: Final = "Pump Configuration and Control"
     ep_attribute: Final = "pump"
 
@@ -347,7 +347,7 @@ class Thermostat(Cluster):
     RunningMode: Final = RunningMode
     RunningState: Final = RunningState
 
-    cluster_id: Final = 0x0201
+    cluster_id: Final[t.uint16_t] = 0x0201
     ep_attribute: Final = "thermostat"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -571,7 +571,7 @@ class Fan(Cluster):
     FanMode: Final = FanMode
     FanModeSequence: Final = FanModeSequence
 
-    cluster_id: Final = 0x0202
+    cluster_id: Final[t.uint16_t] = 0x0202
     name: Final = "Fan Control"
     ep_attribute: Final = "fan"
 
@@ -604,7 +604,7 @@ class Dehumidification(Cluster):
     DehumidificationLockout: Final = DehumidificationLockout
     RelativeHumidityDisplay: Final = RelativeHumidityDisplay
 
-    cluster_id: Final = 0x0203
+    cluster_id: Final[t.uint16_t] = 0x0203
     ep_attribute: Final = "dehumidification"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -665,7 +665,7 @@ class UserInterface(Cluster):
     KeypadLockout: Final = KeypadLockout
     ScheduleProgrammingVisibility: Final = ScheduleProgrammingVisibility
 
-    cluster_id: Final = 0x0204
+    cluster_id: Final[t.uint16_t] = 0x0204
     name: Final = "Thermostat User Interface Configuration"
     ep_attribute: Final = "thermostat_ui"
 

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -100,7 +100,7 @@ class Color(Cluster):
     DriftCompensation: Final = DriftCompensation
     Options: Final = Options
 
-    cluster_id: Final = 0x0300
+    cluster_id: Final[t.uint16_t] = 0x0300
     name: Final = "Color Control"
     ep_attribute: Final = "light_color"
 
@@ -443,7 +443,7 @@ class Ballast(Cluster):
     BallastStatus: Final = BallastStatus
     LampAlarmMode: Final = LampAlarmMode
 
-    cluster_id: Final = 0x0301
+    cluster_id: Final[t.uint16_t] = 0x0301
     ep_attribute: Final = "light_ballast"
 
     class AttributeDefs(BaseAttributeDefs):

--- a/zigpy/zcl/clusters/lightlink.py
+++ b/zigpy/zcl/clusters/lightlink.py
@@ -78,7 +78,7 @@ class EndpointInfoRecord(t.Struct):
 
 
 class LightLink(Cluster):
-    cluster_id: Final = 0x1000
+    cluster_id: Final[t.uint16_t] = 0x1000
     ep_attribute: Final = "lightlink"
 
     class ServerCommandDefs(BaseCommandDefs):

--- a/zigpy/zcl/clusters/measurement.py
+++ b/zigpy/zcl/clusters/measurement.py
@@ -18,7 +18,7 @@ class LightSensorType(t.enum8):
 class IlluminanceMeasurement(Cluster):
     LightSensorType: Final = LightSensorType
 
-    cluster_id: Final = 0x0400
+    cluster_id: Final[t.uint16_t] = 0x0400
     name: Final = "Illuminance Measurement"
     ep_attribute: Final = "illuminance"
 
@@ -50,7 +50,7 @@ class IlluminanceLevelSensing(Cluster):
     LevelStatus: Final = LevelStatus
     LightSensorType: Final = LightSensorType
 
-    cluster_id: Final = 0x0401
+    cluster_id: Final[t.uint16_t] = 0x0401
     name: Final = "Illuminance Level Sensing"
     ep_attribute: Final = "illuminance_level"
 
@@ -70,7 +70,7 @@ class IlluminanceLevelSensing(Cluster):
 
 
 class TemperatureMeasurement(Cluster):
-    cluster_id: Final = 0x0402
+    cluster_id: Final[t.uint16_t] = 0x0402
     name: Final = "Temperature Measurement"
     ep_attribute: Final = "temperature"
 
@@ -93,7 +93,7 @@ class TemperatureMeasurement(Cluster):
 
 
 class PressureMeasurement(Cluster):
-    cluster_id: Final = 0x0403
+    cluster_id: Final[t.uint16_t] = 0x0403
     name: Final = "Pressure Measurement"
     ep_attribute: Final = "pressure"
 
@@ -122,7 +122,7 @@ class PressureMeasurement(Cluster):
 
 
 class FlowMeasurement(Cluster):
-    cluster_id: Final = 0x0404
+    cluster_id: Final[t.uint16_t] = 0x0404
     name: Final = "Flow Measurement"
     ep_attribute: Final = "flow"
 
@@ -142,7 +142,7 @@ class FlowMeasurement(Cluster):
 
 
 class RelativeHumidity(Cluster):
-    cluster_id: Final = 0x0405
+    cluster_id: Final[t.uint16_t] = 0x0405
     name: Final = "Relative Humidity Measurement"
     ep_attribute: Final = "humidity"
 
@@ -184,7 +184,7 @@ class OccupancySensing(Cluster):
     OccupancySensorType: Final = OccupancySensorType
     OccupancySensorTypeBitmap: Final = OccupancySensorTypeBitmap
 
-    cluster_id: Final = 0x0406
+    cluster_id: Final[t.uint16_t] = 0x0406
     name: Final = "Occupancy Sensing"
     ep_attribute: Final = "occupancy"
 
@@ -231,7 +231,7 @@ class OccupancySensing(Cluster):
 
 
 class LeafWetness(Cluster):
-    cluster_id: Final = 0x0407
+    cluster_id: Final[t.uint16_t] = 0x0407
     name: Final = "Leaf Wetness Measurement"
     ep_attribute: Final = "leaf_wetness"
 
@@ -252,7 +252,7 @@ class LeafWetness(Cluster):
 
 
 class SoilMoisture(Cluster):
-    cluster_id: Final = 0x0408
+    cluster_id: Final[t.uint16_t] = 0x0408
     name: Final = "Soil Moisture Measurement"
     ep_attribute: Final = "soil_moisture"
 
@@ -273,7 +273,7 @@ class SoilMoisture(Cluster):
 
 
 class PH(Cluster):
-    cluster_id: Final = 0x0409
+    cluster_id: Final[t.uint16_t] = 0x0409
     name: Final = "pH Measurement"
     ep_attribute: Final = "ph"
 
@@ -294,7 +294,7 @@ class PH(Cluster):
 
 
 class ElectricalConductivity(Cluster):
-    cluster_id: Final = 0x040A
+    cluster_id: Final[t.uint16_t] = 0x040A
     name: Final = "Electrical Conductivity"
     ep_attribute: Final = "electrical_conductivity"
 
@@ -314,7 +314,7 @@ class ElectricalConductivity(Cluster):
 
 
 class WindSpeed(Cluster):
-    cluster_id: Final = 0x040B
+    cluster_id: Final[t.uint16_t] = 0x040B
     name: Final = "Wind Speed Measurement"
     ep_attribute: Final = "wind_speed"
 
@@ -353,91 +353,91 @@ class _ConcentrationMixin:
 
 
 class CarbonMonoxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x040C
+    cluster_id: Final[t.uint16_t] = 0x040C
     name: Final = "Carbon Monoxide (CO) Concentration"
     ep_attribute: Final = "carbon_monoxide_concentration"
 
 
 class CarbonDioxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x040D
+    cluster_id: Final[t.uint16_t] = 0x040D
     name: Final = "Carbon Dioxide (CO₂) Concentration"
     ep_attribute: Final = "carbon_dioxide_concentration"
 
 
 class EthyleneConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x040E
+    cluster_id: Final[t.uint16_t] = 0x040E
     name: Final = "Ethylene (CH₂) Concentration"
     ep_attribute: Final = "ethylene_concentration"
 
 
 class EthyleneOxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x040F
+    cluster_id: Final[t.uint16_t] = 0x040F
     name: Final = "Ethylene Oxide (C₂H₄O) Concentration"
     ep_attribute: Final = "ethylene_oxide_concentration"
 
 
 class HydrogenConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0410
+    cluster_id: Final[t.uint16_t] = 0x0410
     name: Final = "Hydrogen (H) Concentration"
     ep_attribute: Final = "hydrogen_concentration"
 
 
 class HydrogenSulfideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0411
+    cluster_id: Final[t.uint16_t] = 0x0411
     name: Final = "Hydrogen Sulfide (H₂S) Concentration"
     ep_attribute: Final = "hydrogen_sulfide_concentration"
 
 
 class NitricOxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0412
+    cluster_id: Final[t.uint16_t] = 0x0412
     name: Final = "Nitric Oxide (NO) Concentration"
     ep_attribute: Final = "nitric_oxide_concentration"
 
 
 class NitrogenDioxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0413
+    cluster_id: Final[t.uint16_t] = 0x0413
     name: Final = "Nitrogen Dioxide (NO₂) Concentration"
     ep_attribute: Final = "nitrogen_dioxide_concentration"
 
 
 class OxygenConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0414
+    cluster_id: Final[t.uint16_t] = 0x0414
     name: Final = "Oxygen (O₂) Concentration"
     ep_attribute: Final = "oxygen_concentration"
 
 
 class OzoneConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0415
+    cluster_id: Final[t.uint16_t] = 0x0415
     name: Final = "Ozone (O₃) Concentration"
     ep_attribute: Final = "ozone_concentration"
 
 
 class SulfurDioxideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0416
+    cluster_id: Final[t.uint16_t] = 0x0416
     name: Final = "Sulfur Dioxide (SO₂) Concentration"
     ep_attribute: Final = "sulfur_dioxide_concentration"
 
 
 class DissolvedOxygenConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0417
+    cluster_id: Final[t.uint16_t] = 0x0417
     name: Final = "Dissolved Oxygen (DO) Concentration"
     ep_attribute: Final = "dissolved_oxygen_concentration"
 
 
 class BromateConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0418
+    cluster_id: Final[t.uint16_t] = 0x0418
     name: Final = "Bromate Concentration"
     ep_attribute: Final = "bromate_concentration"
 
 
 class ChloraminesConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0419
+    cluster_id: Final[t.uint16_t] = 0x0419
     name: Final = "Chloramines Concentration"
     ep_attribute: Final = "chloramines_concentration"
 
 
 class ChlorineConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041A
+    cluster_id: Final[t.uint16_t] = 0x041A
     name: Final = "Chlorine Concentration"
     ep_attribute: Final = "chlorine_concentration"
 
@@ -445,31 +445,33 @@ class ChlorineConcentration(_ConcentrationMixin, Cluster):
 class FecalColiformAndEColiFraction(_ConcentrationMixin, Cluster):
     """Percent of positive samples"""
 
-    cluster_id: Final = 0x041B
+    cluster_id: Final[t.uint16_t] = 0x041B
     name: Final = "Fecal coliform & E. Coli Fraction"
     ep_attribute: Final = "fecal_coliform_and_e_coli_fraction"
 
 
 class FluorideConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041C  # XXX: spec repeats 0x041B but this seems like a mistake
+    cluster_id: Final[t.uint16_t] = (
+        0x041C  # XXX: spec repeats 0x041B but this seems like a mistake
+    )
     name: Final = "Fluoride Concentration"
     ep_attribute: Final = "fluoride_concentration"
 
 
 class HaloaceticAcidsConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041D
+    cluster_id: Final[t.uint16_t] = 0x041D
     name: Final = "Haloacetic Acids Concentration"
     ep_attribute: Final = "haloacetic_acids_concentration"
 
 
 class TotalTrihalomethanesConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041E
+    cluster_id: Final[t.uint16_t] = 0x041E
     name: Final = "Total Trihalomethanes Concentration"
     ep_attribute: Final = "total_trihalomethanes_concentration"
 
 
 class TotalColiformBacteriaFraction(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x041F
+    cluster_id: Final[t.uint16_t] = 0x041F
     name: Final = "Total Coliform Bacteria Fraction"
     ep_attribute: Final = "total_coliform_bacteria_fraction"
 
@@ -478,61 +480,61 @@ class TotalColiformBacteriaFraction(_ConcentrationMixin, Cluster):
 class Turbidity(_ConcentrationMixin, Cluster):
     """Cloudiness of particles in water where an average person would notice a 5 or higher"""
 
-    cluster_id: Final = 0x0420
+    cluster_id: Final[t.uint16_t] = 0x0420
     name: Final = "Turbidity"
     ep_attribute: Final = "turbidity"
 
 
 class CopperConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0421
+    cluster_id: Final[t.uint16_t] = 0x0421
     name: Final = "Copper Concentration"
     ep_attribute: Final = "copper_concentration"
 
 
 class LeadConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0422
+    cluster_id: Final[t.uint16_t] = 0x0422
     name: Final = "Lead Concentration"
     ep_attribute: Final = "lead_concentration"
 
 
 class ManganeseConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0423
+    cluster_id: Final[t.uint16_t] = 0x0423
     name: Final = "Manganese Concentration"
     ep_attribute: Final = "manganese_concentration"
 
 
 class SulfateConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0424
+    cluster_id: Final[t.uint16_t] = 0x0424
     name: Final = "Sulfate Concentration"
     ep_attribute: Final = "sulfate_concentration"
 
 
 class BromodichloromethaneConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0425
+    cluster_id: Final[t.uint16_t] = 0x0425
     name: Final = "Bromodichloromethane Concentration"
     ep_attribute: Final = "bromodichloromethane_concentration"
 
 
 class BromoformConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0426
+    cluster_id: Final[t.uint16_t] = 0x0426
     name: Final = "Bromoform Concentration"
     ep_attribute: Final = "bromoform_concentration"
 
 
 class ChlorodibromomethaneConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0427
+    cluster_id: Final[t.uint16_t] = 0x0427
     name: Final = "Chlorodibromomethane Concentration"
     ep_attribute: Final = "chlorodibromomethane_concentration"
 
 
 class ChloroformConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0428
+    cluster_id: Final[t.uint16_t] = 0x0428
     name: Final = "Chloroform Concentration"
     ep_attribute: Final = "chloroform_concentration"
 
 
 class SodiumConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x0429
+    cluster_id: Final[t.uint16_t] = 0x0429
     name: Final = "Sodium Concentration"
     ep_attribute: Final = "sodium_concentration"
 
@@ -541,12 +543,12 @@ class SodiumConcentration(_ConcentrationMixin, Cluster):
 class PM25(_ConcentrationMixin, Cluster):
     """Particulate Matter 2.5 microns or less"""
 
-    cluster_id: Final = 0x042A
+    cluster_id: Final[t.uint16_t] = 0x042A
     name: Final = "PM2.5"
     ep_attribute: Final = "pm25"
 
 
 class FormaldehydeConcentration(_ConcentrationMixin, Cluster):
-    cluster_id: Final = 0x042B
+    cluster_id: Final[t.uint16_t] = 0x042B
     name: Final = "Formaldehyde Concentration"
     ep_attribute: Final = "formaldehyde_concentration"

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -20,7 +20,7 @@ class DateTime(t.Struct):
 
 
 class GenericTunnel(Cluster):
-    cluster_id: Final = 0x0600
+    cluster_id: Final[t.uint16_t] = 0x0600
     ep_attribute: Final = "generic_tunnel"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -41,7 +41,7 @@ class GenericTunnel(Cluster):
 
 
 class BacnetProtocolTunnel(Cluster):
-    cluster_id: Final = 0x0601
+    cluster_id: Final[t.uint16_t] = 0x0601
     ep_attribute: Final = "bacnet_tunnel"
 
     class ServerCommandDefs(BaseCommandDefs):
@@ -51,7 +51,7 @@ class BacnetProtocolTunnel(Cluster):
 
 
 class AnalogInputRegular(Cluster):
-    cluster_id: Final = 0x0602
+    cluster_id: Final[t.uint16_t] = 0x0602
     ep_attribute: Final = "bacnet_regular_analog_input"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -65,7 +65,7 @@ class AnalogInputRegular(Cluster):
 
 
 class AnalogInputExtended(Cluster):
-    cluster_id: Final = 0x0603
+    cluster_id: Final[t.uint16_t] = 0x0603
     ep_attribute: Final = "bacnet_extended_analog_input"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -90,7 +90,7 @@ class AnalogInputExtended(Cluster):
 
 
 class AnalogOutputRegular(Cluster):
-    cluster_id: Final = 0x0604
+    cluster_id: Final[t.uint16_t] = 0x0604
     ep_attribute: Final = "bacnet_regular_analog_output"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -104,7 +104,7 @@ class AnalogOutputRegular(Cluster):
 
 
 class AnalogOutputExtended(Cluster):
-    cluster_id: Final = 0x0605
+    cluster_id: Final[t.uint16_t] = 0x0605
     ep_attribute: Final = "bacnet_extended_analog_output"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -123,7 +123,7 @@ class AnalogOutputExtended(Cluster):
 
 
 class AnalogValueRegular(Cluster):
-    cluster_id: Final = 0x0606
+    cluster_id: Final[t.uint16_t] = 0x0606
     ep_attribute: Final = "bacnet_regular_analog_value"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -135,7 +135,7 @@ class AnalogValueRegular(Cluster):
 
 
 class AnalogValueExtended(Cluster):
-    cluster_id: Final = 0x0607
+    cluster_id: Final[t.uint16_t] = 0x0607
     ep_attribute: Final = "bacnet_extended_analog_value"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -152,7 +152,7 @@ class AnalogValueExtended(Cluster):
 
 
 class BinaryInputRegular(Cluster):
-    cluster_id: Final = 0x0608
+    cluster_id: Final[t.uint16_t] = 0x0608
     ep_attribute: Final = "bacnet_regular_binary_input"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -169,7 +169,7 @@ class BinaryInputRegular(Cluster):
 
 
 class BinaryInputExtended(Cluster):
-    cluster_id: Final = 0x0609
+    cluster_id: Final[t.uint16_t] = 0x0609
     ep_attribute: Final = "bacnet_extended_binary_input"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -185,7 +185,7 @@ class BinaryInputExtended(Cluster):
 
 
 class BinaryOutputRegular(Cluster):
-    cluster_id: Final = 0x060A
+    cluster_id: Final[t.uint16_t] = 0x060A
     ep_attribute: Final = "bacnet_regular_binary_output"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -203,7 +203,7 @@ class BinaryOutputRegular(Cluster):
 
 
 class BinaryOutputExtended(Cluster):
-    cluster_id: Final = 0x060B
+    cluster_id: Final[t.uint16_t] = 0x060B
     ep_attribute: Final = "bacnet_extended_binary_output"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -218,7 +218,7 @@ class BinaryOutputExtended(Cluster):
 
 
 class BinaryValueRegular(Cluster):
-    cluster_id: Final = 0x060C
+    cluster_id: Final[t.uint16_t] = 0x060C
     ep_attribute: Final = "bacnet_regular_binary_value"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -234,7 +234,7 @@ class BinaryValueRegular(Cluster):
 
 
 class BinaryValueExtended(Cluster):
-    cluster_id: Final = 0x060D
+    cluster_id: Final[t.uint16_t] = 0x060D
     ep_attribute: Final = "bacnet_extended_binary_value"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -250,7 +250,7 @@ class BinaryValueExtended(Cluster):
 
 
 class MultistateInputRegular(Cluster):
-    cluster_id: Final = 0x060E
+    cluster_id: Final[t.uint16_t] = 0x060E
     ep_attribute: Final = "bacnet_regular_multistate_input"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -262,7 +262,7 @@ class MultistateInputRegular(Cluster):
 
 
 class MultistateInputExtended(Cluster):
-    cluster_id: Final = 0x060F
+    cluster_id: Final[t.uint16_t] = 0x060F
     ep_attribute: Final = "bacnet_extended_multistate_input"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -279,7 +279,7 @@ class MultistateInputExtended(Cluster):
 
 
 class MultistateOutputRegular(Cluster):
-    cluster_id: Final = 0x0610
+    cluster_id: Final[t.uint16_t] = 0x0610
     ep_attribute: Final = "bacnet_regular_multistate_output"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -292,7 +292,7 @@ class MultistateOutputRegular(Cluster):
 
 
 class MultistateOutputExtended(Cluster):
-    cluster_id: Final = 0x0611
+    cluster_id: Final[t.uint16_t] = 0x0611
     ep_attribute: Final = "bacnet_extended_multistate_output"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -307,7 +307,7 @@ class MultistateOutputExtended(Cluster):
 
 
 class MultistateValueRegular(Cluster):
-    cluster_id: Final = 0x0612
+    cluster_id: Final[t.uint16_t] = 0x0612
     ep_attribute: Final = "bacnet_regular_multistate_value"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -318,7 +318,7 @@ class MultistateValueRegular(Cluster):
 
 
 class MultistateValueExtended(Cluster):
-    cluster_id: Final = 0x0613
+    cluster_id: Final[t.uint16_t] = 0x0613
     ep_attribute: Final = "bacnet_extended_multistate_value"
 
     class AttributeDefs(BaseAttributeDefs):

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -75,7 +75,7 @@ class IasZone(Cluster):
     ZoneStatus: Final = ZoneStatus
     EnrollResponse: Final = EnrollResponse
 
-    cluster_id: Final = 0x0500
+    cluster_id: Final[t.uint16_t] = 0x0500
     name: Final = "IAS Zone"
     ep_attribute: Final = "ias_zone"
 
@@ -241,7 +241,7 @@ class IasAce(Cluster):
     ZoneStatus: Final = IasZone.ZoneStatus
     ZoneStatusRsp: Final = ZoneStatusRsp
 
-    cluster_id: Final = 0x0501
+    cluster_id: Final[t.uint16_t] = 0x0501
     name: Final = "IAS Ancillary Control Equipment"
     ep_attribute: Final = "ias_ace"
 
@@ -484,7 +484,7 @@ class IasWd(Cluster):
     Warning: Final = WarningType
     Squawk: Final = Squawk
 
-    cluster_id: Final = 0x0502
+    cluster_id: Final[t.uint16_t] = 0x0502
     name: Final = "IAS Warning Device"
     ep_attribute: Final = "ias_wd"
 

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -13,12 +13,12 @@ from zigpy.zcl.foundation import (
 
 
 class Price(Cluster):
-    cluster_id: Final = 0x0700
+    cluster_id: Final[t.uint16_t] = 0x0700
     ep_attribute: Final = "smartenergy_price"
 
 
 class Drlc(Cluster):
-    cluster_id: Final = 0x0701
+    cluster_id: Final[t.uint16_t] = 0x0701
     ep_attribute: Final = "smartenergy_drlc"
 
 
@@ -44,7 +44,7 @@ class RegisteredTier(t.enum8):
 class Metering(Cluster):
     RegisteredTier: Final = RegisteredTier
 
-    cluster_id: Final = 0x0702
+    cluster_id: Final[t.uint16_t] = 0x0702
     ep_attribute: Final = "smartenergy_metering"
 
     class AttributeDefs(BaseAttributeDefs):
@@ -440,45 +440,45 @@ class Metering(Cluster):
 
 
 class Messaging(Cluster):
-    cluster_id: Final = 0x0703
+    cluster_id: Final[t.uint16_t] = 0x0703
     ep_attribute: Final = "smartenergy_messaging"
 
 
 class Tunneling(Cluster):
-    cluster_id: Final = 0x0704
+    cluster_id: Final[t.uint16_t] = 0x0704
     ep_attribute: Final = "smartenergy_tunneling"
 
 
 class Prepayment(Cluster):
-    cluster_id: Final = 0x0705
+    cluster_id: Final[t.uint16_t] = 0x0705
     ep_attribute: Final = "smartenergy_prepayment"
 
 
 class EnergyManagement(Cluster):
-    cluster_id: Final = 0x0706
+    cluster_id: Final[t.uint16_t] = 0x0706
     ep_attribute: Final = "smartenergy_energy_management"
 
 
 class Calendar(Cluster):
-    cluster_id: Final = 0x0707
+    cluster_id: Final[t.uint16_t] = 0x0707
     ep_attribute: Final = "smartenergy_calendar"
 
 
 class DeviceManagement(Cluster):
-    cluster_id: Final = 0x0708
+    cluster_id: Final[t.uint16_t] = 0x0708
     ep_attribute: Final = "smartenergy_device_management"
 
 
 class Events(Cluster):
-    cluster_id: Final = 0x0709
+    cluster_id: Final[t.uint16_t] = 0x0709
     ep_attribute: Final = "smartenergy_events"
 
 
 class MduPairing(Cluster):
-    cluster_id: Final = 0x070A
+    cluster_id: Final[t.uint16_t] = 0x070A
     ep_attribute: Final = "smartenergy_mdu_pairing"
 
 
 class KeyEstablishment(Cluster):
-    cluster_id: Final = 0x0800
+    cluster_id: Final[t.uint16_t] = 0x0800
     ep_attribute: Final = "smartenergy_key_establishment"


### PR DESCRIPTION
**REQUIRES** https://github.com/zigpy/workflows/pull/14

This pull request includes a variety of changes, primarily focusing on updating dependencies, modifying configuration files, and improving code readability. The most significant changes are the updates to the `jobs:` in the `.github/workflows/ci.yml` file and the removal of several repositories in the `.pre-commit-config.yaml` file. There are also several changes to the `zigpy` python files, with a focus on improving code readability and type safety.

Dependency and Configuration Updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL12-R14): Updated `CACHE_VERSION` from 2 to 3 and `PYTHON_VERSION_DEFAULT` from 3.9.15 to 3.9.18.
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L2-L32): Removed several repositories and updated the revisions of `mirrors-mypy` and `ruff-pre-commit`. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L2-L32) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L41-R15)
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L115-R114): Updated `pyupgrade` from `py37plus` to `py38plus`.
* [`requirements_test.txt`](diffhunk://#diff-8e46fa47648f051555a15d35f67ccace2ed6fcbb3404460adb964140d9f119a1L11): Removed `ruff==0.0.261` from the list of requirements.

Code Readability and Type Safety Improvements:
* `zigpy/group.py`, `zigpy/ota/image.py`, `zigpy/types/basic.py`, `zigpy/types/named.py`: Replaced string formatting with f-strings for improved readability. [[1]](diffhunk://#diff-e67b2ce2bf57be56010585ab3814bf0bd47abc0a4d2e09612768f1332006689fL88-R88) [[2]](diffhunk://#diff-1a8890fa01ed7508851d7ad9cd3bd426a374262ca7aab1178cdf69cd5307c57fL25-R25)
* `zigpy/ota/image.py`, `zigpy/types/basic.py`, `zigpy/types/named.py`: Added type ignore comments to suppress type checking warnings. [[1]](diffhunk://#diff-1a8890fa01ed7508851d7ad9cd3bd426a374262ca7aab1178cdf69cd5307c57fL245-R243) [[2]](diffhunk://#diff-3ff532aacf1c40ef428558c2dfef4d3cbc6f09b60df416fc25c6ca0a92cce304L56-R56) [[3]](diffhunk://#diff-ff53389916a14b4ad53305066b603ed0625184c5e04d6af901d9db0f896cc969L20-R20)
* `zigpy/zcl/clusters/closures.py`, `zigpy/zcl/clusters/general.py`: Updated `cluster_id` to use `t.uint16_t` for type safety. [[1]](diffhunk://#diff-bb53c66ffb6d941c12d67af33172944ec99397994accd1b16d33a159d416714dL36-R36) [[2]](diffhunk://#diff-0b4f6cbcedf1380a7f374102d05922298b8eb48fbb3a4cf635ffebec8de0cf89L217-R217)