### PR TITLE
Require `fallback_name` and add `translation_key` validation

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -111,6 +111,7 @@ async def test_quirks_v2(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            fallback_name="Start Up On/Off",
         )
         .add_to_registry()
     )
@@ -206,6 +207,7 @@ async def test_quirks_v2_model_manufacturer(device_mock):
                 OnOff.AttributeDefs.start_up_on_off.name,
                 OnOff.StartUpOnOff,
                 OnOff.cluster_id,
+                fallback_name="Start Up On/Off",
             )
             .add_to_registry()
         )
@@ -223,6 +225,7 @@ async def test_quirks_v2_quirk_builder_cloning(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            fallback_name="Start Up On/Off",
         )
         .applies_to("foo", "bar")
     )
@@ -267,6 +270,7 @@ async def test_quirks_v2_signature_match(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            fallback_name="Start Up On/Off",
         )
         .add_to_registry()
     )
@@ -287,6 +291,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            fallback_name="Start Up On/Off",
         )
         .add_to_registry()
     )
@@ -300,6 +305,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            fallback_name="Start Up On/Off",
         )
         .add_to_registry()
     )
@@ -329,6 +335,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            fallback_name="Start Up On/Off",
         )
         .add_to_registry()
     )
@@ -341,6 +348,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            fallback_name="Start Up On/Off",
         )
         .add_to_registry()
     )
@@ -366,6 +374,7 @@ async def test_quirks_v2_with_custom_device_class(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            fallback_name="Start Up On/Off",
         )
         .add_to_registry()
     )
@@ -528,7 +537,11 @@ async def test_quirks_v2_sensor(device_mock):
     (
         QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .adds(OnOff.cluster_id)
-        .sensor(OnOff.AttributeDefs.on_time.name, OnOff.cluster_id)
+        .sensor(
+            OnOff.AttributeDefs.on_time.name,
+            OnOff.cluster_id,
+            fallback_name="On Time",
+        )
         .add_to_registry()
     )
 
@@ -564,6 +577,7 @@ async def test_quirks_v2_switch(device_mock):
             OnOff.cluster_id,
             force_inverted=True,
             invert_attribute_name=OnOff.AttributeDefs.off_wait_time.name,
+            fallback_name="On Time",
         )
         .add_to_registry()
     )
@@ -603,6 +617,7 @@ async def test_quirks_v2_number(device_mock):
             max_value=100,
             step=1,
             unit="s",
+            fallback_name="On Time",
         )
         .add_to_registry()
     )
@@ -641,6 +656,7 @@ async def test_quirks_v2_binary_sensor(device_mock):
         .binary_sensor(
             OnOff.AttributeDefs.on_off.name,
             OnOff.cluster_id,
+            fallback_name="On/Off",
         )
         .add_to_registry()
     )
@@ -674,6 +690,7 @@ async def test_quirks_v2_write_attribute_button(device_mock):
             OnOff.AttributeDefs.on_time.name,
             20,
             OnOff.cluster_id,
+            fallback_name="On Time",
         )
         .add_to_registry()
     )
@@ -708,6 +725,7 @@ async def test_quirks_v2_command_button(device_mock):
             OnOff.ServerCommandDefs.on_with_timed_off.name,
             OnOff.cluster_id,
             command_kwargs={"on_off_control": OnOff.OnOffControl.Accept_Only_When_On},
+            fallback_name="On With Timed Off",
         )
         .command_button(
             OnOff.ServerCommandDefs.on_with_timed_off.name,
@@ -715,10 +733,12 @@ async def test_quirks_v2_command_button(device_mock):
             command_kwargs={
                 "on_off_control_foo": OnOff.OnOffControl.Accept_Only_When_On
             },
+            fallback_name="On With Timed Off",
         )
         .command_button(
             OnOff.ServerCommandDefs.on_with_timed_off.name,
             OnOff.cluster_id,
+            fallback_name="On With Timed Off",
         )
         .add_to_registry()
     )
@@ -774,6 +794,7 @@ async def test_quirks_v2_also_applies_to(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            fallback_name="Start Up On/Off",
         )
         .add_to_registry()
     )
