### PR TITLE
Fix cancellation bug in semaphore implementation

### DIFF
--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -109,6 +109,33 @@ async def test_dynamic_bounded_semaphore_hanging_bug():
         assert True
 
 
+def test_dynamic_bounded_semaphore_multiple_event_loops():
+    """Test semaphore detecting multiple loops."""
+
+    async def test_semaphore(sem):
+        async with sem:
+            await asyncio.sleep(0.1)
+
+    async def make_semaphore():
+        sem = datastructures.PriorityDynamicBoundedSemaphore(1)
+
+        # The loop reference is lazily created so we need to actually lock the semaphore
+        await asyncio.gather(test_semaphore(sem), test_semaphore(sem))
+
+        return sem
+
+    loop1 = asyncio.new_event_loop()
+    sem = loop1.run_until_complete(make_semaphore())
+
+    async def inner():
+        await asyncio.gather(test_semaphore(sem), test_semaphore(sem))
+
+    loop2 = asyncio.new_event_loop()
+
+    with pytest.raises(RuntimeError):
+        loop2.run_until_complete(inner())
+
+
 async def test_dynamic_bounded_semaphore_runtime_limit_increase(event_loop):
     """Test changing the max_value at runtime."""
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -345,3 +345,57 @@ async def test_debouncer_low_resolution_clock():
         # The two objects cannot be compared
         with pytest.raises(TypeError):
             obj1 < obj2  # noqa: B015
+
+
+async def test_debouncer_cleaning_bug():
+    """Test debouncer bug when using heapq improperly."""
+    debouncer = datastructures.Debouncer()
+
+    obj1 = object()
+    obj2 = object()
+    obj3 = object()
+
+    # Filter obj1 with an expiration of 0.3 seconds
+    debouncer.filter(obj1, expire_in=0.3)
+
+    # Slight delay to ensure different expiration times
+    await asyncio.sleep(0.05)
+
+    # Filter obj2 with an expiration of 0.1 seconds
+    debouncer.filter(obj2, expire_in=0.1)
+
+    # Another slight delay
+    await asyncio.sleep(0.05)
+
+    # Filter obj3 with an expiration of 0.2 seconds
+    debouncer.filter(obj3, expire_in=0.2)
+
+    assert debouncer.is_filtered(obj1)
+    assert debouncer.is_filtered(obj2)
+    assert debouncer.is_filtered(obj3)
+
+    # Wait until after obj2 should have expired
+    await asyncio.sleep(0.11)  # Total elapsed time ~0.21 seconds from start
+
+    # Clean up expired items
+    debouncer.clean()
+
+    # obj2 should have expired, but due to the bug, it might still be filtered
+    assert not debouncer.is_filtered(obj2)
+
+    # obj1 and obj3 should still be filtered
+    assert debouncer.is_filtered(obj1)
+    assert debouncer.is_filtered(obj3)
+
+    # Wait until after obj1 and obj3 should have expired
+    await asyncio.sleep(0.1)  # Total elapsed time ~0.31 seconds from start
+
+    # Clean up expired items
+    debouncer.clean()
+
+    # Now all objects should have expired
+    assert not debouncer.is_filtered(obj1)
+    assert not debouncer.is_filtered(obj3)
+
+    # The queue should be empty
+    assert len(debouncer._queue) == 0

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -83,6 +83,32 @@ async def test_dynamic_bounded_semaphore_multiple_locking():
     assert not sem.locked()
 
 
+async def test_dynamic_bounded_semaphore_hanging_bug():
+    """Test semaphore hanging bug."""
+    sem = datastructures.PriorityDynamicBoundedSemaphore(1)
+
+    async def c1():
+        async with sem:
+            await asyncio.sleep(0)
+        t2.cancel()
+
+    async def c2():
+        async with sem:
+            pytest.fail("Should never get here")
+
+    t1 = asyncio.create_task(c1())
+    t2 = asyncio.create_task(c2())
+
+    r1, r2 = await asyncio.gather(t1, t2, return_exceptions=True)
+    assert r1 is None
+    assert isinstance(r2, asyncio.CancelledError)
+
+    assert not sem.locked()
+
+    async with sem:
+        assert True
+
+
 async def test_dynamic_bounded_semaphore_runtime_limit_increase(event_loop):
     """Test changing the max_value at runtime."""
 

