### PR TITLE
Add new quirks v2 metadata type that allows replacing all instances of a cluster on a device

### DIFF
--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -594,9 +594,10 @@ class QuirkBuilder:
         replacement_cluster_class should be a subclass of Cluster or CustomCluster and
         will be used to create a new cluster instance to replace the existing cluster.
 
-        If cluster_id is provided, it will be used as the cluster_id for the cluster to
-        be removed. If cluster_id is not provided, the cluster_id of the replacement
-        cluster will be used.
+        replace_server_instances and replace_client_instances control the cluster types
+        that will be replaced. If replace_server_instances is True, all server instances
+        of the cluster will be replaced. If replace_client_instances is True, all client
+        instances of the cluster will be replaced.
         """
         types = []
         if replace_server_instances:


### PR DESCRIPTION
This PR adds a new metadata type and a new builder method to allow replacing all instances of a cluster without having to add replaces for each occurrence. There are times where depending on the firmware version of device variant where a cluster may need to be replaced across all endpoints but the device signature isn't consistent. The existing replaces ensures the specified endpoint exists and is endpoint specific.