### PR TITLE
Fix advanced file provider setup

### DIFF
--- a/tests/ota/test_ota_config.py
+++ b/tests/ota/test_ota_config.py
@@ -82,7 +82,7 @@ async def test_ota_enabled_legacy(tmp_path: pathlib.Path) -> None:
     )
 
     # All are enabled
-    assert len(ota._providers) == 10
+    assert len(ota._providers) == 9
 
 
 async def test_ota_config(tmp_path: pathlib.Path) -> None:
@@ -182,6 +182,11 @@ async def test_ota_config_complex(tmp_path: pathlib.Path) -> None:
                         config.CONF_OTA_PROVIDER_URL: "https://ikea3.example.org/",
                         config.CONF_OTA_PROVIDER_MANUF_IDS: [0xABCD, 0xDCBA],
                     },
+                    {
+                        config.CONF_OTA_PROVIDER_TYPE: "advanced",
+                        config.CONF_OTA_PROVIDER_PATH: tmp_path,
+                        config.CONF_OTA_PROVIDER_WARNING: config.CONF_OTA_ALLOW_ADVANCED_DIR_STRING,
+                    },
                 ],
             }
         ),
@@ -198,6 +203,7 @@ async def test_ota_config_complex(tmp_path: pathlib.Path) -> None:
             url="https://ikea3.example.org/",
             manufacturer_ids=[0xABCD, 0xDCBA],
         ),
+        zigpy.ota.providers.AdvancedFileProvider(path=tmp_path),
     ]
 
 

--- a/zigpy/config/__init__.py
+++ b/zigpy/config/__init__.py
@@ -37,7 +37,6 @@ from zigpy.config.defaults import (
 from zigpy.config.validators import (
     cv_boolean,
     cv_deprecated,
-    cv_exact_object,
     cv_folder,
     cv_hex,
     cv_json_file,
@@ -177,7 +176,7 @@ SCHEMA_OTA_PROVIDER_JSON_INDEX = SCHEMA_OTA_PROVIDER_BASE.extend(
 SCHEMA_OTA_PROVIDER_FOLDER = SCHEMA_OTA_PROVIDER_BASE.extend(
     {
         vol.Required(CONF_OTA_PROVIDER_PATH): cv_folder,
-        vol.Required(CONF_OTA_PROVIDER_WARNING): cv_exact_object(
+        vol.Required(CONF_OTA_PROVIDER_WARNING): vol.Equal(
             CONF_OTA_ALLOW_ADVANCED_DIR_STRING
         ),
     }
@@ -313,7 +312,7 @@ SCHEMA_OTA_DEPRECATED = {
             " to the `extra_providers` list instead: `extra_providers: [{'type': 'advanced',"
             " 'warning': 'I understand ...'}]"
         ),
-        cv_exact_object(CONF_OTA_ALLOW_ADVANCED_DIR_STRING),
+        vol.Equal(CONF_OTA_ALLOW_ADVANCED_DIR_STRING),
     ),
     vol.Optional(CONF_OTA_REMOTE_PROVIDERS): vol.All(
         cv_deprecated(

--- a/zigpy/config/validators.py
+++ b/zigpy/config/validators.py
@@ -89,20 +89,6 @@ def cv_deprecated(message: str) -> typing.Callable[[typing.Any], typing.Any]:
     return wrapper
 
 
-def cv_exact_object(
-    expected_value: str,
-) -> typing.Callable[[typing.Any], typing.Literal[True]]:
-    """Factory function for creating an exact object comparison validator."""
-
-    def wrapper(obj: typing.Any) -> typing.Literal[True]:
-        if obj != expected_value:
-            raise vol.Invalid(f"Expected {expected_value!r}, got {obj!r}")
-
-        return True
-
-    return wrapper
-
-
 def cv_json_file(value: str) -> pathlib.Path:
     """Validate a JSON file."""
     path = pathlib.Path(value)

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -709,6 +709,9 @@ class AdvancedFileProvider(BaseOtaProvider):
     VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_FOLDER
 
     def __init__(self, path: pathlib.Path, **kwargs):
+        # The `vol` schema passes through the `warning` key, which is unused
+        kwargs.pop("warning", None)
+
         super().__init__(url=None, **kwargs)
         self.path = path
 


### PR DESCRIPTION
Unit tests apparently did not ever set it up and the `warning` key was propagating without being handled.

Thanks @MattWestb! (https://github.com/zigpy/zigpy/pull/1400#issuecomment-2275404330)