### PR TITLE
Drop duplicate `async-timeout` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "attrs",
     "aiohttp",
     "aiosqlite>=0.20.0",
-    "async_timeout",
     "crccheck",
     "cryptography",
     'async-timeout; python_version<"3.11"',

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import pathlib
+import sys
 import typing
 from typing import Literal
 import urllib.parse
 
-import async_timeout
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
+else:
+    from asyncio import timeout as asyncio_timeout  # pragma: no cover
+
 import serial as pyserial
 
 from zigpy.typing import UNDEFINED, UndefinedType
@@ -108,7 +113,7 @@ async def create_serial_connection(
     parsed_url = urllib.parse.urlparse(url)
 
     if parsed_url.scheme in ("socket", "tcp"):
-        async with async_timeout.timeout(SOCKET_CONNECT_TIMEOUT):
+        async with asyncio_timeout(SOCKET_CONNECT_TIMEOUT):
             transport, protocol = await loop.create_connection(
                 protocol_factory=protocol_factory,
                 host=parsed_url.hostname,


### PR DESCRIPTION
We already specify the package once with `async-timeout; python_version<"3.11"',`, this second version is a bug.