@@ -1023,6 +1044,7 @@ async def test_quirks_v2_add_to_registry_v2_logs_error(caplog):
         .binary_sensor(
             OnOff.AttributeDefs.on_off.name,
             OnOff.cluster_id,
+            fallback_name="On/Off",
         )
         .add_to_registry()
     )

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -112,7 +112,7 @@ async def test_quirks_v2(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
             translation_key="start_up_on_off",
-            fallback_name="Start Up On/Off",
+            fallback_name="Start up on/off",
         )
         .add_to_registry()
     )
@@ -209,7 +209,7 @@ async def test_quirks_v2_model_manufacturer(device_mock):
                 OnOff.StartUpOnOff,
                 OnOff.cluster_id,
                 translation_key="start_up_on_off",
-                fallback_name="Start Up On/Off",
+                fallback_name="Start up on/off",
             )
             .add_to_registry()
         )
@@ -228,7 +228,7 @@ async def test_quirks_v2_quirk_builder_cloning(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
             translation_key="start_up_on_off",
-            fallback_name="Start Up On/Off",
+            fallback_name="Start up on/off",
         )
         .applies_to("foo", "bar")
     )
@@ -274,7 +274,7 @@ async def test_quirks_v2_signature_match(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
             translation_key="start_up_on_off",
-            fallback_name="Start Up On/Off",
+            fallback_name="Start up on/off",
         )
         .add_to_registry()
     )
@@ -296,7 +296,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
             translation_key="start_up_on_off",
-            fallback_name="Start Up On/Off",
+            fallback_name="Start up on/off",
         )
         .add_to_registry()
     )
@@ -311,7 +311,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
             translation_key="start_up_on_off",
-            fallback_name="Start Up On/Off",
+            fallback_name="Start up on/off",
         )
         .add_to_registry()
     )
@@ -342,7 +342,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
             translation_key="start_up_on_off",
-            fallback_name="Start Up On/Off",
+            fallback_name="Start up on/off",
         )
         .add_to_registry()
     )
@@ -356,7 +356,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
             translation_key="start_up_on_off",
-            fallback_name="Start Up On/Off",
+            fallback_name="Start up on/off",
         )
         .add_to_registry()
     )
@@ -383,7 +383,7 @@ async def test_quirks_v2_with_custom_device_class(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
             translation_key="start_up_on_off",
-            fallback_name="Start Up On/Off",
+            fallback_name="Start up on/off",
         )
         .add_to_registry()
     )
@@ -550,7 +550,7 @@ async def test_quirks_v2_sensor(device_mock):
             OnOff.AttributeDefs.on_time.name,
             OnOff.cluster_id,
             translation_key="on_time",
-            fallback_name="On Time",
+            fallback_name="On time",
         )
         .add_to_registry()
     )
@@ -586,7 +586,7 @@ async def test_quirks_v2_sensor_validation_failure_no_translation_key(device_moc
             .sensor(
                 OnOff.AttributeDefs.on_time.name,
                 OnOff.cluster_id,
-                fallback_name="On Time",
+                fallback_name="On time",
             )
             .add_to_registry()
         )
@@ -605,7 +605,7 @@ async def test_quirks_v2_switch(device_mock):
             force_inverted=True,
             invert_attribute_name=OnOff.AttributeDefs.off_wait_time.name,
             translation_key="on_time",
-            fallback_name="On Time",
+            fallback_name="On time",
         )
         .add_to_registry()
     )
@@ -646,7 +646,7 @@ async def test_quirks_v2_number(device_mock):
             step=1,
             unit="s",
             translation_key="on_time",
-            fallback_name="On Time",
+            fallback_name="On time",
         )
         .add_to_registry()
     )
@@ -686,7 +686,7 @@ async def test_quirks_v2_binary_sensor(device_mock):
             OnOff.AttributeDefs.on_off.name,
             OnOff.cluster_id,
             translation_key="on_off",
-            fallback_name="On/Off",
+            fallback_name="On/off",
         )
         .add_to_registry()
     )
