### PR TITLE
Fix parsing of Array types in attribute reports

### DIFF
--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -790,7 +790,7 @@ def test_command_definition_backwards_compat():
 
 
 def test_array():
-    data = bytes.fromhex(
+    orig_data = data = bytes.fromhex(
         "183c010100004841040006000d0106000206010d0206000206020d0306000206030d04060002"
     )
     hdr, data = foundation.ZCLHeader.deserialize(data)
@@ -804,19 +804,18 @@ def test_array():
         foundation.ReadAttributeRecord(
             attrid=0x0001,
             status=foundation.Status.SUCCESS,
-            value=foundation.TypeValue(
-                type=foundation.DATA_TYPES.pytype_to_datatype_id(foundation.Array),
-                value=foundation.Array(
-                    type=foundation.DATA_TYPES.pytype_to_datatype_id(t.LVBytes),
-                    value=t.LVList[t.LVBytes, t.uint16_t](
-                        [
-                            b"\x00\r\x01\x06\x00\x02",
-                            b"\x01\r\x02\x06\x00\x02",
-                            b"\x02\r\x03\x06\x00\x02",
-                            b"\x03\r\x04\x06\x00\x02",
-                        ]
-                    ),
+            value=foundation.Array(
+                type=foundation.DATA_TYPES.pytype_to_datatype_id(t.LVBytes),
+                value=t.LVList[t.LVBytes, t.uint16_t](
+                    [
+                        b"\x00\r\x01\x06\x00\x02",
+                        b"\x01\r\x02\x06\x00\x02",
+                        b"\x02\r\x03\x06\x00\x02",
+                        b"\x03\r\x04\x06\x00\x02",
+                    ]
                 ),
             ),
         )
     ]
+
+    assert orig_data == hdr.serialize() + rsp.serialize()

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -272,13 +272,16 @@ class CustomCluster(zigpy.zcl.Cluster):
 
         succeeded = [
             foundation.ReadAttributeRecord(
-                attr, foundation.Status.SUCCESS, foundation.TypeValue()
+                attrid=attr,
+                status=foundation.Status.SUCCESS,
+                value=foundation.TypeValue(
+                    type=None,
+                    value=self._CONSTANT_ATTRIBUTES[attr],
+                ),
             )
             for attr in attributes
             if attr in self._CONSTANT_ATTRIBUTES
         ]
-        for record in succeeded:
-            record.value.value = self._CONSTANT_ATTRIBUTES[record.attrid]
 
         attrs_to_read = [
             attr for attr in attributes if attr not in self._CONSTANT_ATTRIBUTES

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -247,8 +247,8 @@ class ReadAttributeRecord:
 
     def __init__(
         self,
-        attrid: t.uint16_t | Self | None = None,
-        status: Status | None = None,
+        attrid: t.uint16_t | Self = t.uint16_t(0x0000),
+        status: Status = Status.SUCCESS,
         value: TypeValue | Array | Bag | Set | None = None,
     ) -> None:
         if isinstance(attrid, self.__class__):
@@ -256,10 +256,11 @@ class ReadAttributeRecord:
             self.attrid = attrid.attrid
             self.status = attrid.status
             self.value = attrid.value
-        else:
-            self.attrid = t.uint16_t(attrid)
-            self.status = Status(status)
-            self.value = value
+            return
+
+        self.attrid = t.uint16_t(attrid)
+        self.status = Status(status)
+        self.value = value
 
     @classmethod
     def deserialize(cls, data: bytes) -> tuple[Self, bytes]:

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -157,10 +157,10 @@ class DataTypes(dict):
     ) -> None:
         super().__init__(data_types)
         self._idx_by_class = {
-            _type: type_id for type_id, (name, _type, ad) in self.items()
+            _type: t.uint8_t(type_id) for type_id, (name, _type, ad) in self.items()
         }
 
-    def pytype_to_datatype_id(self, python_type: typing.Any) -> int:
+    def pytype_to_datatype_id(self, python_type: typing.Any) -> t.uint8_t:
         """Return Zigbee Datatype ID for a give python type."""
 
         # We return the most specific parent class
@@ -168,7 +168,7 @@ class DataTypes(dict):
             if cls in self._idx_by_class:
                 return self._idx_by_class[cls]
 
-        return 0xFF
+        return t.uint8_t(0xFF)
 
 
 class ZCLStructure(t.LVList, item_type=TypeValue, length_type=t.uint16_t):
@@ -237,12 +237,64 @@ DATA_TYPES = DataTypes(
 )
 
 
-class ReadAttributeRecord(t.Struct):
+@dataclasses.dataclass()
+class ReadAttributeRecord:
     """Read Attribute Record."""
 
-    attrid: t.uint16_t = t.StructField(repr=_hex_uint16_repr)
+    attrid: t.uint16_t
     status: Status
-    value: TypeValue = t.StructField(requires=lambda s: s.status == Status.SUCCESS)
+    value: TypeValue | Array | Bag | Set | None
+
+    def __init__(
+        self,
+        attrid: t.uint16_t | Self,
+        status: Status = None,
+        value: TypeValue | Array | Bag | Set | None = None,
+    ) -> None:
+        if isinstance(attrid, self.__class__):
+            # "Copy constructor"
+            self.attrid = attrid.attrid
+            self.status = attrid.status
+            self.value = attrid.value
+        else:
+            self.attrid = attrid
+            self.status = status
+            self.value = value
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
+        attrid, data = t.uint16_t.deserialize(data)
+        status, data = Status.deserialize(data)
+        value = None
+
+        if status == Status.SUCCESS:
+            data_type, data = t.uint8_t.deserialize(data)
+            py_data_type = DATA_TYPES[data_type][1]
+
+            # Arrays, Sets, and Bags are treated differently
+            if py_data_type in (Array, Set, Bag):
+                value, data = py_data_type.deserialize(data)
+            else:
+                value, data = TypeValue.deserialize(data_type.serialize() + data)
+
+        return cls(attrid=attrid, status=status, value=value), data
+
+    def serialize(self) -> bytes:
+        data = self.attrid.serialize()
+        data += self.status.serialize()
+
+        if self.status == Status.SUCCESS:
+            assert self.value is not None
+
+            if isinstance(self.value, (Array, Set, Bag)):
+                data += (
+                    DATA_TYPES.pytype_to_datatype_id(type(self.value)).serialize()
+                    + self.value.serialize()
+                )
+            else:
+                data += self.value.serialize()
+
+        return data
 
 
 class Attribute(t.Struct):

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -247,8 +247,8 @@ class ReadAttributeRecord:
 
     def __init__(
         self,
-        attrid: t.uint16_t | Self,
-        status: Status = None,
+        attrid: t.uint16_t | Self | None = None,
+        status: Status | None = None,
         value: TypeValue | Array | Bag | Set | None = None,
     ) -> None:
         if isinstance(attrid, self.__class__):
@@ -257,8 +257,8 @@ class ReadAttributeRecord:
             self.status = attrid.status
             self.value = attrid.value
         else:
-            self.attrid = attrid
-            self.status = status
+            self.attrid = t.uint16_t(attrid)
+            self.status = Status(status)
             self.value = value
 
     @classmethod


### PR DESCRIPTION
Fixes https://github.com/zigpy/zigpy/issues/1454. The ZCL treats Arrays differently from other data types when parsing attribute reports...

![image](https://github.com/user-attachments/assets/b8f9aa4c-0071-42bc-8001-dd387110e1ec)
