### PR TITLE
Open serial ports exclusively by default and implement `flow_control` as a kwarg

### DIFF
--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest.mock
 
 import zigpy.serial
@@ -9,11 +10,12 @@ import zigpy.serial
         return_value=(unittest.mock.AsyncMock(), unittest.mock.AsyncMock())
     ),
 )
-async def test_serial_normal(event_loop):
+async def test_serial_normal() -> None:
+    loop = asyncio.get_running_loop()
     protocol_factory = unittest.mock.Mock()
 
     await zigpy.serial.create_serial_connection(
-        event_loop, protocol_factory, "/dev/ttyUSB1"
+        loop, protocol_factory, "/dev/ttyUSB1"
     )
 
     mock_calls = zigpy.serial.pyserial_asyncio.create_serial_connection.mock_calls
@@ -21,25 +23,26 @@ async def test_serial_normal(event_loop):
     assert mock_calls[0].kwargs["url"] == "/dev/ttyUSB1"
 
 
-async def test_serial_socket(event_loop):
+async def test_serial_socket() -> None:
+    loop = asyncio.get_running_loop()
     protocol_factory = unittest.mock.Mock()
 
     with unittest.mock.patch.object(
-        event_loop,
+        loop,
         "create_connection",
         unittest.mock.AsyncMock(
             return_value=(unittest.mock.AsyncMock(), unittest.mock.AsyncMock())
         ),
     ):
         await zigpy.serial.create_serial_connection(
-            event_loop, protocol_factory, "socket://1.2.3.4:5678"
+            loop, protocol_factory, "socket://1.2.3.4:5678"
         )
         await zigpy.serial.create_serial_connection(
-            event_loop, protocol_factory, "socket://1.2.3.4"
+            loop, protocol_factory, "socket://1.2.3.4"
         )
 
-        assert len(event_loop.create_connection.mock_calls) == 2
-        assert event_loop.create_connection.mock_calls[0].kwargs["host"] == "1.2.3.4"
-        assert event_loop.create_connection.mock_calls[0].kwargs["port"] == 5678
-        assert event_loop.create_connection.mock_calls[1].kwargs["host"] == "1.2.3.4"
-        assert event_loop.create_connection.mock_calls[1].kwargs["port"] == 6638
+        assert len(loop.create_connection.mock_calls) == 2
+        assert loop.create_connection.mock_calls[0].kwargs["host"] == "1.2.3.4"
+        assert loop.create_connection.mock_calls[0].kwargs["port"] == 5678
+        assert loop.create_connection.mock_calls[1].kwargs["host"] == "1.2.3.4"
+        assert loop.create_connection.mock_calls[1].kwargs["port"] == 6638

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import asyncio
 import unittest.mock

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,26 +1,67 @@
+import pytest
 import asyncio
 import unittest.mock
 
 import zigpy.serial
+from zigpy.typing import UNDEFINED, UndefinedType
 
+# fmt: off
+@pytest.mark.parametrize(("url", "flow_control", "xonxoff", "rtscts", "expected_kwargs"), [
+    # `flow_control` on its own
+    ("/dev/ttyUSB1", "hardware", UNDEFINED, UNDEFINED, {"xonxoff": False, "rtscts": True}),
+    ("/dev/ttyUSB1", "software", UNDEFINED, UNDEFINED, {"xonxoff": True,  "rtscts": False}),
+    ("/dev/ttyUSB1", None,       UNDEFINED, UNDEFINED, {"xonxoff": False, "rtscts": False}),
 
-@unittest.mock.patch(
-    "zigpy.serial.pyserial_asyncio.create_serial_connection",
-    unittest.mock.AsyncMock(
-        return_value=(unittest.mock.AsyncMock(), unittest.mock.AsyncMock())
-    ),
-)
-async def test_serial_normal() -> None:
+    # `flow_control` overrides `xonxoff` and `rtscts`
+    ("/dev/ttyUSB1", "hardware", True,      False,     {"xonxoff": False, "rtscts": True}),
+    ("/dev/ttyUSB1", "software", False,      True,     {"xonxoff": True,  "rtscts": False}),
+    ("/dev/ttyUSB1", None,       True,      False,     {"xonxoff": False, "rtscts": False}),
+
+    # `flow_control` defaults to undefined so `xonxoff` and `rtscts` are used
+    ("/dev/ttyUSB1", UNDEFINED,  True,      False,     {"xonxoff": True,  "rtscts": False}),
+    ("/dev/ttyUSB1", UNDEFINED,  False,      True,     {"xonxoff": False, "rtscts": True}),
+    ("/dev/ttyUSB1", UNDEFINED,  True,       True,     {"xonxoff": True,  "rtscts": True}),
+
+    # The defaults are used when `flow_control`, `xonxoff`, and `rtscts` are all undefined
+    ("/dev/ttyUSB1", UNDEFINED,  UNDEFINED, UNDEFINED, {"xonxoff": False, "rtscts": False}),
+])
+# fmt: on
+async def test_serial_normal(
+    url: str,
+    flow_control: str | UndefinedType,
+    xonxoff: bool | UndefinedType,
+    rtscts: bool | UndefinedType,
+    expected_kwargs: dict[str, bool],
+) -> None:
     loop = asyncio.get_running_loop()
     protocol_factory = unittest.mock.Mock()
 