@@ -721,7 +721,7 @@ async def test_quirks_v2_write_attribute_button(device_mock):
             20,
             OnOff.cluster_id,
             translation_key="on_time",
-            fallback_name="On Time",
+            fallback_name="On time",
         )
         .add_to_registry()
     )
@@ -757,7 +757,7 @@ async def test_quirks_v2_command_button(device_mock):
             OnOff.cluster_id,
             command_kwargs={"on_off_control": OnOff.OnOffControl.Accept_Only_When_On},
             translation_key="on_with_timed_off",
-            fallback_name="On With Timed Off",
+            fallback_name="On with timed off",
         )
         .command_button(
             OnOff.ServerCommandDefs.on_with_timed_off.name,
@@ -766,13 +766,13 @@ async def test_quirks_v2_command_button(device_mock):
                 "on_off_control_foo": OnOff.OnOffControl.Accept_Only_When_On
             },
             translation_key="on_with_timed_off",
-            fallback_name="On With Timed Off",
+            fallback_name="On with timed off",
         )
         .command_button(
             OnOff.ServerCommandDefs.on_with_timed_off.name,
             OnOff.cluster_id,
             translation_key="on_with_timed_off",
-            fallback_name="On With Timed Off",
+            fallback_name="On with timed off",
         )
         .add_to_registry()
     )
@@ -829,7 +829,7 @@ async def test_quirks_v2_also_applies_to(device_mock):
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
             translation_key="start_up_on_off",
-            fallback_name="Start Up On/Off",
+            fallback_name="Start up on/off",
         )
         .add_to_registry()
     )
@@ -1080,7 +1080,7 @@ async def test_quirks_v2_add_to_registry_v2_logs_error(caplog):
             OnOff.AttributeDefs.on_off.name,
             OnOff.cluster_id,
             translation_key="on_off",
-            fallback_name="On/Off",
+            fallback_name="On/off",
         )
         .add_to_registry()
     )

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -575,6 +575,23 @@ async def test_quirks_v2_sensor(device_mock):
     assert sensor_metadata.multiplier == 1
 
 
+async def test_quirks_v2_sensor_validation_failure_no_translation_key(device_mock):
+    """Test translation key and device class both not set causes exception."""
+    registry = DeviceRegistry()
+
+    with pytest.raises(ValueError, match="must have a translation_key or device_class"):
+        (
+            QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+            .adds(OnOff.cluster_id)
+            .sensor(
+                OnOff.AttributeDefs.on_time.name,
+                OnOff.cluster_id,
+                fallback_name="On Time",
+            )
+            .add_to_registry()
+        )
+
+
 async def test_quirks_v2_switch(device_mock):
     """Test adding a quirk that defines a switch to the registry."""
     registry = DeviceRegistry()

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -111,6 +111,7 @@ async def test_quirks_v2(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            translation_key="start_up_on_off",
             fallback_name="Start Up On/Off",
         )
         .add_to_registry()
@@ -207,6 +208,7 @@ async def test_quirks_v2_model_manufacturer(device_mock):
                 OnOff.AttributeDefs.start_up_on_off.name,
                 OnOff.StartUpOnOff,
                 OnOff.cluster_id,
+                translation_key="start_up_on_off",
                 fallback_name="Start Up On/Off",
             )
             .add_to_registry()
@@ -225,6 +227,7 @@ async def test_quirks_v2_quirk_builder_cloning(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            translation_key="start_up_on_off",
             fallback_name="Start Up On/Off",
         )
         .applies_to("foo", "bar")
@@ -270,6 +273,7 @@ async def test_quirks_v2_signature_match(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            translation_key="start_up_on_off",
             fallback_name="Start Up On/Off",
         )
         .add_to_registry()
@@ -291,6 +295,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            translation_key="start_up_on_off",
             fallback_name="Start Up On/Off",
         )
         .add_to_registry()
@@ -305,6 +310,7 @@ async def test_quirks_v2_multiple_matches_raises(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            translation_key="start_up_on_off",
             fallback_name="Start Up On/Off",
         )
         .add_to_registry()
