### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.2
+    rev: v0.6.2
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix", "--config", "pyproject.toml"]
@@ -15,6 +15,6 @@ repos:
         args: ["--toml", "pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
+    rev: v1.11.2
     hooks:
       - id: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "GPL-3.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "attrs",
     "aiohttp",
@@ -20,7 +20,6 @@ dependencies = [
     "async_timeout",
     "crccheck",
     "cryptography",
-    'importlib_resources; python_version<"3.9"',
     'async-timeout; python_version<"3.11"',
     "voluptuous",
     "jsonschema",
@@ -58,7 +57,7 @@ asyncio_mode = "auto"
 
 [tool.ruff]
 required-version = ">=0.5.0"
-target-version = "py38"
+target-version = "py39"
 line-length = 88
 
 exclude = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,13 +149,13 @@ def make_app(
     return app
 
 
-@pytest.fixture()
+@pytest.fixture
 def app():
     """ControllerApplication Mock."""
     return make_app({})
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_mock():
     """ControllerApplication Mock."""
     return make_app({})
@@ -197,7 +197,7 @@ def add_initialized_device(app, nwk, ieee):
     return dev
 
 
-@pytest.fixture()
+@pytest.fixture
 def make_initialized_device():
     count = 1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
-import sys
 import threading
 import typing
 from unittest.mock import Mock
@@ -274,10 +273,6 @@ def verify_cleanup(
     event_loop: asyncio.AbstractEventLoop,
 ) -> typing.Generator[None, None, None]:
     """Verify that the test has cleaned up resources correctly."""
-    # Skip with Python 3.8 and below
-    if sys.version_info < (3, 9):
-        yield
-        return
 
     threads_before = frozenset(threading.enumerate())
     tasks_before = asyncio.all_tasks(event_loop)

--- a/tests/ota/test_ota_image.py
+++ b/tests/ota/test_ota_image.py
@@ -10,7 +10,7 @@ MANUFACTURER_ID = mock.sentinel.manufacturer_id
 IMAGE_TYPE = mock.sentinel.image_type
 
 
-@pytest.fixture()
+@pytest.fixture
 def image():
     img = firmware.OTAImage()
     img.header = firmware.OTAImageHeader(
@@ -233,7 +233,7 @@ def test_subelement_repr():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw_header():
     def data(elements_size=0):
         d = b"\x1e\xf1\xee\x0b\x00\x018\x00\x00\x00"
@@ -245,7 +245,7 @@ def raw_header():
     return data
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw_sub_element():
     def data(tag_id, payload=b""):
         r = t.uint16_t(tag_id).serialize()

--- a/tests/ota/test_ota_metadata.py
+++ b/tests/ota/test_ota_metadata.py
@@ -10,7 +10,7 @@ from zigpy.ota.providers import BaseOtaImageMetadata
 from zigpy.zcl.clusters.general import Ota
 
 
-@pytest.fixture()
+@pytest.fixture
 def image_with_metadata() -> OtaImageWithMetadata:
     firmware = zigpy.ota.image.OTAImage(
         header=zigpy.ota.image.OTAImageHeader(

--- a/tests/test_app_state.py
+++ b/tests/test_app_state.py
@@ -7,7 +7,7 @@ import zigpy.state as app_state
 COUNTER_NAMES = ["counter_1", "counter_2", "some random name"]
 
 
-@pytest.fixture()
+@pytest.fixture
 def counters():
     """Counters fixture."""
     counters = app_state.CounterGroup("ezsp_counters")

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1024,8 +1024,9 @@ def test_pysqlite_load_success(stdlib_version, use_sqlite):
     pysqlite3 = MagicMock()
     pysqlite3.sqlite_version_info = (3, 30, 0)
 
-    with patch.dict(sys.modules, {"pysqlite3": pysqlite3}), patch.object(
-        sys.modules["sqlite3"], "sqlite_version_info", new=stdlib_version
+    with (
+        patch.dict(sys.modules, {"pysqlite3": pysqlite3}),
+        patch.object(sys.modules["sqlite3"], "sqlite_version_info", new=stdlib_version),
     ):
         module = zigpy.appdb._import_compatible_sqlite3(zigpy.appdb.MIN_SQLITE_VERSION)
 
@@ -1054,8 +1055,9 @@ def test_pysqlite_load_failure(stdlib_version, pysqlite3_version):
     else:
         pysqlite3_patch = patch.dict(sys.modules, {"pysqlite3": None})
 
-    with pysqlite3_patch, patch.object(
-        sys.modules["sqlite3"], "sqlite_version_info", new=stdlib_version
+    with (
+        pysqlite3_patch,
+        patch.object(sys.modules["sqlite3"], "sqlite_version_info", new=stdlib_version),
     ):
         with pytest.raises(RuntimeError):
             zigpy.appdb._import_compatible_sqlite3(zigpy.appdb.MIN_SQLITE_VERSION)

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -15,7 +15,7 @@ import zigpy.types as t
 from zigpy.zdo import types as zdo_t
 
 
-@pytest.fixture()
+@pytest.fixture
 def test_db(tmp_path):
     def inner(filename):
         databases = pathlib.Path(__file__).parent / "databases"

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -464,9 +464,10 @@ async def test_get_device(app):
 async def test_probe_success():
     config = {"path": "/dev/test"}
 
-    with patch.object(App, "connect") as connect, patch.object(
-        App, "disconnect"
-    ) as disconnect:
+    with (
+        patch.object(App, "connect") as connect,
+        patch.object(App, "disconnect") as disconnect,
+    ):
         result = await App.probe(config)
 
     assert set(config.items()) <= set(result.items())
@@ -478,9 +479,10 @@ async def test_probe_success():
 async def test_probe_failure():
     config = {"path": "/dev/test"}
 
-    with patch.object(
-        App, "connect", side_effect=asyncio.TimeoutError
-    ) as connect, patch.object(App, "disconnect") as disconnect:
+    with (
+        patch.object(App, "connect", side_effect=asyncio.TimeoutError) as connect,
+        patch.object(App, "disconnect") as disconnect,
+    ):
         result = await App.probe(config)
 
     assert result is False

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -32,7 +32,7 @@ from .conftest import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def ieee():
     return make_ieee()
 
@@ -736,7 +736,7 @@ async def test_request_concurrency():
     assert peak_concurrency == 16
 
 
-@pytest.fixture()
+@pytest.fixture
 def device():
     device = MagicMock()
     device.nwk = 0xABCD
@@ -745,7 +745,7 @@ def device():
     return device
 
 
-@pytest.fixture()
+@pytest.fixture
 def packet(app, device):
     return t.ZigbeePacket(
         src=t.AddrModeAddress(
@@ -891,7 +891,7 @@ async def test_send_broadcast(app, packet):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def zdo_packet(app, device):
     return t.ZigbeePacket(
         src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=device.nwk),

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -11,7 +11,7 @@ import zigpy.types as t
 import zigpy.zdo.types as zdo_t
 
 
-@pytest.fixture()
+@pytest.fixture
 def backup_factory():
     def inner():
         return zigpy.backups.NetworkBackup(
@@ -92,12 +92,12 @@ def backup_factory():
     return inner
 
 
-@pytest.fixture()
+@pytest.fixture
 def backup(backup_factory):
     return backup_factory()
 
 
-@pytest.fixture()
+@pytest.fixture
 def z2m_backup_json():
     return {
         "metadata": {
@@ -169,7 +169,7 @@ def z2m_backup_json():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def zigate_backup_json():
     return {
         "backup_time": "2022-07-20T17:58:16.694438+00:00",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -20,7 +20,7 @@ from zigpy.zdo import types as zdo_t
 from .async_mock import ANY, AsyncMock, MagicMock, int_sentinel, patch, sentinel
 
 
-@pytest.fixture()
+@pytest.fixture
 def dev(monkeypatch, app_mock):
     monkeypatch.setattr(device, "APS_REPLY_TIMEOUT_EXTENDED", 0.1)
     ieee = t.EUI64(map(t.uint8_t, [0, 1, 2, 3, 4, 5, 6, 7]))

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -12,7 +12,7 @@ from zigpy.zdo import types
 from .async_mock import AsyncMock, MagicMock, patch, sentinel
 
 
-@pytest.fixture()
+@pytest.fixture
 def ep():
     dev = MagicMock()
     dev.request = AsyncMock()

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -12,14 +12,14 @@ FIXTURE_GRP_ID = 0x1001
 FIXTURE_GRP_NAME = "fixture group"
 
 
-@pytest.fixture()
+@pytest.fixture
 def endpoint(app_mock):
     ieee = t.EUI64(map(t.uint8_t, [0, 1, 2, 3, 4, 5, 6, 7]))
     dev = zigpy.device.Device(app_mock, ieee, 65535)
     return zigpy.endpoint.Endpoint(dev, 3)
 
 
-@pytest.fixture()
+@pytest.fixture
 def groups(app_mock):
     groups = zigpy.group.Groups(app_mock)
     groups.listener_event = MagicMock()
@@ -27,14 +27,14 @@ def groups(app_mock):
     return groups
 
 
-@pytest.fixture()
+@pytest.fixture
 def group():
     groups_mock = MagicMock(spec_set=zigpy.group.Groups)
     groups_mock.application.mrequest = AsyncMock()
     return zigpy.group.Group(FIXTURE_GRP_ID, FIXTURE_GRP_NAME, groups_mock)
 
 
-@pytest.fixture()
+@pytest.fixture
 def group_endpoint(group):
     group.request = AsyncMock()
     return zigpy.group.GroupEndpoint(group)

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -44,7 +44,7 @@ def test_registry():
     assert TestDevice not in zigpy.quirks._DEVICE_REGISTRY
 
 
-@pytest.fixture()
+@pytest.fixture
 def real_device(app_mock):
     ieee = sentinel.ieee
     nwk = 0x2233
@@ -60,7 +60,7 @@ def real_device(app_mock):
     return real_device
 
 
-@pytest.fixture()
+@pytest.fixture
 def real_device_2(app_mock):
     ieee = sentinel.ieee_2
     nwk = 0x3344
@@ -532,7 +532,7 @@ class ManufacturerSpecificCluster(zigpy.quirks.CustomCluster):
         )
 
 
-@pytest.fixture()
+@pytest.fixture
 def manuf_cluster():
     """Return a manufacturer specific cluster fixture."""
 
@@ -541,7 +541,7 @@ def manuf_cluster():
     return ManufacturerSpecificCluster.from_id(ep, 0x2222)
 
 
-@pytest.fixture()
+@pytest.fixture
 def manuf_cluster2():
     """Return a manufacturer specific cluster fixture."""
 

--- a/tests/test_quirks_registry.py
+++ b/tests/test_quirks_registry.py
@@ -11,7 +11,7 @@ class FakeDevice:
         self.signature = {}
 
 
-@pytest.fixture()
+@pytest.fixture
 def fake_dev():
     return FakeDevice()
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -10,7 +10,7 @@ from zigpy.zcl.foundation import Status
 import zigpy.zdo.types as zdo_t
 
 
-@pytest.fixture()
+@pytest.fixture
 def expose_global():
     """`typing.get_type_hints` does not work for types defined within functions"""
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -22,7 +22,7 @@ def remove_request_delay():
         yield
 
 
-@pytest.fixture()
+@pytest.fixture
 def topology(make_initialized_device):
     app = App(
         {

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -16,7 +16,7 @@ from .async_mock import AsyncMock, MagicMock, int_sentinel, patch, sentinel
 DEFAULT_TSN = 123
 
 
-@pytest.fixture()
+@pytest.fixture
 def endpoint():
     ep = zigpy.endpoint.Endpoint(MagicMock(), 1)
     ep.add_input_cluster(0)
@@ -88,7 +88,7 @@ def test_manufacturer_specific_cluster():
     assert hasattr(c, "cluster_id")
 
 
-@pytest.fixture()
+@pytest.fixture
 def cluster_by_id():
     def _cluster(cluster_id=0):
         epmock = MagicMock()
@@ -101,12 +101,12 @@ def cluster_by_id():
     return _cluster
 
 
-@pytest.fixture()
+@pytest.fixture
 def cluster(cluster_by_id):
     return cluster_by_id(0)
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_cluster():
     epmock = AsyncMock()
     epmock.device.get_sequence = MagicMock(return_value=DEFAULT_TSN)

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -141,8 +141,9 @@ def ota_cluster(dev):
 
     cluster = zcl.Cluster._registry[0x0019](ep)
 
-    with patch.object(cluster, "reply", AsyncMock()), patch.object(
-        cluster, "request", AsyncMock()
+    with (
+        patch.object(cluster, "reply", AsyncMock()),
+        patch.object(cluster, "request", AsyncMock()),
     ):
         yield cluster
 

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -122,7 +122,7 @@ async def test_time_cluster_unsupported():
     assert ep.reply.call_args[0][2][-6:] == b"\xc7\x00\x86\x80\x00\x86"
 
 
-@pytest.fixture()
+@pytest.fixture
 def dev(monkeypatch, app_mock):
     monkeypatch.setattr(device, "APS_REPLY_TIMEOUT_EXTENDED", 0.1)
     ieee = types.EUI64(map(types.uint8_t, [0, 1, 2, 3, 4, 5, 6, 7]))
@@ -135,7 +135,7 @@ def dev(monkeypatch, app_mock):
         yield dev
 
 
-@pytest.fixture()
+@pytest.fixture
 def ota_cluster(dev):
     ep = dev.add_endpoint(1)
 

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -20,7 +20,7 @@ def test_commands():
             assert hasattr(paramtype, "deserialize")
 
 
-@pytest.fixture()
+@pytest.fixture
 def zdo_f(app):
     ieee = t.EUI64(map(t.uint8_t, [0, 1, 2, 3, 4, 5, 6, 7]))
     dev = zigpy.device.Device(app, ieee, 65535)

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 import time
 import typing
 
@@ -90,9 +89,6 @@ def test_log():
     log.error("Test error")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="logging stacklevel kwarg was introduced in 3.8"
-)
 def test_log_stacklevel():
     class MockHandler(logging.Handler):
         emit = MagicMock()

--- a/zigpy/appdb_schemas/__init__.py
+++ b/zigpy/appdb_schemas/__init__.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-import sys
-
-if sys.version_info >= (3, 9):
-    import importlib.resources as importlib_resources
-else:
-    import importlib_resources
+import importlib.resources
 
 # Map each schema version to its SQL
 SCHEMAS = {}
 
-for file in importlib_resources.files(__name__).glob("schema_v*.sql"):
+for file in importlib.resources.files(__name__).glob("schema_v*.sql"):
     n = int(file.name.replace("schema_v", "").replace(".sql", ""), 10)
     SCHEMAS[n] = file.read_text()

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import asyncio
 import collections
+from collections.abc import Coroutine
 import contextlib
 import errno
 import logging
@@ -11,7 +12,7 @@ import random
 import sys
 import time
 import typing
-from typing import Any, Coroutine, TypeVar
+from typing import Any, TypeVar
 import warnings
 
 if sys.version_info[:2] < (3, 11):

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -69,7 +69,7 @@ class NetworkBackup(t.BaseDataclassMixin):
         """Checks if this backup captures enough network state to recreate the network."""
 
         return (
-            self.node_info.ieee != t.EUI64.UNKNOWN
+            self.node_info.ieee != t.EUI64.UNKNOWN  # noqa: PLR1714
             and self.network_info.extended_pan_id != t.EUI64.UNKNOWN
             and self.network_info.pan_id not in (0x0000, 0xFFFF)
             and self.network_info.channel in range(11, 26 + 1)

--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -44,7 +44,7 @@ class PriorityDynamicBoundedSemaphore(asyncio.Semaphore):
         self._wakeup_scheduled: bool = False
 
     @property
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def _loop(self) -> asyncio.BaseEventLoop:
         return asyncio.get_running_loop()
 

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -18,9 +18,9 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-TYPE_MANUF_QUIRKS_DICT = typing.Dict[
+TYPE_MANUF_QUIRKS_DICT = dict[
     typing.Optional[str],
-    typing.Dict[typing.Optional[str], typing.List["zigpy.quirks.CustomDevice"]],
+    dict[typing.Optional[str], list["zigpy.quirks.CustomDevice"]],
 ]
 
 

--- a/zigpy/state.py
+++ b/zigpy/state.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 import dataclasses
 from dataclasses import InitVar
 import functools
-from typing import Any, Iterator
+from typing import Any
 
 import zigpy.config as conf
 import zigpy.types as t

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -370,7 +370,7 @@ class uint64_t_be(uint_t_be, bits=64):
 class AlwaysCreateEnumType(enum.EnumMeta):
     """Enum metaclass that skips the functional creation API."""
 
-    def __call__(self, value, names=None, *values) -> type[enum.Enum]:  # type: ignore[override]
+    def __call__(self, value, names=None, *values) -> type[enum.Enum]:  # type: ignore[override]  # noqa: N804
         """Custom implementation of Enum.__new__.
 
         From https://github.com/python/cpython/blob/v3.11.5/Lib/enum.py#L1091-L1140
@@ -426,7 +426,7 @@ class AlwaysCreateEnumType(enum.EnumMeta):
 
 
 class _IntEnumMeta(AlwaysCreateEnumType):
-    def __call__(self, value, names=None, *args, **kwargs):
+    def __call__(self, value, names=None, *args, **kwargs):  # noqa: N804
         if isinstance(value, str):
             if value.startswith("0x"):
                 value = int(value, base=16)

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -81,7 +81,7 @@ class Struct:
         cls._frozen = False
 
     def __new__(cls: type[Self], *args, **kwargs) -> Self:
-        cls = cls._real_cls()
+        cls = cls._real_cls()  # noqa: PLW0642
 
         if len(args) == 1 and isinstance(args[0], cls):
             # Like a copy constructor

--- a/zigpy/typing.py
+++ b/zigpy/typing.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import enum
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Union
 
-ConfigType = Dict[str, Any]
+ConfigType = dict[str, Any]
 
 # pylint: disable=invalid-name
 ClusterType = "Cluster"

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import collections
+from collections.abc import Iterable, Sequence
 from datetime import datetime, timezone
 import enum
 import functools
 import itertools
 import logging
 import types
-from typing import TYPE_CHECKING, Any, Iterable, Sequence
+from typing import TYPE_CHECKING, Any
 import warnings
 
 from zigpy import util

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Coroutine
 import functools
 import logging
-from typing import Coroutine
 
 import zigpy.profiles
 import zigpy.types as t


### PR DESCRIPTION
Python 3.8 is receiving only security updates. That will end next month.

@pipiche38 Domoticz seems to be the only user of zigpy on older Pythons. What version are you actually using right now? There are many language features that we miss with every older release we support so if you don't use 3.9, 3.10, or 3.11, we can drop them too.