-    await zigpy.serial.create_serial_connection(
-        loop, protocol_factory, "/dev/ttyUSB1"
-    )
+    kwargs = {"url": url}
 
-    mock_calls = zigpy.serial.pyserial_asyncio.create_serial_connection.mock_calls
+    if flow_control is not UNDEFINED:
+        kwargs["flow_control"] = flow_control
+
+    if xonxoff is not UNDEFINED:
+        kwargs["xonxoff"] = xonxoff
+
+    if rtscts is not UNDEFINED:
+        kwargs["rtscts"] = rtscts
+
+    with unittest.mock.patch(
+        "zigpy.serial.pyserial_asyncio.create_serial_connection",
+        unittest.mock.AsyncMock(
+            return_value=(unittest.mock.AsyncMock(), unittest.mock.AsyncMock())
+        ),
+    ) as mock_create_serial_connection:
+        await zigpy.serial.create_serial_connection(loop, protocol_factory, **kwargs)
+
+    mock_calls = mock_create_serial_connection.mock_calls
     assert len(mock_calls) == 1
+
     assert mock_calls[0].kwargs["url"] == "/dev/ttyUSB1"
+
+    for kwarg in expected_kwargs:
+        assert mock_calls[0].kwargs[kwarg] == expected_kwargs[kwarg]
 
 
 async def test_serial_socket() -> None:

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -6,9 +6,9 @@ import typing
 import urllib.parse
 
 import async_timeout
-import serial as pyserial
 
 from typing import Literal
+from zigpy.typing import UndefinedType, UNDEFINED
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_SOCKET_PORT = 6638
@@ -28,26 +28,26 @@ async def create_serial_connection(
     url: str,
     *,
     baudrate: int = 115200,  # We default to 115200 instead of 9600
-    parity: Literal[
-        pyserial.PARITY_NONE,
-        pyserial.PARITY_EVEN,
-        pyserial.PARITY_ODD,
-        pyserial.PARITY_MARK,
-        pyserial.PARITY_SPACE,
-    ] = pyserial.PARITY_NONE,
-    stopbits: Literal[
-        pyserial.STOPBITS_ONE,
-        pyserial.STOPBITS_ONE_POINT_FIVE,
-        pyserial.STOPBITS_TWO,
-    ] = pyserial.STOPBITS_ONE,
     exclusive: bool = True,  # We open serial ports exclusively by default
-    xonxoff: bool = False,
-    rtscts: bool = False,
+    xonxoff: bool | UndefinedType = UNDEFINED,
+    rtscts: bool | UndefinedType = UNDEFINED,
+    flow_control: Literal["hardware", "software", None] | UndefinedType = UNDEFINED,
     **kwargs: typing.Any,
 ) -> tuple[asyncio.Transport, asyncio.Protocol]:
     """Wrapper around pyserial-asyncio that transparently substitutes a normal TCP
     transport and protocol when a `socket` connection URI is provided.
     """
