### PR TITLE
Fix double converting `config`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,7 +136,7 @@ def make_app(
         config_updates,
     )
 
-    app = app_base(app_base.SCHEMA(config))
+    app = app_base(config)
     app.state.node_info = app_state.NodeInfo(
         nwk=t.NWK(0x0000), ieee=NCP_IEEE, logical_type=zdo_t.LogicalType.Coordinator
     )

--- a/tests/ota/test_ota_config.py
+++ b/tests/ota/test_ota_config.py
@@ -85,22 +85,6 @@ async def test_ota_enabled_legacy(tmp_path: pathlib.Path) -> None:
     assert len(ota._providers) == 10
 
 
-async def test_ota_enabled_legacy_advanced(tmp_path: pathlib.Path) -> None:
-    app = make_app(
-        {
-            config.CONF_OTA: {
-                config.CONF_OTA_ENABLED: True,
-                config.CONF_OTA_ADVANCED_DIR: tmp_path,
-                config.CONF_OTA_ALLOW_ADVANCED_DIR: config.CONF_OTA_ALLOW_ADVANCED_DIR_STRING,
-            }
-        }
-    )
-
-    await app.startup()
-
-    assert zigpy.ota.providers.AdvancedFileProvider(path=tmp_path) in app.ota._providers
-
-
 async def test_ota_config(tmp_path: pathlib.Path) -> None:
     # Enable all the providers
     ota = zigpy.ota.OTA(

--- a/tests/ota/test_ota_config.py
+++ b/tests/ota/test_ota_config.py
@@ -85,6 +85,22 @@ async def test_ota_enabled_legacy(tmp_path: pathlib.Path) -> None:
     assert len(ota._providers) == 10
 
 
+async def test_ota_enabled_legacy_advanced(tmp_path: pathlib.Path) -> None:
+    app = make_app(
+        {
+            config.CONF_OTA: {
+                config.CONF_OTA_ENABLED: True,
+                config.CONF_OTA_ADVANCED_DIR: tmp_path,
+                config.CONF_OTA_ALLOW_ADVANCED_DIR: config.CONF_OTA_ALLOW_ADVANCED_DIR_STRING,
+            }
+        }
+    )
+
+    await app.startup()
+
+    assert zigpy.ota.providers.AdvancedFileProvider(path=tmp_path) in app.ota._providers
+
+
 async def test_ota_config(tmp_path: pathlib.Path) -> None:
     # Enable all the providers
     ota = zigpy.ota.OTA(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,12 +1,10 @@
 import asyncio
-import copy
 import errno
 import logging
 from unittest import mock
 from unittest.mock import ANY, PropertyMock, call
 
 import pytest
-import voluptuous as vol
 
 import zigpy.application
 import zigpy.config as conf
@@ -332,48 +330,6 @@ def test_props(app):
     assert app.state.network_info.extended_pan_id is not None
     assert app.state.network_info.pan_id is not None
     assert app.state.network_info.nwk_update_id is not None
-
-
-def test_app_config_setter(app):
-    """Test configuration setter."""
-
-    cfg_copy = copy.deepcopy(app.config)
-    assert app.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED] is False
-    cfg_copy[conf.CONF_OTA][conf.CONF_OTA_ENABLED] = "invalid bool"
-
-    with pytest.raises(vol.Invalid):
-        app.config = cfg_copy
-
-    assert app.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED] is False
-
-    cfg_copy[conf.CONF_OTA][conf.CONF_OTA_ENABLED] = True
-    app.config = cfg_copy
-    assert app.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED] is True
-
-    cfg_copy[conf.CONF_OTA][conf.CONF_OTA_ENABLED] = "invalid bool"
-
-    with pytest.raises(vol.Invalid):
-        app.config = cfg_copy
-
-    assert app.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED] is True
-
-
-def test_app_update_config(app):
-    """Test configuration partial update."""
-
-    assert app.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED] is False
-    with pytest.raises(vol.Invalid):
-        app.update_config({conf.CONF_OTA: {conf.CONF_OTA_ENABLED: "invalid bool"}})
-
-    assert app.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED] is False
-
-    app.update_config({conf.CONF_OTA: {conf.CONF_OTA_ENABLED: "yes"}})
-    assert app.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED] is True
-
-    with pytest.raises(vol.Invalid):
-        app.update_config({conf.CONF_OTA: {conf.CONF_OTA_ENABLED: "invalid bool"}})
-
-    assert app.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED] is True
 
 
 async def test_uninitialized_message_handlers(app, ieee):

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -25,12 +25,10 @@ def remove_request_delay():
 @pytest.fixture()
 def topology(make_initialized_device):
     app = App(
-        conf.ZIGPY_SCHEMA(
-            {
-                conf.CONF_DEVICE: {conf.CONF_DEVICE_PATH: "/dev/null"},
-                conf.CONF_TOPO_SKIP_COORDINATOR: True,
-            }
-        )
+        {
+            conf.CONF_DEVICE: {conf.CONF_DEVICE_PATH: "/dev/null"},
+            conf.CONF_TOPO_SKIP_COORDINATOR: True,
+        }
     )
 
     coordinator = make_initialized_device(app)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -77,7 +77,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             self._config[conf.CONF_MAX_CONCURRENT_REQUESTS]
         )
 