@@ -335,6 +341,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            translation_key="start_up_on_off",
             fallback_name="Start Up On/Off",
         )
         .add_to_registry()
@@ -348,6 +355,7 @@ async def test_quirks_v2_multiple_matches_not_raises(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            translation_key="start_up_on_off",
             fallback_name="Start Up On/Off",
         )
         .add_to_registry()
@@ -374,6 +382,7 @@ async def test_quirks_v2_with_custom_device_class(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            translation_key="start_up_on_off",
             fallback_name="Start Up On/Off",
         )
         .add_to_registry()
@@ -540,6 +549,7 @@ async def test_quirks_v2_sensor(device_mock):
         .sensor(
             OnOff.AttributeDefs.on_time.name,
             OnOff.cluster_id,
+            translation_key="on_time",
             fallback_name="On Time",
         )
         .add_to_registry()
@@ -577,6 +587,7 @@ async def test_quirks_v2_switch(device_mock):
             OnOff.cluster_id,
             force_inverted=True,
             invert_attribute_name=OnOff.AttributeDefs.off_wait_time.name,
+            translation_key="on_time",
             fallback_name="On Time",
         )
         .add_to_registry()
@@ -617,6 +628,7 @@ async def test_quirks_v2_number(device_mock):
             max_value=100,
             step=1,
             unit="s",
+            translation_key="on_time",
             fallback_name="On Time",
         )
         .add_to_registry()
@@ -656,6 +668,7 @@ async def test_quirks_v2_binary_sensor(device_mock):
         .binary_sensor(
             OnOff.AttributeDefs.on_off.name,
             OnOff.cluster_id,
+            translation_key="on_off",
             fallback_name="On/Off",
         )
         .add_to_registry()
@@ -690,6 +703,7 @@ async def test_quirks_v2_write_attribute_button(device_mock):
             OnOff.AttributeDefs.on_time.name,
             20,
             OnOff.cluster_id,
+            translation_key="on_time",
             fallback_name="On Time",
         )
         .add_to_registry()
@@ -725,6 +739,7 @@ async def test_quirks_v2_command_button(device_mock):
             OnOff.ServerCommandDefs.on_with_timed_off.name,
             OnOff.cluster_id,
             command_kwargs={"on_off_control": OnOff.OnOffControl.Accept_Only_When_On},
+            translation_key="on_with_timed_off",
             fallback_name="On With Timed Off",
         )
         .command_button(
@@ -733,11 +748,13 @@ async def test_quirks_v2_command_button(device_mock):
             command_kwargs={
                 "on_off_control_foo": OnOff.OnOffControl.Accept_Only_When_On
             },
+            translation_key="on_with_timed_off",
             fallback_name="On With Timed Off",
         )
         .command_button(
             OnOff.ServerCommandDefs.on_with_timed_off.name,
             OnOff.cluster_id,
+            translation_key="on_with_timed_off",
             fallback_name="On With Timed Off",
         )
         .add_to_registry()
@@ -794,6 +811,7 @@ async def test_quirks_v2_also_applies_to(device_mock):
             OnOff.AttributeDefs.start_up_on_off.name,
             OnOff.StartUpOnOff,
             OnOff.cluster_id,
+            translation_key="start_up_on_off",
             fallback_name="Start Up On/Off",
         )
         .add_to_registry()
@@ -1044,6 +1062,7 @@ async def test_quirks_v2_add_to_registry_v2_logs_error(caplog):
         .binary_sensor(
             OnOff.AttributeDefs.on_off.name,
             OnOff.cluster_id,
+            translation_key="on_off",
             fallback_name="On/Off",
         )
         .add_to_registry()

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -246,11 +246,24 @@ class EntityMetadata:
     translation_key: str | None = attrs.field(default=None)
     fallback_name: str = attrs.field(validator=attrs.validators.instance_of(str))
 
+    def __attrs_post_init__(self) -> None:
+        """Validate the entity metadata."""
+        self._validate()
+
     def __call__(self, device: CustomDeviceV2) -> None:
         """Add the entity metadata to the quirks v2 device."""
