### PR TITLE
Allow `CRITICAL` priority packets to bypass concurrency checks

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -747,6 +747,11 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         start_time = time.monotonic()
         was_locked = self._concurrent_requests_semaphore.locked()
 
+        if priority == t.PacketPriority.CRITICAL:
+            LOGGER.debug("Critical packet is being sent, ignoring concurrency")
+            yield
+            return
+
         if was_locked:
             LOGGER.debug(
                 "Max concurrency (%s) reached, delaying request (%s enqueued)",

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -110,6 +110,11 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         start_time = time.monotonic()
         was_locked = self._concurrent_requests_semaphore.locked()
 
+        if priority == t.PacketPriority.CRITICAL:
+            LOGGER.debug("Critical packet is being sent, ignoring concurrency")
+            yield
+            return
+
         if was_locked:
             LOGGER.debug(
                 "Device concurrency (%s) reached, delaying device request (%s enqueued)",


### PR DESCRIPTION
I noticed that the new per-device concurrency limiting code negatively affects joining of devices that are slow to respond when they initially join, requiring a ZHA reload to kill the stalled initialization (why does it never complete?) and a re-configure.