### PR TITLE
Set default value for ZDO request: `expect_reply=True`

### DIFF
--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -49,6 +49,7 @@ async def test_request(zdo_f):
     ) as get_sequence:
         await zdo_f.request(2, 65535)
         assert zdo_f.device.request.call_count == 1
+        assert zdo_f.device.request.mock_calls[0].kwargs["expect_reply"] is True
         assert get_sequence.call_count == 1
 
 

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -56,7 +56,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         command,
         *args,
         timeout=APS_REPLY_TIMEOUT,
-        expect_reply: bool = False,
+        expect_reply: bool = True,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
         priority: int = t.PacketPriority.NORMAL,


### PR DESCRIPTION
<https://github.com/zigpy/zigpy/pull/1482> introduced a bug where `zdo.request` did not expect a reply and thus returned `None`.