### PR TITLE
Fix closure command parsing with an invalid `CharacterString`

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -371,6 +371,15 @@ def test_char_string_too_short():
         t.CharacterString.deserialize(b"\x04123")
 
 
+def test_char_string_invalid():
+    r, rest = t.CharacterString.deserialize(b"\xFFabcd")
+    assert r == ""
+    assert r.invalid is True
+    assert rest == b"abcd"
+
+    assert r.serialize() == b"\xFF"
+
+
 def test_long_char_string():
     orig_len = 65532
     to_serialize = "".join(itertools.repeat("a", orig_len))

--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -677,7 +677,7 @@ class DoorLock(Cluster):
                 "local_time": t.LocalTime,
                 "data?": t.CharacterString,
             },
-            direction=False,
+            direction=True,
         )
         programming_event_notification: Final = ZCLCommandDef(
             id=0x21,
@@ -691,7 +691,7 @@ class DoorLock(Cluster):
                 "local_time": t.LocalTime,
                 "data?": t.CharacterString,
             },
-            direction=False,
+            direction=True,
         )
 
 


### PR DESCRIPTION
A device is sending an "invalid" CharacterString (really should be LVBytes for this cluster!). This is according to the spec and should be treated as an empty string.

Maybe there is a better way to store this flag, not on the type instance itself?