### PR TITLE
Clean up listeners and increase API ergonomics

### DIFF
--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -14,8 +14,7 @@ from .async_mock import AsyncMock, MagicMock, call, patch, sentinel
 
 
 class Listenable(util.ListenableMixin):
-    def __init__(self):
-        self._listeners = {}
+    pass
 
 
 def test_listenable():

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -61,13 +61,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     _probe_configs: list[dict[str, Any]] = []
 
     def __init__(self, config: dict) -> None:
+        super().__init__()
         self.devices: dict[t.EUI64, zigpy.device.Device] = {}
         self.state: zigpy.state.State = zigpy.state.State()
-        self._listeners = {}
         self._config = self.SCHEMA(config)
         self._dblistener = None
         self._groups = zigpy.group.Groups(self)
-        self._listeners = {}
         self._send_sequence = 0
         self._tasks: set[asyncio.Future[Any]] = set()
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -72,6 +72,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     manufacturer_id_override = None
 
     def __init__(self, application: ControllerApplication, ieee: t.EUI64, nwk: t.NWK):
+        super().__init__()
         self._application: ControllerApplication = application
         self._ieee: t.EUI64 = ieee
         self.nwk: t.NWK = t.NWK(nwk)
@@ -83,7 +84,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._last_seen: datetime | None = None
         self._initialize_task: asyncio.Task | None = None
         self._group_scan_task: asyncio.Task | None = None
-        self._listeners = {}
         self._manufacturer: str | None = None
         self._model: str | None = None
         self.node_desc: zdo_t.NodeDescriptor | None = None

--- a/zigpy/topology.py
+++ b/zigpy/topology.py
@@ -40,8 +40,8 @@ class Topology(zigpy.util.ListenableMixin):
 
     def __init__(self, app: zigpy.application.ControllerApplication) -> None:
         """Instantiate."""
+        super().__init__()
         self._app: zigpy.application.ControllerApplication = app
-        self._listeners: dict = {}
         self._scan_task: asyncio.Task | None = None
         self._scan_loop_task: asyncio.Task | None = None
 

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -49,6 +49,11 @@ class ListenableMixin:
 
     def remove_listener(self, listener: ListenerMeta) -> None:
         if not isinstance(listener, ListenerMeta):
+            warnings.warn(
+                "Pass the output of `add_context_listener`, not the function itself",
+                DeprecationWarning,
+            )
+
             for meta in self._listeners:
                 if meta.obj == listener:
                     listener = meta

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -209,11 +209,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             cls._registry_range[cls.cluster_id_range] = cls
 
     def __init__(self, endpoint: EndpointType, is_server: bool = True) -> None:
+        super().__init__()
         self._endpoint: EndpointType = endpoint
         self._attr_cache: dict[int, Any] = {}
         self._attr_last_updated: dict[int, datetime] = {}
         self.unsupported_attributes: set[int | str] = set()
-        self._listeners = {}
         self._type: ClusterType = (
             ClusterType.Server if is_server else ClusterType.Client
         )

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -27,8 +27,8 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         Rejoin = 1 << 7
 
     def __init__(self, device):
+        super().__init__()
         self._device = device
-        self._listeners = {}
 
     def _serialize(self, command, *args):
         schema = types.CLUSTERS[command][1]


### PR DESCRIPTION
I think it would be easiest to add another method for listening to a *specific* listener event. The current approach of passing an object and having the object listen to *all* events is a little nonstandard. 

I've also added `kwarg` support. Not sure if this is the best way forward, as it maybe would be better to ensure we can only pass around dataclass event objects like zigpy/zha currently does.