### PR TITLE
Device alerts in quirks v2

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -131,7 +131,7 @@ async def test_quirks_v2(device_mock):
     assert str(quirked.quirk_metadata.quirk_file).endswith(
         "zigpy/tests/test_quirks_v2.py"
     )
-    assert quirked.quirk_metadata.quirk_file_line == 107
+    assert quirked.quirk_metadata.quirk_file_line == 105
 
     ep = quirked.endpoints[1]
 

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -21,6 +21,8 @@ from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import (
     BinarySensorMetadata,
     CustomDeviceV2,
+    DeviceAlertLevel,
+    DeviceAlertMetadata,
     EntityMetadata,
     EntityPlatform,
     EntityType,
@@ -129,7 +131,7 @@ async def test_quirks_v2(device_mock):
     assert str(quirked.quirk_metadata.quirk_file).endswith(
         "zigpy/tests/test_quirks_v2.py"
     )
-    assert quirked.quirk_metadata.quirk_file_line == 103
+    assert quirked.quirk_metadata.quirk_file_line == 107
 
     ep = quirked.endpoints[1]
 
@@ -1132,3 +1134,27 @@ async def test_quirks_v2_no_friendly_name(device_mock: Device) -> None:
     )
 
     assert entry.friendly_name is None
+
+
+async def test_quirks_v2_device_alerts(device_mock: Device) -> None:
+    registry = DeviceRegistry()
+
+    entry = (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .device_alert(level="warning", message="This device has routing problems.")
+        .device_alert(
+            level="error", message="This device irreparably crashes the mesh."
+        )
+        .add_to_registry()
+    )
+
+    assert entry.device_alerts == (
+        DeviceAlertMetadata(
+            level=DeviceAlertLevel.WARNING,
+            message="This device has routing problems.",
+        ),
+        DeviceAlertMetadata(
+            level=DeviceAlertLevel.ERROR,
+            message="This device irreparably crashes the mesh.",
+        ),
+    )

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import collections
 from copy import deepcopy
 import dataclasses
-from enum import Enum, StrEnum
+from enum import Enum
 import inspect
 import logging
 import pathlib
@@ -367,7 +367,7 @@ class FriendlyNameMetadata:
     manufacturer: str = attrs.field()
 
 
-class DeviceAlertLevel(StrEnum):
+class DeviceAlertLevel(Enum):
     """Device alert level."""
 
     INFO = "info"

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import collections
 from copy import deepcopy
 import dataclasses
-from enum import Enum
+from enum import Enum, StrEnum
 import inspect
 import logging
 import pathlib
@@ -367,6 +367,22 @@ class FriendlyNameMetadata:
     manufacturer: str = attrs.field()
 
 
+class DeviceAlertLevel(StrEnum):
+    """Device alert level."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class DeviceAlertMetadata:
+    """Metadata for device-specific alerts."""
+
+    level: DeviceAlertLevel = attrs.field()
+    text: str = attrs.field()
+
+
 @attrs.define(frozen=True, kw_only=True, repr=True)
 class QuirksV2RegistryEntry:
     """Quirks V2 registry entry."""
@@ -377,6 +393,7 @@ class QuirksV2RegistryEntry:
         factory=tuple
     )
     friendly_name: FriendlyNameMetadata | None = attrs.field(default=None)
+    device_alerts: tuple[DeviceAlertMetadata] = attrs.field(factory=tuple)
     filters: tuple[FilterType] = attrs.field(factory=tuple)
     custom_device_class: type[CustomDeviceV2] | None = attrs.field(default=None)
     device_node_descriptor: NodeDescriptor | None = attrs.field(default=None)
@@ -430,6 +447,7 @@ class QuirkBuilder:
         self.registry: DeviceRegistry = registry
         self.manufacturer_model_metadata: list[ManufacturerModelMetadata] = []
         self.friendly_name_metadata: FriendlyNameMetadata | None = None
+        self.device_alerts: list[DeviceAlertMetadata] = []
         self.filters: list[FilterType] = []
         self.custom_device_class: type[CustomDeviceV2] | None = None
         self.device_node_descriptor: NodeDescriptor | None = None
@@ -915,6 +933,11 @@ class QuirkBuilder:
         self.friendly_name_metadata = FriendlyNameMetadata(
             model=model, manufacturer=manufacturer
         )
+        return self
+
+    def device_alert(self, *, level: DeviceAlertLevel, text: str) -> QuirkBuilder:
+        """Adds a device alert."""
+        self.device_alerts.append(DeviceAlertMetadata(level=level, text=text))
         return self
 
     def add_to_registry(self) -> QuirksV2RegistryEntry:

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -379,8 +379,8 @@ class DeviceAlertLevel(Enum):
 class DeviceAlertMetadata:
     """Metadata for device-specific alerts."""
 
-    level: DeviceAlertLevel = attrs.field()
-    text: str = attrs.field()
+    level: DeviceAlertLevel = attrs.field(converter=DeviceAlertLevel)
+    message: str = attrs.field()
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -935,9 +935,9 @@ class QuirkBuilder:
         )
         return self
 
-    def device_alert(self, *, level: DeviceAlertLevel, text: str) -> QuirkBuilder:
+    def device_alert(self, *, level: DeviceAlertLevel, message: str) -> QuirkBuilder:
         """Adds a device alert."""
-        self.device_alerts.append(DeviceAlertMetadata(level=level, text=text))
+        self.device_alerts.append(DeviceAlertMetadata(level=level, message=message))
         return self
 
     def add_to_registry(self) -> QuirksV2RegistryEntry:
@@ -949,6 +949,7 @@ class QuirkBuilder:
         quirk: QuirksV2RegistryEntry = QuirksV2RegistryEntry(
             manufacturer_model_metadata=tuple(self.manufacturer_model_metadata),
             friendly_name=self.friendly_name_metadata,
+            device_alerts=tuple(self.device_alerts),
             quirk_file=self.quirk_file,
             quirk_file_line=self.quirk_file_line,
             filters=tuple(self.filters),


### PR DESCRIPTION
This will allow us to flag devices and show alerts in Home Assistant. I think `ERROR` should be mapped to repairs, the rest to a `<ha-alert>` on the device page.