### PR TITLE
Use zigpy serialization for attributes reads and writes in the database

### DIFF
--- a/zigpy/appdb_schemas/schema_v14.sql
+++ b/zigpy/appdb_schemas/schema_v14.sql
@@ -1,0 +1,214 @@
+PRAGMA user_version = 14;
+
+-- devices
+DROP TABLE IF EXISTS devices_v14;
+CREATE TABLE devices_v14 (
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+    last_seen REAL NOT NULL
+);
+
+CREATE UNIQUE INDEX devices_idx_v14
+    ON devices_v14(ieee);
+
+
+-- endpoints
+DROP TABLE IF EXISTS endpoints_v14;
+CREATE TABLE endpoints_v14 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    profile_id INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v14(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX endpoint_idx_v14
+    ON endpoints_v14(ieee, endpoint_id);
+
+
+-- clusters
+DROP TABLE IF EXISTS clusters_v14;
+CREATE TABLE clusters_v14 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v14(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX clusters_idx_v14
+    ON clusters_v14(ieee, endpoint_id, cluster_type, cluster_id);
+
+
+-- attributes
+DROP TABLE IF EXISTS attributes_cache_v14;
+CREATE TABLE attributes_cache_v14 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+    attr_id INTEGER NOT NULL,
+    value BLOB NOT NULL,
+    last_updated REAL NOT NULL,
+
+    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
+    -- DB but whose values still need to be cached
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v14(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX attributes_cache_idx_v14
+    ON attributes_cache_v14(ieee, endpoint_id, cluster_type, cluster_id, attr_id);
+
+
+-- neighbors
+DROP TABLE IF EXISTS neighbors_v14;
+CREATE TABLE neighbors_v14 (
+    device_ieee ieee NOT NULL,
+    extended_pan_id ieee NOT NULL,
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    rx_on_when_idle INTEGER NOT NULL,
+    relationship INTEGER NOT NULL,
+    reserved1 INTEGER NOT NULL,
+    permit_joining INTEGER NOT NULL,
+    reserved2 INTEGER NOT NULL,
+    depth INTEGER NOT NULL,
+    lqi INTEGER NOT NULL,
+
+    FOREIGN KEY(device_ieee)
+        REFERENCES devices_v14(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX neighbors_idx_v14
+    ON neighbors_v14(device_ieee);
+
+
+-- routes
+DROP TABLE IF EXISTS routes_v14;
+CREATE TABLE routes_v14 (
+    device_ieee ieee NOT NULL,
+    dst_nwk INTEGER NOT NULL,
+    route_status INTEGER NOT NULL,
+    memory_constrained INTEGER NOT NULL,
+    many_to_one INTEGER NOT NULL,
+    route_record_required INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    next_hop INTEGER NOT NULL
+);
+
+CREATE INDEX routes_idx_v14
+    ON routes_v14(device_ieee);
+
+
+-- node descriptors
+DROP TABLE IF EXISTS node_descriptors_v14;
+CREATE TABLE node_descriptors_v14 (
+    ieee ieee NOT NULL,
+
+    logical_type INTEGER NOT NULL,
+    complex_descriptor_available INTEGER NOT NULL,
+    user_descriptor_available INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    aps_flags INTEGER NOT NULL,
+    frequency_band INTEGER NOT NULL,
+    mac_capability_flags INTEGER NOT NULL,
+    manufacturer_code INTEGER NOT NULL,
+    maximum_buffer_size INTEGER NOT NULL,
+    maximum_incoming_transfer_size INTEGER NOT NULL,
+    server_mask INTEGER NOT NULL,
+    maximum_outgoing_transfer_size INTEGER NOT NULL,
+    descriptor_capability_field INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v14(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX node_descriptors_idx_v14
+    ON node_descriptors_v14(ieee);
+
+
+-- groups
+DROP TABLE IF EXISTS groups_v14;
+CREATE TABLE groups_v14 (
+    group_id INTEGER NOT NULL,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX groups_idx_v14
+    ON groups_v14(group_id);
+
+
+-- group members
+DROP TABLE IF EXISTS group_members_v14;
+CREATE TABLE group_members_v14 (
+    group_id INTEGER NOT NULL,
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+
+    FOREIGN KEY(group_id)
+        REFERENCES groups_v14(group_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v14(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX group_members_idx_v14
+    ON group_members_v14(group_id, ieee, endpoint_id);
+
+
+-- relays
+DROP TABLE IF EXISTS relays_v14;
+CREATE TABLE relays_v14 (
+    ieee ieee NOT NULL,
+    relays BLOB NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v14(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX relays_idx_v14
+    ON relays_v14(ieee);
+
+
+-- unsupported attributes
+DROP TABLE IF EXISTS unsupported_attributes_v14;
+CREATE TABLE unsupported_attributes_v14 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+    attr_id INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v14(ieee)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id, cluster_type, cluster_id)
+        REFERENCES clusters_v14(ieee, endpoint_id, cluster_type, cluster_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX unsupported_attributes_idx_v14
+    ON unsupported_attributes_v14(ieee, endpoint_id, cluster_type, cluster_id, attr_id);
+
+
+-- network backups
+DROP TABLE IF EXISTS network_backups_v14;
+CREATE TABLE network_backups_v14 (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    backup_json TEXT NOT NULL
+);


### PR DESCRIPTION
(WIP)

This PR splits up database loading into two halves: a mostly stateless phase, where devices are loaded and populated as much as possible within `appdb` alone, and then a part to mutate `ControllerApplication`. This is necessary because we need to load quirks completely when figuring out which attributes exist and which don't.

Bad attributes are logged and dropped during migration:

```
2024-08-16 11:51:40.386 WARNING (MainThread) [zigpy.appdb] [0x57fb:1:0xff01] Attribute 0x0001 with serialized value 1 does not exist, ignoring
2024-08-16 11:51:40.376 WARNING (MainThread) [zigpy.appdb] [0xe9e7:1:0xff01] Attribute 0x0080 with serialized value 16908288 does not exist, ignoring
...
```

This one is a bug in zigpy, we're missing the `reporting_status` attribute on a bunch of clusters:

```
2024-08-16 11:51:40.371 WARNING (MainThread) [zigpy.appdb] [0x0217:1:0x0702] Attribute 0xFFFD with serialized value 1 does not exist, ignoring
```

This one is a bug in quirks:

```
2024-08-16 11:51:40.378 WARNING (MainThread) [zigpy.appdb] [0xc7c8:1:0xfc31] Failed to deserialize attribute periodic_power_and_energy_reports (<class 'zigpy.types.basic.uint8_t'>) = 3600: ValueError('3600 is not an unsigned 8 bit integer')
```

Warnings will be logged when an unknown attribute is cached.