### PR TITLE
Fix `entity_metadata` typing not including `ZCLSensorMetadata`

### DIFF
--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -460,6 +460,7 @@ class QuirkBuilder:
         ] = []
         self.entity_metadata: list[
             ZCLEnumMetadata
+            | ZCLSensorMetadata
             | SwitchMetadata
             | NumberMetadata
             | BinarySensorMetadata


### PR DESCRIPTION
Fix quirks v2 `entity_metadata` typing not including `ZCLSensorMetadata`