+        self._validate()
         device.exposes_metadata[
             (self.endpoint_id, self.cluster_id, self.cluster_type)
         ].append(self)
+
+    def _validate(self) -> None:
+        """Validate the entity metadata."""
+        has_device_class: bool = getattr(self, "device_class", None) is not None
+        if self.translation_key is None and not has_device_class:
+            raise ValueError(
+                f"EntityMetadata must have a translation_key or device_class: {self}"
+            )
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -243,7 +243,7 @@ class EntityMetadata:
     cluster_type: ClusterType = attrs.field(default=ClusterType.Server)
     initially_disabled: bool = attrs.field(default=False)
     attribute_initialized_from_cache: bool = attrs.field(default=True)
-    translation_key: str = attrs.field()
+    translation_key: str | None = attrs.field(default=None)
     fallback_name: str = attrs.field(validator=attrs.validators.instance_of(str))
 
     def __call__(self, device: CustomDeviceV2) -> None:

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -244,7 +244,7 @@ class EntityMetadata:
     initially_disabled: bool = attrs.field(default=False)
     attribute_initialized_from_cache: bool = attrs.field(default=True)
     translation_key: str = attrs.field()
-    fallback_name: str = attrs.field()
+    fallback_name: str = attrs.field(validator=attrs.validators.instance_of(str))
 
     def __call__(self, device: CustomDeviceV2) -> None:
         """Add the entity metadata to the quirks v2 device."""


### PR DESCRIPTION
# Proposed change

This PR makes a couple of changes to v2 quirks `EntityMetadata`:
- require `fallback_name` (and validate it)
- require `translation_key` or `device_class` (and validate it)
- adjust tests

The changes are also clearly separated in the commits of the branch/PR for easy review.

# Why?

## `fallback_name`

When we add v2 quirk entities, we need to add translation keys to `strings.json` in Home Assistant.
In order for quirk entities to include a proper (English) name that we can use to add to `strings.json`, we now require `fallback_name`. This will be the default entity name added to `strings.json`.

I already have some rudimentary scripts to automatically add these names when bumping ZHA (with it: zha-quirks) in HA and the test validating translations that I plan to re-add to HA soon (tracking issue: https://github.com/zigpy/zha/issues/72).

## `translation_key`

When we want Home Assistant to use the name of a device class, we want to explicitly set `translation_key=None`.
At the moment, ZHA does not allow for this and also defaults to `attribute_name` (or `command_name`) if the `translation_key` isn't provided. `None` is not accepted at all. ZHA code: [zha/application/platforms/__init__.py#L350-L355](https://github.com/zigpy/zha/blob/2cfd334cf9e3c1fb6337ddfb8062827692e24944/zha/application/platforms/__init__.py#L350-L355)*

IMO, it's best if we just always require `translation_key` and do not default to `attribute_name`.

### Example: Tamper binary sensor

See this example of a tamper binary sensor: [zhaquirks/philips/soc001.py#L48-L56](https://github.com/zigpy/zha-device-handlers/blob/c7887583a83e05ffaed149fd09e3c8a0b1079b0d/zhaquirks/philips/soc001.py#L48-L56)
Here, the `device_class` is set to `TAMPER`. That alone would automatically set a proper name in Home Assistant. However, we also set a `translation_key` that overrides that.

If we were to keep defaulting `translation_key` to `attribute_name` in ZHA, we would still need to explicitly add `translation_key=None` if we want to keep the name of the device class (and make some changes to zigpy/ZHA to allow differentiating between setting it to `None` versus not setting it at all).

It seems much clearer to just separate the `attribute_name` and `translation_key` completely, so to also require `translation_key` when we actually want to set it (instead of setting it to `None` when we do not want to set it).

---

*: A follow-up PR to ZHA will remove the section that defaults the `_attr_translation_key` to `attribute_name` or `command_name`.
`fallback_name` and `translation_key` will also be added to a few quirks v2 entities in ZHA tests.