### PR TITLE
Add quirk v2 builder methods for modifying endpoints

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -526,7 +526,7 @@ async def test_quirks_v2_endpoints(device_mock):
         .adds_endpoint(1, profile_id=260, device_type=260)  # 1 not modified
         .removes_endpoint(2)
         .replaces_endpoint(3, profile_id=260, device_type=260)
-        .adds_endpoint(4, profile_id=260, device_type=260)
+        .adds_endpoint(4)
         .add_to_registry()
     )
 
@@ -546,10 +546,10 @@ async def test_quirks_v2_endpoints(device_mock):
     assert quirked.endpoints[3].profile_id == 260
     assert quirked.endpoints[3].device_type == 260
 
-    # verify endpoint 4 was added
+    # verify endpoint 4 was added with default profile id and device type
     assert 4 in quirked.endpoints
     assert quirked.endpoints[4].profile_id == 260
-    assert quirked.endpoints[4].device_type == 260
+    assert quirked.endpoints[4].device_type == 255
 
 
 async def test_quirks_v2_apply_custom_configuration(device_mock):

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -503,6 +503,55 @@ async def test_quirks_v2_removes(device_mock):
     assert quirked_device.endpoints[1].in_clusters.get(Identify.cluster_id) is None
 
 
+async def test_quirks_v2_endpoints(device_mock):
+    """Test adding a quirk that modifies endpoints to the registry."""
+    registry = DeviceRegistry()
+
+    device_mock[1].add_output_cluster(Identify.cluster_id)
+
+    device_mock.add_endpoint(2)
+    device_mock[2].profile_id = 255
+    device_mock[2].device_type = 255
+    device_mock[2].add_input_cluster(Identify.cluster_id)
+    device_mock[2].add_output_cluster(OnOff.cluster_id)
+
+    device_mock.add_endpoint(3)
+    device_mock[3].profile_id = 255
+    device_mock[3].device_type = 255
+    device_mock[3].add_input_cluster(Identify.cluster_id)
+    device_mock[3].add_output_cluster(OnOff.cluster_id)
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .adds_endpoint(1, profile_id=260, device_type=260)  # 1 not modified
+        .removes_endpoint(2)
+        .replaces_endpoint(3, profile_id=260, device_type=260)
+        .adds_endpoint(4, profile_id=260, device_type=260)
+        .add_to_registry()
+    )
+
+    quirked: CustomDeviceV2 = registry.get_device(device_mock)
+    assert isinstance(quirked, CustomDeviceV2)
+
+    # verify endpoint 1 was not modified, as it already existed before
+    assert 1 in quirked.endpoints
+    assert quirked.endpoints[1].profile_id == 255
+    assert quirked.endpoints[1].device_type == 255
+
+    # verify endpoint 2 was removed
+    assert 2 not in quirked.endpoints
+
+    # verify endpoint 3 profile id and device type were replaced
+    assert 3 in quirked.endpoints
+    assert quirked.endpoints[3].profile_id == 260
+    assert quirked.endpoints[3].device_type == 260
+
+    # verify endpoint 4 was added
+    assert 4 in quirked.endpoints
+    assert quirked.endpoints[4].profile_id == 260
+    assert quirked.endpoints[4].device_type == 260
+
+
 async def test_quirks_v2_apply_custom_configuration(device_mock):
     """Test adding a quirk custom configuration to the registry."""
     registry = DeviceRegistry()

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -527,6 +527,7 @@ async def test_quirks_v2_endpoints(device_mock):
         .removes_endpoint(2)
         .replaces_endpoint(3, profile_id=260, device_type=260)
         .adds_endpoint(4)
+        .adds(OnOff.cluster_id, endpoint_id=4)
         .add_to_registry()
     )
 
@@ -550,6 +551,9 @@ async def test_quirks_v2_endpoints(device_mock):
     assert 4 in quirked.endpoints
     assert quirked.endpoints[4].profile_id == 260
     assert quirked.endpoints[4].device_type == 255
+
+    # verify cluster was added to endpoint 4
+    assert quirked.endpoints[4].in_clusters.get(OnOff.cluster_id) is not None
 
 
 async def test_quirks_v2_apply_custom_configuration(device_mock):

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -263,9 +263,9 @@ class AddsEndpointMetadata:
     def __call__(self, device: CustomDeviceV2) -> None:
         """Process the add."""
         if self.endpoint_id not in device.endpoints:
