### PR TITLE
Handle OTA image page requests

### DIFF
--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -1,13 +1,22 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
-from tests.conftest import make_app, make_node_desc
+import pytest
+
+from tests.conftest import add_initialized_device, make_app, make_node_desc
 from tests.ota.test_ota_metadata import image_with_metadata  # noqa: F401
+import zigpy.application
 import zigpy.device
+import zigpy.exceptions
 from zigpy.ota import OtaImageWithMetadata
+import zigpy.ota.image
+from zigpy.ota.manager import update_firmware
+import zigpy.state
 import zigpy.types as t
+import zigpy.util
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters import Cluster
 from zigpy.zcl.clusters.general import Ota
+from zigpy.zdo import types as zdo_t
 import zigpy.zdo.types as zdo_t
 
 
@@ -126,3 +135,413 @@ async def test_ota_manger_device_reject(
 
     status = await dev.update_firmware(img)
     assert status == foundation.Status.NO_IMAGE_AVAILABLE
+
+
+async def test_ota_manager():
+    """Test that device firmware updates execute the expected calls."""
+
+    app = make_app({})
+    dev = add_initialized_device(
+        app, nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77")
+    )
+    cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
+
+    await dev.initialize()
+
+    # Stop the general cluster handler from interfering
+    dev.ota_in_progress = True
+
+    fw_image = zigpy.ota.OtaImageWithMetadata(
+        metadata=zigpy.ota.providers.BaseOtaImageMetadata(
+            file_version=0x12345678,
+            manufacturer_id=0x1234,
+            image_type=0x90,
+        ),
+        firmware=zigpy.ota.image.OTAImage(
+            header=zigpy.ota.image.OTAImageHeader(
+                upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
+                file_version=0x12345678,
+                image_type=0x90,
+                manufacturer_id=0x1234,
+                header_version=256,
+                header_length=56,
+                field_control=0,
+                stack_version=2,
+                header_string="This is a test header!",
+                image_size=56 + 2 + 4 + 8,
+            ),
+            subelements=[zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")],
+        ),
+    )
+
+    reconstructed_firmware = bytearray()
+
+    async def send_packet(packet: t.ZigbeePacket):
+        if packet.cluster_id != Ota.cluster_id:
+            return
+
+        hdr, cmd = cluster.deserialize(packet.data.serialize())
+
+        if isinstance(cmd, Ota.ImageNotifyCommand):
+            assert cmd.query_jitter == 100
+
+            # Ask for the next image
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "query_next_image",
+                    field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                    manufacturer_code=fw_image.firmware.header.manufacturer_id,
+                    image_type=fw_image.firmware.header.image_type,
+                    current_file_version=fw_image.firmware.header.file_version - 10,
+                    hardware_version=1,
+                )
+            )
+        elif isinstance(cmd, Ota.ClientCommandDefs.query_next_image_response.schema):
+            assert cmd.status == foundation.Status.SUCCESS
+            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
+            assert cmd.image_type == fw_image.firmware.header.image_type
+            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert cmd.image_size == fw_image.firmware.header.image_size
+
+            # Ask for the first block to get things started
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "image_block",
+                    field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                    manufacturer_code=fw_image.firmware.header.manufacturer_id,
+                    image_type=fw_image.firmware.header.image_type,
+                    file_version=fw_image.firmware.header.file_version,
+                    file_offset=0,
+                    maximum_data_size=40,
+                    request_node_addr=dev.ieee,
+                )
+            )
+        elif isinstance(cmd, Ota.ClientCommandDefs.image_block_response.schema):
+            assert cmd.status == foundation.Status.SUCCESS
+            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
+            assert cmd.image_type == fw_image.firmware.header.image_type
+            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert len(cmd.image_data) > 0
+
+            reconstructed_firmware[
+                cmd.file_offset : cmd.file_offset + len(cmd.image_data)
+            ] = cmd.image_data
+
+            if cmd.file_offset + len(cmd.image_data) == len(
+                fw_image.firmware.serialize()
+            ):
+                # End the upgrade
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        cluster,
+                        "upgrade_end",
+                        status=foundation.Status.SUCCESS,
+                        manufacturer_code=fw_image.firmware.header.manufacturer_id,
+                        image_type=fw_image.firmware.header.image_type,
+                        file_version=fw_image.firmware.header.file_version,
+                    )
+                )
+            else:
+                # Keep going
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        cluster,
+                        "image_block",
+                        field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                        manufacturer_code=fw_image.firmware.header.manufacturer_id,
+                        image_type=fw_image.firmware.header.image_type,
+                        file_version=fw_image.firmware.header.file_version,
+                        file_offset=cmd.file_offset + 40,
+                        maximum_data_size=40,
+                        request_node_addr=dev.ieee,
+                    )
+                )
+
+        elif isinstance(cmd, Ota.ClientCommandDefs.upgrade_end_response.schema):
+            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
+            assert cmd.image_type == fw_image.firmware.header.image_type
+            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert cmd.current_time == 0
+            assert cmd.upgrade_time == 0
+        elif isinstance(
+            cmd,
+            foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Read_Attributes
+            ].schema,
+        ):
+            assert cmd.attribute_ids == [Ota.AttributeDefs.current_file_version.id]
+
+            req_hdr, req_cmd = cluster._create_request(
+                general=True,
+                command_id=foundation.GeneralCommand.Read_Attributes_rsp,
+                schema=foundation.GENERAL_COMMANDS[
+                    foundation.GeneralCommand.Read_Attributes_rsp
+                ].schema,
+                tsn=hdr.tsn,
+                disable_default_response=True,
+                direction=foundation.Direction.Server_to_Client,
+                args=(),
+                kwargs={
+                    "status_records": [
+                        foundation.ReadAttributeRecord(
+                            attrid=Ota.AttributeDefs.current_file_version.id,
+                            status=foundation.Status.SUCCESS,
+                            value=foundation.TypeValue(
+                                type=foundation.DATA_TYPES.pytype_to_datatype_id(
+                                    t.uint32_t
+                                ),
+                                value=fw_image.firmware.header.file_version,
+                            ),
+                        )
+                    ]
+                },
+            )
+
+            dev.application.packet_received(
+                t.ZigbeePacket(
+                    src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+                    src_ep=1,
+                    dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+                    dst_ep=1,
+                    tsn=hdr.tsn,
+                    profile_id=260,
+                    cluster_id=cluster.cluster_id,
+                    data=t.SerializableBytes(req_hdr.serialize() + req_cmd.serialize()),
+                    lqi=255,
+                    rssi=-30,
+                )
+            )
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    progress_callback = MagicMock()
+    result = await update_firmware(dev, fw_image, progress_callback)
+
+    assert progress_callback.mock_calls == [
+        call(40, 70, pytest.approx(40 / 70 * 100)),
+        call(70, 70, 100.0),
+    ]
+    assert result == foundation.Status.SUCCESS
+
+    assert bytes(reconstructed_firmware) == fw_image.firmware.serialize()
+
+
+async def test_ota_manager_image_page():
+    """Test that device firmware updates execute the expected calls."""
+
+    app = make_app({})
+    dev = add_initialized_device(
+        app, nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77")
+    )
+    cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
+
+    await dev.initialize()
+
+    # Stop the general cluster handler from interfering
+    dev.ota_in_progress = True
+
+    fw_image = zigpy.ota.OtaImageWithMetadata(
+        metadata=zigpy.ota.providers.BaseOtaImageMetadata(
+            file_version=0x12345678,
+            manufacturer_id=0x1234,
+            image_type=0x90,
+        ),
+        firmware=zigpy.ota.image.OTAImage(
+            header=zigpy.ota.image.OTAImageHeader(
+                upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
+                file_version=0x12345678,
+                image_type=0x90,
+                manufacturer_id=0x1234,
+                header_version=256,
+                header_length=56,
+                field_control=0,
+                stack_version=2,
+                header_string="This is a test header!",
+                image_size=56 + 2 + 4 + 8,
+            ),
+            subelements=[zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")],
+        ),
+    )
+
+    reconstructed_firmware = bytearray()
+
+    async def send_packet(packet: t.ZigbeePacket):
+        if packet.cluster_id != Ota.cluster_id:
+            return
+
+        hdr, cmd = cluster.deserialize(packet.data.serialize())
+
+        if isinstance(cmd, Ota.ImageNotifyCommand):
+            assert cmd.query_jitter == 100
+
+            # Ask for the next image
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "query_next_image",
+                    field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                    manufacturer_code=fw_image.firmware.header.manufacturer_id,
+                    image_type=fw_image.firmware.header.image_type,
+                    current_file_version=fw_image.firmware.header.file_version - 10,
+                    hardware_version=1,
+                )
+            )
+        elif isinstance(cmd, Ota.ClientCommandDefs.query_next_image_response.schema):
+            assert cmd.status == foundation.Status.SUCCESS
+            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
+            assert cmd.image_type == fw_image.firmware.header.image_type
+            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert cmd.image_size == fw_image.firmware.header.image_size
+
+            # Ask for the first page to get things started
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "image_page",
+                    field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                    manufacturer_code=fw_image.firmware.header.manufacturer_id,
+                    image_type=fw_image.firmware.header.image_type,
+                    file_version=fw_image.firmware.header.file_version,
+                    file_offset=0,
+                    maximum_data_size=5,
+                    page_size=40,
+                    response_spacing=0,
+                    request_node_addr=dev.ieee,
+                )
+            )
+        elif isinstance(cmd, Ota.ClientCommandDefs.image_block_response.schema):
+            assert cmd.status == foundation.Status.SUCCESS
+            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
+            assert cmd.image_type == fw_image.firmware.header.image_type
+            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert len(cmd.image_data) > 0
+
+            if cmd.file_offset + len(cmd.image_data) > len(reconstructed_firmware):
+                reconstructed_firmware.extend(
+                    b"\x00"
+                    * (
+                        cmd.file_offset
+                        + len(cmd.image_data)
+                        - len(reconstructed_firmware)
+                    )
+                )
+
+            reconstructed_firmware[
+                cmd.file_offset : cmd.file_offset + len(cmd.image_data)
+            ] = cmd.image_data
+
+            if cmd.file_offset + len(cmd.image_data) == len(
+                fw_image.firmware.serialize()
+            ):
+                # End the upgrade
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        cluster,
+                        "upgrade_end",
+                        status=foundation.Status.SUCCESS,
+                        manufacturer_code=fw_image.firmware.header.manufacturer_id,
+                        image_type=fw_image.firmware.header.image_type,
+                        file_version=fw_image.firmware.header.file_version,
+                    )
+                )
+            else:
+                current_page_start = (cmd.file_offset // 40) * 40
+                current_page = reconstructed_firmware[
+                    current_page_start : current_page_start + 40
+                ]
+
+                # Only ask for another page if the current one has been filled
+                if (
+                    current_page_start + 40 >= len(fw_image.firmware.serialize())
+                    and len(current_page)
+                    == len(fw_image.firmware.serialize()) - current_page_start
+                ) or len(current_page) == 40:
+                    # Keep going
+                    dev.application.packet_received(
+                        make_packet(
+                            dev,
+                            cluster,
+                            "image_page",
+                            field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                            manufacturer_code=fw_image.firmware.header.manufacturer_id,
+                            image_type=fw_image.firmware.header.image_type,
+                            file_version=fw_image.firmware.header.file_version,
+                            file_offset=cmd.file_offset + 5,
+                            maximum_data_size=5,
+                            page_size=40,
+                            response_spacing=0,
+                            request_node_addr=dev.ieee,
+                        )
+                    )
+
+        elif isinstance(cmd, Ota.ClientCommandDefs.upgrade_end_response.schema):
+            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
+            assert cmd.image_type == fw_image.firmware.header.image_type
+            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert cmd.current_time == 0
+            assert cmd.upgrade_time == 0
+        elif isinstance(
+            cmd,
+            foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Read_Attributes
+            ].schema,
+        ):
+            assert cmd.attribute_ids == [Ota.AttributeDefs.current_file_version.id]
+
+            req_hdr, req_cmd = cluster._create_request(
+                general=True,
+                command_id=foundation.GeneralCommand.Read_Attributes_rsp,
+                schema=foundation.GENERAL_COMMANDS[
+                    foundation.GeneralCommand.Read_Attributes_rsp
+                ].schema,
+                tsn=hdr.tsn,
+                disable_default_response=True,
+                direction=foundation.Direction.Server_to_Client,
+                args=(),
+                kwargs={
+                    "status_records": [
+                        foundation.ReadAttributeRecord(
+                            attrid=Ota.AttributeDefs.current_file_version.id,
+                            status=foundation.Status.SUCCESS,
+                            value=foundation.TypeValue(
+                                type=foundation.DATA_TYPES.pytype_to_datatype_id(
+                                    t.uint32_t
+                                ),
+                                value=fw_image.firmware.header.file_version,
+                            ),
+                        )
+                    ]
+                },
+            )
+
+            dev.application.packet_received(
+                t.ZigbeePacket(
+                    src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+                    src_ep=1,
+                    dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+                    dst_ep=1,
+                    tsn=hdr.tsn,
+                    profile_id=260,
+                    cluster_id=cluster.cluster_id,
+                    data=t.SerializableBytes(req_hdr.serialize() + req_cmd.serialize()),
+                    lqi=255,
+                    rssi=-30,
+                )
+            )
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    progress_callback = MagicMock()
+    result = await update_firmware(dev, fw_image, progress_callback)
+
+    assert result == foundation.Status.SUCCESS
+    assert progress_callback.mock_calls == [
+        call(i, 70, pytest.approx(i / 70 * 100)) for i in range(5, 70 + 1, 5)
+    ]

