### PR TITLE
Block updates for IKEA image types 8704 and 8710

### DIFF
--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -279,7 +279,7 @@ async def test_tradfri_provider_old(index_url: str, index_file: str) -> None:
         if obj["fw_type"] == 2 and obj["fw_image_type"] not in (8710, 8704)
     ]
     assert index
-    assert len(index) == len(index_obj) - 2 == len(filtered_version_info_obj)
+    assert len(index) == len(filtered_version_info_obj)
 
     for obj, meta in zip(filtered_version_info_obj, index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -279,7 +279,7 @@ async def test_tradfri_provider_old(index_url: str, index_file: str) -> None:
         if obj["fw_type"] == 2 and obj["fw_image_type"] not in (8710, 8704)
     ]
     assert index
-    assert len(index) == len(index_obj) - 4 == len(filtered_version_info_obj)
+    assert len(index) == len(index_obj) - 2 == len(filtered_version_info_obj)
 
     for obj, meta in zip(filtered_version_info_obj, index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -200,9 +200,11 @@ async def test_tradfri_provider_dirigera():
 
     # Skip the gateway firmware
     filtered_version_info_obj = [
-        obj for obj in index_obj if obj["fw_type"] == 2 and obj["fw_image_type"] != 8710
+        obj
+        for obj in index_obj
+        if obj["fw_type"] == 2 and obj["fw_image_type"] not in (8710, 8704)
     ]
-    assert len(index) == len(index_obj) - 2 == len(filtered_version_info_obj)
+    assert len(index) == len(index_obj) - 3 == len(filtered_version_info_obj)
 
     for obj, meta in zip(filtered_version_info_obj, index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)
@@ -271,9 +273,13 @@ async def test_tradfri_provider_old(index_url: str, index_file: str) -> None:
         mock_http.assert_not_called()
 
     # Skip the gateway firmware
-    filtered_version_info_obj = [obj for obj in index_obj if obj["fw_type"] == 2]
+    filtered_version_info_obj = [
+        obj
+        for obj in index_obj
+        if obj["fw_type"] == 2 and obj["fw_image_type"] not in (8710, 8704)
+    ]
     assert index
-    assert len(index) == len(index_obj) - 2 == len(filtered_version_info_obj)
+    assert len(index) == len(index_obj) - 4 == len(filtered_version_info_obj)
 
     for obj, meta in zip(filtered_version_info_obj, index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)
@@ -387,7 +393,7 @@ async def test_tradfri_provider_invalid_json():
 
         index = await provider.load_index()
 
-    assert len(index) == len(index_obj) - 3
+    assert len(index) == len(index_obj) - 4
 
 
 async def test_ledvance_provider():

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -199,8 +199,10 @@ async def test_tradfri_provider_dirigera():
         mock_http.assert_not_called()
 
     # Skip the gateway firmware
-    filtered_version_info_obj = [obj for obj in index_obj if obj["fw_type"] == 2]
-    assert len(index) == len(index_obj) - 1 == len(filtered_version_info_obj)
+    filtered_version_info_obj = [
+        obj for obj in index_obj if obj["fw_type"] == 2 and obj["fw_image_type"] != 8710
+    ]
+    assert len(index) == len(index_obj) - 2 == len(filtered_version_info_obj)
 
     for obj, meta in zip(filtered_version_info_obj, index):
         assert isinstance(meta, providers.RemoteOtaImageMetadata)
@@ -385,7 +387,7 @@ async def test_tradfri_provider_invalid_json():
 
         index = await provider.load_index()
 
-    assert len(index) == len(index_obj) - 2
+    assert len(index) == len(index_obj) - 3
 
 
 async def test_ledvance_provider():

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -307,7 +307,7 @@ ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
                     LOGGER.warning("Could not parse IKEA OTA JSON: %r", fw)
                     continue
 
-                yield IkeaRemoteOtaImageMetadata(  # type: ignore[call-arg]
+                image = IkeaRemoteOtaImageMetadata(  # type: ignore[call-arg]
                     file_version=int(file_version_match.group("v"), 10),
                     manufacturer_id=self.MANUFACTURER_IDS[0],
                     image_type=fw["fw_image_type"],
@@ -320,7 +320,7 @@ ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
                 if fw["fw_type"] != 2:
                     continue
 
-                yield SignedIkeaRemoteOtaImageMetadata(  # type: ignore[call-arg]
+                image = SignedIkeaRemoteOtaImageMetadata(  # type: ignore[call-arg]
                     file_version=(
                         (fw["fw_file_version_MSB"] << 16)
                         | (fw["fw_file_version_LSB"] << 0)
@@ -332,6 +332,12 @@ ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
                     url=fw["fw_binary_url"].replace("http://", "https://", 1),
                     source="IKEA (TRÅDFRI)",
                 )
+
+            # Bricking update: https://github.com/zigpy/zigpy/issues/1428
+            if image.image_type == 8710:
+                continue
+
+            yield image
 
 
 @register_provider

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -334,7 +334,7 @@ ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
                 )
 
             # Bricking update: https://github.com/zigpy/zigpy/issues/1428
-            if image.image_type == 8710:
+            if image.image_type in (8704, 8710):
                 continue
 
             yield image


### PR DESCRIPTION
Fixes #1428.

We'll re-enable them whenever IKEA fixes this problem. I'd rather not take the risk of figuring out which exact devices are affected.