### PR TITLE
Raise an exception when an invalid attribute value is written

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -415,8 +415,10 @@ async def test_write_unknown_attribute(cluster):
 
 async def test_write_attributes_wrong_type(cluster):
     with patch.object(cluster, "_write_attributes", new=AsyncMock()):
-        await cluster.write_attributes({18: 0x2222})
-        assert cluster._write_attributes.call_count == 1
+        with pytest.raises(ValueError):
+            await cluster.write_attributes({18: 0x2222})
+
+        assert cluster._write_attributes.call_count == 0
 
 
 async def test_write_attributes_raw(cluster):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -605,14 +605,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             except ValueError as e:
                 if isinstance(attrid, int):
                     attrid = f"0x{attrid:04X}"
-                self.error(
-                    "Failed to convert attribute %s from %s (%s) to type %s: %s",
-                    str(attrid),
-                    value,
-                    type(value),
-                    attr_def.type,
-                    e,
-                )
+
+                raise ValueError(
+                    f"Failed to convert attribute {attrid} from {value!r}"
+                    f" ({type(value)}) to type {attr_def.type}"
+                ) from e
             else:
                 args.append(attr)
 


### PR DESCRIPTION
Currently, we log an error but allow the write to proceed. This can result in empty attribute writes occurring.