--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -1,3 +1,4 @@
+import itertools
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -7,6 +8,7 @@ from tests.ota.test_ota_metadata import image_with_metadata  # noqa: F401
 import zigpy.application
 import zigpy.device
 import zigpy.exceptions
+from zigpy.exceptions import DeliveryError
 from zigpy.ota import OtaImageWithMetadata
 import zigpy.ota.image
 from zigpy.ota.manager import update_firmware
@@ -18,6 +20,49 @@ from zigpy.zcl.clusters import Cluster
 from zigpy.zcl.clusters.general import Ota
 from zigpy.zdo import types as zdo_t
 import zigpy.zdo.types as zdo_t
+
+
+def lcg(*, x: int = 0, a: int, c: int, m: int):
+    while True:
+        x = (a * x + c) % m
+        yield x
+
+
+FW_IMAGE = zigpy.ota.OtaImageWithMetadata(
+    metadata=zigpy.ota.providers.BaseOtaImageMetadata(
+        file_version=0x12345678,
+        manufacturer_id=0x1234,
+        image_type=0x90,
+    ),
+    firmware=zigpy.ota.image.OTAImage(
+        header=zigpy.ota.image.OTAImageHeader(
+            upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
+            file_version=0x12345678,
+            image_type=0x90,
+            manufacturer_id=0x1234,
+            header_version=256,
+            header_length=56,
+            field_control=0,
+            stack_version=2,
+            header_string="This is a test header!",
+            image_size=2048 + 56 + 2 + 4,
+        ),
+        subelements=[
+            zigpy.ota.image.SubElement(
+                tag_id=0x0000,
+                data=bytes(
+                    [
+                        x & 0xFF
+                        for x in itertools.islice(
+                            lcg(x=1, a=16807, c=0, m=7**5),
+                            2048,
+                        )
+                    ]
+                ),
+            )
+        ],
+    ),
+)
 
 
 def make_packet(dev: zigpy.device.Device, cluster: Cluster, cmd_name: str, **kwargs):
