### PR TITLE
QuirksRegistryV2: BugFix MultipleQuirksMatchException when reloading ZHA integration

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -14,7 +14,6 @@ from zigpy.const import (
     SIG_MODELS_INFO,
 )
 from zigpy.device import Device
-from zigpy.exceptions import MultipleQuirksMatchException
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice, signature_matches
 from zigpy.quirks.registry import DeviceRegistry
@@ -187,13 +186,16 @@ async def test_quirks_v2_signature_match(device_mock):
 
 
 async def test_quirks_v2_multiple_quirks_added_once(device_mock):
-    """Test that adding multiple quirks v2 entries for the same device raises."""
+    """Test that adding multiple quirks v2 entries for the same device is registgered once."""
     registry = DeviceRegistry()
 
+    class CustomTestDevice1(CustomDeviceV2):
+        """Custom test device for testing quirks v2."""
     (
         add_to_registry_v2(
             device_mock.manufacturer, device_mock.model, registry=registry
         )
+        .device_class(CustomTestDevice1)
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .enum(
@@ -203,10 +205,13 @@ async def test_quirks_v2_multiple_quirks_added_once(device_mock):
         )
     )
 
+    class CustomTestDevice2(CustomDeviceV2):
+        """Custom test device for testing quirks v2."""
     (
         add_to_registry_v2(
             device_mock.manufacturer, device_mock.model, registry=registry
         )
+        .device_class(CustomTestDevice2)
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .enum(
@@ -217,7 +222,7 @@ async def test_quirks_v2_multiple_quirks_added_once(device_mock):
     )
 
     quirked = registry.get_device(device_mock)
-    assert not isinstance(quirked, CustomDeviceV2)
+    assert isinstance(quirked, CustomTestDevice1)
 
 
 async def test_quirks_v2_with_custom_device_class(device_mock):

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -186,7 +186,7 @@ async def test_quirks_v2_signature_match(device_mock):
     assert not isinstance(quirked, CustomDeviceV2)
 
 
-async def test_quirks_v2_multiple_matches_raises(device_mock):
+async def test_quirks_v2_multiple_quirks_added_once(device_mock):
     """Test that adding multiple quirks v2 entries for the same device raises."""
     registry = DeviceRegistry()
 
@@ -216,10 +216,8 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
         )
     )
 
-    with pytest.raises(
-        MultipleQuirksMatchException, match="Multiple matches found for device"
-    ):
-        registry.get_device(device_mock)
+    quirked = registry.get_device(device_mock)
+    assert not isinstance(quirked, CustomDeviceV2)
 
 
 async def test_quirks_v2_with_custom_device_class(device_mock):

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -58,7 +58,7 @@ class DeviceRegistry:
             if not entry.registry:
                 entry.registry = self
             self._registry_v2[key].append(entry)        
-        return self._registry_v2[key]
+        return self._registry_v2[key][0]
 
     def remove(self, custom_device: CustomDeviceType) -> None:
         """Remove a device from the registry"""

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -54,10 +54,11 @@ class DeviceRegistry:
     ) -> QuirksV2RegistryEntry:
         """Add an entry to the registry."""
         key = (manufacturer, model)
-        if not entry.registry:
-            entry.registry = self
-        self._registry_v2[key].append(entry)
-        return entry
+        if key not in self._registry_v2:
+            if not entry.registry:
+                entry.registry = self
+            self._registry_v2[key].append(entry)        
+        return self._registry_v2[key]
 
     def remove(self, custom_device: CustomDeviceType) -> None:
         """Remove a device from the registry"""

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -57,7 +57,7 @@ class DeviceRegistry:
         if key not in self._registry_v2:
             if not entry.registry:
                 entry.registry = self
-            self._registry_v2[key].append(entry)        
+            self._registry_v2[key].append(entry)
         return self._registry_v2[key][0]
 
     def remove(self, custom_device: CustomDeviceType) -> None:


### PR DESCRIPTION
solves MultipleQuirksMatchException when reloading zha integration. for further details see issue #1410 