### PR TITLE
Support Codecov v4 changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,5 @@ jobs:
       PRE_COMMIT_CACHE_PATH: ~/.cache/pre-commit
       PYTHON_VERSION_DEFAULT: 3.9.15
       MINIMUM_COVERAGE_PERCENTAGE: 99
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### ~~DRAFT -- do not merge yet (needs below workflow PR merged first, CI will fail for now)~~

Passes the `CODECOV_TOKEN` GH secret to the shared workflow.
Related PR with more information:
- https://github.com/zigpy/workflows/pull/17