@@ -151,29 +196,6 @@ async def test_ota_manager():
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True
 
-    fw_image = zigpy.ota.OtaImageWithMetadata(
-        metadata=zigpy.ota.providers.BaseOtaImageMetadata(
-            file_version=0x12345678,
-            manufacturer_id=0x1234,
-            image_type=0x90,
-        ),
-        firmware=zigpy.ota.image.OTAImage(
-            header=zigpy.ota.image.OTAImageHeader(
-                upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
-                file_version=0x12345678,
-                image_type=0x90,
-                manufacturer_id=0x1234,
-                header_version=256,
-                header_length=56,
-                field_control=0,
-                stack_version=2,
-                header_string="This is a test header!",
-                image_size=56 + 2 + 4 + 8,
-            ),
-            subelements=[zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")],
-        ),
-    )
-
     reconstructed_firmware = bytearray()
 
     async def send_packet(packet: t.ZigbeePacket):
@@ -181,6 +203,7 @@ async def test_ota_manager():
             return
 
         hdr, cmd = cluster.deserialize(packet.data.serialize())
+        assert FW_IMAGE.firmware is not None
 
         if isinstance(cmd, Ota.ImageNotifyCommand):
             assert cmd.query_jitter == 100
@@ -192,18 +215,18 @@ async def test_ota_manager():
                     cluster,
                     "query_next_image",
                     field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
-                    manufacturer_code=fw_image.firmware.header.manufacturer_id,
-                    image_type=fw_image.firmware.header.image_type,
-                    current_file_version=fw_image.firmware.header.file_version - 10,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    current_file_version=FW_IMAGE.firmware.header.file_version - 10,
                     hardware_version=1,
                 )
             )
         elif isinstance(cmd, Ota.ClientCommandDefs.query_next_image_response.schema):
             assert cmd.status == foundation.Status.SUCCESS
