### PR TITLE
Replace `inspect.stack` with `inspect.currentframe.f_back`

### DIFF
--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -9,6 +9,7 @@ from enum import Enum
 import inspect
 import logging
 import pathlib
+from types import FrameType
 import typing
 from typing import TYPE_CHECKING, Any
 
@@ -471,7 +472,7 @@ class QuirkBuilder:
             tuple[str, str], dict[str, str]
         ] = {}
 
-        caller = inspect.currentframe().f_back
+        caller: FrameType = inspect.currentframe().f_back
         self.quirk_file = pathlib.Path(caller.f_code.co_filename)
         self.quirk_file_line = caller.f_lineno
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -472,7 +472,8 @@ class QuirkBuilder:
             tuple[str, str], dict[str, str]
         ] = {}
 
-        caller: FrameType = inspect.currentframe().f_back
+        current_frame: FrameType = inspect.currentframe()
+        caller: FrameType = current_frame.f_back
         self.quirk_file = pathlib.Path(caller.f_code.co_filename)
         self.quirk_file_line = caller.f_lineno
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -471,10 +471,9 @@ class QuirkBuilder:
             tuple[str, str], dict[str, str]
         ] = {}
 
-        stack: list[inspect.FrameInfo] = inspect.stack()
-        caller: inspect.FrameInfo = stack[1]
-        self.quirk_file = pathlib.Path(caller.filename)
-        self.quirk_file_line = caller.lineno
+        caller = inspect.currentframe().f_back
+        self.quirk_file = pathlib.Path(caller.f_code.co_filename)
+        self.quirk_file_line = caller.f_lineno
 
         if manufacturer and model:
             self.applies_to(manufacturer, model)


### PR DESCRIPTION
Ref https://github.com/home-assistant/core/pull/132463

Based on https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow