### PR TITLE
Add a `priority` field to packets

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -35,7 +35,7 @@ def dev(monkeypatch, app_mock):
 
 
 async def test_initialize(monkeypatch, dev):
-    async def mockrequest(nwk, tries=None, delay=None):
+    async def mockrequest(*args, **kwargs):
         return [0, None, [0, 1, 2, 3, 4]]
 
     async def mockepinit(self, *args, **kwargs):
@@ -285,7 +285,7 @@ async def test_broadcast(app_mock):
 
 
 async def _get_node_descriptor(dev, zdo_success=True, request_success=True):
-    async def mockrequest(nwk, tries=None, delay=None):
+    async def mockrequest(nwk, tries=None, delay=None, **kwargs):
         if not request_success:
             raise asyncio.TimeoutError
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -20,7 +20,7 @@ def ep():
 
 
 async def _test_initialize(ep, profile):
-    async def mockrequest(nwk, epid, tries=None, delay=None):
+    async def mockrequest(*args, **kwargs):
         sd = types.SimpleDescriptor()
         sd.endpoint = 1
         sd.profile = profile
@@ -38,7 +38,7 @@ async def _test_initialize(ep, profile):
 
 
 async def test_inactive_initialize(ep):
-    async def mockrequest(nwk, epid, tries=None, delay=None):
+    async def mockrequest(*args, **kwargs):
         sd = types.SimpleDescriptor()
         sd.endpoint = 2
         return [131, None, sd]
@@ -61,7 +61,7 @@ async def test_initialize_other(ep):
 
 
 async def test_initialize_fail(ep):
-    async def mockrequest(nwk, epid, tries=None, delay=None):
+    async def mockrequest(*args, **kwargs):
         return [1, None, None]
 
     ep._device.zdo.Simple_Desc_req = mockrequest

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -198,6 +198,7 @@ async def test_reply_change_profile_id(ep):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
     ]
 
@@ -215,6 +216,7 @@ async def test_reply_change_profile_id(ep):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
     ]
 
@@ -233,6 +235,7 @@ async def test_reply_change_profile_id(ep):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
     ]
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1140,7 +1140,7 @@ async def test_zcl_reply_direction(app_mock):
 
     await asyncio.sleep(0.1)
 
-    packet = app_mock.send_packet.mock_calls[0].kwargs["packet"]
+    packet = app_mock.send_packet.mock_calls[0].args[0]
     assert packet.cluster_id == zcl.clusters.general.OnOff.cluster_id
 
     # The direction is correct

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1140,7 +1140,7 @@ async def test_zcl_reply_direction(app_mock):
 
     await asyncio.sleep(0.1)
 
-    packet = app_mock.send_packet.mock_calls[0].args[0]
+    packet = app_mock.send_packet.mock_calls[0].kwargs["packet"]
     assert packet.cluster_id == zcl.clusters.general.OnOff.cluster_id
 
     # The direction is correct

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -58,7 +58,7 @@ async def test_bind(zdo_f):
     cluster.cluster_id = 1026
     await zdo_f.bind(cluster)
     assert zdo_f.device.request.call_count == 1
-    assert zdo_f.device.request.call_args[0][1] == 0x0021
+    assert zdo_f.device.request.mock_calls[0].kwargs["cluster"] == 0x0021
 
 
 async def test_unbind(zdo_f):
@@ -67,7 +67,7 @@ async def test_unbind(zdo_f):
     cluster.cluster_id = 1026
     await zdo_f.unbind(cluster)
     assert zdo_f.device.request.call_count == 1
-    assert zdo_f.device.request.call_args[0][1] == 0x0022
+    assert zdo_f.device.request.mock_calls[0].kwargs["cluster"] == 0x0022
 
 
 @pytest.mark.parametrize(
@@ -92,7 +92,7 @@ async def test_leave(zdo_f, remove_children, rejoin, flags):
 async def test_permit(zdo_f):
     await zdo_f.permit()
     assert zdo_f.device.request.call_count == 1
-    assert zdo_f.device.request.call_args[0][1] == 0x0036
+    assert zdo_f.device.request.mock_calls[0].kwargs["cluster"] == 0x0036
 
 
 async def test_broadcast(app):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -798,6 +798,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         use_ieee: bool = False,
         extended_timeout: bool = False,
         ask_for_ack: bool | None = None,
+        priority: int = t.PacketPriority.NORMAL,
     ) -> tuple[zigpy.zcl.foundation.Status, str]:
         """Submit and send data out as an unicast transmission.
         :param device: destination device
@@ -850,6 +851,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 extended_timeout=extended_timeout,
                 source_route=source_route,
                 tx_options=tx_options,
+                priority=priority,
             )
         )
 
@@ -866,6 +868,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         *,
         hops: int = 0,
         non_member_radius: int = 3,
+        priority: int = t.PacketPriority.NORMAL,
     ):
         """Submit and send data out as a multicast transmission.
         :param group_id: destination multicast address