-            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
-            assert cmd.image_type == fw_image.firmware.header.image_type
-            assert cmd.file_version == fw_image.firmware.header.file_version
-            assert cmd.image_size == fw_image.firmware.header.image_size
+            assert cmd.manufacturer_code == FW_IMAGE.firmware.header.manufacturer_id
+            assert cmd.image_type == FW_IMAGE.firmware.header.image_type
+            assert cmd.file_version == FW_IMAGE.firmware.header.file_version
+            assert cmd.image_size == FW_IMAGE.firmware.header.image_size
 
             # Ask for the first block to get things started
             dev.application.packet_received(
@@ -212,9 +235,9 @@ async def test_ota_manager():
                     cluster,
                     "image_block",
                     field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
-                    manufacturer_code=fw_image.firmware.header.manufacturer_id,
-                    image_type=fw_image.firmware.header.image_type,
-                    file_version=fw_image.firmware.header.file_version,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    file_version=FW_IMAGE.firmware.header.file_version,
                     file_offset=0,
                     maximum_data_size=40,
                     request_node_addr=dev.ieee,
@@ -222,9 +245,9 @@ async def test_ota_manager():
             )
         elif isinstance(cmd, Ota.ClientCommandDefs.image_block_response.schema):
             assert cmd.status == foundation.Status.SUCCESS
-            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
-            assert cmd.image_type == fw_image.firmware.header.image_type
-            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert cmd.manufacturer_code == FW_IMAGE.firmware.header.manufacturer_id
+            assert cmd.image_type == FW_IMAGE.firmware.header.image_type
+            assert cmd.file_version == FW_IMAGE.firmware.header.file_version
             assert len(cmd.image_data) > 0
 
             reconstructed_firmware[
@@ -232,7 +255,7 @@ async def test_ota_manager():
             ] = cmd.image_data
 
             if cmd.file_offset + len(cmd.image_data) == len(
-                fw_image.firmware.serialize()
+                FW_IMAGE.firmware.serialize()
             ):
                 # End the upgrade
                 dev.application.packet_received(
@@ -241,9 +264,9 @@ async def test_ota_manager():
                         cluster,
                         "upgrade_end",
                         status=foundation.Status.SUCCESS,
-                        manufacturer_code=fw_image.firmware.header.manufacturer_id,
-                        image_type=fw_image.firmware.header.image_type,
-                        file_version=fw_image.firmware.header.file_version,
+                        manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                        image_type=FW_IMAGE.firmware.header.image_type,
+                        file_version=FW_IMAGE.firmware.header.file_version,
                     )
                 )
             else:
@@ -254,9 +277,9 @@ async def test_ota_manager():
                         cluster,
                         "image_block",
                         field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
-                        manufacturer_code=fw_image.firmware.header.manufacturer_id,
-                        image_type=fw_image.firmware.header.image_type,
-                        file_version=fw_image.firmware.header.file_version,
+                        manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                        image_type=FW_IMAGE.firmware.header.image_type,
+                        file_version=FW_IMAGE.firmware.header.file_version,
                         file_offset=cmd.file_offset + 40,
                         maximum_data_size=40,
                         request_node_addr=dev.ieee,
@@ -264,9 +287,9 @@ async def test_ota_manager():
                 )
 
         elif isinstance(cmd, Ota.ClientCommandDefs.upgrade_end_response.schema):
