### PR TITLE
Fix advanced provider concurrency combining

### DIFF
--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -360,12 +360,11 @@ class OTA:
 
     @zigpy.util.combine_concurrent_calls
     async def _load_provider_index(
-        self, provider_index: int
+        self, provider: zigpy.ota.providers.BaseOtaProvider
     ) -> list[zigpy.ota.providers.BaseOtaImageMetadata]:
         """Load the index of a provider."""
-
         async with asyncio_timeout(OTA_FETCH_TIMEOUT):
-            return await self._providers[provider_index].load_index()
+            return await provider.load_index()
 
     @zigpy.util.combine_concurrent_calls
     async def _fetch_image(
@@ -383,18 +382,13 @@ class OTA:
     ) -> OtaImageWithMetadata | None:
         # Only consider providers that are compatible with the device
         compatible_providers = [
-            (index, provider)
-            for index, provider in enumerate(self._providers)
-            if provider.compatible_with_device(device)
+            p for p in self._providers if p.compatible_with_device(device)
         ]
 
         # Load the index of every provider
-        for index, provider in compatible_providers:
+        for provider in compatible_providers:
             try:
-                # We load the provider's index by its index in the list of providers
-                # to avoid making the providers hashable, allowing concurrency to be
-                # combined
-                index = await self._load_provider_index(provider_index=index)
+                index = await self._load_provider_index(provider)
             except Exception as exc:  # noqa: BLE001
                 _LOGGER.debug("Failed to load provider %s", provider, exc_info=exc)
                 continue

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -249,8 +249,8 @@ class BaseOtaProvider:
 
         return self.url == other.url and self.manufacturer_ids == other.manufacturer_ids
 
-    # We don't want the above `__eq__` to change object hashing semantics
-    __hash__ = object.__hash__
+    def __hash__(self) -> int:
+        return hash((self.url, self.manufacturer_ids))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(url={self.url!r}, manufacturer_ids={self.manufacturer_ids!r})"
@@ -576,6 +576,9 @@ class LocalZigpyProvider(BaseZigpyProvider):
 
         return super().__eq__(other) and self.index_file == other.index_file
 
+    def __hash__(self) -> int:
+        return hash((self.index_file, self.manufacturer_ids))
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(index_file={self.index_file!r}, manufacturer_ids={self.manufacturer_ids!r})"
 
@@ -662,6 +665,9 @@ class LocalZ2MProvider(BaseZ2MProvider):
             return NotImplemented
 
         return super().__eq__(other) and self.index_file == other.index_file
+
+    def __hash__(self) -> int:
+        return hash((self.index_file, self.manufacturer_ids))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(index_file={self.index_file!r}, manufacturer_ids={self.manufacturer_ids!r})"
@@ -758,6 +764,9 @@ class AdvancedFileProvider(BaseOtaProvider):
             return NotImplemented
 
         return super().__eq__(other) and self.path == other.path
+
+    def __hash__(self) -> int:
+        return hash((self.path, self.manufacturer_ids))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(path={self.path!r}, manufacturer_ids={self.manufacturer_ids!r})"


### PR DESCRIPTION
Some OTA providers (namely `Advanced`) are not hashable because they override `__eq__` and break `combine_concurrent_requests`.

An alternate hack would be to use `id()` for `combine_concurrent_requests` for non-hashable objects.