--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -32,7 +32,7 @@ class WrappedContextManager:
         await self.context_manager.__aexit__(exc_type, exc, traceback)
 
 
-class PriorityDynamicBoundedSemaphore(asyncio.Semaphore):
+class PriorityDynamicBoundedSemaphore:
     """`asyncio.BoundedSemaphore` with public interface to change the max value."""
 
     def __init__(self, value: int = 0) -> None:
@@ -42,7 +42,7 @@ class PriorityDynamicBoundedSemaphore(asyncio.Semaphore):
         self._waiters: list[tuple[int, int, asyncio.Future]] = []
         self._loop: asyncio.BaseEventLoop | None = None
 
-    def _get_loop(self):
+    def _get_loop(self) -> asyncio.BaseEventLoop:
         loop = asyncio.get_running_loop()
 
         if self._loop is None:
@@ -53,7 +53,7 @@ class PriorityDynamicBoundedSemaphore(asyncio.Semaphore):
 
         return loop
 
-    def _wake_up_next(self):
+    def _wake_up_next(self) -> bool:
         """Wake up the first waiter that isn't done."""
         if not self._waiters:
             return False
@@ -144,7 +144,7 @@ class PriorityDynamicBoundedSemaphore(asyncio.Semaphore):
                     break  # There was no-one to wake up.
         return True
 
-    def release(self):
+    def release(self) -> None:
         """Release a semaphore, incrementing the internal counter by one.
 
         When it was zero on entry and another task is waiting for it to
@@ -156,7 +156,7 @@ class PriorityDynamicBoundedSemaphore(asyncio.Semaphore):
         self._value += 1
         self._wake_up_next()
 
-    def __call__(self, priority: int = 0):
+    def __call__(self, priority: int = 0) -> WrappedContextManager:
         """Allows specifying the priority by calling the context manager.
 
         This allows both `async with sem:` and `async with sem(priority=5):`.

--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -6,7 +6,6 @@ import asyncio
 import bisect
 import contextlib
 import functools
-import heapq
 import types
 import typing
 
@@ -297,7 +296,7 @@ class Debouncer:
 
         # Otherwise, queue it
         self._times[obj] = now + expire_in
-        heapq.heappush(self._queue, (-(now + expire_in), self._dedup_counter, obj))
+        bisect.insort_right(self._queue, (-(now + expire_in), self._dedup_counter, obj))
 
         return False
 

--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import bisect
 import contextlib
 import functools
 import heapq
@@ -39,23 +40,32 @@ class PriorityDynamicBoundedSemaphore(asyncio.Semaphore):
         self._value: int = value
         self._max_value: int = value
         self._comparison_counter: int = 0
-
         self._waiters: list[tuple[int, int, asyncio.Future]] = []
-        self._wakeup_scheduled: bool = False
+        self._loop: asyncio.BaseEventLoop | None = None
 
-    @property
-    @functools.cache
-    def _loop(self) -> asyncio.BaseEventLoop:
-        return asyncio.get_running_loop()
+    def _get_loop(self):
+        loop = asyncio.get_running_loop()
 
-    def _wake_up_next(self) -> None:
-        while self._waiters:
-            _, _, waiter = heapq.heappop(self._waiters)
+        if self._loop is None:
+            self._loop = loop
 
-            if not waiter.done():
-                waiter.set_result(None)
-                self._wakeup_scheduled = True
-                return
+        if loop is not self._loop:
+            raise RuntimeError(f"{self!r} is bound to a different event loop")
+
+        return loop
+
+    def _wake_up_next(self):
+        """Wake up the first waiter that isn't done."""
+        if not self._waiters:
+            return False
+
+        for _, _, fut in self._waiters:
+            if not fut.done():
+                self._value -= 1
+                fut.set_result(True)
+                # `fut` is now `done()` and not `cancelled()`.
+                return True
+        return False
 
     @property
     def value(self) -> int:
@@ -76,8 +86,9 @@ class PriorityDynamicBoundedSemaphore(asyncio.Semaphore):
         self._max_value += delta
 
         # Wake up any pending waiters
