### PR TITLE
Allow custom v2 quirks to override built-in ones

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -1147,26 +1147,26 @@ QuirkBuilder("manufacturer2", "model2").adds(
 
     registry = zigpy.quirks.DEVICE_REGISTRY
 
-    assert not registry._registry.get("manufacturer1", {}).get("model1", [])
-    assert not registry._registry_v2.get(("manufacturer2", "model2"), set())
+    assert not registry.registry_v1.get("manufacturer1", {}).get("model1", [])
+    assert not registry.registry_v2.get(("manufacturer2", "model2"), set())
 
     load_quirks()
 
-    assert registry._registry.get("manufacturer1", {}).get("model1", [])
-    assert registry._registry_v2.get(("manufacturer2", "model2"), set())
+    assert registry.registry_v1.get("manufacturer1", {}).get("model1", [])
+    assert registry.registry_v2.get(("manufacturer2", "model2"), set())
 
     assert type(registry.get_device(dev1)).__name__ == "TestQuirk1"
     assert registry.get_device(dev2).quirk_metadata.quirk_file.name == "quirk2.py"
 
     # Only quirks from the passed directory are purged so this is a no-op
     registry.purge_custom_quirks(tmp_path / "some_other_dir")
-    assert registry._registry.get("manufacturer1", {}).get("model1", [])
-    assert registry._registry_v2.get(("manufacturer2", "model2"), set())
+    assert registry.registry_v1.get("manufacturer1", {}).get("model1", [])
+    assert registry.registry_v2.get(("manufacturer2", "model2"), set())
 
     # Now we really remove them
     registry.purge_custom_quirks(tmp_path)
-    assert not registry._registry.get("manufacturer1", {}).get("model1", [])
-    assert not registry._registry_v2.get(("manufacturer2", "model2"), set())
+    assert not registry.registry_v1.get("manufacturer1", {}).get("model1", [])
+    assert not registry.registry_v2.get(("manufacturer2", "model2"), set())
 
     assert registry.get_device(dev1) is dev1
     assert registry.get_device(dev2) is dev2

--- a/tests/test_quirks_registry.py
+++ b/tests/test_quirks_registry.py
@@ -1,3 +1,4 @@
+from collections import deque
 from unittest import mock
 
 import pytest
@@ -35,24 +36,11 @@ def test_add_to_registry_new_sig(fake_dev):
     }
 
     reg = DeviceRegistry()
-
-    quirk_list = mock.MagicMock()
-    model_dict = mock.MagicMock(spec_set=dict)
-    model_dict.__getitem__.return_value = quirk_list
-    manuf_dict = mock.MagicMock()
-    manuf_dict.__getitem__.return_value = model_dict
-    reg._registry = manuf_dict
-
     reg.add_to_registry(fake_dev)
-    assert manuf_dict.__getitem__.call_count == 2
-    assert manuf_dict.__getitem__.call_args[0][0] is mock.sentinel.dev_manufacturer
-    assert model_dict.__getitem__.call_count == 2
-    assert model_dict.__getitem__.call_args[0][0] is mock.sentinel.dev_model
-    assert quirk_list.insert.call_count == 1
-    assert quirk_list.insert.call_args[0][1] is fake_dev
-    quirk_list.reset_mock()
-    model_dict.reset_mock()
-    manuf_dict.reset_mock()
+
+    assert reg._registry_v1[mock.sentinel.dev_manufacturer][
+        mock.sentinel.dev_model
+    ] == deque([fake_dev])
 
 
 def test_add_to_registry_models_info(fake_dev):
@@ -76,27 +64,14 @@ def test_add_to_registry_models_info(fake_dev):
     }
 
     reg = DeviceRegistry()
-
-    quirk_list = mock.MagicMock()
-    model_dict = mock.MagicMock(spec_set=dict)
-    model_dict.__getitem__.return_value = quirk_list
-    manuf_dict = mock.MagicMock()
-    manuf_dict.__getitem__.return_value = model_dict
-    reg._registry = manuf_dict
-
     reg.add_to_registry(fake_dev)
