### PR TITLE
Catch TypeError along with KeyError in read_attributes

### DIFF
--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -536,7 +536,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 if record.status == foundation.Status.SUCCESS:
                     try:
                         value = self.attributes[record.attrid].type(record.value.value)
-                    except KeyError:
+                    except (KeyError, TypeError):
                         value = record.value.value
                     except ValueError:
                         value = record.value.value


### PR DESCRIPTION
Currently the MultiStateInput returns an Array for the state_text value. This throws a TypeError since the Array is not iterable.

Not convinced this it the right solution, but opening for discussion.

Closes https://github.com/zigpy/zigpy/issues/1454
