### PR TITLE
Merge `in_clusters` and `out_clusters` in the database

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -24,11 +24,12 @@ import zigpy.types as t
 import zigpy.typing
 import zigpy.util
 from zigpy.zcl.clusters.general import Basic
+from zigpy.zcl import ClusterType
 from zigpy.zdo import types as zdo_t
 
 LOGGER = logging.getLogger(__name__)
 
-DB_VERSION = 12
+DB_VERSION = 13
 DB_V = f"_v{DB_VERSION}"
 MIN_SQLITE_VERSION = (3, 24, 0)
 
@@ -278,6 +279,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             "_save_attribute",
             cluster.endpoint.device.ieee,
             cluster.endpoint.endpoint_id,
+            cluster.cluster_type,
             cluster.cluster_id,
             attrid,
             value,
@@ -289,6 +291,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             "_clear_attribute",
             cluster.endpoint.device.ieee,
             cluster.endpoint.endpoint_id,
+            cluster.cluster_type,
             cluster.cluster_id,
             attrid,
         )
@@ -300,17 +303,23 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             "_unsupported_attribute_added",
             cluster.endpoint.device.ieee,
             cluster.endpoint.endpoint_id,
+            cluster.cluster_type,
             cluster.cluster_id,
             attrid,
         )
 
     async def _unsupported_attribute_added(
-        self, ieee: t.EUI64, endpoint_id: int, cluster_id: int, attrid: int
+        self,
+        ieee: t.EUI64,
+        endpoint_id: int,
+        cluster_id: int,
+        cluster_type: ClusterType,
+        attrid: int,
     ) -> None:
-        q = f"""INSERT INTO unsupported_attributes{DB_V} VALUES (?, ?, ?, ?)
-                   ON CONFLICT (ieee, endpoint_id, cluster, attrid)
+        q = f"""INSERT INTO unsupported_attributes{DB_V} VALUES (?, ?, ?, ?, ?)
+                   ON CONFLICT (ieee, endpoint_id, cluster_type, cluster_id, attr_id)
                    DO NOTHING"""
-        await self.execute(q, (ieee, endpoint_id, cluster_id, attrid))
+        await self.execute(q, (ieee, endpoint_id, cluster_type, cluster_id, attrid))
         await self._db.commit()
 
     def unsupported_attribute_removed(
@@ -320,18 +329,25 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             "_unsupported_attribute_removed",
             cluster.endpoint.device.ieee,
             cluster.endpoint.endpoint_id,
+            cluster.cluster_type,
             cluster.cluster_id,
             attrid,
         )
 
     async def _unsupported_attribute_removed(
-        self, ieee: t.EUI64, endpoint_id: int, cluster_id: int, attrid: int
+        self,
+        ieee: t.EUI64,
+        endpoint_id: int,
+        cluster_type: ClusterType,
+        cluster_id: int,
+        attrid: int,
     ) -> None:
         q = f"""DELETE FROM unsupported_attributes{DB_V} WHERE ieee = ?
                                                          AND endpoint_id = ?
-                                                         AND cluster = ?
-                                                         AND attrid = ?"""
-        await self.execute(q, (ieee, endpoint_id, cluster_id, attrid))
+                                                         AND cluster_type = ?
+                                                         AND cluster_id = ?
+                                                         AND attr_id = ?"""
+        await self.execute(q, (ieee, endpoint_id, cluster_type, cluster_id, attrid))
         await self._db.commit()
 
     def neighbors_updated(self, ieee: t.EUI64, neighbors: list[zdo_t.Neighbor]) -> None:
@@ -451,10 +467,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         await self._save_endpoints(device)
         for ep in device.non_zdo_endpoints:
-            await self._save_input_clusters(ep)
+            await self._save_clusters(ep)
             await self._save_attribute_cache(ep)
             await self._save_unsupported_attributes(ep)
-            await self._save_output_clusters(ep)
         await self._db.commit()
 
     async def _save_endpoints(self, device: zigpy.typing.DeviceType) -> None:
@@ -499,13 +514,18 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         await self.execute(q, (device.ieee,) + device.node_desc.as_tuple())
 
