### PR TITLE
Revert "Open serial ports exclusively by default and implement `flow_control` as a kwarg (#1418)"

### DIFF
--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,91 +1,45 @@
-from __future__ import annotations
-
-import pytest
-import asyncio
 import unittest.mock
 
 import zigpy.serial
-from zigpy.typing import UNDEFINED, UndefinedType
 
-# fmt: off
-@pytest.mark.parametrize(("url", "flow_control", "xonxoff", "rtscts", "expected_kwargs"), [
-    # `flow_control` on its own
-    ("/dev/ttyUSB1", "hardware", UNDEFINED, UNDEFINED, {"xonxoff": False, "rtscts": True}),
-    ("/dev/ttyUSB1", "software", UNDEFINED, UNDEFINED, {"xonxoff": True,  "rtscts": False}),
-    ("/dev/ttyUSB1", None,       UNDEFINED, UNDEFINED, {"xonxoff": False, "rtscts": False}),
 
-    # `flow_control` overrides `xonxoff` and `rtscts`
-    ("/dev/ttyUSB1", "hardware", True,      False,     {"xonxoff": False, "rtscts": True}),
-    ("/dev/ttyUSB1", "software", False,      True,     {"xonxoff": True,  "rtscts": False}),
-    ("/dev/ttyUSB1", None,       True,      False,     {"xonxoff": False, "rtscts": False}),
-
-    # `flow_control` defaults to undefined so `xonxoff` and `rtscts` are used
-    ("/dev/ttyUSB1", UNDEFINED,  True,      False,     {"xonxoff": True,  "rtscts": False}),
-    ("/dev/ttyUSB1", UNDEFINED,  False,      True,     {"xonxoff": False, "rtscts": True}),
-    ("/dev/ttyUSB1", UNDEFINED,  True,       True,     {"xonxoff": True,  "rtscts": True}),
-
-    # The defaults are used when `flow_control`, `xonxoff`, and `rtscts` are all undefined
-    ("/dev/ttyUSB1", UNDEFINED,  UNDEFINED, UNDEFINED, {"xonxoff": False, "rtscts": False}),
-])
-# fmt: on
-async def test_serial_normal(
-    url: str,
-    flow_control: str | UndefinedType,
-    xonxoff: bool | UndefinedType,
-    rtscts: bool | UndefinedType,
-    expected_kwargs: dict[str, bool],
-) -> None:
-    loop = asyncio.get_running_loop()
+@unittest.mock.patch(
+    "zigpy.serial.pyserial_asyncio.create_serial_connection",
+    unittest.mock.AsyncMock(
+        return_value=(unittest.mock.AsyncMock(), unittest.mock.AsyncMock())
+    ),
+)
+async def test_serial_normal(event_loop):
     protocol_factory = unittest.mock.Mock()
 
-    kwargs = {"url": url}
+    await zigpy.serial.create_serial_connection(
+        event_loop, protocol_factory, "/dev/ttyUSB1"
+    )
 
-    if flow_control is not UNDEFINED:
-        kwargs["flow_control"] = flow_control
-
-    if xonxoff is not UNDEFINED:
-        kwargs["xonxoff"] = xonxoff
-
-    if rtscts is not UNDEFINED:
-        kwargs["rtscts"] = rtscts
-
-    with unittest.mock.patch(
-        "zigpy.serial.pyserial_asyncio.create_serial_connection",
-        unittest.mock.AsyncMock(
-            return_value=(unittest.mock.AsyncMock(), unittest.mock.AsyncMock())
-        ),
-    ) as mock_create_serial_connection:
-        await zigpy.serial.create_serial_connection(loop, protocol_factory, **kwargs)
-
-    mock_calls = mock_create_serial_connection.mock_calls
+    mock_calls = zigpy.serial.pyserial_asyncio.create_serial_connection.mock_calls
     assert len(mock_calls) == 1
-
     assert mock_calls[0].kwargs["url"] == "/dev/ttyUSB1"
 
-    for kwarg in expected_kwargs:
-        assert mock_calls[0].kwargs[kwarg] == expected_kwargs[kwarg]
 
-
-async def test_serial_socket() -> None:
-    loop = asyncio.get_running_loop()
+async def test_serial_socket(event_loop):
     protocol_factory = unittest.mock.Mock()
 
     with unittest.mock.patch.object(
-        loop,
+        event_loop,
         "create_connection",
         unittest.mock.AsyncMock(
             return_value=(unittest.mock.AsyncMock(), unittest.mock.AsyncMock())
         ),
     ):
         await zigpy.serial.create_serial_connection(
-            loop, protocol_factory, "socket://1.2.3.4:5678"
+            event_loop, protocol_factory, "socket://1.2.3.4:5678"
         )
         await zigpy.serial.create_serial_connection(
-            loop, protocol_factory, "socket://1.2.3.4"
+            event_loop, protocol_factory, "socket://1.2.3.4"
         )
 
-        assert len(loop.create_connection.mock_calls) == 2
-        assert loop.create_connection.mock_calls[0].kwargs["host"] == "1.2.3.4"
-        assert loop.create_connection.mock_calls[0].kwargs["port"] == 5678
-        assert loop.create_connection.mock_calls[1].kwargs["host"] == "1.2.3.4"
-        assert loop.create_connection.mock_calls[1].kwargs["port"] == 6638
+        assert len(event_loop.create_connection.mock_calls) == 2
+        assert event_loop.create_connection.mock_calls[0].kwargs["host"] == "1.2.3.4"
+        assert event_loop.create_connection.mock_calls[0].kwargs["port"] == 5678
+        assert event_loop.create_connection.mock_calls[1].kwargs["host"] == "1.2.3.4"
+        assert event_loop.create_connection.mock_calls[1].kwargs["port"] == 6638

--- a/zigpy/typing.py
+++ b/zigpy/typing.py
@@ -1,6 +1,5 @@
 """Typing helpers for Zigpy."""
 from __future__ import annotations
-import enum
 
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -16,15 +15,6 @@ DeviceType = "Device"
 EndpointType = "Endpoint"
 ZDOType = "ZDO"
 AddressingMode = "AddressingMode"
-
-
-class UndefinedType(enum.Enum):
-    """Singleton type for use with not set sentinel values."""
-
-    _singleton = 0
-
-UNDEFINED = UndefinedType._singleton  # noqa: SLF001
-
 
 if TYPE_CHECKING:
     import zigpy.application


### PR DESCRIPTION
Reverts #1418.

It seems like we aren't cleanly closing the ports in `universal-silabs-flasher`, possibly other places.