-    assert manuf_dict.__getitem__.call_count == 4
-    assert manuf_dict.__getitem__.call_args_list[0][0][0] is mock.sentinel.manuf_1
-    assert manuf_dict.__getitem__.call_args_list[2][0][0] is mock.sentinel.manuf_2
-    assert model_dict.__getitem__.call_count == 4
-    assert model_dict.__getitem__.call_args_list[0][0][0] is mock.sentinel.model_1
-    assert model_dict.__getitem__.call_args_list[2][0][0] is mock.sentinel.model_2
-    assert quirk_list.insert.call_count == 2
-    assert quirk_list.insert.call_args_list[0][0][1] is fake_dev
-    assert quirk_list.insert.call_args_list[1][0][1] is fake_dev
-    quirk_list.reset_mock()
-    model_dict.reset_mock()
-    manuf_dict.reset_mock()
+
+    assert reg._registry_v1[mock.sentinel.manuf_1][mock.sentinel.model_1] == deque(
+        [fake_dev]
+    )
+    assert reg._registry_v1[mock.sentinel.manuf_2][mock.sentinel.model_2] == deque(
+        [fake_dev]
+    )
 
 
 def test_remove_new_sig(fake_dev):
@@ -124,7 +99,7 @@ def test_remove_new_sig(fake_dev):
     model_dict.__getitem__.return_value = quirk_list
     manuf_dict = mock.MagicMock()
     manuf_dict.__getitem__.return_value = model_dict
-    reg._registry = manuf_dict
+    reg._registry_v1 = manuf_dict
 
     reg.remove(fake_dev)
     assert manuf_dict.__getitem__.call_count == 1
@@ -163,7 +138,7 @@ def test_remove_models_info(fake_dev):
     model_dict.__getitem__.return_value = quirk_list
     manuf_dict = mock.MagicMock()
     manuf_dict.__getitem__.return_value = model_dict
-    reg._registry = manuf_dict
+    reg._registry_v1 = manuf_dict
 
     reg.remove(fake_dev)
     assert manuf_dict.__getitem__.call_count == 2

--- a/tests/test_quirks_registry.py
+++ b/tests/test_quirks_registry.py
@@ -151,3 +151,10 @@ def test_remove_models_info(fake_dev):
     assert quirk_list.remove.call_count == 2
     assert quirk_list.remove.call_args_list[0][0][0] is fake_dev
     assert quirk_list.remove.call_args_list[1][0][0] is fake_dev
+
+
+def test_property_accessors():
+    reg = DeviceRegistry()
+    assert reg.registry is reg._registry_v1
+    assert reg.registry_v1 is reg._registry_v1
+    assert reg.registry_v2 is reg._registry_v2

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -14,7 +14,6 @@ from zigpy.const import (
     SIG_MODELS_INFO,
 )
 from zigpy.device import Device
-from zigpy.exceptions import MultipleQuirksMatchException
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice, signature_matches
 from zigpy.quirks.registry import DeviceRegistry
@@ -284,48 +283,6 @@ async def test_quirks_v2_signature_match(device_mock):
 
     quirked = registry.get_device(device_mock)
     assert not isinstance(quirked, CustomDeviceV2)
