### PR TITLE
Clean serial port shutdown

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -450,6 +450,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             except Exception:  # noqa: BLE001
                 LOGGER.warning("Failed to disconnect from database", exc_info=True)
 
+        LOGGER.debug("Waiting for radio disconnection event")
         await self._connection_lost_event.wait()
         self._connection_lost_event.clear()
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -74,6 +74,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._tasks: set[asyncio.Future[Any]] = set()
 
         self._watchdog_task: asyncio.Task | None = None
+        self._connection_lost_event = asyncio.Event()
 
         self._concurrent_requests_semaphore = PriorityDynamicBoundedSemaphore(
             self._config[conf.CONF_MAX_CONCURRENT_REQUESTS]
@@ -449,6 +450,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             except Exception:  # noqa: BLE001
                 LOGGER.warning("Failed to disconnect from database", exc_info=True)
 
+        await self._connection_lost_event.wait()
+        self._connection_lost_event.clear()
+
     def add_device(self, ieee: t.EUI64, nwk: t.NWK) -> zigpy.device.Device:
         """Creates a zigpy `Device` object with the provided IEEE and NWK addresses."""
 
@@ -641,7 +645,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         return False
 
     @abc.abstractmethod
-    async def connect(self):
+    async def connect(self) -> None:
         """Connect to the radio hardware and verify that it is compatible with the library.
         This method should be stateless if the connection attempt fails.
         """
@@ -680,6 +684,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         LOGGER.debug("Connection to the radio has been lost: %r", exc)
         self.listener_event("connection_lost", exc)
+        self._connection_lost_event.set()
 
     @abc.abstractmethod
     async def disconnect(self):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -74,7 +74,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._tasks: set[asyncio.Future[Any]] = set()
 
         self._watchdog_task: asyncio.Task | None = None
-        self._connection_lost_event = asyncio.Event()
 
         self._concurrent_requests_semaphore = PriorityDynamicBoundedSemaphore(
             self._config[conf.CONF_MAX_CONCURRENT_REQUESTS]
@@ -450,10 +449,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             except Exception:  # noqa: BLE001
                 LOGGER.warning("Failed to disconnect from database", exc_info=True)
 
-        LOGGER.debug("Waiting for radio disconnection event")
-        await self._connection_lost_event.wait()
-        self._connection_lost_event.clear()
-
     def add_device(self, ieee: t.EUI64, nwk: t.NWK) -> zigpy.device.Device:
         """Creates a zigpy `Device` object with the provided IEEE and NWK addresses."""
 
@@ -685,7 +680,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         LOGGER.debug("Connection to the radio has been lost: %r", exc)
         self.listener_event("connection_lost", exc)
-        self._connection_lost_event.set()
 
     @abc.abstractmethod
     async def disconnect(self):

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -52,15 +52,6 @@ class SerialProtocol(asyncio.Protocol):
         self._disconnected_event.set()
         self._transport = None
 
-    def send_data(self, data: bytes) -> None:
-        """Sends data over the connected transport."""
-        assert self._transport is not None
-
-        if not isinstance(data, (bytes, bytearray)):
-            data = bytes(data)
-
-        self._transport.write(data)
-
     def data_received(self, data: bytes) -> None:
         self._buffer += data
 
@@ -75,7 +66,6 @@ class SerialProtocol(asyncio.Protocol):
         await self._disconnected_event.wait()
 
     async def disconnect(self) -> None:
-        LOGGER.debug("Disconnecting from serial port")
         self.close()
         await self.wait_until_closed()
 

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -72,9 +72,8 @@ class SerialProtocol(asyncio.Protocol):
         if self._transport is None:
             return
 
-        self.close()
-        self._buffer.clear()
         self._transport.close()
+        self._buffer.clear()
 
         LOGGER.debug("Waiting for serial port to close")
         await self._disconnected_event.wait()
@@ -82,6 +81,7 @@ class SerialProtocol(asyncio.Protocol):
         LOGGER.debug("Disconnected from serial port")
 
         self._transport = None
+        self.close()
 
     async def _wait_for_pyserial_to_actually_close(self) -> None:
         # pyserial-asyncio calls `connection_lost` *before* the serial port is closed
@@ -151,7 +151,5 @@ async def create_serial_connection(
                 raise exc.__context__ from None
 
             raise
-
-    await protocol.wait_until_connected()
 
     return transport, protocol

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -24,6 +24,71 @@ except ImportError:
     import serial_asyncio as pyserial_asyncio
 
 
+class SerialProtocol(asyncio.Protocol):
+    """Base class for packet-parsing serial protocol implementations."""
+
+    def __init__(self) -> None:
+        self._buffer = bytearray()
+        self._transport: pyserial_asyncio.SerialTransport | None = None
+
+        self._connected_event = asyncio.Event()
+        self._disconnected_event = asyncio.Event()
+        self._disconnected_event.set()
+
+    async def wait_until_connected(self) -> None:
+        """Wait for the protocol's transport to be connected."""
+        await self._connected_event.wait()
+
+    def connection_made(self, transport: pyserial_asyncio.SerialTransport) -> None:
+        LOGGER.debug("Connection made: %s", transport)
+
+        self._transport = transport
+        self._disconnected_event.clear()
+        self._connected_event.set()
+
+    def connection_lost(self, exc: BaseException | None) -> None:
+        LOGGER.debug("Connection lost: %r", exc)
+        self._connected_event.clear()
+        self._disconnected_event.set()
+
+    def send_data(self, data: bytes) -> None:
+        """Sends data over the connected transport."""
+        assert self._transport is not None
+
+        if not isinstance(data, (bytes, bytearray)):
+            data = bytes(data)
+
+        self._transport.write(data)
+
+    def data_received(self, data: bytes) -> None:
+        self._buffer += data
+
+    def close(self) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        LOGGER.debug("Disconnecting from serial port")
+
+        if self._transport is None:
+            return
+
+        self.close()
+        self._buffer.clear()
+        self._transport.close()
+
+        LOGGER.debug("Waiting for serial port to close")
+        await self._disconnected_event.wait()
+        await self._wait_for_pyserial_to_actually_close()
+        LOGGER.debug("Disconnected from serial port")
+
+        self._transport = None
+
+    async def _wait_for_pyserial_to_actually_close(self) -> None:
+        # pyserial-asyncio calls `connection_lost` *before* the serial port is closed
+        while getattr(self._transport, "_serial", None) is not None:
+            await asyncio.sleep(0.1)
+
+
 async def create_serial_connection(
     loop: asyncio.BaseEventLoop,
     protocol_factory: typing.Callable[[], asyncio.Protocol],
@@ -86,5 +151,7 @@ async def create_serial_connection(
                 raise exc.__context__ from None
 
             raise
+
+    await protocol.wait_until_connected()
 
     return transport, protocol

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -50,6 +50,7 @@ class SerialProtocol(asyncio.Protocol):
         LOGGER.debug("Connection lost: %r", exc)
         self._connected_event.clear()
         self._disconnected_event.set()
+        self._transport = None
 
     def send_data(self, data: bytes) -> None:
         """Sends data over the connected transport."""
@@ -64,29 +65,19 @@ class SerialProtocol(asyncio.Protocol):
         self._buffer += data
 
     def close(self) -> None:
-        pass
+        self._buffer.clear()
+
+        if self._transport is not None:
+            self._transport.close()
+
+    async def wait_until_closed(self) -> None:
+        LOGGER.debug("Waiting for serial port to close")
+        await self._disconnected_event.wait()
 
     async def disconnect(self) -> None:
         LOGGER.debug("Disconnecting from serial port")
-
-        if self._transport is None:
-            return
-
-        self._transport.close()
-        self._buffer.clear()
-
-        LOGGER.debug("Waiting for serial port to close")
-        await self._disconnected_event.wait()
-        await self._wait_for_pyserial_to_actually_close()
-        LOGGER.debug("Disconnected from serial port")
-
-        self._transport = None
         self.close()
-
-    async def _wait_for_pyserial_to_actually_close(self) -> None:
-        # pyserial-asyncio calls `connection_lost` *before* the serial port is closed
-        while getattr(self._transport, "_serial", None) is not None:
-            await asyncio.sleep(0.1)
+        await self.wait_until_closed()
 
 
 async def create_serial_connection(


### PR DESCRIPTION
There is currently a connection lifecycle bug[^1] with pyserial-asyncio(-fast) that causes a race condition on shutdown. Various radio libraries and other implementations have workarounds for this issue (usually `await asyncio.sleep(0)` or similar) but the crux of the problem is that we do not *wait* for the serial connection to close. There are two events:

1. `connection_made`
2. `connection_lost`

We currently wait for `connection_made` but react synchronously when shutting down a transport, assuming `transport.close()` shuts down the serial connection in the same event loop iteration. This is not true.

To help solve this issue, I would like to incorporate a serial protocol base class into zigpy so that radio libraries can have a more coordinated implementation and not have to re-implement basic functionality repeatedly.

This will unfortunately have to be an API change: `disconnect()` in the various radio libraries does not actually wait for the port to disconnect, nor do failures during `connect()`, and so on.

Radio library progress:
- https://github.com/zigpy/zigpy-deconz/pull/259
- https://github.com/NabuCasa/universal-silabs-flasher/pull/75
- https://github.com/zigpy/zigpy-zigate/pull/160
- https://github.com/zigpy/zigpy-znp/pull/256
- https://github.com/zigpy/zigpy-xbee/pull/177


[^1]: https://github.com/home-assistant-libs/pyserial-asyncio-fast/pull/16