### PR TITLE
Fix CustomDevice checks

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -460,7 +460,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         if device.node_desc is not None:
             await self._save_node_descriptor(device)
 
-        if isinstance(device, zigpy.quirks.CustomDevice):
+        if isinstance(device, zigpy.quirks.BaseCustomDevice):
             await self._db.commit()
             return
 

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -152,7 +152,7 @@ class CustomEndpoint(zigpy.endpoint.Endpoint):
 
     def __init__(
         self,
-        device: CustomDevice,
+        device: BaseCustomDevice,
         endpoint_id: int,
         replacement_data: dict[str, typing.Any],
         replace_device: zigpy.device.Device,

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -106,7 +106,7 @@ class DeviceRegistry:
 
     def get_device(self, device: DeviceType) -> CustomDeviceType | DeviceType:
         """Get a CustomDevice object, if one is available"""
-        if isinstance(device, zigpy.quirks.CustomDevice):
+        if isinstance(device, zigpy.quirks.BaseCustomDevice):
             return device
 
         key = (device.manufacturer, device.model)

--- a/zigpy/typing.py
+++ b/zigpy/typing.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     ClusterType = zigpy.zcl.Cluster
     ControllerApplicationType = zigpy.application.ControllerApplication
     CustomClusterType = zigpy.quirks.CustomCluster
-    CustomDeviceType = zigpy.quirks.CustomDevice
+    CustomDeviceType = zigpy.quirks.BaseCustomDevice
     CustomEndpointType = zigpy.quirks.CustomEndpoint
     DeviceType = zigpy.device.Device
     EndpointType = zigpy.endpoint.Endpoint


### PR DESCRIPTION
https://github.com/zigpy/zigpy/pull/1450 reorganized the class hierarchy, so we need to check for `BaseCustomDevice` in most cases now to cover both v1 and v2 quirks.

The original signature in the database for devices using v2 quirks may have been overwritten. This could have caused custom endpoints or modified cluster types to appear in the database.
Hopefully, this shouldn't be a big issue though, as current v2 quirks do not check the endpoint/cluster part of the device signature.