-    async def _save_input_clusters(self, endpoint: zigpy.typing.EndpointType) -> None:
+    async def _save_clusters(self, endpoint: zigpy.typing.EndpointType) -> None:
         clusters = [
-            (endpoint.device.ieee, endpoint.endpoint_id, cluster.cluster_id)
-            for cluster in endpoint.in_clusters.values()
+            (
+                endpoint.device.ieee,
+                endpoint.endpoint_id,
+                cluster.cluster_type,
+                cluster.cluster_id,
+            )
+            for cluster in endpoint.clusters
         ]
-        q = f"""INSERT INTO in_clusters{DB_V} VALUES (?, ?, ?)
-                    ON CONFLICT (ieee, endpoint_id, cluster)
+        q = f"""INSERT INTO clusters{DB_V} VALUES (?, ?, ?, ?)
+                    ON CONFLICT (ieee, endpoint_id, cluster_type, cluster_id)
                     DO NOTHING"""
         await self._db.executemany(q, clusters)
 
@@ -514,38 +534,35 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             (
                 ep.device.ieee,
                 ep.endpoint_id,
+                cluster.cluster_type,
                 cluster.cluster_id,
                 attrid,
                 value,
                 cluster._attr_last_updated.get(attrid, UNIX_EPOCH).timestamp(),
             )
-            for cluster in ep.in_clusters.values()
+            for cluster in ep.clusters
             for attrid, value in cluster._attr_cache.items()
         ]
-        q = f"""INSERT INTO attributes_cache{DB_V} VALUES (?, ?, ?, ?, ?, ?)
-                    ON CONFLICT (ieee, endpoint_id, cluster, attrid)
+        q = f"""INSERT INTO attributes_cache{DB_V} VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT (ieee, endpoint_id, cluster_type, cluster_id, attr_id)
                     DO UPDATE SET value=excluded.value, last_updated=excluded.last_updated"""
         await self._db.executemany(q, clusters)
 
     async def _save_unsupported_attributes(self, ep: zigpy.typing.EndpointType) -> None:
         clusters = [
-            (ep.device.ieee, ep.endpoint_id, cluster.cluster_id, attr)
-            for cluster in ep.in_clusters.values()
+            (
+                ep.device.ieee,
+                ep.endpoint_id,
+                cluster.cluster_type,
+                cluster.cluster_id,
+                attr,
+            )
+            for cluster in ep.clusters
             for attr in cluster.unsupported_attributes
             if isinstance(attr, int)
         ]
-        q = f"""INSERT INTO unsupported_attributes{DB_V} VALUES (?, ?, ?, ?)
-                    ON CONFLICT (ieee, endpoint_id, cluster, attrid)
-                    DO NOTHING"""
-        await self._db.executemany(q, clusters)
-
-    async def _save_output_clusters(self, endpoint: zigpy.typing.EndpointType) -> None:
-        clusters = [
-            (endpoint.device.ieee, endpoint.endpoint_id, cluster.cluster_id)
-            for cluster in endpoint.out_clusters.values()
-        ]
-        q = f"""INSERT INTO out_clusters{DB_V} VALUES (?, ?, ?)
-                    ON CONFLICT (ieee, endpoint_id, cluster)
+        q = f"""INSERT INTO unsupported_attributes{DB_V} VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT (ieee, endpoint_id, cluster_type, cluster_id, attr_id)
                     DO NOTHING"""
         await self._db.executemany(q, clusters)
 
@@ -553,6 +570,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         self,
         ieee: t.EUI64,
         endpoint_id: int,
+        cluster_type: ClusterType,
         cluster_id: int,
         attrid: int,
         value: Any,
@@ -560,8 +578,8 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     ) -> None:
         q = f"""
             INSERT INTO attributes_cache{DB_V}
-            VALUES (:ieee, :endpoint_id, :cluster_id, :attrid, :value, :timestamp)
-                ON CONFLICT (ieee, endpoint_id, cluster, attrid) DO UPDATE
+            VALUES (:ieee, :endpoint_id, :cluster_type, :cluster_id, :attr_id, :value, :timestamp)
+                ON CONFLICT (ieee, endpoint_id, cluster_type, cluster_id, attr_id) DO UPDATE
                 SET value=excluded.value, last_updated=excluded.last_updated
                 WHERE
                     value != excluded.value
