### PR TITLE
Prevent loading the same quirk multiple times

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     'pyserial-asyncio; platform_system!="Windows"',
     'pyserial-asyncio!=0.5; platform_system=="Windows"',
     "typing_extensions",
+    "frozendict",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -98,7 +98,7 @@ async def test_quirks_v2(device_mock):
             # pylint: disable=disallowed-name, invalid-name
             report: Final = ZCLAttributeDef(id=0x0000, type=t.uint8_t)
 
-    (
+    entry = (
         add_to_registry_v2(
             device_mock.manufacturer, device_mock.model, registry=registry
         )
@@ -115,6 +115,9 @@ async def test_quirks_v2(device_mock):
         )
         .build()
     )
+
+    # coverage for overridden __eq__ method
+    assert entry.adds_metadata[0] != entry.adds_metadata[1]
 
     quirked = registry.get_device(device_mock)
     assert isinstance(quirked, CustomDeviceV2)
@@ -649,6 +652,11 @@ async def test_quirks_v2_command_button(device_mock):
             OnOff.cluster_id,
             command_kwargs={"on_off_control": OnOff.OnOffControl.Accept_Only_When_On},
         )
+        .command_button(
+            OnOff.ServerCommandDefs.on_with_timed_off.name,
+            OnOff.cluster_id,
+            command_kwargs={"on_off_control_foo": OnOff.OnOffControl.Accept_Only_When_On},
+        )
         .build()
     )
 
@@ -670,6 +678,12 @@ async def test_quirks_v2_command_button(device_mock):
     assert button.command_name == OnOff.ServerCommandDefs.on_with_timed_off.name
     assert len(button.kwargs) == 1
     assert button.kwargs["on_off_control"] == OnOff.OnOffControl.Accept_Only_When_On
+
+    # coverage for overridden eq method
+    assert button != quirked_device.exposes_metadata[
+        (1, OnOff.cluster_id, ClusterType.Server)
+    ][1]
+
 
 
 async def test_quirks_v2_also_applies_to(device_mock):

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -113,6 +113,7 @@ async def test_quirks_v2(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
+        .build()
     )
 
     quirked = registry.get_device(device_mock)
@@ -180,6 +181,7 @@ async def test_quirks_v2_signature_match(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
+        .build()
     )
 
     quirked = registry.get_device(device_mock)
@@ -201,6 +203,50 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
+        .build()
+    )
+
+    (
+        add_to_registry_v2(
+            device_mock.manufacturer, device_mock.model, registry=registry
+        )
+        .adds(Basic.cluster_id)
+        .adds(OnOff.cluster_id)
+        .adds(Identify.cluster_id)
+        .enum(
+            OnOff.AttributeDefs.start_up_on_off.name,
+            OnOff.StartUpOnOff,
+            OnOff.cluster_id,
+        )
+        .build()
+    )
+
+    with pytest.raises(
+        MultipleQuirksMatchException, match="Multiple matches found for device"
+    ):
+        registry.get_device(device_mock)
+
+
+async def test_quirks_v2_multiple_matches_not_raises(device_mock):
+    """Test that adding multiple quirks v2 entries for the same device doesn't raise.
+
+       When the quirk is EXACTLY the same the semantics of sets prevents us from
+       having multiple quirks in the registry.
+    """
+    registry = DeviceRegistry()
+
+    (
+        add_to_registry_v2(
+            device_mock.manufacturer, device_mock.model, registry=registry
+        )
+        .adds(Basic.cluster_id)
+        .adds(OnOff.cluster_id)
+        .enum(
+            OnOff.AttributeDefs.start_up_on_off.name,
+            OnOff.StartUpOnOff,
+            OnOff.cluster_id,
+        )
+        .build()
     )
 
     (
@@ -214,12 +260,10 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
+        .build()
     )
 
-    with pytest.raises(
-        MultipleQuirksMatchException, match="Multiple matches found for device"
-    ):
-        registry.get_device(device_mock)
+    assert isinstance(registry.get_device(device_mock), CustomDeviceV2)
 
 
 async def test_quirks_v2_with_custom_device_class(device_mock):
@@ -241,6 +285,7 @@ async def test_quirks_v2_with_custom_device_class(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
+        .build()
     )
 
     assert isinstance(registry.get_device(device_mock), CustomTestDevice)
@@ -275,6 +320,7 @@ async def test_quirks_v2_with_node_descriptor(device_mock):
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .node_descriptor(node_descriptor)
+        .build()
     )
 
     quirked: CustomDeviceV2 = registry.get_device(device_mock)
@@ -293,6 +339,7 @@ async def test_quirks_v2_skip_configuration(device_mock):
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .skip_configuration()
+        .build()
     )
 
     quirked: CustomDeviceV2 = registry.get_device(device_mock)
@@ -308,6 +355,7 @@ async def test_quirks_v2_removes(device_mock):
         add_to_registry_v2(
             device_mock.manufacturer, device_mock.model, registry=registry
         ).removes(Identify.cluster_id)
+        .build()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -329,6 +377,7 @@ async def test_quirks_v2_apply_custom_configuration(device_mock):
         )
         .adds(CustomOnOffCluster)
         .adds(CustomOnOffCluster, cluster_type=ClusterType.Client)
+        .build()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -365,6 +414,7 @@ async def test_quirks_v2_sensor(device_mock):
         )
         .adds(OnOff.cluster_id)
         .sensor(OnOff.AttributeDefs.on_time.name, OnOff.cluster_id)
+        .build()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -405,6 +455,7 @@ async def test_quirks_v2_sensor_validation_failure_translation_key(device_mock):
                 device_class="bad",
                 translation_key="bad",
             )
+            .build()
         )
 
 
@@ -424,6 +475,7 @@ async def test_quirks_v2_sensor_validation_failure_unit(device_mock):
                 device_class="bad",
                 unit="bad",
             )
+            .build()
         )
 
 
@@ -442,6 +494,7 @@ async def test_quirks_v2_switch(device_mock):
             force_inverted=True,
             invert_attribute_name=OnOff.AttributeDefs.off_wait_time.name,
         )
+        .build()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -482,6 +535,7 @@ async def test_quirks_v2_number(device_mock):
             step=1,
             unit="s",
         )
+        .build()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -521,6 +575,7 @@ async def test_quirks_v2_binary_sensor(device_mock):
             OnOff.AttributeDefs.on_off.name,
             OnOff.cluster_id,
         )