-        for _ in range(min(len(self._waiters), max(0, delta))):
-            self._wake_up_next()
+        for _ in range(max(0, delta)):
+            if not self._wake_up_next():
+                break
 
     @property
     def num_waiting(self) -> int:
@@ -85,46 +96,60 @@ class PriorityDynamicBoundedSemaphore(asyncio.Semaphore):
 
     def locked(self) -> bool:
         """Returns True if semaphore cannot be acquired immediately."""
-        return self._value <= 0
+        # Due to state, or FIFO rules (must allow others to run first).
+        return self._value <= 0 or (any(not w.cancelled() for _, _, w in self._waiters))
 
     async def acquire(self, priority: int = 0) -> typing.Literal[True]:
         """Acquire a semaphore.
 
-        If the internal counter is larger than zero on entry, decrement it by one and
-        return True immediately.  If it is zero on entry, block, waiting until some
-        other coroutine has called release() to make it larger than 0, and then return
+        If the internal counter is larger than zero on entry,
+        decrement it by one and return True immediately.  If it is
+        zero on entry, block, waiting until some other task has
+        called release() to make it larger than 0, and then return
         True.
         """
+        if not self.locked():
+            # Maintain FIFO, wait for others to start even if _value > 0.
+            self._value -= 1
+            return True
 
-        # _wakeup_scheduled is set if *another* task is scheduled to wakeup
-        # but its acquire() is not resumed yet
-        while self._wakeup_scheduled or self._value <= 0:
-            # To ensure that our objects don't have to be themselves comparable, we
-            # maintain a global count and increment it on every insert. This way,
-            # the tuple `(-priority, count, item)` will never have to compare `item`.
-            self._comparison_counter += 1
+        # To ensure that our objects don't have to be themselves comparable, we
+        # maintain a global count and increment it on every insert. This way,
+        # the tuple `(-priority, count, item)` will never have to compare `item`.
+        self._comparison_counter += 1
 
-            fut = self._loop.create_future()
-            obj = (-priority, self._comparison_counter, fut)
-            heapq.heappush(self._waiters, obj)
+        fut = self._get_loop().create_future()
+        obj = (-priority, self._comparison_counter, fut)
+        bisect.insort_right(self._waiters, obj)
 
+        try:
             try:
                 await fut
-                # reset _wakeup_scheduled *after* waiting for a future
-                self._wakeup_scheduled = False
-            except asyncio.CancelledError:
-                self._wake_up_next()
-                raise
+            finally:
+                self._waiters.remove(obj)
+        except asyncio.CancelledError:
+            # Currently the only exception designed be able to occur here.
+            if fut.done() and not fut.cancelled():
+                # Our Future was successfully set to True via _wake_up_next(),
+                # but we are not about to successfully acquire(). Therefore we
+                # must undo the bookkeeping already done and attempt to wake
+                # up someone else.
+                self._value += 1
+            raise
 
-        assert self._value > 0
-        self._value -= 1
+        finally:
+            # New waiters may have arrived but had to wait due to FIFO.
+            # Wake up as many as are allowed.
+            while self._value > 0:
+                if not self._wake_up_next():
+                    break  # There was no-one to wake up.
         return True
 
-    def release(self) -> None:
+    def release(self):
         """Release a semaphore, incrementing the internal counter by one.
 
-        When it was zero on entry and another coroutine is waiting for it to become
-        larger than zero again, wake up that coroutine.
+        When it was zero on entry and another task is waiting for it to
+        become larger than zero again, wake up that task.
         """
         if self._value >= self._max_value:
             raise ValueError("Semaphore released too many times")


### PR DESCRIPTION
Seen here: https://github.com/home-assistant/core/issues/130259#issuecomment-2471047766
Root cause was fixed here: https://github.com/python/cpython/pull/93222

Our semaphore is a copy/paste of the CPython one (since we tweak the internals and can't rely on an unstable API). Unfortunately, it had a nasty bug.

I've also fixed an unrelated bug with `Debouncer.clean` with an improper use of a `heapq`-managed list. This wouldn't cause problems at runtime other than unnecessary memory usage.