### PR TITLE
Make `CharacterString` backwards compatible with earlier releases

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -333,6 +333,8 @@ def test_lvbytes_0_len():
 
 
 def test_character_string():
+    assert t.CharacterString() == ""
+
     d, r = t.CharacterString.deserialize(b"\x0412345")
     assert r == b"5"
     assert d == "1234"

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -932,7 +932,7 @@ class CharacterString(str):
     _prefix_length = 1
     _invalid_length = (1 << (8 * _prefix_length)) - 1
 
-    def __new__(cls, value: str, *, invalid: bool = False) -> Self:
+    def __new__(cls, value: str = "", *, invalid: bool = False) -> Self:
         instance = super().__new__(cls, value)
         instance.invalid = invalid
         instance.raw = value


### PR DESCRIPTION
#1412 changes the default constructor for `CharacterString`.

https://github.com/zigpy/zha-device-handlers/issues/1687
https://github.com/home-assistant/core/issues/123574