@@ -572,8 +590,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             {
                 "ieee": ieee,
                 "endpoint_id": endpoint_id,
+                "cluster_type": cluster_type,
                 "cluster_id": cluster_id,
-                "attrid": attrid,
+                "attr_id": attrid,
                 "value": value,
                 "timestamp": timestamp.timestamp(),
                 "min_update_delta": MIN_UPDATE_DELTA,
@@ -585,6 +604,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         self,
         ieee: t.EUI64,
         endpoint_id: int,
+        cluster_type: ClusterType,
         cluster_id: int,
         attrid: int,
     ) -> None:
@@ -593,8 +613,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             WHERE
                 ieee = :ieee
                 AND endpoint_id = :endpoint_id
-                AND cluster = :cluster_id
-                AND attrid = :attrid
+                AND cluster_type = :cluster_type
+                AND cluster_id = :cluster_id
+                AND attr_id = :attr_id
             """
 
         await self.execute(
@@ -602,8 +623,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             {
                 "ieee": ieee,
                 "endpoint_id": endpoint_id,
+                "cluster_type": cluster_type,
                 "cluster_id": cluster_id,
-                "attrid": attrid,
+                "attr_id": attrid,
             },
         )
         await self._db.commit()
@@ -638,7 +660,16 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._load_clusters()
 
         # Quirks require the manufacturer and model name to be populated
-        await self._load_attributes("attrid=4 OR attrid=5")
+        await self._load_attributes(
+            f"""
+                cluster_type={ClusterType.Server}
+            AND cluster_id={Basic.cluster_id}
+            AND (
+                   attr_id={Basic.AttributeDefs.manufacturer.id}
+                OR attr_id={Basic.AttributeDefs.model.id}
+            )
+            """
+        )
 
         for device in self._application.devices.values():
             device = zigpy.quirks.get_device(device)
@@ -664,8 +695,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             async for (
                 ieee,
                 endpoint_id,
-                cluster,
-                attrid,
+                cluster_type,
+                cluster_id,
+                attr_id,
                 value,
                 last_updated,
             ) in cursor:
@@ -676,28 +708,33 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     continue
 
                 ep = dev.endpoints[endpoint_id]
+                clusters = (
+                    ep.in_clusters
+                    if cluster_type == ClusterType.Server
+                    else ep.out_clusters
+                )
 
-                if cluster not in ep.in_clusters:
+                if cluster_id not in clusters:
                     continue
 
-                ep.in_clusters[cluster]._attr_cache[attrid] = value
-                ep.in_clusters[cluster]._attr_last_updated[
-                    attrid
+                clusters[cluster_id]._attr_cache[attr_id] = value
+                clusters[cluster_id]._attr_last_updated[
+                    attr_id
                 ] = datetime.fromtimestamp(last_updated, timezone.utc)
 
                 LOGGER.debug(
                     "[0x%04x:%s:0x%04x] Attribute id: %s value: %s",
                     dev.nwk,
                     endpoint_id,
-                    cluster,
-                    attrid,
+                    cluster_id,
+                    attr_id,
                     value,
                 )
 
                 # Populate the device's manufacturer and model attributes
-                if cluster == Basic.cluster_id and attrid == 0x0004:
+                if cluster_id == Basic.cluster_id and attr_id == Basic.AttributeDefs.manufacturer.id:
                     dev.manufacturer = decode_str_attribute(value)
-                elif cluster == Basic.cluster_id and attrid == 0x0005:
+                elif cluster_id == Basic.cluster_id and attr_id == Basic.AttributeDefs.model.id:
                     dev.model = decode_str_attribute(value)
 
     async def _load_unsupported_attributes(self) -> None:
@@ -706,7 +743,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         async with self.execute(
             f"SELECT * FROM unsupported_attributes{DB_V}"
         ) as cursor:
-            async for (ieee, endpoint_id, cluster_id, attrid) in cursor:
+            async for (ieee, endpoint_id, cluster_id, attr_id) in cursor:
                 dev = self._application.get_device(ieee)
 
                 try:
@@ -719,7 +756,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 except KeyError:
                     continue
 
-                cluster.add_unsupported_attribute(attrid, inhibit_events=True)
+                cluster.add_unsupported_attribute(attr_id, inhibit_events=True)
 
     async def _load_devices(self) -> None:
         async with self.execute(f"SELECT * FROM devices{DB_V}") as cursor:
@@ -753,17 +790,15 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     ep.device_type = device_type
 
     async def _load_clusters(self) -> None:
-        async with self.execute(f"SELECT * FROM in_clusters{DB_V}") as cursor:
-            async for (ieee, endpoint_id, cluster) in cursor:
+        async with self.execute(f"SELECT * FROM clusters{DB_V}") as cursor:
+            async for (ieee, endpoint_id, cluster_type, cluster_id) in cursor:
                 dev = self._application.get_device(ieee)
                 ep = dev.endpoints[endpoint_id]
-                ep.add_input_cluster(cluster)
 
-        async with self.execute(f"SELECT * FROM out_clusters{DB_V}") as cursor:
-            async for (ieee, endpoint_id, cluster) in cursor:
-                dev = self._application.get_device(ieee)
-                ep = dev.endpoints[endpoint_id]
-                ep.add_output_cluster(cluster)
+                if ClusterType(cluster_type) == ClusterType.Server:
+                    ep.add_input_cluster(cluster_id)
+                else:
+                    ep.add_output_cluster(cluster_id)
 
     async def _load_groups(self) -> None:
         async with self.execute(f"SELECT * FROM groups{DB_V}") as cursor:
@@ -902,6 +937,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 (self._migrate_to_v10, 10),
                 (self._migrate_to_v11, 11),
                 (self._migrate_to_v12, 12),
+                (self._migrate_to_v13, 13),
             ]:
                 if db_version >= min(to_db_version, DB_VERSION):
                     continue
@@ -1205,4 +1241,68 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 await self.execute(
                     "INSERT INTO attributes_cache_v12 VALUES (?, ?, ?, ?, ?, ?)",
                     (ieee, endpoint_id, cluster_id, attrid, value, 0),
+                )
+
+    async def _migrate_to_v13(self):
+        """Schema v13 combines both cluster types and caching for all attributes."""
+
+        await self._migrate_tables(
+            {
+                "devices_v12": "devices_v13",
+                "endpoints_v12": "endpoints_v13",
+                "neighbors_v12": "neighbors_v13",
+                "routes_v12": "routes_v13",
+                "node_descriptors_v12": "node_descriptors_v13",
+                "groups_v12": "groups_v13",
+                "group_members_v12": "group_members_v13",
+                "relays_v12": "relays_v13",
+                "network_backups_v12": "network_backups_v13",
+                "in_clusters_v12": None,
+                "out_clusters_v12": None,
+                "unsupported_attributes_v12": None,
+                "attributes_cache_v12": None,
+            }
+        )
+
+        async with self.execute("SELECT * FROM in_clusters_v12") as cursor:
+            async for (ieee, endpoint_id, cluster_id) in cursor:
+                await self.execute(
+                    "INSERT INTO clusters_v13 VALUES (?, ?, ?, ?)",
+                    (ieee, endpoint_id, ClusterType.Server, cluster_id),
+                )
+
+        async with self.execute("SELECT * FROM out_clusters_v12") as cursor:
+            async for (ieee, endpoint_id, cluster_id) in cursor:
+                await self.execute(
+                    "INSERT INTO clusters_v13 VALUES (?, ?, ?, ?)",
+                    (ieee, endpoint_id, ClusterType.Client, cluster_id),
+                )
+
+        async with self.execute("SELECT * FROM unsupported_attributes_v12") as cursor:
+            async for (ieee, endpoint_id, cluster_id, attrid) in cursor:
+                await self.execute(
+                    "INSERT INTO unsupported_attributes_v13 VALUES (?, ?, ?, ?, ?)",
+                    (ieee, endpoint_id, ClusterType.Client, cluster_id, attrid),
+                )
+
+        async with self.execute("SELECT * FROM attributes_cache_v12") as cursor:
+            async for (
+                ieee,
+                endpoint_id,
+                cluster_id,
+                attrid,
+                value,
+                last_updated,
+            ) in cursor:
+                await self.execute(
+                    "INSERT INTO attributes_cache_v13 VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        ieee,
+                        endpoint_id,
+                        ClusterType.Client,
+                        cluster_id,
+                        attrid,
+                        value,
+                        last_updated,
+                    ),
                 )

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -743,7 +743,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         async with self.execute(
             f"SELECT * FROM unsupported_attributes{DB_V}"
         ) as cursor:
-            async for (ieee, endpoint_id, cluster_id, attr_id) in cursor:
+            async for (ieee, endpoint_id, cluster_type, cluster_id, attr_id) in cursor:
                 dev = self._application.get_device(ieee)
 
                 try:
@@ -751,8 +751,14 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 except KeyError:
                     continue
 
+                clusters = (
+                    ep.in_clusters
+                    if cluster_type == ClusterType.Server
+                    else ep.out_clusters
+                )
+
                 try:
-                    cluster = ep.in_clusters[cluster_id]
+                    cluster = clusters[cluster_id]
                 except KeyError:
                     continue
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -1288,7 +1288,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             async for (ieee, endpoint_id, cluster_id, attrid) in cursor:
                 await self.execute(
                     "INSERT INTO unsupported_attributes_v13 VALUES (?, ?, ?, ?, ?)",
-                    (ieee, endpoint_id, ClusterType.Client, cluster_id, attrid),
+                    (ieee, endpoint_id, ClusterType.Server, cluster_id, attrid),
                 )
 
         async with self.execute("SELECT * FROM attributes_cache_v12") as cursor:
@@ -1305,7 +1305,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     (
                         ieee,
                         endpoint_id,
-                        ClusterType.Client,
+                        ClusterType.Server,
                         cluster_id,
                         attrid,
                         value,

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -312,8 +312,8 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         self,
         ieee: t.EUI64,
         endpoint_id: int,
-        cluster_id: int,
         cluster_type: ClusterType,
+        cluster_id: int,
         attrid: int,
     ) -> None:
         q = f"""INSERT INTO unsupported_attributes{DB_V} VALUES (?, ?, ?, ?, ?)