+        .build()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -555,6 +610,7 @@ async def test_quirks_v2_write_attribute_button(device_mock):
             20,
             OnOff.cluster_id,
         )
+        .build()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -590,6 +646,7 @@ async def test_quirks_v2_command_button(device_mock):
             OnOff.cluster_id,
             command_kwargs={"on_off_control": OnOff.OnOffControl.Accept_Only_When_On},
         )
+        .build()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -633,6 +690,7 @@ async def test_quirks_v2_also_applies_to(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
+        .build()
     )
 
     assert isinstance(registry.get_device(device_mock), CustomTestDevice)
@@ -672,6 +730,7 @@ async def test_quirks_v2_with_custom_device_class_raises(device_mock):
                 OnOff.StartUpOnOff,
                 OnOff.cluster_id,
             )
+            .build()
         )
 
 
@@ -841,6 +900,7 @@ async def test_quirks_v2_matches_v1(app_mock):
         .replaces(PowerConfig1CRCluster)
         .replaces(ScenesCluster, cluster_type=ClusterType.Client)
         .device_automation_triggers(triggers)
+        .build()
     )
 
     quirked_v2 = registry.get_device(ikea_device)

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -25,11 +25,11 @@ from zigpy.quirks.v2 import (
     EntityPlatform,
     EntityType,
     NumberMetadata,
+    QuirkBuilder,
     SwitchMetadata,
     WriteAttributeButtonMetadata,
     ZCLCommandButtonMetadata,
     ZCLSensorMetadata,
-    add_to_registry_v2,
 )
 import zigpy.types as t
 from zigpy.zcl import ClusterType
