### PR TITLE
Fix quirks v2 constant attributes not using attribute id

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -139,7 +139,7 @@ async def test_quirks_v2(device_mock):
     assert isinstance(ep.basic, Basic)
     assert isinstance(ep.basic, TestCustomCluster)
     # pylint: disable=protected-access
-    assert ep.basic._CONSTANT_ATTRIBUTES[TestCustomCluster.AttributeDefs.foo.name] == 3
+    assert ep.basic._CONSTANT_ATTRIBUTES[TestCustomCluster.AttributeDefs.foo.id] == 3
 
     assert ep.on_off is not None
     assert isinstance(ep.on_off, OnOff)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -177,7 +177,7 @@ class AddsMetadata:
 
         if self.constant_attributes:
             cluster._CONSTANT_ATTRIBUTES = {
-                attribute.name: value
+                attribute.id: value
                 for attribute, value in self.constant_attributes.items()
             }
 


### PR DESCRIPTION
## Proposed change
This fixes an issue where constant attributes provided via the quirks v2 API weren't fully working due to quirks v2 using `attr.name` instead of `attr.id` for `_CONSTANT_ATTRIBUTES`.

The PR changes this by using the expected `attr.id`.


## Additional information

`_CONSTANT_ATTRIBUTES` are typed as `dict[int, typing.Any] | None` [here](https://github.com/zigpy/zigpy/blob/8e9f5163ef93ff71fa0ce4992076d8bc248eac44/zigpy/quirks/__init__.py#L215-L215).
We'll have issues (e.g. [here](https://github.com/zigpy/zigpy/blob/8e9f5163ef93ff71fa0ce4992076d8bc248eac44/zigpy/quirks/__init__.py#L320-L322)) when we have an attribute `name` in `_CONSTANT_ATTRIBUTES`, instead of the expected attribute `id`.

Fixes https://github.com/zigpy/zigpy/issues/1509