### PR TITLE
Simplify server-side attribute reads

### DIFF
--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -12,7 +12,7 @@ from zigpy import device, types, zcl
 import zigpy.endpoint
 from zigpy.ota import OtaImagesResult
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Ota, Time
+from zigpy.zcl.clusters.general import Basic, Ota, Time
 import zigpy.zcl.clusters.security as sec
 from zigpy.zdo import types as zdo_t
 
@@ -75,33 +75,67 @@ def test_ep_attributes():
         assert not hasattr(ep, cluster.ep_attribute)
 
 
+async def read_attributes(cluster, attribute_ids: list[int]) -> dict[int, Any]:
+    schema = foundation.GENERAL_COMMANDS[
+        foundation.GeneralCommand.Read_Attributes
+    ].schema
+    hdr, _ = cluster._create_request(
+        general=True,
+        command_id=foundation.GeneralCommand.Read_Attributes,
+        schema=schema,
+        disable_default_response=False,
+        direction=foundation.Direction.Client_to_Server,
+        args=(),
+        kwargs={"attribute_ids": attribute_ids},
+    )
+
+    command = schema(attribute_ids=attribute_ids)
+
+    with patch.object(cluster, "reply") as reply_mock:
+        cluster.handle_message(hdr, command)
+        call = reply_mock.mock_calls[0]
+
+    return call.args[2](call.args[3])
+
+
+async def test_basic_cluster():
+    ep = MagicMock()
+    ep.reply = AsyncMock()
+
+    cluster = Basic(ep)
+
+    rsp = await read_attributes(
+        cluster,
+        [
+            Basic.AttributeDefs.zcl_version.id,
+            Basic.AttributeDefs.power_source.id,
+        ],
+    )
+
+    assert rsp.status_records[0] == foundation.ReadAttributeRecord(
+        attrid=Basic.AttributeDefs.zcl_version.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.uint8,
+            value=8,
+        ),
+    )
+
+    assert rsp.status_records[1] == foundation.ReadAttributeRecord(
+        attrid=Basic.AttributeDefs.power_source.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.enum8,
+            value=Basic.PowerSource.DC_Source,
+        ),
+    )
+
+
 async def test_time_cluster():
     ep = MagicMock()
     ep.reply = AsyncMock()
 
     cluster = Time(ep)
-
-    async def read_attributes(attribute_ids: list[int]) -> dict[int, Any]:
-        schema = foundation.GENERAL_COMMANDS[
-            foundation.GeneralCommand.Read_Attributes
-        ].schema
-        hdr, _ = cluster._create_request(
-            general=True,
-            command_id=foundation.GeneralCommand.Read_Attributes,
-            schema=schema,
-            disable_default_response=False,
-            direction=foundation.Direction.Client_to_Server,
-            args=(),
-            kwargs={"attribute_ids": attribute_ids},
-        )
-
-        command = schema(attribute_ids=attribute_ids)
-
-        with patch.object(cluster, "reply") as reply_mock:
-            cluster.handle_message(hdr, command)
-            call = reply_mock.mock_calls[0]
-
-        return call.args[2](call.args[3])
 
     Read_Attributes_rsp = foundation.GENERAL_COMMANDS[
         foundation.GeneralCommand.Read_Attributes_rsp
@@ -147,12 +181,13 @@ async def test_time_cluster():
     with patch("zigpy.zcl.clusters.general.datetime", PatchedDatetime):
         # Supported attributes
         rsp1 = await read_attributes(
+            cluster,
             [
                 Time.AttributeDefs.time.id,
                 Time.AttributeDefs.time_status.id,
                 Time.AttributeDefs.time_zone.id,
                 Time.AttributeDefs.local_time.id,
-            ]
+            ],
         )
 
     assert rsp1.status_records[0] == foundation.ReadAttributeRecord(
@@ -199,7 +234,7 @@ async def test_time_cluster():
     )
 
     # Unsupported
-    rsp2 = await read_attributes([0xABCD])
+    rsp2 = await read_attributes(cluster, [0xABCD])
     assert rsp2 == Read_Attributes_rsp(
         status_records=[
             foundation.ReadAttributeRecord(

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -109,6 +109,7 @@ async def test_basic_cluster():
         [
             Basic.AttributeDefs.zcl_version.id,
             Basic.AttributeDefs.power_source.id,
+            Basic.AttributeDefs.serial_number.id,
         ],
     )
 
@@ -128,6 +129,11 @@ async def test_basic_cluster():
             type=foundation.DataTypeId.enum8,
             value=Basic.PowerSource.DC_Source,
         ),
+    )
+
+    assert rsp.status_records[2] == foundation.ReadAttributeRecord(
+        attrid=Basic.AttributeDefs.serial_number.id,
+        status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
     )
 
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -486,6 +486,35 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                     foundation.Status.SUCCESS,
                 )
 
+        if hdr.command_id == foundation.GeneralCommand.Read_Attributes:
+            records = []
+
+            for attrid in args[0].attribute_ids:
+                record = foundation.ReadAttributeRecord(attrid=attrid)
+                records.append(record)
+
+                try:
+                    attr_def = self.find_attribute(attrid)
+                except KeyError:
+                    record.status = foundation.Status.UNSUPPORTED_ATTRIBUTE
+                    continue
+
+                attr_read_func = getattr(
+                    self, f"handle_read_attribute_{attr_def.name}", None
+                )
+
+                if attr_read_func is None:
+                    record.status = foundation.Status.UNSUPPORTED_ATTRIBUTE
+                    continue
+
+                record.status = foundation.Status.SUCCESS
+                record.value = foundation.TypeValue(
+                    type=attr_def.zcl_type,
+                    value=attr_read_func(),
+                )
+
+            self.create_catching_task(self.read_attributes_rsp(records, tsn=hdr.tsn))
+
     def read_attributes_raw(self, attributes, manufacturer=None):
         attributes = [t.uint16_t(a) for a in attributes]
         return self._read_attributes(attributes, manufacturer=manufacturer)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -489,7 +489,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         if hdr.command_id == foundation.GeneralCommand.Read_Attributes:
             records = []
 
-            for attrid in args[0].attribute_ids:
+            for attrid in args.attribute_ids:
                 record = foundation.ReadAttributeRecord(attrid=attrid)
                 records.append(record)
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -283,6 +283,12 @@ class Basic(Cluster):
             id=0x00, schema={}, direction=Direction.Client_to_Server
         )
 
+    def handle_read_attribute_zcl_version(self) -> t.uint8_t:
+        return t.uint8_t(8)
+
+    def handle_read_attribute_power_source(self) -> PowerSource:
+        return PowerSource.DC_Source
+
 
 class MainsAlarmMask(t.bitmap8):
     Voltage_Too_Low = 0b00000001


### PR DESCRIPTION
This PR allows for new server-side attribute reads to be added without manually handling the entire attribute read command. I've implemented a few required attributes on the `Basic` cluster as an example and converted the existing `Time` ones.