### PR TITLE
Expose `fallback_name` in v2 quirks

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -467,44 +467,6 @@ async def test_quirks_v2_sensor(device_mock):
     assert sensor_metadata.multiplier == 1
 
 
-async def test_quirks_v2_sensor_validation_failure_translation_key(device_mock):
-    """Test translation key and device class both set causes exception."""
-    registry = DeviceRegistry()
-
-    with pytest.raises(
-        ValueError, match="cannot have both a translation_key and a device_class"
-    ):
-        (
-            QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
-            .adds(OnOff.cluster_id)
-            .sensor(
-                OnOff.AttributeDefs.on_time.name,
-                OnOff.cluster_id,
-                device_class="bad",
-                translation_key="bad",
-            )
-            .add_to_registry()
-        )
-
-
-async def test_quirks_v2_sensor_validation_failure_unit(device_mock):
-    """Test unit and device class both set causes exception."""
-    registry = DeviceRegistry()
-
-    with pytest.raises(ValueError, match="cannot have both unit and device_class"):
-        (
-            QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
-            .adds(OnOff.cluster_id)
-            .sensor(
-                OnOff.AttributeDefs.on_time.name,
-                OnOff.cluster_id,
-                device_class="bad",
-                unit="bad",
-            )
-            .add_to_registry()
-        )
-
-
 async def test_quirks_v2_switch(device_mock):
     """Test adding a quirk that defines a switch to the registry."""
     registry = DeviceRegistry()

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -243,6 +243,7 @@ class EntityMetadata:
     initially_disabled: bool = attrs.field(default=False)
     attribute_initialized_from_cache: bool = attrs.field(default=True)
     translation_key: str | None = attrs.field(default=None)
+    fallback_name: str | None = attrs.field(default=None)
 
     def __attrs_post_init__(self) -> None:
         self._validate()
@@ -267,6 +268,15 @@ class EntityMetadata:
         if has_device_class and self.translation_key is not None:
             raise ValueError(
                 f"EntityMetadata cannot have both a translation_key and a device_class: {self}"
+            )
+        if (
+            not has_device_class
+            and self.translation_key is None
+            and self.fallback_name is None
+        ):
+            _LOGGER.warning(
+                "Entity %s must have a `translation_key` (preferable) or `fallback_name`",
+                self,
             )
 
 
@@ -605,6 +615,7 @@ class QuirkBuilder:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
+        fallback_name: str | None = None,
     ) -> QuirkBuilder:
         """Add an EntityMetadata containing ZCLEnumMetadata and return self.
 
@@ -620,6 +631,7 @@ class QuirkBuilder:
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
                 translation_key=translation_key,
+                fallback_name=fallback_name,
                 enum=enum_class,
                 attribute_name=attribute_name,
             )
@@ -641,6 +653,7 @@ class QuirkBuilder:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
+        fallback_name: str | None = None,
     ) -> QuirkBuilder:
         """Add an EntityMetadata containing ZCLSensorMetadata and return self.
 
@@ -656,6 +669,7 @@ class QuirkBuilder:
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
                 translation_key=translation_key,
+                fallback_name=fallback_name,
                 attribute_name=attribute_name,
                 divisor=divisor,
                 multiplier=multiplier,
@@ -680,6 +694,7 @@ class QuirkBuilder:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
+        fallback_name: str | None = None,
     ) -> QuirkBuilder:
         """Add an EntityMetadata containing SwitchMetadata and return self.
 
@@ -695,6 +710,7 @@ class QuirkBuilder:
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
                 translation_key=translation_key,
+                fallback_name=fallback_name,
                 attribute_name=attribute_name,
                 force_inverted=force_inverted,
                 invert_attribute_name=invert_attribute_name,
@@ -720,6 +736,7 @@ class QuirkBuilder:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
+        fallback_name: str | None = None,
     ) -> QuirkBuilder:
         """Add an EntityMetadata containing NumberMetadata and return self.
 
@@ -735,6 +752,7 @@ class QuirkBuilder:
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
                 translation_key=translation_key,