-            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
-            assert cmd.image_type == fw_image.firmware.header.image_type
-            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert cmd.manufacturer_code == FW_IMAGE.firmware.header.manufacturer_id
+            assert cmd.image_type == FW_IMAGE.firmware.header.image_type
+            assert cmd.file_version == FW_IMAGE.firmware.header.file_version
             assert cmd.current_time == 0
             assert cmd.upgrade_time == 0
         elif isinstance(
@@ -296,7 +319,7 @@ async def test_ota_manager():
                                 type=foundation.DATA_TYPES.pytype_to_datatype_id(
                                     t.uint32_t
                                 ),
-                                value=fw_image.firmware.header.file_version,
+                                value=FW_IMAGE.firmware.header.file_version,
                             ),
                         )
                     ]
@@ -320,15 +343,16 @@ async def test_ota_manager():
 
     dev.application.send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
-    result = await update_firmware(dev, fw_image, progress_callback)
+    result = await update_firmware(dev, FW_IMAGE, progress_callback)
 
+    image_size = FW_IMAGE.firmware.header.image_size
     assert progress_callback.mock_calls == [
-        call(40, 70, pytest.approx(40 / 70 * 100)),
-        call(70, 70, 100.0),
-    ]
+        call(i, image_size, pytest.approx(i * 100 / image_size))
+        for i in range(40, image_size + 1, 40)
+    ] + [call(image_size, image_size, 100.0)]
     assert result == foundation.Status.SUCCESS
 
-    assert bytes(reconstructed_firmware) == fw_image.firmware.serialize()
+    assert bytes(reconstructed_firmware) == FW_IMAGE.firmware.serialize()
 
 
 async def test_ota_manager_image_page():
@@ -345,29 +369,6 @@ async def test_ota_manager_image_page():
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True
 
-    fw_image = zigpy.ota.OtaImageWithMetadata(
-        metadata=zigpy.ota.providers.BaseOtaImageMetadata(
-            file_version=0x12345678,
-            manufacturer_id=0x1234,
-            image_type=0x90,
-        ),
-        firmware=zigpy.ota.image.OTAImage(
-            header=zigpy.ota.image.OTAImageHeader(
-                upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
-                file_version=0x12345678,
-                image_type=0x90,
-                manufacturer_id=0x1234,
-                header_version=256,
-                header_length=56,
-                field_control=0,
-                stack_version=2,
-                header_string="This is a test header!",
-                image_size=56 + 2 + 4 + 8,
-            ),
-            subelements=[zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")],
-        ),
-    )
-
     reconstructed_firmware = bytearray()
 
     async def send_packet(packet: t.ZigbeePacket):
@@ -375,6 +376,7 @@ async def test_ota_manager_image_page():
             return
 
         hdr, cmd = cluster.deserialize(packet.data.serialize())
+        assert FW_IMAGE.firmware is not None
 
         if isinstance(cmd, Ota.ImageNotifyCommand):
             assert cmd.query_jitter == 100
@@ -386,18 +388,18 @@ async def test_ota_manager_image_page():
                     cluster,
                     "query_next_image",
                     field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
-                    manufacturer_code=fw_image.firmware.header.manufacturer_id,
-                    image_type=fw_image.firmware.header.image_type,
-                    current_file_version=fw_image.firmware.header.file_version - 10,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    current_file_version=FW_IMAGE.firmware.header.file_version - 10,
                     hardware_version=1,
                 )
             )
         elif isinstance(cmd, Ota.ClientCommandDefs.query_next_image_response.schema):
             assert cmd.status == foundation.Status.SUCCESS
-            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
-            assert cmd.image_type == fw_image.firmware.header.image_type
-            assert cmd.file_version == fw_image.firmware.header.file_version
-            assert cmd.image_size == fw_image.firmware.header.image_size
+            assert cmd.manufacturer_code == FW_IMAGE.firmware.header.manufacturer_id
+            assert cmd.image_type == FW_IMAGE.firmware.header.image_type
+            assert cmd.file_version == FW_IMAGE.firmware.header.file_version
+            assert cmd.image_size == FW_IMAGE.firmware.header.image_size
 
             # Ask for the first page to get things started
             dev.application.packet_received(
@@ -406,9 +408,9 @@ async def test_ota_manager_image_page():
                     cluster,
                     "image_page",
                     field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
-                    manufacturer_code=fw_image.firmware.header.manufacturer_id,
-                    image_type=fw_image.firmware.header.image_type,
-                    file_version=fw_image.firmware.header.file_version,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    file_version=FW_IMAGE.firmware.header.file_version,
                     file_offset=0,
                     maximum_data_size=5,
                     page_size=40,
@@ -418,9 +420,9 @@ async def test_ota_manager_image_page():
             )
         elif isinstance(cmd, Ota.ClientCommandDefs.image_block_response.schema):
             assert cmd.status == foundation.Status.SUCCESS
-            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
-            assert cmd.image_type == fw_image.firmware.header.image_type
-            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert cmd.manufacturer_code == FW_IMAGE.firmware.header.manufacturer_id
+            assert cmd.image_type == FW_IMAGE.firmware.header.image_type
+            assert cmd.file_version == FW_IMAGE.firmware.header.file_version
             assert len(cmd.image_data) > 0
 
             if cmd.file_offset + len(cmd.image_data) > len(reconstructed_firmware):