-            device.add_endpoint(self.endpoint_id)
-            setattr(device.endpoints[self.endpoint_id], SIG_EP_PROFILE, self.profile_id)
-            setattr(device.endpoints[self.endpoint_id], SIG_EP_TYPE, self.device_type)
+            ep = device.add_endpoint(self.endpoint_id)
+            ep.profile_id = self.profile_id
+            ep.device_type = self.device_type
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -88,6 +88,16 @@ class CustomDeviceV2(BaseCustomDevice):
             list[EntityMetadata],
         ] = collections.defaultdict(list)
 
+        # endpoints need to be modified before clusters
+        for add_endpoint_meta in quirk_metadata.adds_endpoint_metadata:
+            add_endpoint_meta(self)
+
+        for remove_endpoint_meta in quirk_metadata.removes_endpoint_metadata:
+            remove_endpoint_meta(self)
+
+        for replace_endpoint_meta in quirk_metadata.replaces_endpoint_metadata:
+            replace_endpoint_meta(self)
+
         for add_meta in quirk_metadata.adds_metadata:
             add_meta(self)
 
@@ -101,15 +111,6 @@ class CustomDeviceV2(BaseCustomDevice):
             replace_occurrences_meta
         ) in quirk_metadata.replaces_cluster_occurrences_metadata:
             replace_occurrences_meta(self)
-
-        for add_endpoint_meta in quirk_metadata.adds_endpoint_metadata:
-            add_endpoint_meta(self)
-
-        for remove_endpoint_meta in quirk_metadata.removes_endpoint_metadata:
-            remove_endpoint_meta(self)
-
-        for replace_endpoint_meta in quirk_metadata.replaces_endpoint_metadata:
-            replace_endpoint_meta(self)
 
         for entity_meta in quirk_metadata.entity_metadata:
             entity_meta(self)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -25,6 +25,7 @@ from zigpy.const import (
     SIG_NODE_DESC,
     SIG_SKIP_CONFIG,
 )
+import zigpy.profiles.zha
 from zigpy.quirks import _DEVICE_REGISTRY, BaseCustomDevice, CustomCluster, FilterType
 from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
@@ -705,7 +706,10 @@ class QuirkBuilder:
         return self
 
     def adds_endpoint(
-        self, endpoint_id: int, profile_id: int, device_type: int
+        self,
+        endpoint_id: int,
+        profile_id: int = zigpy.profiles.zha.PROFILE_ID,
+        device_type: int = 0xFF,
     ) -> QuirkBuilder:
         """Add an AddsEndpointMetadata entry and return self."""
         add = AddsEndpointMetadata(
@@ -723,8 +727,8 @@ class QuirkBuilder:
     def replaces_endpoint(
         self,
         endpoint_id: int,
-        profile_id: int,
-        device_type: int,
+        profile_id: int = zigpy.profiles.zha.PROFILE_ID,
+        device_type: int = 0xFF,
     ) -> QuirkBuilder:
         """Add a ReplacesEndpointMetadata entry and return self."""
         remove = RemovesEndpointMetadata(endpoint_id=endpoint_id)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -101,6 +101,15 @@ class CustomDeviceV2(BaseCustomDevice):
         ) in quirk_metadata.replaces_cluster_occurrences_metadata:
             replace_occurrences_meta(self)
 
+        for add_endpoint_meta in quirk_metadata.adds_endpoint_metadata:
+            add_endpoint_meta(self)
+
+        for remove_endpoint_meta in quirk_metadata.removes_endpoint_metadata:
+            remove_endpoint_meta(self)
+
+        for replace_endpoint_meta in quirk_metadata.replaces_endpoint_metadata:
+            replace_endpoint_meta(self)
+
         for entity_meta in quirk_metadata.entity_metadata:
             entity_meta(self)
 