+                fallback_name=fallback_name,
                 attribute_name=attribute_name,
                 min=min_value,
                 max=max_value,
@@ -757,6 +775,7 @@ class QuirkBuilder:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
+        fallback_name: str | None = None,
     ) -> QuirkBuilder:
         """Add an EntityMetadata containing BinarySensorMetadata and return self.
 
@@ -772,6 +791,7 @@ class QuirkBuilder:
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
                 translation_key=translation_key,
+                fallback_name=fallback_name,
                 attribute_name=attribute_name,
                 device_class=device_class,
             )
@@ -789,6 +809,7 @@ class QuirkBuilder:
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
         translation_key: str | None = None,
+        fallback_name: str | None = None,
     ) -> QuirkBuilder:
         """Add an EntityMetadata containing WriteAttributeButtonMetadata and return self.
 
@@ -805,6 +826,7 @@ class QuirkBuilder:
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
                 translation_key=translation_key,
+                fallback_name=fallback_name,
                 attribute_name=attribute_name,
                 attribute_value=attribute_value,
             )
@@ -822,6 +844,7 @@ class QuirkBuilder:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         translation_key: str | None = None,
+        fallback_name: str | None = None,
     ) -> QuirkBuilder:
         """Add an EntityMetadata containing ZCLCommandButtonMetadata and return self.
 
@@ -837,6 +860,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 translation_key=translation_key,
+                fallback_name=fallback_name,
                 command_name=command_name,
                 args=command_args if command_args is not None else (),
                 kwargs=command_kwargs if command_kwargs is not None else frozendict(),

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -274,8 +274,9 @@ class EntityMetadata:
             and self.translation_key is None
             and self.fallback_name is None
         ):
-            raise ValueError(
-                f"Entity {self} must have a `translation_key` (preferable) or `fallback_name`"
+            _LOGGER.warning(
+                "Entity %s must have a `translation_key` (preferable) or `fallback_name`",
+                self,
             )
 
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -242,42 +242,14 @@ class EntityMetadata:
     cluster_type: ClusterType = attrs.field(default=ClusterType.Server)
     initially_disabled: bool = attrs.field(default=False)
     attribute_initialized_from_cache: bool = attrs.field(default=True)
-    translation_key: str | None = attrs.field(default=None)
-    fallback_name: str | None = attrs.field(default=None)
-
-    def __attrs_post_init__(self) -> None:
-        self._validate()
+    translation_key: str = attrs.field()
+    fallback_name: str = attrs.field()
 
     def __call__(self, device: CustomDeviceV2) -> None:
         """Add the entity metadata to the quirks v2 device."""
-        self._validate()
         device.exposes_metadata[
             (self.endpoint_id, self.cluster_id, self.cluster_type)
         ].append(self)
-
-    def _validate(self) -> None:
-        """Validate the entity metadata."""
-        has_unit: bool = hasattr(self, "unit") and getattr(self, "unit") is not None
-        has_device_class: bool = hasattr(self, "device_class") and (
-            getattr(self, "device_class") is not None
-        )
-        if has_device_class and has_unit:
-            raise ValueError(
-                f"EntityMetadata cannot have both unit and device_class: {self}"
-            )
-        if has_device_class and self.translation_key is not None:
-            raise ValueError(
-                f"EntityMetadata cannot have both a translation_key and a device_class: {self}"
-            )
-        if (
-            not has_device_class
-            and self.translation_key is None
-            and self.fallback_name is None
-        ):
-            _LOGGER.warning(
-                "Entity %s must have a `translation_key` (preferable) or `fallback_name`",
-                self,
-            )
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -274,9 +274,8 @@ class EntityMetadata:
             and self.translation_key is None
             and self.fallback_name is None
         ):
-            _LOGGER.warning(
-                "Entity %s must have a `translation_key` (preferable) or `fallback_name`",
-                self,
+            raise ValueError(
+                f"Entity {self} must have a `translation_key` (preferable) or `fallback_name`"
             )
 
 


### PR DESCRIPTION
I think we should deprecate creating quirks v2 entities without a translation key or a fallback name. For now, this is logged as a warning but it should throw an error in the future.