@@ -99,9 +99,7 @@ async def test_quirks_v2(device_mock):
             report: Final = ZCLAttributeDef(id=0x0000, type=t.uint8_t)
 
     entry = (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .filter(signature_matches(signature))
         .adds(
             TestCustomCluster,
@@ -113,7 +111,7 @@ async def test_quirks_v2(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     # coverage for overridden __eq__ method
@@ -123,7 +121,7 @@ async def test_quirks_v2(device_mock):
     quirked = registry.get_device(device_mock)
     assert isinstance(quirked, CustomDeviceV2)
     assert quirked in registry
-    # this would need to be updated if the line number of the call to add_to_registry_v2
+    # this would need to be updated if the line number of the call to QuirkBuilder
     # changes in this test in the future
     assert quirked.quirk_metadata.quirk_location.endswith(
         "zigpy/tests/test_quirks_v2.py]-line:102"
@@ -174,9 +172,7 @@ async def test_quirks_v2_signature_match(device_mock):
     }
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .filter(signature_matches(signature_no_match))
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
@@ -185,7 +181,7 @@ async def test_quirks_v2_signature_match(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     quirked = registry.get_device(device_mock)
@@ -197,9 +193,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
     registry = DeviceRegistry()
 
     entry1 = (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .enum(
@@ -207,13 +201,11 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     entry2 = (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .adds(Identify.cluster_id)
@@ -222,7 +214,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     assert entry1 != entry2
@@ -243,9 +235,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
     registry = DeviceRegistry()
 
     entry1 = (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .enum(
@@ -253,13 +243,11 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     entry2 = (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .enum(
@@ -267,7 +255,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     assert entry1 == entry2
@@ -283,9 +271,7 @@ async def test_quirks_v2_with_custom_device_class(device_mock):
         """Custom test device for testing quirks v2."""
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .device_class(CustomTestDevice)
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
@@ -294,7 +280,7 @@ async def test_quirks_v2_with_custom_device_class(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     assert isinstance(registry.get_device(device_mock), CustomTestDevice)
@@ -323,13 +309,11 @@ async def test_quirks_v2_with_node_descriptor(device_mock):
     assert device_mock.node_desc != node_descriptor
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .node_descriptor(node_descriptor)
-        .build()
+        .add_to_registry()
     )
 
     quirked: CustomDeviceV2 = registry.get_device(device_mock)
@@ -342,13 +326,11 @@ async def test_quirks_v2_skip_configuration(device_mock):
     registry = DeviceRegistry()
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(Basic.cluster_id)
         .adds(OnOff.cluster_id)
         .skip_configuration()
-        .build()
+        .add_to_registry()
     )
 
     quirked: CustomDeviceV2 = registry.get_device(device_mock)
@@ -361,11 +343,9 @@ async def test_quirks_v2_removes(device_mock):
     registry = DeviceRegistry()
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .removes(Identify.cluster_id)
-        .build()
+        .add_to_registry()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -382,12 +362,10 @@ async def test_quirks_v2_apply_custom_configuration(device_mock):
         """Custom on off cluster for testing quirks v2."""
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(CustomOnOffCluster)
         .adds(CustomOnOffCluster, cluster_type=ClusterType.Client)
-        .build()
+        .add_to_registry()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -419,12 +397,10 @@ async def test_quirks_v2_sensor(device_mock):
     registry = DeviceRegistry()
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(OnOff.cluster_id)
         .sensor(OnOff.AttributeDefs.on_time.name, OnOff.cluster_id)
-        .build()
+        .add_to_registry()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -455,9 +431,7 @@ async def test_quirks_v2_sensor_validation_failure_translation_key(device_mock):
         ValueError, match="cannot have both a translation_key and a device_class"
     ):
         (
-            add_to_registry_v2(
-                device_mock.manufacturer, device_mock.model, registry=registry
-            )
+            QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
             .adds(OnOff.cluster_id)
             .sensor(
                 OnOff.AttributeDefs.on_time.name,
@@ -465,7 +439,7 @@ async def test_quirks_v2_sensor_validation_failure_translation_key(device_mock):
                 device_class="bad",
                 translation_key="bad",
             )
-            .build()
+            .add_to_registry()
         )
 
 
@@ -475,9 +449,7 @@ async def test_quirks_v2_sensor_validation_failure_unit(device_mock):
 
     with pytest.raises(ValueError, match="cannot have both unit and device_class"):
         (
-            add_to_registry_v2(
-                device_mock.manufacturer, device_mock.model, registry=registry
-            )
+            QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
             .adds(OnOff.cluster_id)
             .sensor(
                 OnOff.AttributeDefs.on_time.name,
@@ -485,7 +457,7 @@ async def test_quirks_v2_sensor_validation_failure_unit(device_mock):
                 device_class="bad",
                 unit="bad",
             )
-            .build()
+            .add_to_registry()
         )
 
 
@@ -494,9 +466,7 @@ async def test_quirks_v2_switch(device_mock):
     registry = DeviceRegistry()
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(OnOff.cluster_id)
         .switch(
             OnOff.AttributeDefs.on_time.name,
@@ -504,7 +474,7 @@ async def test_quirks_v2_switch(device_mock):
             force_inverted=True,
             invert_attribute_name=OnOff.AttributeDefs.off_wait_time.name,
         )
-        .build()
+        .add_to_registry()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -533,9 +503,7 @@ async def test_quirks_v2_number(device_mock):
     registry = DeviceRegistry()
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(OnOff.cluster_id)
         .number(
             OnOff.AttributeDefs.on_time.name,
@@ -545,7 +513,7 @@ async def test_quirks_v2_number(device_mock):
             step=1,
             unit="s",
         )
-        .build()
+        .add_to_registry()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -577,15 +545,13 @@ async def test_quirks_v2_binary_sensor(device_mock):
     registry = DeviceRegistry()
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(OnOff.cluster_id)
         .binary_sensor(
             OnOff.AttributeDefs.on_off.name,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -611,16 +577,14 @@ async def test_quirks_v2_write_attribute_button(device_mock):
     registry = DeviceRegistry()
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(OnOff.cluster_id)
         .write_attr_button(
             OnOff.AttributeDefs.on_time.name,
             20,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -647,9 +611,7 @@ async def test_quirks_v2_command_button(device_mock):
     registry = DeviceRegistry()
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(OnOff.cluster_id)
         .command_button(
             OnOff.ServerCommandDefs.on_with_timed_off.name,
@@ -663,7 +625,7 @@ async def test_quirks_v2_command_button(device_mock):
                 "on_off_control_foo": OnOff.OnOffControl.Accept_Only_When_On
             },
         )
-        .build()
+        .add_to_registry()
     )
 
     quirked_device: CustomDeviceV2 = registry.get_device(device_mock)
@@ -701,9 +663,7 @@ async def test_quirks_v2_also_applies_to(device_mock):
         """Custom test device for testing quirks v2."""
 
     (
-        add_to_registry_v2(
-            device_mock.manufacturer, device_mock.model, registry=registry
-        )
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .also_applies_to("manufacturer2", "model2")
         .also_applies_to("manufacturer3", "model3")
         .device_class(CustomTestDevice)
@@ -714,7 +674,7 @@ async def test_quirks_v2_also_applies_to(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
         )
-        .build()
+        .add_to_registry()
     )
 
     assert isinstance(registry.get_device(device_mock), CustomTestDevice)
@@ -743,9 +703,7 @@ async def test_quirks_v2_with_custom_device_class_raises(device_mock):
         match="is not a subclass of CustomDeviceV2",
     ):
         (
-            add_to_registry_v2(
-                device_mock.manufacturer, device_mock.model, registry=registry
-            )
+            QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
             .device_class(CustomTestDevice)
             .adds(Basic.cluster_id)
             .adds(OnOff.cluster_id)
@@ -754,7 +712,7 @@ async def test_quirks_v2_with_custom_device_class_raises(device_mock):
                 OnOff.StartUpOnOff,
                 OnOff.cluster_id,
             )
-            .build()
+            .add_to_registry()
         )
 
 
@@ -918,13 +876,11 @@ async def test_quirks_v2_matches_v1(app_mock):
     registry = DeviceRegistry()
 
     (
-        add_to_registry_v2(
-            ikea_device.manufacturer, ikea_device.model, registry=registry
-        )
+        QuirkBuilder(ikea_device.manufacturer, ikea_device.model, registry=registry)
         .replaces(PowerConfig1CRCluster)
         .replaces(ScenesCluster, cluster_type=ClusterType.Client)
         .device_automation_triggers(triggers)
-        .build()
+        .add_to_registry()
     )
 
     quirked_v2 = registry.get_device(ikea_device)

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -237,8 +237,8 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
 async def test_quirks_v2_multiple_matches_not_raises(device_mock):
     """Test that adding multiple quirks v2 entries for the same device doesn't raise.
 
-       When the quirk is EXACTLY the same the semantics of sets prevents us from
-       having multiple quirks in the registry.
+    When the quirk is EXACTLY the same the semantics of sets prevents us from
+    having multiple quirks in the registry.
     """
     registry = DeviceRegistry()
 
@@ -363,7 +363,8 @@ async def test_quirks_v2_removes(device_mock):
     (
         add_to_registry_v2(
             device_mock.manufacturer, device_mock.model, registry=registry
-        ).removes(Identify.cluster_id)
+        )
+        .removes(Identify.cluster_id)
         .build()
     )
 
@@ -658,7 +659,9 @@ async def test_quirks_v2_command_button(device_mock):
         .command_button(
             OnOff.ServerCommandDefs.on_with_timed_off.name,
             OnOff.cluster_id,
-            command_kwargs={"on_off_control_foo": OnOff.OnOffControl.Accept_Only_When_On},
+            command_kwargs={
+                "on_off_control_foo": OnOff.OnOffControl.Accept_Only_When_On
+            },
         )
         .build()
     )
@@ -683,11 +686,11 @@ async def test_quirks_v2_command_button(device_mock):
     assert button.kwargs["on_off_control"] == OnOff.OnOffControl.Accept_Only_When_On
 
     # coverage for overridden eq method
-    assert button != quirked_device.exposes_metadata[
-        (1, OnOff.cluster_id, ClusterType.Server)
-    ][1]
+    assert (
+        button
+        != quirked_device.exposes_metadata[(1, OnOff.cluster_id, ClusterType.Server)][1]
+    )
     assert button != quirked_device
-
 
 
 async def test_quirks_v2_also_applies_to(device_mock):

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -30,6 +30,7 @@ from zigpy.quirks.v2 import (
     WriteAttributeButtonMetadata,
     ZCLCommandButtonMetadata,
     ZCLSensorMetadata,
+    add_to_registry_v2,
 )
 import zigpy.types as t
 from zigpy.zcl import ClusterType
@@ -124,7 +125,7 @@ async def test_quirks_v2(device_mock):
     # this would need to be updated if the line number of the call to QuirkBuilder
     # changes in this test in the future
     assert quirked.quirk_metadata.quirk_location.endswith(
-        "zigpy/tests/test_quirks_v2.py]-line:102"
+        "zigpy/tests/test_quirks_v2.py]-line:103"
     )
 
     ep = quirked.endpoints[1]
@@ -910,3 +911,23 @@ async def test_quirks_v2_matches_v1(app_mock):
         )
 
     assert quirked.device_automation_triggers == quirked_v2.device_automation_triggers
+
+
+async def test_quirks_v2_add_to_registry_v2_logs_error(caplog):
+    """Test adding a quirk with old API logs."""
+    registry = DeviceRegistry()
+
+    (
+        add_to_registry_v2("foo", "bar", registry=registry)
+        .adds(OnOff.cluster_id)
+        .binary_sensor(
+            OnOff.AttributeDefs.on_off.name,
+            OnOff.cluster_id,
+        )
+        .add_to_registry()
+    )
+
+    assert (
+        "add_to_registry_v2 is deprecated and will be removed in a future release"
+        in caplog.text
+    )

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -192,7 +192,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
     """Test that adding multiple quirks v2 entries for the same device raises."""
     registry = DeviceRegistry()
 
-    (
+    entry1 = (
         add_to_registry_v2(
             device_mock.manufacturer, device_mock.model, registry=registry
         )
@@ -206,7 +206,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
         .build()
     )
 
-    (
+    entry2 = (
         add_to_registry_v2(
             device_mock.manufacturer, device_mock.model, registry=registry
         )
@@ -220,6 +220,8 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
         )
         .build()
     )
+
+    assert entry1 != entry2
 
     with pytest.raises(
         MultipleQuirksMatchException, match="Multiple matches found for device"
@@ -235,7 +237,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
     """
     registry = DeviceRegistry()
 
-    (
+    entry1 = (
         add_to_registry_v2(
             device_mock.manufacturer, device_mock.model, registry=registry
         )
@@ -249,7 +251,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
         .build()
     )
 
-    (
+    entry2 = (
         add_to_registry_v2(
             device_mock.manufacturer, device_mock.model, registry=registry
         )
@@ -263,6 +265,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
         .build()
     )
 
+    assert entry1 == entry2
     assert isinstance(registry.get_device(device_mock), CustomDeviceV2)
 
 

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -118,6 +118,7 @@ async def test_quirks_v2(device_mock):
 
     # coverage for overridden __eq__ method
     assert entry.adds_metadata[0] != entry.adds_metadata[1]
+    assert entry.adds_metadata[0] != entry
 
     quirked = registry.get_device(device_mock)
     assert isinstance(quirked, CustomDeviceV2)
@@ -225,6 +226,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
     )
 
     assert entry1 != entry2
+    assert entry1 != registry
 
     with pytest.raises(
         MultipleQuirksMatchException, match="Multiple matches found for device"
@@ -269,6 +271,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
     )
 
     assert entry1 == entry2
+    assert entry1 != registry
     assert isinstance(registry.get_device(device_mock), CustomDeviceV2)
 
 
@@ -683,6 +686,7 @@ async def test_quirks_v2_command_button(device_mock):
     assert button != quirked_device.exposes_metadata[
         (1, OnOff.cluster_id, ClusterType.Server)
     ][1]
+    assert button != quirked_device
 
 
 

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -32,8 +32,8 @@ class DeviceRegistry:
         self._registry: TYPE_MANUF_QUIRKS_DICT = collections.defaultdict(
             lambda: collections.defaultdict(list)
         )
-        self._registry_v2: dict[tuple[str, str], list[QuirksV2RegistryEntry]] = (
-            collections.defaultdict(list)
+        self._registry_v2: dict[tuple[str, str], set[QuirksV2RegistryEntry]] = (
+            collections.defaultdict(set)
         )
 
     def add_to_registry(self, custom_device: CustomDeviceType) -> None:
@@ -56,7 +56,7 @@ class DeviceRegistry:
         key = (manufacturer, model)
         if not entry.registry:
             entry.registry = self
-        self._registry_v2[key].append(entry)
+        self._registry_v2[key].add(entry)
         return entry
 
     def remove(self, custom_device: CustomDeviceType) -> None:
@@ -86,8 +86,9 @@ class DeviceRegistry:
             matches: list[QuirksV2RegistryEntry] = []
             entries = self._registry_v2[key]
             if len(entries) == 1:
-                if entries[0].matches_device(device):
-                    matches.append(entries[0])
+                entry = next(iter(entries))
+                if entry.matches_device(device):
+                    matches.append(entry)
             else:
                 for entry in entries:
                     if entry.matches_device(device):

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -51,13 +51,9 @@ class DeviceRegistry:
 
     def add_to_registry_v2(
         self, manufacturer: str, model: str, entry: QuirksV2RegistryEntry
-    ) -> QuirksV2RegistryEntry:
+    ) -> None:
         """Add an entry to the registry."""
-        key = (manufacturer, model)
-        if not entry.registry:
-            entry.registry = self
-        self._registry_v2[key].add(entry)
-        return entry
+        self._registry_v2[(manufacturer, model)].add(entry)
 
     def remove(self, custom_device: CustomDeviceType) -> None:
         """Remove a device from the registry"""

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -407,6 +407,7 @@ class QuirkBuilder:
         )
 
         self.also_applies_to(manufacturer, model)
+        UNBUILT_QUIRK_BUILDERS.append(self)
 
     def also_applies_to(self, manufacturer: str, model: str) -> QuirkBuilder:
         """Register this quirks v2 entry for an additional manufacturer and model."""
@@ -830,6 +831,4 @@ def add_to_registry_v2(
         "add_to_registry_v2 is deprecated and will be removed in a future release. "
         "Please QuirkBuilder() instead"
     )
-    quirk_builder = QuirkBuilder(manufacturer, model, registry=registry)
-    UNBUILT_QUIRK_BUILDERS.append(quirk_builder)
-    return quirk_builder
+    return QuirkBuilder(manufacturer, model, registry=registry)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -744,6 +744,16 @@ class QuirksV2RegistryEntry:
             )
         return CustomDeviceV2(device.application, device.ieee, device.nwk, device, self)
 
+    def __hash__(self) -> int:
+        """Return the hash of the quirks v2 registry entry."""
+        return hash(self.quirk_location)
+
+    def __eq__(self, other: Any) -> bool:
+        """Check if the quirks v2 registry entry is equal to another object."""
+        if not isinstance(other, QuirksV2RegistryEntry):
+            return False
+        return self.quirk_location == other.quirk_location
+
 
 def add_to_registry_v2(
     manufacturer: str, model: str, registry: DeviceRegistry = _DEVICE_REGISTRY

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -462,7 +462,7 @@ class QuirksV2RegistryEntry:
         """Return whether this object is equal to another object."""
         if not isinstance(other, QuirksV2RegistryEntry):
             return False
-        return self._cached_hash == other._cached_hash
+        return self.__hash__() == other.__hash__()
 
 
 @attrs.define

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -331,7 +331,7 @@ class ManufacturerModelMetadata:
 class QuirksV2RegistryEntry:
     """Quirks V2 registry entry."""
 
-    quirk_location: str = None
+    quirk_location: str = attrs.field(default=None, eq=False)
     manufacturer_model_metadata: tuple[ManufacturerModelMetadata] = attrs.field(
         factory=tuple
     )
@@ -371,8 +371,8 @@ class QuirksV2RegistryEntry:
 class QuirksV2RegistryEntryBuilder:
     """Quirks V2 registry entry."""
 
-    registry: DeviceRegistry = None
-    quirk_location: str = None
+    registry: DeviceRegistry = attrs.field(default=None)
+    quirk_location: str = attrs.field(default=None, eq=False)
     manufacturer_model_metadata: list[ManufacturerModelMetadata] = attrs.field(
         factory=list
     )

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import collections
 from enum import Enum
 import inspect
-from frozendict import frozendict, deepfreeze
 import logging
 import typing
 from typing import TYPE_CHECKING, Any
+
+import attrs
+from frozendict import deepfreeze, frozendict
 
 from zigpy.const import (
     SIG_ENDPOINTS,
@@ -28,7 +30,6 @@ from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateC
 import zigpy.types as t
 from zigpy.zcl import ClusterType
 from zigpy.zdo import ZDO
-import attrs
 from zigpy.zdo.types import NodeDescriptor
 
 if TYPE_CHECKING:
@@ -154,7 +155,9 @@ class AddsMetadata:
     cluster: int | type[Cluster | CustomCluster] = attrs.field()
     endpoint_id: int = attrs.field(default=1)
     cluster_type: ClusterType = attrs.field(default=ClusterType.Server)
-    constant_attributes: frozendict[ZCLAttributeDef, typing.Any] = attrs.field(factory=frozendict, converter=deepfreeze)
+    constant_attributes: frozendict[ZCLAttributeDef, typing.Any] = attrs.field(
+        factory=frozendict, converter=deepfreeze
+    )
 
     def __call__(self, device: CustomDeviceV2) -> None:
         """Process the add."""
@@ -350,9 +353,9 @@ class QuirksV2RegistryEntry:
         | WriteAttributeButtonMetadata
         | ZCLCommandButtonMetadata
     ] = attrs.field(factory=tuple)
-    device_automation_triggers_metadata: frozendict[tuple[str, str], frozendict[str, str]] = (
-        attrs.field(factory=frozendict, converter=deepfreeze)
-    )
+    device_automation_triggers_metadata: frozendict[
+        tuple[str, str], frozendict[str, str]
+    ] = attrs.field(factory=frozendict, converter=deepfreeze)
 
     def matches_device(self, device: Device) -> bool:
         """Determine if this quirk should be applied to the passed in device."""

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -41,8 +41,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-UNBUILT_QUIRK_BUILDERS: list[QuirkBuilder] = []
-
 
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-arguments
@@ -407,7 +405,6 @@ class QuirkBuilder:
         )
 
         self.also_applies_to(manufacturer, model)
-        UNBUILT_QUIRK_BUILDERS.append(self)
 
     def also_applies_to(self, manufacturer: str, model: str) -> QuirkBuilder:
         """Register this quirks v2 entry for an additional manufacturer and model."""
@@ -816,9 +813,6 @@ class QuirkBuilder:
             self.registry.add_to_registry_v2(
                 manufacturer_model.manufacturer, manufacturer_model.model, quirk
             )
-
-        if self in UNBUILT_QUIRK_BUILDERS:
-            UNBUILT_QUIRK_BUILDERS.remove(self)
 
         return quirk
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -9,6 +9,7 @@ import logging
 import typing
 from typing import TYPE_CHECKING, Any
 
+from attr._make import _CacheHashWrapper
 import attrs
 
 from zigpy.const import (
@@ -57,9 +58,9 @@ class CustomDeviceV2(CustomDevice):
         ieee: t.EUI64,
         nwk: t.NWK,
         replaces: Device,
-        quirk_metadata: QuirksV2RegistryEntry,
+        quirk_metadata: QuirksV2RegistryEntryBuilder,
     ) -> None:
-        self.quirk_metadata: QuirksV2RegistryEntry = quirk_metadata
+        self.quirk_metadata: QuirksV2RegistryEntryBuilder = quirk_metadata
         # this is done to simplify extending from CustomDevice
         self._replacement_from_replaces(replaces)
         super().__init__(application, ieee, nwk, replaces)
@@ -147,10 +148,11 @@ class CustomDeviceV2(CustomDevice):
                     await cluster.apply_custom_configuration(*args, **kwargs)
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class AddsMetadata:
     """Adds metadata for adding a cluster to a device."""
 
+    _cached_hash: int = 0
     cluster: int | type[Cluster | CustomCluster] = attrs.field()
     endpoint_id: int = attrs.field(default=1)
     cluster_type: ClusterType = attrs.field(default=ClusterType.Server)
@@ -179,8 +181,33 @@ class AddsMetadata:
                 for attribute, value in self.constant_attributes.items()
             }
 
+    def __hash__(self) -> int:
+        """Return the hash of the quirks v2 registry entry."""
+        if self._cached_hash == 0:
+            object.__setattr__(
+                self,
+                "_cached_hash",
+                _CacheHashWrapper(
+                    hash(
+                        (
+                            self.cluster,
+                            self.cluster_type,
+                            self.endpoint_id,
+                            tuple(sorted(self.constant_attributes.items())),
+                        )
+                    )
+                ),
+            )
+        return self._cached_hash
 
-@attrs.define(frozen=True, kw_only=True)
+    def __eq__(self, other: object) -> bool:
+        """Return whether this object is equal to another object."""
+        if not isinstance(other, QuirksV2RegistryEntry):
+            return False
+        return self.__hash__() == other.__hash__()
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class RemovesMetadata:
     """Removes metadata for removing a cluster from a device."""
 
@@ -197,7 +224,7 @@ class RemovesMetadata:
             endpoint.out_clusters.pop(self.cluster_id, None)
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class ReplacesMetadata:
     """Replaces metadata for replacing a cluster on a device."""
 
@@ -210,7 +237,7 @@ class ReplacesMetadata:
         self.add(device)
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class EntityMetadata:
     """Metadata for an exposed entity."""
 
@@ -249,7 +276,7 @@ class EntityMetadata:
             )
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class ZCLEnumMetadata(EntityMetadata):
     """Metadata for exposed ZCL enum based entity."""
 
@@ -257,7 +284,7 @@ class ZCLEnumMetadata(EntityMetadata):
     attribute_name: str = attrs.field()
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class ZCLSensorMetadata(EntityMetadata):
     """Metadata for exposed ZCL attribute based sensor entity."""
 
@@ -269,7 +296,7 @@ class ZCLSensorMetadata(EntityMetadata):
     state_class: SensorStateClass | None = attrs.field(default=None)
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class SwitchMetadata(EntityMetadata):
     """Metadata for exposed switch entity."""
 
@@ -280,7 +307,7 @@ class SwitchMetadata(EntityMetadata):
     on_value: int = attrs.field(default=1)
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class NumberMetadata(EntityMetadata):
     """Metadata for exposed number entity."""
 
@@ -294,7 +321,7 @@ class NumberMetadata(EntityMetadata):
     device_class: NumberDeviceClass | None = attrs.field(default=None)
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class BinarySensorMetadata(EntityMetadata):
     """Metadata for exposed binary sensor entity."""
 
@@ -302,7 +329,7 @@ class BinarySensorMetadata(EntityMetadata):
     device_class: BinarySensorDeviceClass | None = attrs.field(default=None)
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class WriteAttributeButtonMetadata(EntityMetadata):
     """Metadata for exposed button entity that writes an attribute when pressed."""
 
@@ -310,21 +337,143 @@ class WriteAttributeButtonMetadata(EntityMetadata):
     attribute_value: int = attrs.field()
 
 
-@attrs.define(frozen=True, kw_only=True)
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class ZCLCommandButtonMetadata(EntityMetadata):
     """Metadata for exposed button entity that executes a ZCL command when pressed."""
 
+    _cached_hash: int = 0
     command_name: str = attrs.field()
     args: tuple | None = attrs.field(default=None)
     kwargs: dict[str, Any] | None = attrs.field(default=None)
 
+    def __hash__(self) -> int:
+        """Return the hash of the quirks v2 registry entry."""
+        if self._cached_hash == 0:
+            object.__setattr__(
+                self,
+                "_cached_hash",
+                _CacheHashWrapper(
+                    hash(
+                        (
+                            self.entity_platform,
+                            self.entity_type,
+                            self.cluster_id,
+                            self.endpoint_id,
+                            self.cluster_type,
+                            self.initially_disabled,
+                            self.attribute_initialized_from_cache,
+                            self.translation_key,
+                            self.command_name,
+                            self.args,
+                            tuple(sorted(self.kwargs.items())) if self.kwargs else None,
+                        )
+                    )
+                ),
+            )
+        return self._cached_hash
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether this object is equal to another object."""
+        if not isinstance(other, QuirksV2RegistryEntry):
+            return False
+        return self.__hash__() == other.__hash__()
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class ManufacturerModelMetadata:
+    """Metadata for manufacturers and models to apply this quirk to."""
+
+    manufacturer: str = attrs.field(default=None)
+    model: str = attrs.field(default=None)
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class QuirksV2RegistryEntry:
+    """Quirks V2 registry entry."""
+
+    _cached_hash: int = 0
+    quirk_location: str = None
+    manufacturer_model_metadata: tuple[ManufacturerModelMetadata] = attrs.field(
+        factory=tuple
+    )
+    filters: tuple[FilterType] = attrs.field(factory=tuple)
+    custom_device_class: type[CustomDeviceV2] | None = attrs.field(default=None)
+    device_node_descriptor: NodeDescriptor | None = attrs.field(default=None)
+    skip_device_configuration: bool = attrs.field(default=False)
+    adds_metadata: tuple[AddsMetadata] = attrs.field(factory=tuple)
+    removes_metadata: tuple[RemovesMetadata] = attrs.field(factory=tuple)
+    replaces_metadata: tuple[ReplacesMetadata] = attrs.field(factory=tuple)
+    entity_metadata: tuple[
+        ZCLEnumMetadata
+        | SwitchMetadata
+        | NumberMetadata
+        | BinarySensorMetadata
+        | WriteAttributeButtonMetadata
+        | ZCLCommandButtonMetadata
+    ] = attrs.field(factory=tuple)
+    device_automation_triggers_metadata: dict[tuple[str, str], dict[str, str]] = (
+        attrs.field(factory=dict)
+    )
+
+    def matches_device(self, device: Device) -> bool:
+        """Determine if this quirk should be applied to the passed in device."""
+        return all(_filter(device) for _filter in self.filters)
+
+    def create_device(self, device: Device) -> CustomDeviceV2:
+        """Create the quirked device."""
+        if self.custom_device_class:
+            return self.custom_device_class(
+                device.application, device.ieee, device.nwk, device, self
+            )
+        return CustomDeviceV2(device.application, device.ieee, device.nwk, device, self)
+
+    def __hash__(self) -> int:
+        """Return the hash of the quirks v2 registry entry."""
+        if self._cached_hash == 0:
+            object.__setattr__(
+                self,
+                "_cached_hash",
+                _CacheHashWrapper(
+                    hash(
+                        (
+                            self.manufacturer_model_metadata,
+                            self.filters,
+                            self.custom_device_class,
+                            self.device_node_descriptor.as_tuple()
+                            if self.device_node_descriptor
+                            else None,
+                            self.skip_device_configuration,
+                            self.adds_metadata,
+                            self.removes_metadata,
+                            self.replaces_metadata,
+                            self.entity_metadata,
+                            # triggers can be nested a few layers deep.
+                            # Using the keys should be sufficient.
+                            tuple(
+                                sorted(self.device_automation_triggers_metadata.keys())
+                            ),
+                        )
+                    )
+                ),
+            )
+        return self._cached_hash
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether this object is equal to another object."""
+        if not isinstance(other, QuirksV2RegistryEntry):
+            return False
+        return self._cached_hash == other._cached_hash
+
 
 @attrs.define
-class QuirksV2RegistryEntry:
+class QuirksV2RegistryEntryBuilder:
     """Quirks V2 registry entry."""
 
     registry: DeviceRegistry = None
     quirk_location: str = None
+    manufacturer_model_metadata: list[ManufacturerModelMetadata] = attrs.field(
+        factory=list
+    )
     filters: list[FilterType] = attrs.field(factory=list)
     custom_device_class: type[CustomDeviceV2] | None = attrs.field(default=None)
     device_node_descriptor: NodeDescriptor | None = attrs.field(default=None)
@@ -344,12 +493,16 @@ class QuirksV2RegistryEntry:
         attrs.field(factory=dict)
     )
 
-    def also_applies_to(self, manufacturer: str, model: str) -> QuirksV2RegistryEntry:
+    def also_applies_to(
+        self, manufacturer: str, model: str
+    ) -> QuirksV2RegistryEntryBuilder:
         """Register this quirks v2 entry for an additional manufacturer and model."""
-        self.registry.add_to_registry_v2(manufacturer, model, self)
+        self.manufacturer_model_metadata.append(
+            ManufacturerModelMetadata(manufacturer=manufacturer, model=model)
+        )
         return self
 
-    def filter(self, filter_function: FilterType) -> QuirksV2RegistryEntry:
+    def filter(self, filter_function: FilterType) -> QuirksV2RegistryEntryBuilder:
         """Add a filter and returns self.
 
         The filter function should take a single argument, a zigpy.device.Device
@@ -361,13 +514,9 @@ class QuirksV2RegistryEntry:
         self.filters.append(filter_function)
         return self
 
-    def matches_device(self, device: Device) -> bool:
-        """Determine if this quirk should be applied to the passed in device."""
-        return all(_filter(device) for _filter in self.filters)
-
     def device_class(
         self, custom_device_class: type[CustomDeviceV2]
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Set the custom device class to be used in this quirk and returns self.
 
         The custom device class must be a subclass of CustomDeviceV2.
@@ -378,7 +527,9 @@ class QuirksV2RegistryEntry:
         self.custom_device_class = custom_device_class
         return self
 
-    def node_descriptor(self, node_descriptor: NodeDescriptor) -> QuirksV2RegistryEntry:
+    def node_descriptor(
+        self, node_descriptor: NodeDescriptor
+    ) -> QuirksV2RegistryEntryBuilder:
         """Set the node descriptor and returns self.
 
         The node descriptor must be a NodeDescriptor instance and it will be used
@@ -389,7 +540,7 @@ class QuirksV2RegistryEntry:
 
     def skip_configuration(
         self, skip_configuration: bool = True
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Set the skip_configuration and returns self.
 
         If skip_configuration is True, reporting configuration will not be
@@ -404,7 +555,7 @@ class QuirksV2RegistryEntry:
         cluster_type: ClusterType = ClusterType.Server,
         endpoint_id: int = 1,
         constant_attributes: dict[ZCLAttributeDef, typing.Any] | None = None,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add an AddsMetadata entry and returns self.
 
         This method allows adding a cluster to a device when the quirk is applied.
@@ -431,7 +582,7 @@ class QuirksV2RegistryEntry:
         cluster_id: int,
         cluster_type: ClusterType = ClusterType.Server,
         endpoint_id: int = 1,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add a RemovesMetadata entry and returns self.
 
         This method allows removing a cluster from a device when the quirk is applied.
@@ -450,7 +601,7 @@ class QuirksV2RegistryEntry:
         cluster_id: int | None = None,
         cluster_type: ClusterType = ClusterType.Server,
         endpoint_id: int = 1,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add a ReplacesMetadata entry and returns self.
 
         This method allows replacing a cluster on a device when the quirk is applied.
@@ -490,7 +641,7 @@ class QuirksV2RegistryEntry:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add an EntityMetadata containing ZCLEnumMetadata and return self.
 
         This method allows exposing an enum based entity in Home Assistant.
@@ -526,7 +677,7 @@ class QuirksV2RegistryEntry:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add an EntityMetadata containing ZCLSensorMetadata and return self.
 
         This method allows exposing a sensor entity in Home Assistant.
@@ -565,7 +716,7 @@ class QuirksV2RegistryEntry:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add an EntityMetadata containing SwitchMetadata and return self.
 
         This method allows exposing a switch entity in Home Assistant.
@@ -605,7 +756,7 @@ class QuirksV2RegistryEntry:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add an EntityMetadata containing NumberMetadata and return self.
 
         This method allows exposing a number entity in Home Assistant.
@@ -642,7 +793,7 @@ class QuirksV2RegistryEntry:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add an EntityMetadata containing BinarySensorMetadata and return self.
 
         This method allows exposing a binary sensor entity in Home Assistant.
@@ -674,7 +825,7 @@ class QuirksV2RegistryEntry:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add an EntityMetadata containing WriteAttributeButtonMetadata and return self.
 
         This method allows exposing a button entity in Home Assistant that writes
@@ -707,7 +858,7 @@ class QuirksV2RegistryEntry:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         translation_key: str | None = None,
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add an EntityMetadata containing ZCLCommandButtonMetadata and return self.
 
         This method allows exposing a button entity in Home Assistant that executes
@@ -731,31 +882,42 @@ class QuirksV2RegistryEntry:
 
     def device_automation_triggers(
         self, device_automation_triggers: dict[tuple[str, str], dict[str, str]]
-    ) -> QuirksV2RegistryEntry:
+    ) -> QuirksV2RegistryEntryBuilder:
         """Add device automation triggers and returns self."""
         self.device_automation_triggers_metadata.update(device_automation_triggers)
         return self
 
-    def create_device(self, device: Device) -> CustomDeviceV2:
-        """Create the quirked device."""
-        if self.custom_device_class:
-            return self.custom_device_class(
-                device.application, device.ieee, device.nwk, device, self
+    def build(self) -> QuirksV2RegistryEntry:
+        """Build the quirks v2 registry entry."""
+        quirk: QuirksV2RegistryEntry = QuirksV2RegistryEntry(
+            manufacturer_model_metadata=tuple(self.manufacturer_model_metadata),
+            quirk_location=self.quirk_location,
+            filters=tuple(self.filters),
+            custom_device_class=self.custom_device_class,
+            device_node_descriptor=self.device_node_descriptor,
+            skip_device_configuration=self.skip_device_configuration,
+            adds_metadata=tuple(self.adds_metadata),
+            removes_metadata=tuple(self.removes_metadata),
+            replaces_metadata=tuple(self.replaces_metadata),
+            entity_metadata=tuple(self.entity_metadata),
+            device_automation_triggers_metadata=self.device_automation_triggers_metadata,
+        )
+        for manufacturer_model in self.manufacturer_model_metadata:
+            self.registry.add_to_registry_v2(
+                manufacturer_model.manufacturer, manufacturer_model.model, quirk
             )
-        return CustomDeviceV2(device.application, device.ieee, device.nwk, device, self)
-
-    def __hash__(self) -> int:
-        """Return the hash of the quirks v2 registry entry."""
-        return hash(self.quirk_location)
+        return quirk
 
 
 def add_to_registry_v2(
     manufacturer: str, model: str, registry: DeviceRegistry = _DEVICE_REGISTRY
-) -> QuirksV2RegistryEntry:
+) -> QuirksV2RegistryEntryBuilder:
     """Add an entry to the registry."""
     stack: list[inspect.FrameInfo] = inspect.stack()
     caller: inspect.FrameInfo = stack[1]
     location: str = f"file[{caller.filename}]-line:{caller.lineno}"
-    quirk_entry = QuirksV2RegistryEntry()
-    quirk_entry.quirk_location = location
-    return registry.add_to_registry_v2(manufacturer, model, quirk_entry)
+    quirk_entry_builder = QuirksV2RegistryEntryBuilder()
+    quirk_entry_builder.quirk_location = location
+    quirk_entry_builder.registry = registry
+    quirk_entry_builder.also_applies_to(manufacturer, model)
+    return quirk_entry_builder

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -315,8 +315,8 @@ class ZCLCommandButtonMetadata(EntityMetadata):
     """Metadata for exposed button entity that executes a ZCL command when pressed."""
 
     command_name: str = attrs.field()
-    args: tuple | None = attrs.field(default=None)
-    kwargs: frozendict[str, Any] | None = attrs.field(default=None)
+    args: tuple = attrs.field(default=tuple)
+    kwargs: frozendict[str, Any] = attrs.field(default=frozendict, converter=frozendict)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -41,6 +41,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+UNBUILT_QUIRK_BUILDERS: list[QuirkBuilder] = []
+
 
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-arguments
@@ -405,6 +407,7 @@ class QuirkBuilder:
         )
 
         self.also_applies_to(manufacturer, model)
+        UNBUILT_QUIRK_BUILDERS.append(self)
 
     def also_applies_to(self, manufacturer: str, model: str) -> QuirkBuilder:
         """Register this quirks v2 entry for an additional manufacturer and model."""
@@ -813,6 +816,9 @@ class QuirkBuilder:
             self.registry.add_to_registry_v2(
                 manufacturer_model.manufacturer, manufacturer_model.model, quirk
             )
+
+        if self in UNBUILT_QUIRK_BUILDERS:
+            UNBUILT_QUIRK_BUILDERS.remove(self)
 
         return quirk
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -748,12 +748,6 @@ class QuirksV2RegistryEntry:
         """Return the hash of the quirks v2 registry entry."""
         return hash(self.quirk_location)
 
-    def __eq__(self, other: Any) -> bool:
-        """Check if the quirks v2 registry entry is equal to another object."""
-        if not isinstance(other, QuirksV2RegistryEntry):
-            return False
-        return self.quirk_location == other.quirk_location
-
 
 def add_to_registry_v2(
     manufacturer: str, model: str, registry: DeviceRegistry = _DEVICE_REGISTRY

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -829,6 +829,6 @@ def add_to_registry_v2(
     """Add an entry to the registry."""
     _LOGGER.error(
         "add_to_registry_v2 is deprecated and will be removed in a future release. "
-        "Please QuirkBuilder() instead"
+        "Please QuirkBuilder() instead and ensure you call add_to_registry()."
     )
     return QuirkBuilder(manufacturer, model, registry=registry)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -498,7 +498,9 @@ class QuirksV2RegistryEntryBuilder:
     ) -> QuirksV2RegistryEntryBuilder:
         """Register this quirks v2 entry for an additional manufacturer and model."""
         self.manufacturer_model_metadata.append(
-            ManufacturerModelMetadata(manufacturer=manufacturer, model=model)
+            ManufacturerModelMetadata(  # type: ignore[call-arg]
+                manufacturer=manufacturer, model=model
+            )
         )
         return self
 
@@ -889,7 +891,7 @@ class QuirksV2RegistryEntryBuilder:
 
     def build(self) -> QuirksV2RegistryEntry:
         """Build the quirks v2 registry entry."""
-        quirk: QuirksV2RegistryEntry = QuirksV2RegistryEntry(
+        quirk: QuirksV2RegistryEntry = QuirksV2RegistryEntry(  # type: ignore[call-arg]
             manufacturer_model_metadata=tuple(self.manufacturer_model_metadata),
             quirk_location=self.quirk_location,
             filters=tuple(self.filters),

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -442,7 +442,7 @@ class QuirksV2RegistryEntryBuilder:
         The node descriptor must be a NodeDescriptor instance and it will be used
         to replace the node descriptor of the device when the quirk is applied.
         """
-        self.device_node_descriptor = node_descriptor
+        self.device_node_descriptor = node_descriptor.freeze()
         return self
 
     def skip_configuration(

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -202,7 +202,7 @@ class AddsMetadata:
 
     def __eq__(self, other: object) -> bool:
         """Return whether this object is equal to another object."""
-        if not isinstance(other, QuirksV2RegistryEntry):
+        if not isinstance(other, AddsMetadata):
             return False
         return self.__hash__() == other.__hash__()
 
@@ -374,7 +374,7 @@ class ZCLCommandButtonMetadata(EntityMetadata):
 
     def __eq__(self, other: object) -> bool:
         """Return whether this object is equal to another object."""
-        if not isinstance(other, QuirksV2RegistryEntry):
+        if not isinstance(other, ZCLCommandButtonMetadata):
             return False
         return self.__hash__() == other.__hash__()
 


### PR DESCRIPTION
## This is a slight API tweak so ZHA lib and the quirks lib will need some tweaks to call `.build()`

This PR makes `QuirksV2RegistryEntry` immutable and splits out the QuirksV2RegistryEntryBuilder into its own class. This is done to prevent loading the same v2 quirk information into the v2 registry multiple times.