### PR TITLE
Allow renaming devices with quirks

### DIFF
--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -885,7 +885,7 @@ class QuirkBuilder:
         self.device_automation_triggers_metadata.update(device_automation_triggers)
         return self
 
-    def friendly_name(self, model: str, manufacturer: str) -> QuirkBuilder:
+    def friendly_name(self, *, model: str, manufacturer: str) -> QuirkBuilder:
         """Renames the device."""
         self.friendly_name_metadata = FriendlyNameMetadata(
             model=model, manufacturer=manufacturer

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -414,6 +414,7 @@ class QuirkBuilder:
 
         self.registry: DeviceRegistry = registry
         self.manufacturer_model_metadata: list[ManufacturerModelMetadata] = []
+        self.friendly_name_metadata: FriendlyNameMetadata | None = None
         self.filters: list[FilterType] = []
         self.custom_device_class: type[CustomDeviceV2] | None = None
         self.device_node_descriptor: NodeDescriptor | None = None
@@ -886,7 +887,7 @@ class QuirkBuilder:
 
     def friendly_name(self, model: str, manufacturer: str) -> QuirkBuilder:
         """Renames the device."""
-        self.friendly_name = FriendlyNameMetadata(
+        self.friendly_name_metadata = FriendlyNameMetadata(
             model=model, manufacturer=manufacturer
         )
         return self
@@ -899,6 +900,7 @@ class QuirkBuilder:
             )
         quirk: QuirksV2RegistryEntry = QuirksV2RegistryEntry(
             manufacturer_model_metadata=tuple(self.manufacturer_model_metadata),
+            friendly_name=self.friendly_name_metadata,
             quirk_file=self.quirk_file,
             quirk_file_line=self.quirk_file_line,
             filters=tuple(self.filters),

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -345,6 +345,14 @@ class ManufacturerModelMetadata:
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
+class FriendlyNameMetadata:
+    """Metadata to rename a device."""
+
+    model: str = attrs.field()
+    manufacturer: str = attrs.field()
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class QuirksV2RegistryEntry:
     """Quirks V2 registry entry."""
 
@@ -353,6 +361,7 @@ class QuirksV2RegistryEntry:
     manufacturer_model_metadata: tuple[ManufacturerModelMetadata] = attrs.field(
         factory=tuple
     )
+    friendly_name: FriendlyNameMetadata | None = attrs.field(default=None)
     filters: tuple[FilterType] = attrs.field(factory=tuple)
     custom_device_class: type[CustomDeviceV2] | None = attrs.field(default=None)
     device_node_descriptor: NodeDescriptor | None = attrs.field(default=None)
@@ -873,6 +882,13 @@ class QuirkBuilder:
     ) -> QuirkBuilder:
         """Add device automation triggers and returns self."""
         self.device_automation_triggers_metadata.update(device_automation_triggers)
+        return self
+
+    def friendly_name(self, model: str, manufacturer: str) -> QuirkBuilder:
+        """Renames the device."""
+        self.friendly_name = FriendlyNameMetadata(
+            model=model, manufacturer=manufacturer
+        )
         return self
 
     def add_to_registry(self) -> QuirksV2RegistryEntry:


### PR DESCRIPTION
This will help us implement `model_id` in Core and deal with white label devices (e.g. eWeLink/Sonoff).