### PR TITLE
Expose reporting config in v2 quirks

### DIFF
--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -259,6 +259,7 @@ class ZCLEnumMetadata(EntityMetadata):
 
     enum: type[Enum] = attrs.field()
     attribute_name: str = attrs.field()
+    report_config: tuple[int, int, int] | None = attrs.field(default=None)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -266,6 +267,7 @@ class ZCLSensorMetadata(EntityMetadata):
     """Metadata for exposed ZCL attribute based sensor entity."""
 
     attribute_name: str | None = attrs.field(default=None)
+    report_config: tuple[int, int, int] | None = attrs.field(default=None)
     divisor: int | None = attrs.field(default=None)
     multiplier: int | None = attrs.field(default=None)
     unit: str | None = attrs.field(default=None)
@@ -278,6 +280,7 @@ class SwitchMetadata(EntityMetadata):
     """Metadata for exposed switch entity."""
 
     attribute_name: str = attrs.field()
+    report_config: tuple[int, int, int] | None = attrs.field(default=None)
     force_inverted: bool = attrs.field(default=False)
     invert_attribute_name: str | None = attrs.field(default=None)
     off_value: int = attrs.field(default=0)
@@ -289,6 +292,7 @@ class NumberMetadata(EntityMetadata):
     """Metadata for exposed number entity."""
 
     attribute_name: str = attrs.field()
+    report_config: tuple[int, int, int] | None = attrs.field(default=None)
     min: float | None = attrs.field(default=None)
     max: float | None = attrs.field(default=None)
     step: float | None = attrs.field(default=None)
@@ -303,6 +307,7 @@ class BinarySensorMetadata(EntityMetadata):
     """Metadata for exposed binary sensor entity."""
 
     attribute_name: str = attrs.field()
+    report_config: tuple[int, int, int] | None = attrs.field(default=None)
     device_class: BinarySensorDeviceClass | None = attrs.field(default=None)
 
 
@@ -598,6 +603,7 @@ class QuirkBuilder:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        report_config: tuple[int, int, int] | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -614,6 +620,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
+                report_config=report_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 enum=enum_class,
@@ -636,6 +643,7 @@ class QuirkBuilder:
         unit: str | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        report_config: tuple[int, int, int] | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -652,6 +660,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
+                report_config=report_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
@@ -678,6 +687,7 @@ class QuirkBuilder:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        report_config: tuple[int, int, int] | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -694,6 +704,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
+                report_config=report_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
@@ -721,6 +732,7 @@ class QuirkBuilder:
         device_class: NumberDeviceClass | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        report_config: tuple[int, int, int] | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -737,6 +749,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
+                report_config=report_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
@@ -761,6 +774,7 @@ class QuirkBuilder:
         device_class: BinarySensorDeviceClass | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        report_config: tuple[int, int, int] | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -777,6 +791,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
+                report_config=report_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from zigpy.device import Device
     from zigpy.endpoint import Endpoint
     from zigpy.zcl import Cluster
-    from zigpy.zcl.foundation import ZCLAttributeDef
+    from zigpy.zcl.foundation import ReportingConfig, ZCLAttributeDef
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -259,7 +259,7 @@ class ZCLEnumMetadata(EntityMetadata):
 
     enum: type[Enum] = attrs.field()
     attribute_name: str = attrs.field()
-    report_config: tuple[int, int, int] | None = attrs.field(default=None)
+    reporting_config: ReportingConfig | None = attrs.field(default=None)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -267,7 +267,7 @@ class ZCLSensorMetadata(EntityMetadata):
     """Metadata for exposed ZCL attribute based sensor entity."""
 
     attribute_name: str | None = attrs.field(default=None)
-    report_config: tuple[int, int, int] | None = attrs.field(default=None)
+    reporting_config: ReportingConfig | None = attrs.field(default=None)
     divisor: int | None = attrs.field(default=None)
     multiplier: int | None = attrs.field(default=None)
     unit: str | None = attrs.field(default=None)
@@ -280,7 +280,7 @@ class SwitchMetadata(EntityMetadata):
     """Metadata for exposed switch entity."""
 
     attribute_name: str = attrs.field()
-    report_config: tuple[int, int, int] | None = attrs.field(default=None)
+    reporting_config: ReportingConfig | None = attrs.field(default=None)
     force_inverted: bool = attrs.field(default=False)
     invert_attribute_name: str | None = attrs.field(default=None)
     off_value: int = attrs.field(default=0)
@@ -292,7 +292,7 @@ class NumberMetadata(EntityMetadata):
     """Metadata for exposed number entity."""
 
     attribute_name: str = attrs.field()
-    report_config: tuple[int, int, int] | None = attrs.field(default=None)
+    reporting_config: ReportingConfig | None = attrs.field(default=None)
     min: float | None = attrs.field(default=None)
     max: float | None = attrs.field(default=None)
     step: float | None = attrs.field(default=None)
@@ -307,7 +307,7 @@ class BinarySensorMetadata(EntityMetadata):
     """Metadata for exposed binary sensor entity."""
 
     attribute_name: str = attrs.field()
-    report_config: tuple[int, int, int] | None = attrs.field(default=None)
+    reporting_config: ReportingConfig | None = attrs.field(default=None)
     device_class: BinarySensorDeviceClass | None = attrs.field(default=None)
 
 
@@ -603,7 +603,7 @@ class QuirkBuilder:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        report_config: tuple[int, int, int] | None = None,
+        reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -620,7 +620,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
-                report_config=report_config,
+                reporting_config=reporting_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 enum=enum_class,
@@ -643,7 +643,7 @@ class QuirkBuilder:
         unit: str | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        report_config: tuple[int, int, int] | None = None,
+        reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -660,7 +660,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
-                report_config=report_config,
+                reporting_config=reporting_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
@@ -687,7 +687,7 @@ class QuirkBuilder:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        report_config: tuple[int, int, int] | None = None,
+        reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -704,7 +704,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
-                report_config=report_config,
+                reporting_config=reporting_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
@@ -732,7 +732,7 @@ class QuirkBuilder:
         device_class: NumberDeviceClass | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        report_config: tuple[int, int, int] | None = None,
+        reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -749,7 +749,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
-                report_config=report_config,
+                reporting_config=reporting_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
@@ -774,7 +774,7 @@ class QuirkBuilder:
         device_class: BinarySensorDeviceClass | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        report_config: tuple[int, int, int] | None = None,
+        reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
     ) -> QuirkBuilder:
@@ -791,7 +791,7 @@ class QuirkBuilder:
                 entity_type=entity_type,
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
-                report_config=report_config,
+                reporting_config=reporting_config,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import collections
 from copy import deepcopy
+import dataclasses
 from enum import Enum
 import inspect
 import logging
@@ -39,7 +40,7 @@ if TYPE_CHECKING:
     from zigpy.device import Device
     from zigpy.endpoint import Endpoint
     from zigpy.zcl import Cluster
-    from zigpy.zcl.foundation import ReportingConfig, ZCLAttributeDef
+    from zigpy.zcl.foundation import ZCLAttributeDef
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,6 +50,15 @@ UNBUILT_QUIRK_BUILDERS: list[QuirkBuilder] = []
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-arguments
 # pylint: disable=too-few-public-methods
+
+
+@dataclasses.dataclass(frozen=True)
+class ReportingConfig:
+    """Reporting config for an entity attribute."""
+
+    min_interval: int
+    max_interval: int
+    reportable_change: int
 
 
 class CustomDeviceV2(BaseCustomDevice):

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1285,6 +1285,13 @@ class ZCLAttributeDef(t.BaseDataclassMixin):
         )
 
 
+@dataclasses.dataclass(frozen=True)
+class ReportingConfig:
+    min_interval: int
+    max_interval: int
+    reportable_change: int
+
+
 class IterableMemberMeta(type):
     def __iter__(cls) -> typing.Iterator[typing.Any]:
         for name in dir(cls):

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1285,13 +1285,6 @@ class ZCLAttributeDef(t.BaseDataclassMixin):
         )
 
 
-@dataclasses.dataclass(frozen=True)
-class ReportingConfig:
-    min_interval: int
-    max_interval: int
-    reportable_change: int
-
-
 class IterableMemberMeta(type):
     def __iter__(cls) -> typing.Iterator[typing.Any]:
         for name in dir(cls):


### PR DESCRIPTION
# Proposed change

This change modifies the Quirks V2 API to expose the report configuration to a quirk sensor/entity.

By default, this argument is None, meaning no reporting will get configured by ZHA and it is up to the device to push reports at whatever interval it so chooses (matching current behaviour).

Note: this is just what I've come up with API wise, as my first draft. It may even make more sense to go for a AttributeDefs like approach instead of passing it via entity API. 
My main objective behind opening this PR is to create some discussion around reporting in general, and attempt to understand what other people had envisioned behind implementing reporting and Quirks V2 longer term.

This PR is paired with the following ZHA PR: https://github.com/zigpy/zha/pull/254

# Why?

For some devices, such as Ikea's VINDSTYRKA VOC sensor, the default report rate is roughly once ever half hour - far too infrequent to be at all useful. 
We therefore need to be able to configure the report frequency via the QuirkBuilder interface, allowing for the overriding of such nonsensical behaviour.

### Example

    QuirkBuilder("IKEA of Sweden", "VINDSTYRKA")
    .replaces(VOCIndex)
    .sensor(
        VOCIndex.AttributeDefs.measured_value.name,
        VOCIndex.cluster_id,
        device class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
        report_config=ReportingConfig(
            min_interval=0, max_interval=60, reportable_change=1
        )
    )
    .add_to_registry()