### PR TITLE
[RFC] metadata with class references cause issues when ZHA is reloaded.

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -264,6 +264,68 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
     assert isinstance(registry.get_device(device_mock), CustomDeviceV2)
 
 
+async def test_quirks_v2_multiple_matches_not_raises_simulated_reload(device_mock):
+    """Test that adding multiple quirks v2 entries for the same device doesn't raise.
+
+    When the quirk is EXACTLY the same the semantics of sets prevents us from
+    having multiple quirks in the registry. This test simulates a reload of the
+    integration which would reload the classes and quirks.
+    """
+    registry = DeviceRegistry()
+
+    class Foo(CustomDeviceV2):
+        """Test device class."""
+
+    class StartUpOnOff(t.enum8):
+        """Test enum."""
+
+        Off = 0x00
+        On = 0x01
+        Toggle = 0x02
+        PreviousValue = 0xFF
+
+    entry1 = (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .device_class(Foo)
+        .adds(Basic.cluster_id)
+        .adds(OnOff.cluster_id)
+        .enum(
+            OnOff.AttributeDefs.start_up_on_off.name,
+            StartUpOnOff,
+            OnOff.cluster_id,
+        )
+        .add_to_registry()
+    )
+
+    class Foo(CustomDeviceV2):  # pylint disable=function-redefined
+        """Test device class."""
+
+    class StartUpOnOff(t.enum8):  # pylint disable=function-redefined
+        """Test enum."""
+
+        Off = 0x00
+        On = 0x01
+        Toggle = 0x02
+        PreviousValue = 0xFF
+
+    entry2 = (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .device_class(Foo)
+        .adds(Basic.cluster_id)
+        .adds(OnOff.cluster_id)
+        .enum(
+            OnOff.AttributeDefs.start_up_on_off.name,
+            StartUpOnOff,
+            OnOff.cluster_id,
+        )
+        .add_to_registry()
+    )
+
+    assert entry1 == entry2
+    assert entry1 != registry
+    assert isinstance(registry.get_device(device_mock), CustomDeviceV2)
+
+
 async def test_quirks_v2_with_custom_device_class(device_mock):
     """Test adding a quirk with a custom device class to the registry."""
     registry = DeviceRegistry()

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -261,6 +261,29 @@ class ZCLEnumMetadata(EntityMetadata):
     enum: type[Enum] = attrs.field()
     attribute_name: str = attrs.field()
 
+    def __hash__(self) -> int:
+        """Return the hash of the metadata."""
+        return hash(
+            (
+                self.endpoint_id,
+                self.cluster_id,
+                self.cluster_type,
+                self.enum.__class__.__name__,
+                self.attribute_name,
+                self.entity_platform,
+                self.entity_type,
+                self.initially_disabled,
+                self.attribute_initialized_from_cache,
+                self.translation_key,
+            )
+        )
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether the metadata is equal to another."""
+        if not isinstance(other, ZCLEnumMetadata):
+            return False
+        return self.__hash__() == other.__hash__()
+
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
 class ZCLSensorMetadata(EntityMetadata):
@@ -370,6 +393,31 @@ class QuirksV2RegistryEntry:
                 device.application, device.ieee, device.nwk, device, self
             )
         return CustomDeviceV2(device.application, device.ieee, device.nwk, device, self)
+
+    def __hash__(self) -> int:
+        """Return the hash of the metadata."""
+        return hash(
+            (
+                self.manufacturer_model_metadata,
+                self.filters,
+                self.custom_device_class.__class__.__name__
+                if self.custom_device_class
+                else None,
+                self.device_node_descriptor,
+                self.skip_device_configuration,
+                self.adds_metadata,
+                self.removes_metadata,
+                self.replaces_metadata,
+                self.entity_metadata,
+                self.device_automation_triggers_metadata,
+            )
+        )
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether the metadata is equal to another."""
+        if not isinstance(other, QuirksV2RegistryEntry):
+            return False
+        return self.__hash__() == other.__hash__()
 
 
 class QuirkBuilder:


### PR DESCRIPTION
This is a continuation of #1410 I think the issue is that any metadata classes that contain references to locally defined classes in custom quirks will not match after reloading quirks because the class definitions have different hashes. 

Additional feedback was given here: https://github.com/zigpy/zigpy/issues/1410#issuecomment-2287996706

This PR contains a test that reproduces the issue and a potential solution. 