### PR TITLE
Add `attrs` to mypy pre-commit environment to remove `# type: ignore[call-arg]`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,4 @@ repos:
     rev: v1.11.2
     hooks:
       - id: mypy
+        additional_dependencies: [attrs]

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -81,7 +81,7 @@ async def test_ota_matching_priority(tmp_path: pathlib.Path) -> None:
 
     index = [
         # Manufacturer ID
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             manufacturer_id=query_cmd.manufacturer_code,
             test_data=zigpy.ota.image.OTAImage(
@@ -90,7 +90,7 @@ async def test_ota_matching_priority(tmp_path: pathlib.Path) -> None:
             ).serialize(),
         ),
         # Image type
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             image_type=query_cmd.image_type,
             test_data=zigpy.ota.image.OTAImage(
@@ -99,7 +99,7 @@ async def test_ota_matching_priority(tmp_path: pathlib.Path) -> None:
             ).serialize(),
         ),
         # Model string
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             model_names=(device.model,),
             test_data=zigpy.ota.image.OTAImage(
@@ -108,7 +108,7 @@ async def test_ota_matching_priority(tmp_path: pathlib.Path) -> None:
             ).serialize(),
         ),
         # Model string *and* more specific HW version: this is the right image to pick
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             model_names=(device.model,),
             test_data=zigpy.ota.image.OTAImage(
@@ -120,7 +120,7 @@ async def test_ota_matching_priority(tmp_path: pathlib.Path) -> None:
             ).serialize(),
         ),
         # Nothing to exclude but we can't be sure
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             test_data=zigpy.ota.image.OTAImage(
                 header=ota_hdr,
@@ -128,7 +128,7 @@ async def test_ota_matching_priority(tmp_path: pathlib.Path) -> None:
             ).serialize(),
         ),
         # Irrelevant image
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version - 1,
             test_data=zigpy.ota.image.OTAImage(
                 header=ota_hdr.replace(file_version=query_cmd.current_file_version - 1),
@@ -136,7 +136,7 @@ async def test_ota_matching_priority(tmp_path: pathlib.Path) -> None:
             ).serialize(),
         ),
         # Broken image that won't download
-        BrokenOtaImageMetadata(  # type: ignore[call-arg]
+        BrokenOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
         ),
     ]
