### PR TITLE
fix: convert CONF_OTA_ADVANCED_DIR to a Path

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 """Test configuration."""
+
 import pathlib
 import warnings
 
@@ -206,3 +207,23 @@ def test_cv_json_file(tmp_path: pathlib.Path) -> None:
     # File exists
     path.write_text("{}")
     assert zigpy.config.validators.cv_json_file(str(path)) == path
+
+
+def test_cv_folder(tmp_path: pathlib.Path) -> None:
+    """ "Test `cv_folder` validator."""
+
+    folder_path = tmp_path / "folder"
+    file_path = tmp_path / "not_folder"
+
+    # Does not exist
+    with pytest.raises(vol.Invalid):
+        zigpy.config.validators.cv_folder(str(folder_path))
+
+    # Not a folder
+    file_path.write_text("")
+    with pytest.raises(vol.Invalid):
+        zigpy.config.validators.cv_folder(str(file_path))
+
+    # Folder exists
+    folder_path.mkdir()
+    assert zigpy.config.validators.cv_folder(str(folder_path)) == folder_path

--- a/zigpy/config/__init__.py
+++ b/zigpy/config/__init__.py
@@ -45,6 +45,7 @@ from zigpy.config.validators import (
     cv_boolean,
     cv_deprecated,
     cv_exact_object,
+    cv_folder,
     cv_hex,
     cv_json_file,
     cv_key,
@@ -185,7 +186,7 @@ SCHEMA_OTA = {
     # Advanced OTA config. You *do not* need to use this unless you're testing a new
     # OTA firmware that has no known metadata.
     vol.Optional(CONF_OTA_ADVANCED_DIR, default=CONF_OTA_ADVANCED_DIR_DEFAULT): vol.Any(
-        None, str
+        None, cv_folder
     ),
     vol.Optional(
         CONF_OTA_ALLOW_ADVANCED_DIR, default=CONF_OTA_ALLOW_ADVANCED_DIR_DEFAULT

--- a/zigpy/config/validators.py
+++ b/zigpy/config/validators.py
@@ -107,3 +107,13 @@ def cv_json_file(value: str) -> pathlib.Path:
         raise vol.Invalid(f"{value} is not a JSON file")
 
     return path
+
+
+def cv_folder(value: str) -> pathlib.Path:
+    """Validate a folder path."""
+    path = pathlib.Path(value)
+
+    if not path.is_dir():
+        raise vol.Invalid(f"{value} is not a directory")
+
+    return path

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -1,4 +1,5 @@
 """OTA support for Zigbee devices."""
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
This fixes the following when doing OTA updates with OTA files.

```
2024-03-21 00:34:26.503 DEBUG (MainThread) [zigpy.ota] Failed to load provider <zigpy.ota.providers.AdvancedFileProvider object at 0x7fb84ff994c0>
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/zigpy/ota/__init__.py", line 333, in get_ota_image
    index = await self._load_provider_index(provider)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zigpy/util.py", line 491, in replacement
    return await tasks[key]
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zigpy/ota/__init__.py", line 309, in _load_provider_index
    return await provider.load_index()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zigpy/ota/providers.py", line 160, in load_index
    return [meta async for meta in self._load_index(session)]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zigpy/ota/providers.py", line 432, in _load_index
    for path in self.image_dir.rglob("*"):
                ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'rglob'
```