### PR TITLE
Fix blocking `image_dir.rglob("*")` call

### DIFF
--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import time
 import asyncio
 import logging
+import typing
 import sys
 
 import pytest
@@ -584,3 +586,17 @@ def test_deprecated():
 
     with pytest.raises(AttributeError):
         obj("baz")
+
+
+async def test_async_iterate_in_chunks() -> None:
+    def iterator(n: int) ->  typing.Generator[int, None, None]:
+        for i in range(n):
+            time.sleep(0.1)
+            yield i
+
+    chunks = []
+
+    async for chunk in util.async_iterate_in_chunks(iterator(10), chunk_size=3):
+        chunks.append(chunk)
+
+    assert chunks == [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -506,12 +506,9 @@ async def async_iterate_in_chunks(
     iterator = iter(iterable)
 
     while True:
-        try:
-            chunk = await loop.run_in_executor(
-                None, list, itertools.islice(iterator, chunk_size)
-            )
-        except StopIteration:
-            break
+        chunk = await loop.run_in_executor(
+            None, list, itertools.islice(iterator, chunk_size)
+        )
 
         if not chunk:
             break

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -8,6 +8,7 @@ import logging
 import traceback
 import typing
 import warnings
+import itertools
 
 from crccheck.crc import CrcX25
 from cryptography.hazmat.primitives.ciphers import Cipher
@@ -19,6 +20,8 @@ from zigpy.exceptions import ControllerException, ZigbeeException
 import zigpy.types as t
 
 LOGGER = logging.getLogger(__name__)
+
+_T = typing.TypeVar("_T")
 
 
 class ListenableMixin:
@@ -494,3 +497,23 @@ def combine_concurrent_calls(
             del tasks[key]
 
     return replacement
+
+async def async_iterate_in_chunks(
+    iterable: typing.Iterable[_T], chunk_size: int
+) -> typing.AsyncGenerator[list[_T], None]:
+    """Safely iterate over a synchronous iterable in chunks."""
+    loop = asyncio.get_running_loop()
+    iterator = iter(iterable)
+
+    while True:
+        try:
+            chunk = await loop.run_in_executor(
+                None, list, itertools.islice(iterator, chunk_size)
+            )
+        except StopIteration:
+            break
+
+        if not chunk:
+            break
+
+        yield chunk


### PR DESCRIPTION
Instead of consuming the entire iterator in a thread, I've opted to do 100 items at a time to free up the thread every once in a while.