### PR TITLE
Default serial port `exclusive` to `None` instead of `False`, for Windows

### DIFF
--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -28,7 +28,7 @@ async def create_serial_connection(
     url: str,
     *,
     baudrate: int = 115200,  # We default to 115200 instead of 9600
-    exclusive: bool = False,
+    exclusive: bool | None = None,
     xonxoff: bool | UndefinedType = UNDEFINED,
     rtscts: bool | UndefinedType = UNDEFINED,
     flow_control: Literal["hardware", "software", None] | UndefinedType = UNDEFINED,


### PR DESCRIPTION
Fixes https://github.com/NabuCasa/universal-silabs-flasher/issues/79