@@ -438,7 +440,7 @@ async def test_ota_manager_image_page():
             ] = cmd.image_data
 
             if cmd.file_offset + len(cmd.image_data) == len(
-                fw_image.firmware.serialize()
+                FW_IMAGE.firmware.serialize()
             ):
                 # End the upgrade
                 dev.application.packet_received(
@@ -447,9 +449,9 @@ async def test_ota_manager_image_page():
                         cluster,
                         "upgrade_end",
                         status=foundation.Status.SUCCESS,
-                        manufacturer_code=fw_image.firmware.header.manufacturer_id,
-                        image_type=fw_image.firmware.header.image_type,
-                        file_version=fw_image.firmware.header.file_version,
+                        manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                        image_type=FW_IMAGE.firmware.header.image_type,
+                        file_version=FW_IMAGE.firmware.header.file_version,
                     )
                 )
             else:
@@ -460,9 +462,9 @@ async def test_ota_manager_image_page():
 
                 # Only ask for another page if the current one has been filled
                 if (
-                    current_page_start + 40 >= len(fw_image.firmware.serialize())
+                    current_page_start + 40 >= len(FW_IMAGE.firmware.serialize())
                     and len(current_page)
-                    == len(fw_image.firmware.serialize()) - current_page_start
+                    == len(FW_IMAGE.firmware.serialize()) - current_page_start
                 ) or len(current_page) == 40:
                     # Keep going
                     dev.application.packet_received(
@@ -471,9 +473,9 @@ async def test_ota_manager_image_page():
                             cluster,
                             "image_page",
                             field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
-                            manufacturer_code=fw_image.firmware.header.manufacturer_id,
-                            image_type=fw_image.firmware.header.image_type,
-                            file_version=fw_image.firmware.header.file_version,
+                            manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                            image_type=FW_IMAGE.firmware.header.image_type,
+                            file_version=FW_IMAGE.firmware.header.file_version,
                             file_offset=cmd.file_offset + 5,
                             maximum_data_size=5,
                             page_size=40,
@@ -483,9 +485,9 @@ async def test_ota_manager_image_page():
                     )
 
         elif isinstance(cmd, Ota.ClientCommandDefs.upgrade_end_response.schema):
-            assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
-            assert cmd.image_type == fw_image.firmware.header.image_type
-            assert cmd.file_version == fw_image.firmware.header.file_version
+            assert cmd.manufacturer_code == FW_IMAGE.firmware.header.manufacturer_id
+            assert cmd.image_type == FW_IMAGE.firmware.header.image_type
+            assert cmd.file_version == FW_IMAGE.firmware.header.file_version
             assert cmd.current_time == 0
             assert cmd.upgrade_time == 0
         elif isinstance(
@@ -515,7 +517,7 @@ async def test_ota_manager_image_page():
                                 type=foundation.DATA_TYPES.pytype_to_datatype_id(
                                     t.uint32_t
                                 ),
-                                value=fw_image.firmware.header.file_version,
+                                value=FW_IMAGE.firmware.header.file_version,
                             ),
                         )
                     ]
@@ -539,9 +541,159 @@ async def test_ota_manager_image_page():
 
     dev.application.send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
-    result = await update_firmware(dev, fw_image, progress_callback)
+    result = await update_firmware(dev, FW_IMAGE, progress_callback)
 
     assert result == foundation.Status.SUCCESS
+
+    image_size = FW_IMAGE.firmware.header.image_size
     assert progress_callback.mock_calls == [
-        call(i, 70, pytest.approx(i / 70 * 100)) for i in range(5, 70 + 1, 5)
+        call(i, image_size, pytest.approx(i / image_size * 100))
+        for i in range(5, image_size + 1, 5)
     ]
