### PR TITLE
Cancel pending requests for devices on rejoin

### DIFF
--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -66,6 +66,12 @@ class PriorityDynamicBoundedSemaphore:
                 return True
         return False
 
+    def cancel_waiting(self, exc: BaseException) -> None:
+        """Cancel all waiters with the given exception."""
+        for _, _, fut in self._waiters:
+            if not fut.done():
+                fut.set_exception(exc)
+
     @property
     def value(self) -> int:
         return self._value


### PR DESCRIPTION
I'm seeing logs like this coming in from people with device joining issues:

```
2024-11-20 19:23:25.330 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 3.93s
2024-11-20 19:23:56.058 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 28.05s
2024-11-20 19:24:06.778 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 5.08s
2024-11-20 19:24:14.696 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 0.28s
2024-11-20 19:24:24.101 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 39.94s
2024-11-20 19:24:47.528 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 4.43s
2024-11-20 19:25:03.101 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 67.04s
2024-11-20 19:25:26.865 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 3.01s
2024-11-20 19:25:31.298 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 67.20s
2024-11-20 19:26:06.195 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 3.01s
2024-11-20 19:26:09.197 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 66.08s
2024-11-20 19:26:40.878 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 0.00s
2024-11-20 19:26:43.867 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 0.40s
2024-11-20 19:26:47.580 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 4.98s
2024-11-20 19:26:49.745 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 40.53s
2024-11-20 19:27:27.929 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 3.99s
2024-11-20 19:57:30.879 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 2.11s
2024-11-20 19:57:53.354 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 29.34s
2024-11-20 19:58:21.395 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 28.04s
2024-11-20 19:58:49.431 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 28.04s
2024-11-20 19:59:23.535 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 0.11s
2024-11-20 19:59:44.085 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 28.09s
2024-11-20 20:00:06.077 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 2.23s
2024-11-20 20:00:12.131 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 28.05s
2024-11-20 20:00:40.163 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 28.03s
2024-11-20 20:00:46.728 DEBUG (MainThread) [zigpy.device] Previously delayed device request is now running, delayed by 1.51s
```

I suspect this may have something to do with the new packet prioritization code. I think what happens is that devices that announce themselves multiple times or rejoin multiple times will still have queued up packets that will fail to send, delaying initialization by 30s each time.

This PR implements a method on the packet semaphore to cancel all pending `acquire`s and will clear out pending packets when a device joins or leaves the network.