@@ -895,6 +898,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 tx_options=t.TransmitOptions.NONE,
                 radius=hops,
                 non_member_radius=non_member_radius,
+                priority=priority,
             )
         )
 
@@ -911,6 +915,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         sequence: t.uint8_t,
         data: bytes,
         broadcast_address: t.BroadcastAddress = t.BroadcastAddress.RX_ON_WHEN_IDLE,
+        priority: int = t.PacketPriority.NORMAL,
     ) -> tuple[zigpy.zcl.foundation.Status, str]:
         """Submit and send data out as an unicast transmission.
         :param profile: Zigbee Profile ID to use for outgoing message
@@ -941,6 +946,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 data=t.SerializableBytes(data),
                 tx_options=t.TransmitOptions.NONE,
                 radius=radius,
+                priority=priority,
             )
         )
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -20,10 +20,10 @@ if sys.version_info[:2] < (3, 11):
 else:
     from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
-from zigpy import const
 import zigpy.appdb
 import zigpy.backups
 import zigpy.config as conf
+from zigpy.const import INTERFERENCE_MESSAGE
 from zigpy.datastructures import PriorityDynamicBoundedSemaphore
 import zigpy.device
 import zigpy.endpoint
@@ -187,7 +187,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             # Some radios (like the Conbee) can fail to deliver the startup broadcast
             # due to interference
             LOGGER.warning("Failed to send startup broadcast: %s", e)
-            LOGGER.warning(const.INTERFERENCE_MESSAGE)
+            LOGGER.warning(INTERFERENCE_MESSAGE)
 
         if self.config[conf.CONF_STARTUP_ENERGY_SCAN]:
             # Each scan period is 15.36ms. Scan for at least 200ms (2^4 + 1 periods) to
@@ -203,7 +203,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                     self.state.network_info.channel,
                     100 * results[self.state.network_info.channel] / 255,
                 )
-                LOGGER.warning(const.INTERFERENCE_MESSAGE)
+                LOGGER.warning(INTERFERENCE_MESSAGE)
 
         if self.config[conf.CONF_NWK_BACKUP_ENABLED]:
             self.backups.start_periodic_backups(
@@ -747,7 +747,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             await self.add_endpoint(endpoint)
 
     @contextlib.asynccontextmanager
-    async def _limit_concurrency(self, *, priority: int = 0):
+    async def _limit_concurrency(self, *, priority: int = t.PacketPriority.NORMAL):
         """Async context manager to limit global coordinator request concurrency."""
 
         start_time = time.monotonic()

--- a/zigpy/const.py
+++ b/zigpy/const.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Zigpy Constants."""
+
+from __future__ import annotations
 
 SIG_ENDPOINTS = "endpoints"
 SIG_EP_INPUT = "input_clusters"

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -309,6 +309,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         timeout=APS_REPLY_TIMEOUT,
         use_ieee=False,
         ask_for_ack: bool | None = None,
+        priority: int = t.PacketPriority.NORMAL,
     ):
         extended_timeout = False
 
@@ -330,6 +331,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             use_ieee=use_ieee,
             extended_timeout=extended_timeout,
             ask_for_ack=ask_for_ack,
+            priority=priority,
         )
 
         if not expect_reply:
@@ -516,6 +518,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         expect_reply: bool = False,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
+        priority: int = t.PacketPriority.NORMAL,
     ):
         return await self.request(
             profile=profile,
@@ -528,6 +531,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             timeout=timeout,
             use_ieee=use_ieee,
             ask_for_ack=ask_for_ack,
+            priority=priority,
         )
 
     async def update_firmware(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -188,7 +188,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     async def get_node_descriptor(self) -> zdo_t.NodeDescriptor:
         self.info("Requesting 'Node Descriptor'")
 
-        status, _, node_desc = await self.zdo.Node_Desc_req(self.nwk)
+        status, _, node_desc = await self.zdo.Node_Desc_req(
+            self.nwk,
+            priority=t.PacketPriority.HIGH,
+        )
 
         if status != zdo_t.Status.SUCCESS:
             raise zigpy.exceptions.InvalidResponse(
@@ -231,7 +234,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         else:
             self.info("Discovering endpoints")
 
-            status, _, endpoints = await self.zdo.Active_EP_req(self.nwk)
+            status, _, endpoints = await self.zdo.Active_EP_req(
+                self.nwk, priority=t.PacketPriority.HIGH
+            )
 
             if status != zdo_t.Status.SUCCESS:
                 raise zigpy.exceptions.InvalidResponse(

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -62,7 +62,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.info("Endpoint descriptor already queried")
         else:
             status, _, sd = await self._device.zdo.Simple_Desc_req(
-                self._device.nwk, self._endpoint_id
+                self._device.nwk, self._endpoint_id, priority=t.PacketPriority.HIGH
             )
 
             if status == ZDOStatus.NOT_ACTIVE:
@@ -200,7 +200,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         for names in (["manufacturer", "model"], ["manufacturer"], ["model"]):
             try:
                 success, failure = await self.basic.read_attributes(
-                    names, allow_cache=True
+                    names, allow_cache=True, priority=t.PacketPriority.HIGH
                 )
             except asyncio.TimeoutError:
                 # Only swallow the `TimeoutError` on the double attribute read

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -257,6 +257,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         expect_reply: bool = True,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
+        priority: int = t.PacketPriority.NORMAL,
     ):
         if self.profile_id == zigpy.profiles.zll.PROFILE_ID and not (
             cluster == zigpy.zcl.clusters.lightlink.LightLink.cluster_id
@@ -277,6 +278,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             expect_reply=expect_reply,
             use_ieee=use_ieee,
             ask_for_ack=ask_for_ack,
+            priority=priority,
         )
 
     async def reply(
@@ -289,6 +291,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         expect_reply: bool = False,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
+        priority: int = t.PacketPriority.NORMAL,
     ) -> None:
         if self.profile_id == zigpy.profiles.zll.PROFILE_ID and not (
             cluster == zigpy.zcl.clusters.lightlink.LightLink.cluster_id
@@ -309,6 +312,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             expect_reply=expect_reply,
             use_ieee=use_ieee,
             ask_for_ack=ask_for_ack,
+            priority=priority,
         )
 
     def log(self, lvl: int, msg: str, *args: Any, **kwargs: Any) -> None:

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -288,11 +288,11 @@ class CustomCluster(zigpy.zcl.Cluster):
         )
 
     async def read_attributes_raw(
-        self, attributes: list[uint16_t], manufacturer: uint16_t | None = None
+        self, attributes: list[uint16_t], manufacturer: uint16_t | None = None, **kwargs
     ):
         if not self._CONSTANT_ATTRIBUTES:
             return await super().read_attributes_raw(
-                attributes, manufacturer=manufacturer
+                attributes, manufacturer=manufacturer, **kwargs
             )
 
         succeeded = [
@@ -316,7 +316,7 @@ class CustomCluster(zigpy.zcl.Cluster):
             return [succeeded]
 
         results = await super().read_attributes_raw(
-            attrs_to_read, manufacturer=manufacturer
+            attrs_to_read, manufacturer=manufacturer, **kwargs
         )
         if not isinstance(results[0], list):
             for attrid in attrs_to_read:

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -572,9 +572,9 @@ class PacketPriority(enum.IntEnum):
     """Packet priority"""
 
     CRITICAL = 2
-    INTERACTIVE = 1
+    HIGH = 1
     NORMAL = 0
-    BACKGROUND = -1
+    LOW = -1
 
 
 @dataclasses.dataclass

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -568,6 +568,15 @@ class TransmitOptions(enum.Flag):
     APS_Encryption = 2
 
 
+class PacketPriority(enum.IntEnum):
+    """Packet priority"""
+
+    CRITICAL = 2
+    INTERACTIVE = 1
+    NORMAL = 0
+    BACKGROUND = -1
+
+
 @dataclasses.dataclass
 class ZigbeePacket(BaseDataclassMixin):
     """Container for the information in an incoming or outgoing ZDO or ZCL packet.

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -580,6 +580,9 @@ class ZigbeePacket(BaseDataclassMixin):
         compare=False, default_factory=lambda: datetime.now(timezone.utc)
     )
 
+    # Higher priority will try to be sent before lower
+    priority: int = dataclasses.field(default=0)
+
     # Set to `None` when the packet is outgoing
     src: AddrModeAddress | None = dataclasses.field(default=None)
     src_ep: basic.uint8_t | None = dataclasses.field(default=None)
@@ -629,5 +632,6 @@ class ZigbeePacket(BaseDataclassMixin):
                 self.non_member_radius,
                 self.lqi,
                 self.rssi,
+                self.priority,
             )
         )

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -347,6 +347,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         expect_reply: bool = True,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
+        priority: int = t.PacketPriority.NORMAL,
         tsn: int | t.uint8_t | None = None,
         timeout=APS_REPLY_TIMEOUT,
         **kwargs,
@@ -380,6 +381,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             expect_reply=expect_reply,
             use_ieee=use_ieee,
             ask_for_ack=ask_for_ack,
+            priority=priority,
         )
 
     async def reply(
@@ -394,6 +396,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         expect_reply: bool = False,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
+        priority: int = t.PacketPriority.NORMAL,
         **kwargs,
     ) -> None:
         hdr, request = self._create_request(
@@ -425,6 +428,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             expect_reply=expect_reply,
             use_ieee=use_ieee,
             ask_for_ack=ask_for_ack,
+            priority=priority,
         )
 
     def handle_message(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -638,17 +638,25 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         return args
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer: int | None = None
+        self,
+        attributes: dict[str | int, Any],
+        manufacturer: int | None = None,
+        **kwargs,
     ) -> list:
         """Write attributes to device with internal 'attributes' validation"""
         attrs = self._write_attr_records(attributes)
-        return await self.write_attributes_raw(attrs, manufacturer)
+        return await self.write_attributes_raw(attrs, manufacturer, **kwargs)
 
     async def write_attributes_raw(
-        self, attrs: list[foundation.Attribute], manufacturer: int | None = None
+        self,
+        attrs: list[foundation.Attribute],
+        manufacturer: int | None = None,
+        **kwargs,
     ) -> list:
         """Write attributes to device without internal 'attributes' validation"""
-        result = await self._write_attributes(attrs, manufacturer=manufacturer)
+        result = await self._write_attributes(
+            attrs, manufacturer=manufacturer, **kwargs
+        )
         if not isinstance(result[0], list):
             return result
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -964,7 +964,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 hdr.command_id,
                 status,
                 tsn=hdr.tsn,
-                priority=t.PacketPriority.BACKGROUND,
+                priority=t.PacketPriority.LOW,
             )
         )
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -964,6 +964,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 hdr.command_id,
                 status,
                 tsn=hdr.tsn,
+                priority=t.PacketPriority.BACKGROUND,
             )
         )
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -529,9 +529,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
             self.create_catching_task(self.read_attributes_rsp(records, tsn=hdr.tsn))
 
-    def read_attributes_raw(self, attributes, manufacturer=None):
+    def read_attributes_raw(self, attributes, manufacturer=None, **kwargs):
         attributes = [t.uint16_t(a) for a in attributes]
-        return self._read_attributes(attributes, manufacturer=manufacturer)
+        return self._read_attributes(attributes, manufacturer=manufacturer, **kwargs)
 
     async def read_attributes(
         self,
@@ -539,6 +539,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         allow_cache: bool = False,
         only_cache: bool = False,
         manufacturer: int | t.uint16_t | None = None,
+        **kwargs,
     ) -> Any:
         success, failure = {}, {}
         attribute_ids: list[int] = []
@@ -569,7 +570,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         if not to_read or only_cache:
             return success, failure
 
-        result = await self.read_attributes_raw(to_read, manufacturer=manufacturer)
+        result = await self.read_attributes_raw(
+            to_read, manufacturer=manufacturer, **kwargs
+        )
         if not isinstance(result[0], list):
             for attrid in to_read:
                 orig_attribute = orig_attributes[attrid]

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -107,6 +107,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
                     0,
                     [],
                     tsn=hdr.tsn,
+                    priority=t.PacketPriority.LOW,
                 )
             )
 
@@ -136,6 +137,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
                     0,
                     [],
                     tsn=hdr.tsn,
+                    priority=t.PacketPriority.LOW,
                 )
             )
 
@@ -175,12 +177,24 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         local_addr = self._device.application.state.node_info.nwk
         if profile != zigpy.profiles.zha.PROFILE_ID:
             self.create_catching_task(
-                self.Match_Desc_rsp(0, local_addr, [], tsn=hdr.tsn)
+                self.Match_Desc_rsp(
+                    0,
+                    local_addr,
+                    [],
+                    tsn=hdr.tsn,
+                    priority=t.PacketPriority.HIGH,
+                )
             )
             return
 
         self.create_catching_task(
-            self.Match_Desc_rsp(0, local_addr, [t.uint8_t(1)], tsn=hdr.tsn)
+            self.Match_Desc_rsp(
+                0,
+                local_addr,
+                [t.uint8_t(1)],
+                tsn=hdr.tsn,
+                priority=t.PacketPriority.HIGH,
+            )
         )
 
     def bind(self, cluster):


### PR DESCRIPTION
Currently unused but it should be simple to extend the `request` API to utilize it, after https://github.com/zigpy/zigpy/pull/1481.

Sample implementation for bellows:

```diff
diff --git a/bellows/zigbee/application.py b/bellows/zigbee/application.py
index 08a1169..0680184 100644
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -741,7 +741,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             # Source routing uses address discovery to discover routes
             aps_frame.options |= t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
 
-        async with self._limit_concurrency():
+        async with self._limit_concurrency(priority=packet.priority):
             message_tag = self.get_sequence()
             pending_tag = (packet.dst.address, message_tag)
             with self._pending.new(pending_tag) as req:
```