-
-
-async def test_quirks_v2_multiple_matches_raises(device_mock):
-    """Test that adding multiple quirks v2 entries for the same device raises."""
-    registry = DeviceRegistry()
-
-    entry1 = (
-        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
-        .adds(Basic.cluster_id)
-        .adds(OnOff.cluster_id)
-        .enum(
-            OnOff.AttributeDefs.start_up_on_off.name,
-            OnOff.StartUpOnOff,
-            OnOff.cluster_id,
-            translation_key="start_up_on_off",
-            fallback_name="Start up on/off",
-        )
-        .add_to_registry()
-    )
-
-    entry2 = (
-        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
-        .adds(Basic.cluster_id)
-        .adds(OnOff.cluster_id)
-        .adds(Identify.cluster_id)
-        .enum(
-            OnOff.AttributeDefs.start_up_on_off.name,
-            OnOff.StartUpOnOff,
-            OnOff.cluster_id,
-            translation_key="start_up_on_off",
-            fallback_name="Start up on/off",
-        )
-        .add_to_registry()
-    )
-
-    assert entry1 != entry2
-    assert entry1 != registry
-
-    with pytest.raises(
-        MultipleQuirksMatchException, match="Multiple matches found for device"
-    ):
-        registry.get_device(device_mock)
 
 
 async def test_quirks_v2_multiple_matches_not_raises(device_mock):

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -131,7 +131,7 @@ async def test_quirks_v2(device_mock):
     assert str(quirked.quirk_metadata.quirk_file).endswith(
         "zigpy/tests/test_quirks_v2.py"
     )
-    assert quirked.quirk_metadata.quirk_file_line == 106
+    assert quirked.quirk_metadata.quirk_file_line == 105
 
     ep = quirked.endpoints[1]
 

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from zigpy.const import SIG_MANUFACTURER, SIG_MODEL, SIG_MODELS_INFO
 import zigpy.quirks
 from zigpy.typing import CustomDeviceType, DeviceType
+from zigpy.util import deprecated
 
 if TYPE_CHECKING:
     from zigpy.quirks import CustomDevice
@@ -140,7 +141,13 @@ class DeviceRegistry:
         return device
 
     @property
+    @deprecated("The `registry` property is deprecated, use `registry_v1` instead.")
     def registry(self) -> dict[str | None, dict[str | None, deque[CustomDevice]]]:
+        """Return the v1 registry."""
+        return self._registry_v1
+
+    @property
+    def registry_v1(self) -> dict[str | None, dict[str | None, deque[CustomDevice]]]:
         """Return the v1 registry."""
         return self._registry_v1
 

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -2,28 +2,22 @@
 
 from __future__ import annotations
 
-import collections
+from collections import defaultdict, deque
 import inspect
 import itertools
 import logging
 import pathlib
-import typing
 from typing import TYPE_CHECKING
 
 from zigpy.const import SIG_MANUFACTURER, SIG_MODEL, SIG_MODELS_INFO
-from zigpy.exceptions import MultipleQuirksMatchException
 import zigpy.quirks
 from zigpy.typing import CustomDeviceType, DeviceType
 
 if TYPE_CHECKING:
+    from zigpy.quirks import CustomDevice
     from zigpy.quirks.v2 import QuirksV2RegistryEntry
 
 _LOGGER = logging.getLogger(__name__)
-
-TYPE_MANUF_QUIRKS_DICT = dict[
-    typing.Optional[str],
-    dict[typing.Optional[str], list["zigpy.quirks.CustomDevice"]],
-]
 
 
 class DeviceRegistry:
@@ -31,16 +25,17 @@ class DeviceRegistry:
 
     def __init__(self, *args, **kwargs) -> None:
         """Initialize the registry."""