@@ -241,6 +250,46 @@ class ReplaceClusterOccurrencesMetadata:
                 endpoint.add_output_cluster(
                     self.cluster.cluster_id, self.cluster(endpoint, is_server=False)
                 )
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class AddsEndpointMetadata:
+    """Adds metadata for adding an endpoint to a device."""
+
+    endpoint_id: int = attrs.field()
+    profile_id: int = attrs.field()
+    device_type: int = attrs.field()
+
+    def __call__(self, device: CustomDeviceV2) -> None:
+        """Process the add."""
+        if self.endpoint_id not in device.endpoints:
+            device.add_endpoint(self.endpoint_id)
+            setattr(device.endpoints[self.endpoint_id], SIG_EP_PROFILE, self.profile_id)
+            setattr(device.endpoints[self.endpoint_id], SIG_EP_TYPE, self.device_type)
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class RemovesEndpointMetadata:
+    """Removes metadata for removing an endpoint from a device."""
+
+    endpoint_id: int = attrs.field()
+
+    def __call__(self, device: CustomDeviceV2) -> None:
+        """Process the remove."""
+        device.endpoints.pop(self.endpoint_id, None)
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class ReplacesEndpointMetadata:
+    """Replaces metadata for replacing an endpoint on a device."""
+
+    remove: RemovesEndpointMetadata = attrs.field()
+    add: AddsEndpointMetadata = attrs.field()
+
+    def __call__(self, device: CustomDeviceV2) -> None:
+        """Process the replace."""
+        self.remove(device)
+        self.add(device)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -405,6 +454,13 @@ class QuirksV2RegistryEntry:
     replaces_cluster_occurrences_metadata: tuple[ReplaceClusterOccurrencesMetadata] = (
         attrs.field(factory=tuple)
     )
+    adds_endpoint_metadata: tuple[AddsEndpointMetadata] = attrs.field(factory=tuple)
+    removes_endpoint_metadata: tuple[RemovesEndpointMetadata] = attrs.field(
+        factory=tuple
+    )
+    replaces_endpoint_metadata: tuple[ReplacesEndpointMetadata] = attrs.field(
+        factory=tuple
+    )
     entity_metadata: tuple[
         ZCLEnumMetadata
         | SwitchMetadata
@@ -459,6 +515,9 @@ class QuirkBuilder:
         self.replaces_cluster_occurrences_metadata: list[
             ReplaceClusterOccurrencesMetadata
         ] = []
+        self.adds_endpoint_metadata: list[AddsEndpointMetadata] = []
+        self.removes_endpoint_metadata: list[RemovesEndpointMetadata] = []
+        self.replaces_endpoint_metadata: list[ReplacesEndpointMetadata] = []
         self.entity_metadata: list[
             ZCLEnumMetadata
             | ZCLSensorMetadata
@@ -643,6 +702,37 @@ class QuirkBuilder:
                 cluster=replacement_cluster_class,
             )
         )
+        return self
+
+    def adds_endpoint(
+        self, endpoint_id: int, profile_id: int, device_type: int
+    ) -> QuirkBuilder:
+        """Add an AddsEndpointMetadata entry and return self."""
+        add = AddsEndpointMetadata(
+            endpoint_id=endpoint_id, profile_id=profile_id, device_type=device_type
+        )
+        self.adds_endpoint_metadata.append(add)
+        return self
+
+    def removes_endpoint(self, endpoint_id: int) -> QuirkBuilder:
+        """Add a RemovesEndpointMetadata entry and return self."""
+        remove = RemovesEndpointMetadata(endpoint_id=endpoint_id)
+        self.removes_endpoint_metadata.append(remove)
+        return self
+
+    def replaces_endpoint(
+        self,
+        endpoint_id: int,
+        profile_id: int,
+        device_type: int,
+    ) -> QuirkBuilder:
+        """Add a ReplacesEndpointMetadata entry and return self."""
+        remove = RemovesEndpointMetadata(endpoint_id=endpoint_id)
+        add = AddsEndpointMetadata(
+            endpoint_id=endpoint_id, profile_id=profile_id, device_type=device_type
+        )
+        replace = ReplacesEndpointMetadata(remove=remove, add=add)
+        self.replaces_endpoint_metadata.append(replace)
         return self
 
     def enum(
@@ -964,6 +1054,9 @@ class QuirkBuilder:
             replaces_cluster_occurrences_metadata=tuple(
                 self.replaces_cluster_occurrences_metadata
             ),
+            adds_endpoint_metadata=tuple(self.adds_endpoint_metadata),
+            removes_endpoint_metadata=tuple(self.removes_endpoint_metadata),
+            replaces_endpoint_metadata=tuple(self.replaces_endpoint_metadata),
             entity_metadata=tuple(self.entity_metadata),
             device_automation_triggers_metadata=self.device_automation_triggers_metadata,
         )


### PR DESCRIPTION
This adds quirk v2 builder methods for modifying endpoints.

The methods closely align to the cluster `adds`, `removes`, and `replaces` methods and act the same.
I.e. similar to `adds`, `adds_endpoint` does not modify the `profile_id` and `profile_type` of an existing endpoint.

This is needed to improve https://github.com/zigpy/zha-device-handlers/pull/3564 and to address https://github.com/home-assistant/core/issues/134686.

Other considerations:
- Do we want a default for `profile_id` and/or `profile_type`?