### PR TITLE
Unwrap pyserial exceptions in `create_serial_connection`

### DIFF
--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import pathlib
 import unittest.mock
 
 import pytest
@@ -92,3 +93,14 @@ async def test_serial_socket() -> None:
         assert loop.create_connection.mock_calls[0].kwargs["port"] == 5678
         assert loop.create_connection.mock_calls[1].kwargs["host"] == "1.2.3.4"
         assert loop.create_connection.mock_calls[1].kwargs["port"] == 6638
+
+
+async def test_pyserial_error_remapping() -> None:
+    loop = asyncio.get_running_loop()
+    port = pathlib.Path("/dev/ttySERIALPORTHATDOESNOTEXIST")
+    protocol_factory = unittest.mock.Mock()
+
+    assert not port.exists()
+
+    with pytest.raises(FileNotFoundError):
+        await zigpy.serial.create_serial_connection(loop, protocol_factory, url=port)

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -16,16 +16,6 @@ from zigpy.typing import UNDEFINED, UndefinedType
 LOGGER = logging.getLogger(__name__)
 DEFAULT_SOCKET_PORT = 6638
 SOCKET_CONNECT_TIMEOUT = 5
-
-
-try:
-    import serial_asyncio_fast as pyserial_asyncio
-
-    LOGGER.info("Using pyserial-asyncio-fast in place of pyserial-asyncio")
-except ImportError:
-    import serial_asyncio as pyserial_asyncio
-
-
 ERRNO_TO_EXCEPTION = {
     getattr(errno, name): exc
     # This mapping is taken from CPython. These constants are platform-dependent.
@@ -55,6 +45,13 @@ ERRNO_TO_EXCEPTION = {
     }.items()
     if getattr(errno, name, None) is not None
 }
+
+try:
+    import serial_asyncio_fast as pyserial_asyncio
+
+    LOGGER.info("Using pyserial-asyncio-fast in place of pyserial-asyncio")
+except ImportError:
+    import serial_asyncio as pyserial_asyncio
 
 
 async def create_serial_connection(

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -114,7 +114,7 @@ async def create_serial_connection(
             )
         except pyserial.SerialException as exc:
             # Unwrap unnecessarily wrapped PySerial exceptions
-            if "could not open port" in str(exc):
+            if "could not open port" in str(exc) and exc.errno is not None:
                 exc_class = ERRNO_TO_EXCEPTION.get(exc.errno, OSError)
                 raise exc_class(exc.errno, os.strerror(exc.errno), url) from exc
 

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -4,6 +4,7 @@ import asyncio
 import errno
 import logging
 import os
+import pathlib
 import typing
 from typing import Literal
 import urllib.parse
@@ -57,7 +58,7 @@ except ImportError:
 async def create_serial_connection(
     loop: asyncio.BaseEventLoop,
     protocol_factory: typing.Callable[[], asyncio.Protocol],
-    url: str,
+    url: pathlib.Path | str,
     *,
     baudrate: int = 115200,  # We default to 115200 instead of 9600
     exclusive: bool | None = None,
@@ -88,6 +89,7 @@ async def create_serial_connection(
         rtscts,
     )
 
+    url = str(url)
     parsed_url = urllib.parse.urlparse(url)
 
     if parsed_url.scheme in ("socket", "tcp"):


### PR DESCRIPTION
PySerial currently strips all `OSError` exceptions and re-wraps them in `SerialException`, confusingly itself an `OSError` subclass.

This means code that tries to handle connection-time serial port errors will fail or require pyserial-specific hacks. This PR re-raises the original exception (on POSIX platforms).

Example (with this PR):
```python
2024-10-21 18:38:14.252 DEBUG (MainThread) [homeassistant.components.zha] Failed to set up ZHA
Traceback (most recent call last):
  File "/projects/hass/hass/homeassistant/components/zha/__init__.py", line 151, in async_setup_entry
    await zha_gateway.async_initialize()
  File "/projects/zigpy/zha/zha/application/gateway.py", line 272, in async_initialize
    await self._async_initialize()
  File "/projects/zigpy/zha/zha/application/gateway.py", line 255, in _async_initialize
    await self.application_controller.startup(auto_form=True)
  File "/projects/zigpy/zigpy/application.py", line 235, in startup
    await self.connect()
  File "/projects/hass/hass/.venv/lib/python3.12/site-packages/bellows/zigbee/application.py", line 145, in connect
    await ezsp.connect(use_thread=self.config[CONF_USE_THREAD])
  File "/projects/hass/hass/.venv/lib/python3.12/site-packages/bellows/ezsp/__init__.py", line 141, in connect
    self._gw = await bellows.uart.connect(self._config, self, use_thread=use_thread)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/projects/hass/hass/.venv/lib/python3.12/site-packages/bellows/uart.py", line 172, in connect
    protocol, _ = await _connect(config, application)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/projects/hass/hass/.venv/lib/python3.12/site-packages/bellows/uart.py", line 143, in _connect
    transport, _ = await zigpy.serial.create_serial_connection(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/projects/zigpy/zigpy/serial.py", line 86, in create_serial_connection
    raise exc.__context__ from None
  File "/projects/pyserial/serial/serialposix.py", line 329, in open
    self.fd = os.open(self.portstr, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/dev/cu.SLAB_USBtoUART'
```