+
+
+async def test_ota_manager_image_page_invalid_size():
+    """Test that the OTA manager fails properly with invalid image page requests."""
+
+    app = make_app({})
+    dev = add_initialized_device(
+        app, nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77")
+    )
+    cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
+
+    await dev.initialize()
+
+    # Stop the general cluster handler from interfering
+    dev.ota_in_progress = True
+
+    async def send_packet(packet: t.ZigbeePacket):
+        if packet.cluster_id != Ota.cluster_id:
+            return
+
+        hdr, cmd = cluster.deserialize(packet.data.serialize())
+        assert FW_IMAGE.firmware is not None
+
+        if isinstance(cmd, Ota.ImageNotifyCommand):
+            assert cmd.query_jitter == 100
+
+            # Ask for the next image
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "query_next_image",
+                    field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    current_file_version=FW_IMAGE.firmware.header.file_version - 10,
+                    hardware_version=1,
+                )
+            )
+        elif isinstance(cmd, Ota.ClientCommandDefs.query_next_image_response.schema):
+            assert cmd.status == foundation.Status.SUCCESS
+            assert cmd.manufacturer_code == FW_IMAGE.firmware.header.manufacturer_id
+            assert cmd.image_type == FW_IMAGE.firmware.header.image_type
+            assert cmd.file_version == FW_IMAGE.firmware.header.file_version
+            assert cmd.image_size == FW_IMAGE.firmware.header.image_size
+
+            # Ask for the first page to get things started
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "image_page",
+                    field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    file_version=FW_IMAGE.firmware.header.file_version,
+                    file_offset=FW_IMAGE.firmware.header.image_size,
+                    maximum_data_size=5,
+                    page_size=40,
+                    response_spacing=0,
+                    request_node_addr=dev.ieee,
+                )
+            )
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    progress_callback = MagicMock()
+    result = await update_firmware(dev, FW_IMAGE, progress_callback)
+
+    assert result == foundation.Status.MALFORMED_COMMAND
+
+
+async def test_ota_manager_image_page_failure():
+    """Test that the OTA manager fails properly with invalid image page requests."""
+
+    app = make_app({})
+    dev = add_initialized_device(
+        app, nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77")
+    )
+    cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
+
+    await dev.initialize()
+
+    # Stop the general cluster handler from interfering
+    dev.ota_in_progress = True
+
+    start_failing = False
+
+    async def send_packet(packet: t.ZigbeePacket):
+        nonlocal start_failing
+
+        if start_failing:
+            raise DeliveryError("Broken")
+
+        if packet.cluster_id != Ota.cluster_id:
+            return
+
+        hdr, cmd = cluster.deserialize(packet.data.serialize())
+        assert FW_IMAGE.firmware is not None
+
+        if isinstance(cmd, Ota.ImageNotifyCommand):
+            assert cmd.query_jitter == 100
+
+            # Ask for the next image
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "query_next_image",
+                    field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    current_file_version=FW_IMAGE.firmware.header.file_version - 10,
+                    hardware_version=1,
+                )
+            )
+        elif isinstance(cmd, Ota.ClientCommandDefs.query_next_image_response.schema):
+            assert cmd.status == foundation.Status.SUCCESS
+            assert cmd.manufacturer_code == FW_IMAGE.firmware.header.manufacturer_id
+            assert cmd.image_type == FW_IMAGE.firmware.header.image_type
+            assert cmd.file_version == FW_IMAGE.firmware.header.file_version
+            assert cmd.image_size == FW_IMAGE.firmware.header.image_size
+
+            # Ask for the first page to get things started
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "image_page",
+                    field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    file_version=FW_IMAGE.firmware.header.file_version,
+                    file_offset=0,
+                    maximum_data_size=5,
+                    page_size=40,
+                    response_spacing=0,
+                    request_node_addr=dev.ieee,
+                )
+            )
+
+            start_failing = True
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    progress_callback = MagicMock()
+    result = await update_firmware(dev, FW_IMAGE, progress_callback)
+
+    assert result == foundation.Status.FAILURE

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -256,6 +256,7 @@ class OTAManager:
             except Exception as ex:  # noqa: BLE001
                 self.device.debug("OTA image_page handler exception", exc_info=ex)
                 self._finish(foundation.Status.FAILURE)
+                return
 
             # Delay according to what the device asks
             await asyncio.sleep(command.response_spacing / 1000)

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -142,6 +142,19 @@ class OTAManager:
         if status != foundation.Status.SUCCESS:
             self._finish(status)
 
+    async def _finish_malformed_image_block_response(self, handler: str, tsn: int):
+        """Create an image block response failure."""
+        try:
+            await self.ota_cluster.image_block_response(
+                status=foundation.Status.MALFORMED_COMMAND, tsn=tsn
+            )
+        except Exception as ex:  # noqa: BLE001
+            self.device.debug(
+                "OTA %s handler[MALFORMED_COMMAND] exception", handler, exc_info=ex
+            )
+
+        self._finish(foundation.Status.MALFORMED_COMMAND)
+
     async def _image_block_req(
         self, hdr: foundation.ZCLHeader, command: Ota.ImageBlockCommand
     ) -> None:
@@ -157,17 +170,9 @@ class OTAManager:
         ]
 
         if not block:
-            try:
-                await self.ota_cluster.image_block_response(
-                    status=foundation.Status.MALFORMED_COMMAND,
-                    tsn=hdr.tsn,
-                )
-            except Exception as ex:  # noqa: BLE001
-                self.device.debug(
-                    "OTA image_block handler[MALFORMED_COMMAND] exception", exc_info=ex
-                )
-
-            self._finish(foundation.Status.MALFORMED_COMMAND)
+            await self._finish_malformed_image_block_response(
+                "image_block", tsn=hdr.tsn
+            )
             return
 
         try:
@@ -206,18 +211,10 @@ class OTAManager:
         )
 
         if bytes_remaining <= 0:
-            try:
-                await self.ota_cluster.image_block_response(
-                    status=foundation.Status.MALFORMED_COMMAND,
-                    tsn=hdr.tsn,
-                )
-            except Exception as ex:  # noqa: BLE001
-                self.device.debug(
-                    "OTA image_page_req handler[MALFORMED_COMMAND] exception",
-                    exc_info=ex,
-                )
-
-            self._finish(foundation.Status.MALFORMED_COMMAND)
+            await self._finish_malformed_image_block_response(
+                "image_page_req",
+                tsn=hdr.tsn,
+            )
             return
 
         while bytes_remaining > 0:

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -80,6 +80,16 @@ class OTAManager:
             self.device._application.callback_for_response(
                 src=self.device,
                 filters=[
+                    Ota.ServerCommandDefs.image_page.schema(),
+                ],
+                callback=self._image_page_req,
+            )
+        )
+
+        self.stack.enter_context(
+            self.device._application.callback_for_response(
+                src=self.device,
+                filters=[
                     Ota.ServerCommandDefs.upgrade_end.schema(),
                 ],
                 callback=self._upgrade_end,
@@ -185,6 +195,50 @@ class OTAManager:
         except Exception as ex:  # noqa: BLE001
             self.device.debug("OTA image_block handler exception", exc_info=ex)
             self._finish(foundation.Status.FAILURE)
+
+    async def _image_page_req(
+        self, hdr: foundation.ZCLHeader, command: Ota.ImagePageCommand
+    ) -> None:
+        """Handle image page request."""
+        bytes_remaining = command.page_size
+        offset = command.file_offset
+
+        while bytes_remaining > 0:
+            block_size = min(
+                MAXIMUM_IMAGE_BLOCK_SIZE, command.maximum_data_size, bytes_remaining
+            )
+            block = self._image_data[offset : offset + block_size]
+            offset += block_size
+            bytes_remaining -= block_size
+
+            try:
+                await self.ota_cluster.request(
+                    general=False,
+                    command_id=Ota.ClientCommandDefs.image_block_response.id,
+                    schema=Ota.ClientCommandDefs.image_block_response.schema,
+                    expect_reply=False,
+                    # kwargs
+                    status=foundation.Status.SUCCESS,
+                    manufacturer_code=self.image.firmware.header.manufacturer_id,
+                    image_type=self.image.firmware.header.image_type,
+                    file_version=self.image.firmware.header.file_version,
+                    file_offset=offset,
+                    image_data=block,
+                )
+
+                self._stall_timer.reschedule(MAX_TIME_WITHOUT_PROGRESS)
+
+                if (
+                    self.progress_callback is not None
+                    and not self._upgrade_end_future.done()
+                ):
+                    self.progress_callback(offset + len(block), len(self._image_data))
+            except Exception as ex:  # noqa: BLE001
+                self.device.debug("OTA image_page handler exception", exc_info=ex)
+                self._finish(foundation.Status.FAILURE)
+
+            # Delay according to what the device asks
+            await asyncio.sleep(command.response_spacing / 1000)
 
     async def _upgrade_end(
         self, hdr: foundation.ZCLHeader, command: foundation.CommandSchema

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -222,7 +222,7 @@ class OTAManager:
                     manufacturer_code=self.image.firmware.header.manufacturer_id,
                     image_type=self.image.firmware.header.image_type,
                     file_version=self.image.firmware.header.file_version,
-                    file_offset=offset,
+                    file_offset=offset - block_size,
                     image_data=block,
                 )
 

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -200,18 +200,39 @@ class OTAManager:
         self, hdr: foundation.ZCLHeader, command: Ota.ImagePageCommand
     ) -> None:
         """Handle image page request."""
-        bytes_remaining = command.page_size
         offset = command.file_offset
+        bytes_remaining = min(
+            command.page_size, len(self._image_data) - command.file_offset
+        )
+
+        if bytes_remaining <= 0:
+            try:
+                await self.ota_cluster.image_block_response(
+                    status=foundation.Status.MALFORMED_COMMAND,
+                    tsn=hdr.tsn,
+                )
+            except Exception as ex:  # noqa: BLE001
+                self.device.debug(
+                    "OTA image_page_req handler[MALFORMED_COMMAND] exception",
+                    exc_info=ex,
+                )
+
+            self._finish(foundation.Status.MALFORMED_COMMAND)
+            return
 
         while bytes_remaining > 0:
             block_size = min(
-                MAXIMUM_IMAGE_BLOCK_SIZE, command.maximum_data_size, bytes_remaining
+                MAXIMUM_IMAGE_BLOCK_SIZE,
+                command.maximum_data_size,
+                bytes_remaining,
             )
             block = self._image_data[offset : offset + block_size]
             offset += block_size
             bytes_remaining -= block_size
 
             try:
+                # Once we have a way to send requests without waiting for replies,
+                # this can be converted to just `self.ota_cluster.image_block_response`
                 await self.ota_cluster.request(
                     general=False,
                     command_id=Ota.ClientCommandDefs.image_block_response.id,
@@ -232,7 +253,9 @@ class OTAManager:
                     self.progress_callback is not None
                     and not self._upgrade_end_future.done()
                 ):
-                    self.progress_callback(offset + len(block), len(self._image_data))
+                    self.progress_callback(
+                        offset - block_size + len(block), len(self._image_data)
+                    )
             except Exception as ex:  # noqa: BLE001
                 self.device.debug("OTA image_page handler exception", exc_info=ex)
                 self._finish(foundation.Status.FAILURE)


### PR DESCRIPTION
First time I've seen this, it's with a ThirdReality night light. Instead of sending an image block request, the device sends image *page* requests:

<img width="851" alt="image" src="https://github.com/user-attachments/assets/c0f9910e-ae94-4be8-8875-00d681f5ae5e">

Since image page requests explicitly *disable* ACKs, have no default response, and are optional, the fallback behavior is pretty terrible. The device waits about 10s after sending an image page request and then sends a normal image block request.

This PR implements support for this command and speeds up OTA by a significant amount for devices that require it.

The odd command sending structure is because we do not expose a simple way to send specific commands with specific header flags. This needs to be addressed in a followup PR.