### PR TITLE
Actually pass `baudrate`

### DIFF
--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -61,6 +61,7 @@ async def test_serial_normal(
     assert len(mock_calls) == 1
 
     assert mock_calls[0].kwargs["url"] == "/dev/ttyUSB1"
+    assert mock_calls[0].kwargs["baudrate"] == 115200
 
     for kwarg in expected_kwargs:
         assert mock_calls[0].kwargs[kwarg] == expected_kwargs[kwarg]

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -70,6 +70,7 @@ async def create_serial_connection(
             loop,
             protocol_factory,
             url=url,
+            baudrate=baudrate,
             exclusive=exclusive,
             xonxoff=xonxoff,
             rtscts=rtscts,


### PR DESCRIPTION
🤦. Thanks @dmulcahey!