### PR TITLE
Expose options bitmasks for Color and LevelControl cluster

### DIFF
--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -978,6 +978,11 @@ class StepMode(t.enum8):
     Down = 0x01
 
 
+class OptionsMask(t.bitmap8):
+    Execute_if_off_present = 0b00000001
+    Couple_color_temp_to_level_present = 0b00000010
+
+
 class Options(t.bitmap8):
     Execute_if_off = 0b00000001
     Couple_color_temp_to_level = 0b00000010
@@ -991,6 +996,7 @@ class LevelControl(Cluster):
     MoveMode: Final = MoveMode
     StepMode: Final = StepMode
     Options: Final = Options
+    OptionsMask: Final = OptionsMask
 
     cluster_id: Final[t.uint16_t] = 0x0008
     name: Final = "Level control"
@@ -1034,8 +1040,8 @@ class LevelControl(Cluster):
             schema={
                 "level": t.uint8_t,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=Direction.Client_to_Server,
         )
@@ -1044,8 +1050,8 @@ class LevelControl(Cluster):
             schema={
                 "move_mode": MoveMode,
                 "rate": t.uint8_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=Direction.Client_to_Server,
         )
@@ -1055,16 +1061,16 @@ class LevelControl(Cluster):
                 "step_mode": StepMode,
                 "step_size": t.uint8_t,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=Direction.Client_to_Server,
         )
         stop: Final = ZCLCommandDef(
             id=0x03,
             schema={
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=Direction.Client_to_Server,
         )

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -104,6 +104,7 @@ class Color(Cluster):
     ColorLoopDirection: Final = ColorLoopDirection
     DriftCompensation: Final = DriftCompensation
     Options: Final = Options
+    OptionsMask: Final = OptionsMask
 
     cluster_id: Final[t.uint16_t] = 0x0300
     name: Final = "Color Control"

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -80,6 +80,10 @@ class DriftCompensation(t.enum8):
     Color_monitoring = 0x03
 
 
+class OptionsMask(t.bitmap8):
+    Execute_if_off_present = 0b00000001
+
+
 class Options(t.bitmap8):
     Execute_if_off = 0b00000001
 
@@ -226,8 +230,8 @@ class Color(Cluster):
                 "hue": t.uint8_t,
                 "direction": Direction,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -236,8 +240,8 @@ class Color(Cluster):
             schema={
                 "move_mode": MoveMode,
                 "rate": t.uint8_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -247,8 +251,8 @@ class Color(Cluster):
                 "step_mode": StepMode,
                 "step_size": t.uint8_t,
                 "transition_time": t.uint8_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -257,8 +261,8 @@ class Color(Cluster):
             schema={
                 "saturation": t.uint8_t,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -267,8 +271,8 @@ class Color(Cluster):
             schema={
                 "move_mode": MoveMode,
                 "rate": t.uint8_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -278,8 +282,8 @@ class Color(Cluster):
                 "step_mode": StepMode,
                 "step_size": t.uint8_t,
                 "transition_time": t.uint8_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -289,8 +293,8 @@ class Color(Cluster):
                 "hue": t.uint8_t,
                 "saturation": t.uint8_t,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -300,8 +304,8 @@ class Color(Cluster):
                 "color_x": t.uint16_t,
                 "color_y": t.uint16_t,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -310,8 +314,8 @@ class Color(Cluster):
             schema={
                 "rate_x": t.uint16_t,
                 "rate_y": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -321,8 +325,8 @@ class Color(Cluster):
                 "step_x": t.uint16_t,
                 "step_y": t.uint16_t,
                 "duration": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -331,8 +335,8 @@ class Color(Cluster):
             schema={
                 "color_temp_mireds": t.uint16_t,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -342,8 +346,8 @@ class Color(Cluster):
                 "enhanced_hue": t.uint16_t,
                 "direction": Direction,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -352,8 +356,8 @@ class Color(Cluster):
             schema={
                 "move_mode": MoveMode,
                 "rate": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -363,8 +367,8 @@ class Color(Cluster):
                 "step_mode": StepMode,
                 "step_size": t.uint16_t,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -374,8 +378,8 @@ class Color(Cluster):
                 "enhanced_hue": t.uint16_t,
                 "saturation": t.uint8_t,
                 "transition_time": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -387,16 +391,16 @@ class Color(Cluster):
                 "direction": ColorLoopDirection,
                 "time": t.uint16_t,
                 "start_hue": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
         stop_move_step: Final = ZCLCommandDef(
             id=0x47,
             schema={
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -407,8 +411,8 @@ class Color(Cluster):
                 "rate": t.uint16_t,
                 "color_temp_min_mireds": t.uint16_t,
                 "color_temp_max_mireds": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )
@@ -420,8 +424,8 @@ class Color(Cluster):
                 "transition_time": t.uint16_t,
                 "color_temp_min_mireds": t.uint16_t,
                 "color_temp_max_mireds": t.uint16_t,
-                "options_mask?": t.bitmap8,
-                "options_override?": t.bitmap8,
+                "options_mask?": OptionsMask,
+                "options_override?": Options,
             },
             direction=CommandDirection.Client_to_Server,
         )


### PR DESCRIPTION
Allows for smooth color transitions for Hue lights from an "off" state with the following ZHA patch:

```diff
diff --git a/zha/application/platforms/light/__init__.py b/zha/application/platforms/light/__init__.py
index 87c6034..1a29ea4 100644
--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -580,6 +580,8 @@ class BaseLight(BaseEntity, ABC):
                     enhanced_hue=int(hs_color[0] * 65535 / 360),
                     saturation=int(hs_color[1] * 2.54),
                     transition_time=int(10 * transition_time),
+                    options_mask=Color.OptionsMask.Execute_if_off_present,
+                    options_override=Color.Options.Execute_if_off,
                 )
                 t_log["enhanced_move_to_hue_and_saturation"] = result
             else:
@@ -602,6 +604,8 @@ class BaseLight(BaseEntity, ABC):
                 color_x=int(xy_color[0] * 65535),
                 color_y=int(xy_color[1] * 65535),
                 transition_time=int(10 * transition_time),
+                options_mask=Color.OptionsMask.Execute_if_off_present,
+                options_override=Color.Options.Execute_if_off,
             )
             t_log["move_to_color"] = result
             if result[1] is not Status.SUCCESS:
diff --git a/zha/zigbee/cluster_handlers/lighting.py b/zha/zigbee/cluster_handlers/lighting.py
index e9f034f..d404f6a 100644
--- a/zha/zigbee/cluster_handlers/lighting.py
+++ b/zha/zigbee/cluster_handlers/lighting.py
@@ -197,4 +197,4 @@ class ColorClusterHandler(ClusterHandler):
     @property
     def execute_if_off_supported(self) -> bool:
         """Return True if the cluster handler can execute commands when off."""
-        return Color.Options.Execute_if_off in self.options
+        return self.cluster.get(Color.AttributeDefs.options.name) is not None
```

The `execute_if_off_supported` patch is something that needs to be explored in ZHA. I think what we have now is not accurate: the ZCL expects the `options` attribute to be *writeable* in addition to readable. It'll be set to `0` on a newly joined light.