@@ -184,7 +184,7 @@ async def test_ota_matching_ambiguous_error() -> None:
     )
 
     index = [
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             manufacturer_id=query_cmd.manufacturer_code,
             test_data=zigpy.ota.image.OTAImage(
@@ -194,7 +194,7 @@ async def test_ota_matching_ambiguous_error() -> None:
                 ],
             ).serialize(),
         ),
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             manufacturer_id=query_cmd.manufacturer_code,
             test_data=zigpy.ota.image.OTAImage(
@@ -239,7 +239,7 @@ async def test_ota_matching_ambiguous_specificity_tie_breaker() -> None:
     )
 
     index = [
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             manufacturer_id=query_cmd.manufacturer_code,
             test_data=zigpy.ota.image.OTAImage(
@@ -249,7 +249,7 @@ async def test_ota_matching_ambiguous_specificity_tie_breaker() -> None:
                 ],
             ).serialize(),
         ),
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             manufacturer_id=query_cmd.manufacturer_code,
             test_data=zigpy.ota.image.OTAImage(
@@ -288,7 +288,7 @@ async def test_ota_concurrent_fetching() -> None:
     )
 
     index = [
-        SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+        SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             manufacturer_id=query_cmd.manufacturer_code,
             test_data=zigpy.ota.image.OTAImage(

--- a/tests/ota/test_ota_metadata.py
+++ b/tests/ota/test_ota_metadata.py
@@ -30,7 +30,7 @@ def image_with_metadata() -> OtaImageWithMetadata:
         subelements=[zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")],
     )
 
-    metadata = BaseOtaImageMetadata(  # type: ignore[call-arg]
+    metadata = BaseOtaImageMetadata(
         file_version=0x12345678,
         manufacturer_id=0x1234,
         image_type=0x5678,

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -752,7 +752,7 @@ async def test_ota_fetch_size_and_checksum_validation(
 ) -> None:
     assert image_with_metadata.firmware is not None
 
-    meta = SelfContainedOtaImageMetadata(  # type: ignore[call-arg]
+    meta = SelfContainedOtaImageMetadata(
         file_version=image_with_metadata.metadata.file_version,
         checksum=image_with_metadata.metadata.checksum,
         file_size=image_with_metadata.metadata.file_size,

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -241,7 +241,7 @@ class HueSBLOTAImage(BaseOTAImage):
                 f"Only Hue images are expected. Got: {header.manufacturer_id}"
             )
 
-        return cls(header=header, data=firmware), data[header.image_size :]  # type: ignore[call-arg]
+        return cls(header=header, data=firmware), data[header.image_size :]
 
 
 def parse_ota_image(data: bytes) -> tuple[BaseOTAImage, bytes]:

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -307,7 +307,7 @@ ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
                     LOGGER.warning("Could not parse IKEA OTA JSON: %r", fw)
                     continue
 
-                image = IkeaRemoteOtaImageMetadata(  # type: ignore[call-arg]
+                image = IkeaRemoteOtaImageMetadata(
                     file_version=int(file_version_match.group("v"), 10),
                     manufacturer_id=self.MANUFACTURER_IDS[0],
                     image_type=fw["fw_image_type"],
@@ -320,7 +320,7 @@ ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
                 if fw["fw_type"] != 2:
                     continue
 
-                image = SignedIkeaRemoteOtaImageMetadata(  # type: ignore[call-arg]
+                image = SignedIkeaRemoteOtaImageMetadata(
                     file_version=(
                         (fw["fw_file_version_MSB"] << 16)
                         | (fw["fw_file_version_LSB"] << 0)
@@ -361,7 +361,7 @@ class Ledvance(BaseOtaProvider):
             identity = fw["identity"]
             version = identity["version"]
 
-            yield RemoteOtaImageMetadata(  # type: ignore[call-arg]
+            yield RemoteOtaImageMetadata(
                 file_version=int(fw["fullName"].split("/")[1], 16),
                 manufacturer_id=identity["company"],
                 image_type=identity["product"],
@@ -411,7 +411,7 @@ class Salus(BaseOtaProvider):
 
             # Not every firmware is actually Zigbee but since they filter by model name
             # there is little chance an invalid one will ever be matched
-            yield SalusRemoteOtaImageMetadata(  # type: ignore[call-arg]
+            yield SalusRemoteOtaImageMetadata(
                 file_version=int(fw["version"], 16),
                 model_names=(fw["model"],),
                 # Upgrade HTTP to HTTPS, the server supports it
@@ -439,7 +439,7 @@ class Sonoff(BaseOtaProvider):
         jsonschema.validate(fw_lst, self.JSON_SCHEMA)
 
         for fw in fw_lst:
-            yield RemoteOtaImageMetadata(  # type: ignore[call-arg]
+            yield RemoteOtaImageMetadata(
                 file_version=fw["fw_file_version"],
                 manufacturer_id=fw["fw_manufacturer_id"],
                 image_type=fw["fw_image_type"],
@@ -476,7 +476,7 @@ class Inovelli(BaseOtaProvider):
                     # Only the first firmware was in hex, all others are decimal
                     version = int(fw["version"])
 
-                yield RemoteOtaImageMetadata(  # type: ignore[call-arg]
+                yield RemoteOtaImageMetadata(
                     file_version=version,
                     manufacturer_id=fw["manufacturer_id"],
                     image_type=fw["image_type"],
@@ -503,7 +503,7 @@ class ThirdReality(BaseOtaProvider):
         jsonschema.validate(fw_lst, self.JSON_SCHEMA)
 
         for fw in fw_lst["versions"]:
-            yield RemoteOtaImageMetadata(  # type: ignore[call-arg]
+            yield RemoteOtaImageMetadata(
                 file_version=fw["fileVersion"],
                 manufacturer_id=fw["manufacturerId"],
                 model_names=(fw["modelId"],),
@@ -542,9 +542,9 @@ class BaseZigpyProvider(BaseOtaProvider):
             if "path" in fw and index_root is not None:
                 yield LocalOtaImageMetadata(
                     **shared_kwargs, path=index_root / fw["path"]
-                )  # type: ignore[call-arg]
+                )
             else:
-                yield RemoteOtaImageMetadata(**shared_kwargs, url=fw["binary_url"])  # type: ignore[call-arg]
+                yield RemoteOtaImageMetadata(**shared_kwargs, url=fw["binary_url"])
 
 
 @register_provider
@@ -630,11 +630,11 @@ class BaseZ2MProvider(BaseOtaProvider):
             if "path" in fw and index_root is not None:
                 yield LocalOtaImageMetadata(
                     **shared_kwargs, path=index_root / fw["path"]
-                )  # type: ignore[call-arg]
+                )
             else:
                 yield RemoteOtaImageMetadata(
                     **shared_kwargs, url=fw["url"], ssl_ctx=ssl_ctx
-                )  # type: ignore[call-arg]
+                )
 
 
 @register_provider
@@ -744,7 +744,7 @@ class AdvancedFileProvider(BaseOtaProvider):
                 # This protects against images being swapped out in the local filesystem
                 hasher = await loop.run_in_executor(None, hashlib.sha1, data)
 
-                yield LocalOtaImageMetadata(  # type: ignore[call-arg]
+                yield LocalOtaImageMetadata(
                     path=path,
                     file_version=image.header.file_version,
                     manufacturer_id=image.header.manufacturer_id,

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -416,9 +416,7 @@ class QuirkBuilder:
     def also_applies_to(self, manufacturer: str, model: str) -> QuirkBuilder:
         """Register this quirks v2 entry for an additional manufacturer and model."""
         self.manufacturer_model_metadata.append(
-            ManufacturerModelMetadata(  # type: ignore[call-arg]
-                manufacturer=manufacturer, model=model
-            )
+            ManufacturerModelMetadata(manufacturer=manufacturer, model=model)
         )
         return self
 
@@ -482,7 +480,7 @@ class QuirkBuilder:
         instances and their values. These attributes will be added to the cluster when
         the quirk is applied and the values will be constant.
         """
-        add = AddsMetadata(  # type: ignore[call-arg]
+        add = AddsMetadata(
             endpoint_id=endpoint_id,
             cluster=cluster,
             cluster_type=cluster_type,
@@ -501,7 +499,7 @@ class QuirkBuilder:
 
         This method allows removing a cluster from a device when the quirk is applied.
         """
-        remove = RemovesMetadata(  # type: ignore[call-arg]
+        remove = RemovesMetadata(
             endpoint_id=endpoint_id,
             cluster_id=cluster_id,
             cluster_type=cluster_type,
@@ -527,19 +525,19 @@ class QuirkBuilder:
         be removed. If cluster_id is not provided, the cluster_id of the replacement
         cluster will be used.
         """
-        remove = RemovesMetadata(  # type: ignore[call-arg]
+        remove = RemovesMetadata(
             endpoint_id=endpoint_id,
             cluster_id=cluster_id
             if cluster_id is not None
             else replacement_cluster_class.cluster_id,
             cluster_type=cluster_type,
         )
-        add = AddsMetadata(  # type: ignore[call-arg]
+        add = AddsMetadata(
             endpoint_id=endpoint_id,
             cluster=replacement_cluster_class,
             cluster_type=cluster_type,
         )
-        replace = ReplacesMetadata(remove=remove, add=add)  # type: ignore[call-arg]
+        replace = ReplacesMetadata(remove=remove, add=add)
         self.replaces_metadata.append(replace)
         return self
 
@@ -568,7 +566,7 @@ class QuirkBuilder:
         if replace_client_instances:
             types.append(ClusterType.Client)
         self.replaces_cluster_occurrences_metadata.append(
-            ReplaceClusterOccurrencesMetadata(  # type: ignore[call-arg]
+            ReplaceClusterOccurrencesMetadata(
                 cluster_types=tuple(types),
                 cluster=replacement_cluster_class,
             )
@@ -594,7 +592,7 @@ class QuirkBuilder:
         This method allows exposing an enum based entity in Home Assistant.
         """
         self.entity_metadata.append(
-            ZCLEnumMetadata(  # type: ignore[call-arg]
+            ZCLEnumMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
                 cluster_type=cluster_type,
@@ -632,7 +630,7 @@ class QuirkBuilder:
         This method allows exposing a sensor entity in Home Assistant.
         """
         self.entity_metadata.append(
-            ZCLSensorMetadata(  # type: ignore[call-arg]
+            ZCLSensorMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
                 cluster_type=cluster_type,
@@ -673,7 +671,7 @@ class QuirkBuilder:
         This method allows exposing a switch entity in Home Assistant.
         """
         self.entity_metadata.append(
-            SwitchMetadata(  # type: ignore[call-arg]
+            SwitchMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
                 cluster_type=cluster_type,
@@ -715,7 +713,7 @@ class QuirkBuilder:
         This method allows exposing a number entity in Home Assistant.
         """
         self.entity_metadata.append(
-            NumberMetadata(  # type: ignore[call-arg]
+            NumberMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
                 cluster_type=cluster_type,
@@ -754,7 +752,7 @@ class QuirkBuilder:
         This method allows exposing a binary sensor entity in Home Assistant.
         """
         self.entity_metadata.append(
-            BinarySensorMetadata(  # type: ignore[call-arg]
+            BinarySensorMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
                 cluster_type=cluster_type,
@@ -789,7 +787,7 @@ class QuirkBuilder:
         a value to an attribute when pressed.
         """
         self.entity_metadata.append(
-            WriteAttributeButtonMetadata(  # type: ignore[call-arg]
+            WriteAttributeButtonMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
                 cluster_type=cluster_type,
@@ -824,7 +822,7 @@ class QuirkBuilder:
         a ZCL command when pressed.
         """
         self.entity_metadata.append(
-            ZCLCommandButtonMetadata(  # type: ignore[call-arg]
+            ZCLCommandButtonMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
                 cluster_type=cluster_type,
@@ -849,7 +847,7 @@ class QuirkBuilder:
 
     def add_to_registry(self) -> QuirksV2RegistryEntry:
         """Build the quirks v2 registry entry."""
-        quirk: QuirksV2RegistryEntry = QuirksV2RegistryEntry(  # type: ignore[call-arg]
+        quirk: QuirksV2RegistryEntry = QuirksV2RegistryEntry(
             manufacturer_model_metadata=tuple(self.manufacturer_model_metadata),
             quirk_file=self.quirk_file,
             quirk_file_line=self.quirk_file_line,


### PR DESCRIPTION
It looks like mypy wasn't able to analyze `attrs` objects because the package was missing in the pre-commit environment.