### PR TITLE
Mark bind, unbind, request, reply as async

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -95,6 +95,8 @@ def cluster_by_id():
         epmock = MagicMock()
         epmock._device.get_sequence.return_value = DEFAULT_TSN
         epmock.device.get_sequence.return_value = DEFAULT_TSN
+        epmock.device.zdo.bind = AsyncMock()
+        epmock.device.zdo.unbind = AsyncMock()
         epmock.request = AsyncMock()
         epmock.reply = AsyncMock()
         return zcl.Cluster.from_id(epmock, cluster_id)
@@ -602,12 +604,20 @@ async def test_write_attributes_cache_failure(cluster, attributes, result, faile
                 )
 
 
-def test_bind(cluster):
-    cluster.bind()
+async def test_bind(cluster):
+    result = await cluster.bind()
+
+    cluster._endpoint.device.zdo.bind.assert_called_with(cluster=cluster)
+    assert cluster._endpoint.device.zdo.bind.call_count == 1
+    assert result is cluster._endpoint.device.zdo.bind.return_value
 
 
-def test_unbind(cluster):
-    cluster.unbind()
+async def test_unbind(cluster):
+    result = await cluster.unbind()
+
+    cluster._endpoint.device.zdo.unbind.assert_called_with(cluster=cluster)
+    assert cluster._endpoint.device.zdo.unbind.call_count == 1
+    assert result is cluster._endpoint.device.zdo.unbind.return_value
 
 
 async def test_configure_reporting(cluster):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -682,11 +682,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         args = self._write_attr_records(attributes)
         return self._write_attributes_undivided(args, manufacturer=manufacturer)
 
-    def bind(self):
-        return self._endpoint.device.zdo.bind(cluster=self)
+    async def bind(self):
+        return await self._endpoint.device.zdo.bind(cluster=self)
 
-    def unbind(self):
-        return self._endpoint.device.zdo.unbind(cluster=self)
+    async def unbind(self):
+        return await self._endpoint.device.zdo.unbind(cluster=self)
 
     def _attr_reporting_rec(
         self,

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -51,7 +51,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
 
         return hdr, args
 
-    def request(
+    async def request(
         self,
         command,
         *args,
@@ -64,7 +64,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
     ):
         data = self._serialize(command, *args, **kwargs)
         tsn = self.device.get_sequence()
-        return self._device.request(
+        return await self._device.request(
             profile=0x0000,
             cluster=command,
             src_ep=ZDO_ENDPOINT,
@@ -78,7 +78,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
             priority=priority,
         )
 
-    def reply(
+    async def reply(
         self,
         command,
         *args,
@@ -93,7 +93,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         data = self._serialize(command, *args, **kwargs)
         if tsn is None:
             tsn = self.device.get_sequence()
-        return self._device.reply(
+        return await self._device.reply(
             profile=0x0000,
             cluster=command,
             src_ep=ZDO_ENDPOINT,

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -243,16 +243,16 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
             )
         )
 
-    def bind(self, cluster):
-        return self.Bind_req(
+    async def bind(self, cluster):
+        return await self.Bind_req(
             self._device.ieee,
             cluster.endpoint.endpoint_id,
             cluster.cluster_id,
             self.device.application.get_dst_address(cluster),
         )
 
-    def unbind(self, cluster):
-        return self.Unbind_req(
+    async def unbind(self, cluster):
+        return await self.Unbind_req(
             self._device.ieee,
             cluster.endpoint.endpoint_id,
             cluster.cluster_id,


### PR DESCRIPTION
The ZDO and Cluster methods `bind`, `unbind`, `request`, `reply` are treated in most places (including tests) as async, but are not defined as such. Dependencies such as zha-device-handlers seem to use a mixture of both, whereas [ZHA awaits `bind`](https://github.com/zigpy/zha/blob/fd6cf2f570f1778a9c0933a56ebf476caafe859d/zha/zigbee/cluster_handlers/__init__.py#L280).

Based on the discussion in https://github.com/zigpy/zha-device-handlers/pull/3704#issuecomment-2585520722, this PR fixes the definitions.