-        self.ota = zigpy.ota.OTA(config[conf.CONF_OTA], self)
+        self.ota = zigpy.ota.OTA(self._config[conf.CONF_OTA], self)
         self.backups: zigpy.backups.BackupManager = zigpy.backups.BackupManager(self)
         self.topology: zigpy.topology.Topology = zigpy.topology.Topology(self)
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -625,7 +625,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 device_configs.append(new_config)
 
         for config in device_configs:
-            app = cls(cls.SCHEMA({conf.CONF_DEVICE: config}))
+            app = cls({conf.CONF_DEVICE: config})
 
             try:
                 await app.connect()

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1299,19 +1299,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         dstaddr.endpoint = self.get_endpoint_id(cluster.cluster_id, cluster.is_server)
         return dstaddr
 
-    def update_config(self, partial_config: dict[str, Any]) -> None:
-        """Update existing config."""
-        self.config = {**self.config, **partial_config}
-
     @property
     def config(self) -> dict:
         """Return current configuration."""
         return self._config
-
-    @config.setter
-    def config(self, new_config) -> None:
-        """Configuration setter."""
-        self._config = self.SCHEMA(new_config)
 
     @property
     def groups(self) -> zigpy.group.Groups:

--- a/zigpy/config/validators.py
+++ b/zigpy/config/validators.py
@@ -67,9 +67,7 @@ def cv_key(key: list[int]) -> t.KeyData:
 
 def cv_simple_descriptor(obj: dict[str, typing.Any]) -> zdo_t.SimpleDescriptor:
     """Validates a ZDO simple descriptor."""
-    if isinstance(obj, zdo_t.SimpleDescriptor):
-        return obj
-    elif not isinstance(obj, dict):
+    if not isinstance(obj, dict):
         raise vol.Invalid("Not a dictionary")
 
     descriptor = zdo_t.SimpleDescriptor(**obj)
@@ -135,15 +133,8 @@ def cv_ota_provider_name(name: str | None) -> type[zigpy.ota.providers.BaseOtaPr
     return zigpy.ota.providers.OTA_PROVIDER_TYPES[name]
 
 
-def cv_ota_provider(
-    obj: dict | zigpy.ota.providers.BaseOtaProvider,
-) -> zigpy.ota.providers.BaseOtaProvider:
+def cv_ota_provider(obj: dict) -> zigpy.ota.providers.BaseOtaProvider:
     """Validate OTA provider."""
-    import zigpy.ota.providers
-
-    if isinstance(obj, zigpy.ota.providers.BaseOtaProvider):
-        return obj
-
     provider_type = obj.get(zigpy.config.CONF_OTA_PROVIDER_TYPE)
     provider_cls = cv_ota_provider_name(provider_type)
 


### PR DESCRIPTION
Requires fixes in all radio libraries:

- https://github.com/zigpy/zigpy-znp/pull/250
- https://github.com/zigpy/zigpy-deconz/pull/260
- https://github.com/zigpy/zigpy-xbee/pull/176
- https://github.com/zigpy/zigpy-zigate/pull/157
- `bellows` is fine: https://github.com/zigpy/bellows/blob/a86f7f1341551056ba044d56ccc88bb0a86a46c5/bellows/zigbee/application.py#L81

We double convert the schema in many spots, resulting in `vol` config that gets validated *twice* and unit tests that do not cover what real radios do.