-        self._registry: TYPE_MANUF_QUIRKS_DICT = collections.defaultdict(
-            lambda: collections.defaultdict(list)
+        self._registry_v1: dict[str | None, dict[str | None, deque[CustomDevice]]] = (
+            defaultdict(lambda: defaultdict(deque))
         )
-        self._registry_v2: dict[tuple[str, str], set[QuirksV2RegistryEntry]] = (
-            collections.defaultdict(set)
+
+        self._registry_v2: dict[tuple[str, str], deque[QuirksV2RegistryEntry]] = (
+            defaultdict(deque)
         )
 
     def purge_custom_quirks(self, custom_quirks_root: pathlib.Path) -> None:
         # If zhaquirks aren't being used, we can't tell if a quirk is custom or not
-        for model_registry in self._registry.values():
+        for model_registry in self._registry_v1.values():
             for quirks in model_registry.values():
                 to_remove = []
 
@@ -74,18 +69,18 @@ class DeviceRegistry:
         if models_info:
             for manuf, model in models_info:
                 if custom_device not in self.registry[manuf][model]:
-                    self.registry[manuf][model].insert(0, custom_device)
+                    self.registry[manuf][model].appendleft(custom_device)
         else:
             manufacturer = custom_device.signature.get(SIG_MANUFACTURER)
             model = custom_device.signature.get(SIG_MODEL)
             if custom_device not in self.registry[manufacturer][model]:
-                self.registry[manufacturer][model].insert(0, custom_device)
+                self.registry[manufacturer][model].appendleft(custom_device)
 
     def add_to_registry_v2(
         self, manufacturer: str, model: str, entry: QuirksV2RegistryEntry
     ) -> None:
         """Add an entry to the registry."""
-        self._registry_v2[(manufacturer, model)].add(entry)
+        self._registry_v2[(manufacturer, model)].appendleft(entry)
 
     def remove(self, custom_device: CustomDeviceType) -> None:
         """Remove a device from the registry"""
@@ -109,32 +104,21 @@ class DeviceRegistry:
         if isinstance(device, zigpy.quirks.BaseCustomDevice):
             return device
 
-        key = (device.manufacturer, device.model)
-        if key in self._registry_v2:
-            matches: list[QuirksV2RegistryEntry] = []
-            entries = self._registry_v2[key]
-            if len(entries) == 1:
-                entry = next(iter(entries))
-                if entry.matches_device(device):
-                    matches.append(entry)
-            else:
-                for entry in entries:
-                    if entry.matches_device(device):
-                        matches.append(entry)  # noqa: PERF401
-            if len(matches) > 1:
-                raise MultipleQuirksMatchException(
-                    f"Multiple matches found for device {device}: {matches}"
-                )
-            if len(matches) == 1:
-                quirk_entry: QuirksV2RegistryEntry = matches[0]
-                return quirk_entry.create_device(device)
-
         _LOGGER.debug(
             "Checking quirks for %s %s (%s)",
             device.manufacturer,
             device.model,
             device.ieee,
         )
+
+        # Try v2 quirks first
+        key = (device.manufacturer, device.model)
+        if key in self._registry_v2:
+            for entry in self._registry_v2[key]:
+                if entry.matches_device(device):
+                    return entry.create_device(device)
+
+        # Then, fall back to v1 quirks
         for candidate in itertools.chain(
             self.registry[device.manufacturer][device.model],
             self.registry[device.manufacturer][None],
@@ -150,15 +134,15 @@ class DeviceRegistry:
             _LOGGER.debug(
                 "Found custom device replacement for %s: %s", device.ieee, candidate
             )
-            device = candidate(device._application, device.ieee, device.nwk, device)
-            break
+            return candidate(device._application, device.ieee, device.nwk, device)
 
+        # If none match, return the original device
         return device
 
     @property
-    def registry(self) -> TYPE_MANUF_QUIRKS_DICT:
+    def registry(self) -> dict[str | None, dict[str | None, list[CustomDevice]]]:
         """Return the registry."""
-        return self._registry
+        return self._registry_v1
 
     def __contains__(self, device: CustomDeviceType) -> bool:
         """Check if a device is in the registry."""

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -140,9 +140,14 @@ class DeviceRegistry:
         return device
 
     @property
-    def registry(self) -> dict[str | None, dict[str | None, list[CustomDevice]]]:
-        """Return the registry."""
+    def registry(self) -> dict[str | None, dict[str | None, deque[CustomDevice]]]:
+        """Return the v1 registry."""
         return self._registry_v1
+
+    @property
+    def registry_v2(self) -> dict[tuple[str, str], deque[QuirksV2RegistryEntry]]:
+        """Return the v2 registry."""
+        return self._registry_v2
 
     def __contains__(self, device: CustomDeviceType) -> bool:
         """Check if a device is in the registry."""


### PR DESCRIPTION
This PR basically removes the `MultipleQuirksMatch` exception and reorders the way v2 quirks are inserted into the registry.