### PR TITLE
Fix quirks v2 `adds` using `is_server=True` for client clusters

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -525,6 +525,8 @@ async def test_quirks_v2_apply_custom_configuration(device_mock):
         CustomOnOffCluster.cluster_id
     ]
     assert isinstance(quirked_cluster, CustomOnOffCluster)
+    # verify server cluster type was set when adding
+    assert quirked_cluster.cluster_type == ClusterType.Server
 
     quirked_cluster.apply_custom_configuration = AsyncMock()
 
@@ -532,6 +534,8 @@ async def test_quirks_v2_apply_custom_configuration(device_mock):
         1
     ].out_clusters[CustomOnOffCluster.cluster_id]
     assert isinstance(quirked_client_cluster, CustomOnOffCluster)
+    # verify client cluster type was set when adding
+    assert quirked_client_cluster.cluster_type == ClusterType.Client
 
     quirked_client_cluster.apply_custom_configuration = AsyncMock()
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -161,7 +161,7 @@ class AddsMetadata:
     def __call__(self, device: CustomDeviceV2) -> None:
         """Process the add."""
         endpoint: Endpoint = device.endpoints[self.endpoint_id]
-        if self.cluster_type == ClusterType.Server:
+        if is_server_cluster := self.cluster_type == ClusterType.Server:
             add_cluster = endpoint.add_input_cluster
         else:
             add_cluster = endpoint.add_output_cluster
@@ -170,7 +170,7 @@ class AddsMetadata:
             cluster = None
             cluster_id = self.cluster
         else:
-            cluster = self.cluster(endpoint, is_server=True)
+            cluster = self.cluster(endpoint, is_server=is_server_cluster)
             cluster_id = cluster.cluster_id
 
         cluster = add_cluster(cluster_id, cluster)


### PR DESCRIPTION
## Proposed change

This fixes the cluster type for client clusters added/replaced using the quirks v2 API returning `ClusterType.Server`.

An existing test that adds both a server and client cluster was also modified to verify the cluster type is set correctly.
If preferred, this can also be moved out to a separate test. I think this should be fine though.


## Additional information

I'm not sure if this actually causes/caused any issues anywhere. Just noticed it whilst looking at the various quirks v2 methods.