### PR TITLE
Implement a standard interface for network scanning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,10 @@ class App(zigpy.application.ControllerApplication):
     async def load_network_info(self, *, load_devices=False):
         self.state.network_info.channel = 15
 
+    async def _network_scan(self, channels, duration_exp):
+        if False:
+            yield
+
 
 def recursive_dict_merge(
     obj: dict[str, typing.Any], updates: dict[str, typing.Any]

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1246,7 +1246,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     ) -> AsyncGenerator[t.NetworkBeacon, None]:
         """Scans for 802.15.4 networks with a specified duration exponent."""
         if False:
-            yield
+            yield  # pragma: no cover
 
     async def permit(self, time_s: int = 60, node: t.EUI64 | str | None = None) -> None:
         """Permit joining on a specific node or all router nodes."""

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import asyncio
 import collections
-from collections.abc import Coroutine
+from collections.abc import AsyncGenerator, Coroutine
 import contextlib
 from datetime import datetime, timezone
 import errno
@@ -13,7 +13,7 @@ import random
 import sys
 import time
 import typing
-from typing import Any, AsyncGenerator, Coroutine, TypeVar
+from typing import Any, TypeVar
 import warnings
 
 if sys.version_info[:2] < (3, 11):
@@ -1231,8 +1231,15 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         raise NotImplementedError  # pragma: no cover
 
-    # @abc.abstractmethod
     async def network_scan(
+        self, channels: t.Channels, duration_exp: int
+    ) -> AsyncGenerator[t.NetworkBeacon, None]:
+        """Scans for 802.15.4 networks with a specified duration exponent."""
+        async for network in self._network_scan(channels, duration_exp):
+            yield network
+
+    # @abc.abstractmethod
+    async def _network_scan(
         self, channels: t.Channels, duration_exp: int
     ) -> AsyncGenerator[t.NetworkBeacon, None]:
         """Scans for 802.15.4 networks with a specified duration exponent."""

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1233,9 +1233,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     # @abc.abstractmethod
     async def network_scan(
-        self, channels: t.Channels, duration: int
+        self, channels: t.Channels, duration_exp: int
     ) -> AsyncGenerator[t.NetworkBeacon, None]:
-        """Scans for networks on specified channels for a specified duration."""
+        """Scans for 802.15.4 networks with a specified duration exponent."""
         if False:
             yield
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -13,7 +13,7 @@ import random
 import sys
 import time
 import typing
-from typing import Any, TypeVar
+from typing import Any, AsyncGenerator, Coroutine, TypeVar
 import warnings
 
 if sys.version_info[:2] < (3, 11):
@@ -1230,6 +1230,14 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Leaves the current network."""
 
         raise NotImplementedError  # pragma: no cover
+
+    # @abc.abstractmethod
+    async def network_scan(
+        self, channels: t.Channels, duration: int
+    ) -> AsyncGenerator[t.NetworkBeacon, None]:
+        """Scans for networks on specified channels for a specified duration."""
+        if False:
+            yield
 
     async def permit(self, time_s: int = 60, node: t.EUI64 | str | None = None) -> None:
         """Permit joining on a specific node or all router nodes."""

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1235,7 +1235,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self, channels: t.Channels, duration_exp: int
     ) -> AsyncGenerator[t.NetworkBeacon, None]:
         """Scans for 802.15.4 networks with a specified duration exponent."""
-        async for network in self._network_scan(channels, duration_exp):
+        async for network in self._network_scan(
+            channels=channels, duration_exp=duration_exp
+        ):
             yield network
 
     # @abc.abstractmethod

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -660,6 +660,6 @@ class NetworkBeacon(BaseDataclassMixin):
     src: NWK | None = None
     rssi: basic.int8s | None = None
     depth: basic.uint8_t | None = None
-    router_capacity: basic.uint8_t | None = None
-    device_capacity: basic.uint8_t | None = None
+    router_capacity: bool | None = None
+    device_capacity: bool | None = None
     protocol_version: basic.uint8_t | None = None

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -644,3 +644,20 @@ class ZigbeePacket(BaseDataclassMixin):
                 self.priority,
             )
         )
+
+
+@dataclasses.dataclass(frozen=True)
+class NetworkBeacon:
+    src: NWK | None
+    pan_id: PanId
+    channel: basic.uint8_t
+    permit_joining: bool
+    router_capacity: basic.uint8_t | None
+    device_capacity: basic.uint8_t | None
+    protocol_version: basic.uint8_t | None
+    stack_profile: basic.uint8_t
+    lqi: basic.uint8_t
+    rssi: basic.int8s | None
+    depth: basic.uint8_t
+    update_id: basic.uint8_t
+    extended_pan_id: EUI64

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -647,17 +647,19 @@ class ZigbeePacket(BaseDataclassMixin):
 
 
 @dataclasses.dataclass(frozen=True)
-class NetworkBeacon:
-    src: NWK | None
+class NetworkBeacon(BaseDataclassMixin):
     pan_id: PanId
+    extended_pan_id: EUI64
     channel: basic.uint8_t
     permit_joining: bool
-    router_capacity: basic.uint8_t | None
-    device_capacity: basic.uint8_t | None
-    protocol_version: basic.uint8_t | None
     stack_profile: basic.uint8_t
+    nwk_update_id: basic.uint8_t
     lqi: basic.uint8_t
-    rssi: basic.int8s | None
-    depth: basic.uint8_t
-    update_id: basic.uint8_t
-    extended_pan_id: EUI64
+
+    # Migrate to kwarg-only once we drop 3.9
+    src: NWK | None = None
+    rssi: basic.int8s | None = None
+    depth: basic.uint8_t | None = None
+    router_capacity: basic.uint8_t | None = None
+    device_capacity: basic.uint8_t | None = None
+    protocol_version: basic.uint8_t | None = None


### PR DESCRIPTION
This allows for nearby 802.15.4. networks to be scanned via zigpy. Currently supported by bellows and zigpy-znp, I believe deCONZ can also do it: https://github.com/dresden-elektronik/deconz/blob/dd6a73cfc880185999f4eeaeb963f39009ec563f/src/common/zm_protocol.c#L88