+
+    if flow_control is not UNDEFINED:
+        xonxoff = (flow_control == "software")
+        rtscts = (flow_control == "hardware")
+
+    if xonxoff is UNDEFINED:
+        xonxoff = False
+
+    if rtscts is UNDEFINED:
+        rtscts = False
+
     LOGGER.debug(
         "Opening a serial connection to %r (baudrate=%s, xonxoff=%s, rtscts=%s)",
         url,

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -27,6 +27,9 @@ async def create_serial_connection(
     *,
     parity=pyserial.PARITY_NONE,
     stopbits=pyserial.STOPBITS_ONE,
+    exclusive: bool = True,  # We open serial ports exclusively by default
+    xonxoff: bool = False,
+    rtscts: bool = False,
     **kwargs: typing.Any,
 ) -> tuple[asyncio.Transport, asyncio.Protocol]:
     """Wrapper around pyserial-asyncio that transparently substitutes a normal TCP
@@ -46,7 +49,13 @@ async def create_serial_connection(
             )
     else:
         transport, protocol = await pyserial_asyncio.create_serial_connection(
-            loop, protocol_factory, url=url, **kwargs
+            loop,
+            protocol_factory,
+            url=url,
+            exclusive=exclusive,
+            xonxoff=xonxoff,
+            rtscts=rtscts,
+            **kwargs,
         )
 
     return transport, protocol

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -27,7 +27,7 @@ async def create_serial_connection(
     protocol_factory: typing.Callable[[], asyncio.Protocol],
     url: str,
     *,
-    baudrate: int,
+    baudrate: int = 115200,  # We default to 115200 instead of 9600
     parity: Literal[
         pyserial.PARITY_NONE,
         pyserial.PARITY_EVEN,

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -8,6 +8,8 @@ import urllib.parse
 import async_timeout
 import serial as pyserial
 
+from typing import Literal
+
 LOGGER = logging.getLogger(__name__)
 DEFAULT_SOCKET_PORT = 6638
 SOCKET_CONNECT_TIMEOUT = 5
@@ -25,8 +27,19 @@ async def create_serial_connection(
     protocol_factory: typing.Callable[[], asyncio.Protocol],
     url: str,
     *,
-    parity=pyserial.PARITY_NONE,
-    stopbits=pyserial.STOPBITS_ONE,
+    baudrate: int,
+    parity: Literal[
+        pyserial.PARITY_NONE,
+        pyserial.PARITY_EVEN,
+        pyserial.PARITY_ODD,
+        pyserial.PARITY_MARK,
+        pyserial.PARITY_SPACE,
+    ] = pyserial.PARITY_NONE,
+    stopbits: Literal[
+        pyserial.STOPBITS_ONE,
+        pyserial.STOPBITS_ONE_POINT_FIVE,
+        pyserial.STOPBITS_TWO,
+    ] = pyserial.STOPBITS_ONE,
     exclusive: bool = True,  # We open serial ports exclusively by default
     xonxoff: bool = False,
     rtscts: bool = False,
@@ -35,7 +48,6 @@ async def create_serial_connection(
     """Wrapper around pyserial-asyncio that transparently substitutes a normal TCP
     transport and protocol when a `socket` connection URI is provided.
     """
-    baudrate: int | None = kwargs.get("baudrate")
     LOGGER.debug("Opening a serial connection to %r (%s baudrate)", url, baudrate)
 
     parsed_url = urllib.parse.urlparse(url)

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -48,7 +48,13 @@ async def create_serial_connection(
     """Wrapper around pyserial-asyncio that transparently substitutes a normal TCP
     transport and protocol when a `socket` connection URI is provided.
     """
-    LOGGER.debug("Opening a serial connection to %r (%s baudrate)", url, baudrate)
+    LOGGER.debug(
+        "Opening a serial connection to %r (baudrate=%s, xonxoff=%s, rtscts=%s)",
+        url,
+        baudrate,
+        xonxoff,
+        rtscts,
+    )
 
     parsed_url = urllib.parse.urlparse(url)
 

--- a/zigpy/typing.py
+++ b/zigpy/typing.py
@@ -1,5 +1,6 @@
 """Typing helpers for Zigpy."""
 from __future__ import annotations
+import enum
 
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -15,6 +16,15 @@ DeviceType = "Device"
 EndpointType = "Endpoint"
 ZDOType = "ZDO"
 AddressingMode = "AddressingMode"
+
+
+class UndefinedType(enum.Enum):
+    """Singleton type for use with not set sentinel values."""
+
+    _singleton = 0
+
+UNDEFINED = UndefinedType._singleton  # noqa: SLF001
+
 
 if TYPE_CHECKING:
     import zigpy.application


### PR DESCRIPTION
This should help ZHA and the flashing tools avoid issues with other processes interrupting communication.

pyserial uses `flock` internally on Linux. Windows does this by default.