### PR TITLE
Allow freezing structs

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -916,3 +916,31 @@ def test_int_comparison_non_int(expose_global):
 
     with pytest.raises(TypeError):
         fw_ver >= 0
+
+
+def test_frozen_struct():
+    class OuterStruct(t.Struct):
+        class InnerStruct(t.Struct):
+            b: t.uint8_t
+            c: t.uint8_t
+
+        a: t.uint8_t
+        inner: None = t.StructField(type=InnerStruct)
+        d: t.uint8_t
+        e: t.uint16_t
+
+    struct = OuterStruct(a=1, inner=OuterStruct.InnerStruct(b=2, c=3), d=4)
+    frozen = struct.freeze()
+
+    # Setting attributes has no effect
+    assert frozen.a == 1
+
+    with pytest.raises(AttributeError):
+        frozen.a = 2
+
+    assert frozen.a == 1
+
+    assert {frozen: 2}[frozen] == 2
+    assert {frozen, frozen} == {frozen}
+    assert frozen == frozen.replace(a=1)
+    assert {frozen, frozen, frozen.replace(a=1), frozen.replace(a=2)} == {frozen, frozen.replace(a=2)}

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -932,6 +932,9 @@ def test_frozen_struct():
     struct = OuterStruct(a=1, inner=OuterStruct.InnerStruct(b=2, c=3), d=4)
     frozen = struct.freeze()
 
+    assert 'frozen' not in repr(struct)
+    assert 'frozen' in repr(frozen)
+
     with pytest.raises(TypeError, match="Unhashable type"):
         hash(struct)
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -932,13 +932,21 @@ def test_frozen_struct():
     struct = OuterStruct(a=1, inner=OuterStruct.InnerStruct(b=2, c=3), d=4)
     frozen = struct.freeze()
 
+    with pytest.raises(TypeError, match="Unhashable type"):
+        hash(struct)
+
     # Setting attributes has no effect
     assert frozen.a == 1
+    assert frozen.inner.b == 2
 
     with pytest.raises(AttributeError):
         frozen.a = 2
 
+    with pytest.raises(AttributeError):
+        frozen.inner.b = 5
+
     assert frozen.a == 1
+    assert frozen.inner.b == 2
 
     assert {frozen: 2}[frozen] == 2
     assert {frozen, frozen} == {frozen}


### PR DESCRIPTION
This PR allows for `Struct` instances to be "frozen", preventing modification but more importantly allowing them to be hashed. The main use case is creating an immutable node descriptor object for https://github.com/zigpy/zigpy/pull/1420.