--- a/zigpy/appdb_schemas/schema_v13.sql
+++ b/zigpy/appdb_schemas/schema_v13.sql
@@ -1,0 +1,214 @@
+PRAGMA user_version = 13;
+
+-- devices
+DROP TABLE IF EXISTS devices_v13;
+CREATE TABLE devices_v13 (
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+    last_seen REAL NOT NULL
+);
+
+CREATE UNIQUE INDEX devices_idx_v13
+    ON devices_v13(ieee);
+
+
+-- endpoints
+DROP TABLE IF EXISTS endpoints_v13;
+CREATE TABLE endpoints_v13 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    profile_id INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v13(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX endpoint_idx_v13
+    ON endpoints_v13(ieee, endpoint_id);
+
+
+-- clusters
+DROP TABLE IF EXISTS clusters_v13;
+CREATE TABLE clusters_v13 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v13(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX clusters_idx_v13
+    ON clusters_v13(ieee, endpoint_id, cluster_type, cluster_id);
+
+
+-- attributes
+DROP TABLE IF EXISTS attributes_cache_v13;
+CREATE TABLE attributes_cache_v13 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+    attr_id INTEGER NOT NULL,
+    value BLOB NOT NULL,
+    last_updated REAL NOT NULL,
+
+    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
+    -- DB but whose values still need to be cached
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v13(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX attributes_cache_idx_v13
+    ON attributes_cache_v13(ieee, endpoint_id, cluster_type, cluster_id, attr_id);
+
+
+-- neighbors
+DROP TABLE IF EXISTS neighbors_v13;
+CREATE TABLE neighbors_v13 (
+    device_ieee ieee NOT NULL,
+    extended_pan_id ieee NOT NULL,
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    rx_on_when_idle INTEGER NOT NULL,
+    relationship INTEGER NOT NULL,
+    reserved1 INTEGER NOT NULL,
+    permit_joining INTEGER NOT NULL,
+    reserved2 INTEGER NOT NULL,
+    depth INTEGER NOT NULL,
+    lqi INTEGER NOT NULL,
+
+    FOREIGN KEY(device_ieee)
+        REFERENCES devices_v13(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX neighbors_idx_v13
+    ON neighbors_v13(device_ieee);
+
+
+-- routes
+DROP TABLE IF EXISTS routes_v13;
+CREATE TABLE routes_v13 (
+    device_ieee ieee NOT NULL,
+    dst_nwk INTEGER NOT NULL,
+    route_status INTEGER NOT NULL,
+    memory_constrained INTEGER NOT NULL,
+    many_to_one INTEGER NOT NULL,
+    route_record_required INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    next_hop INTEGER NOT NULL
+);
+
+CREATE INDEX routes_idx_v13
+    ON routes_v13(device_ieee);
+
+
+-- node descriptors
+DROP TABLE IF EXISTS node_descriptors_v13;
+CREATE TABLE node_descriptors_v13 (
+    ieee ieee NOT NULL,
+
+    logical_type INTEGER NOT NULL,
+    complex_descriptor_available INTEGER NOT NULL,
+    user_descriptor_available INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    aps_flags INTEGER NOT NULL,
+    frequency_band INTEGER NOT NULL,
+    mac_capability_flags INTEGER NOT NULL,
+    manufacturer_code INTEGER NOT NULL,
+    maximum_buffer_size INTEGER NOT NULL,
+    maximum_incoming_transfer_size INTEGER NOT NULL,
+    server_mask INTEGER NOT NULL,
+    maximum_outgoing_transfer_size INTEGER NOT NULL,
+    descriptor_capability_field INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v13(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX node_descriptors_idx_v13
+    ON node_descriptors_v13(ieee);
+
+
+-- groups
+DROP TABLE IF EXISTS groups_v13;
+CREATE TABLE groups_v13 (
+    group_id INTEGER NOT NULL,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX groups_idx_v13
+    ON groups_v13(group_id);
+
+
+-- group members
+DROP TABLE IF EXISTS group_members_v13;
+CREATE TABLE group_members_v13 (
+    group_id INTEGER NOT NULL,
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+
+    FOREIGN KEY(group_id)
+        REFERENCES groups_v13(group_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v13(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX group_members_idx_v13
+    ON group_members_v13(group_id, ieee, endpoint_id);
+
+
+-- relays
+DROP TABLE IF EXISTS relays_v13;
+CREATE TABLE relays_v13 (
+    ieee ieee NOT NULL,
+    relays BLOB NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v13(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX relays_idx_v13
+    ON relays_v13(ieee);
+
+
+-- unsupported attributes
+DROP TABLE IF EXISTS unsupported_attributes_v13;
+CREATE TABLE unsupported_attributes_v13 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+    attr_id INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v13(ieee)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id, cluster_type, cluster_id)
+        REFERENCES clusters_v13(ieee, endpoint_id, cluster_type, cluster_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX unsupported_attributes_idx_v13
+    ON unsupported_attributes_v13(ieee, endpoint_id, cluster_type, cluster_id, attr_id);
+
+
+-- network backups
+DROP TABLE IF EXISTS network_backups_v13;
+CREATE TABLE network_backups_v13 (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    backup_json TEXT NOT NULL
+);

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -135,6 +135,13 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             cluster = zigpy.zcl.Cluster.from_id(self, cluster_id, is_server=False)
 
         self.out_clusters[cluster_id] = cluster
+
+        if self._device.application._dblistener is not None:
+            listener = zigpy.zcl.ClusterPersistingListener(
+                self._device.application._dblistener, cluster
+            )
+            cluster.add_listener(listener)
+
         return cluster
 
     async def add_to_group(self, grp_id: int, name: str | None = None) -> ZCLStatus:

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -90,6 +90,11 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         self.status = Status.ZDO_INIT
 
+    @property
+    def clusters(self) -> list[zigpy.zcl.Cluster]:
+        """Return all clusters on this endpoint."""
+        return list(self.in_clusters.values()) + list(self.out_clusters.values())
+
     def add_input_cluster(
         self, cluster_id: int, cluster: zigpy.zcl.Cluster | None = None
     ) -> zigpy.zcl.Cluster:

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -93,7 +93,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     @property
     def clusters(self) -> list[zigpy.zcl.Cluster]:
         """Return all clusters on this endpoint."""
-        return list(self.in_clusters.values()) + list(self.out_clusters.values())
+        return [*self.in_clusters.values(), *self.out_clusters.values()]
 
     def add_input_cluster(
         self, cluster_id: int, cluster: zigpy.zcl.Cluster | None = None

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -791,6 +791,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         )
 
     @property
+    def cluster_type(self) -> ClusterType:
+        """Return the type of this cluster."""
+        return self._type
+
+    @property
     def is_client(self) -> bool:
         """Return True if this is a client cluster."""
         return self._type == ClusterType.Client


### PR DESCRIPTION
While working on OTA startup caching issues, I noticed that our database format only really "operates" on `in_clusters` and ignores `out_clusters` for the attribute cache and the unsupported attribute table. This feels like a bug, as this isn't mirrored in `zcl/__init__.py`. To solve this, I am merging the two cluster tables into one and allowing output/client cluster attributes to be cached and marked unsupported.

This requires a database migration so I've also renamed `attrid` to `attr_id` in the columns to clean things up.