### PR TITLE
Allow v2 quirks to opt out of default entity registration

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -132,7 +132,7 @@ async def test_quirks_v2(device_mock):
     assert str(quirked.quirk_metadata.quirk_file).endswith(
         "zigpy/tests/test_quirks_v2.py"
     )
-    assert quirked.quirk_metadata.quirk_file_line == 105
+    assert quirked.quirk_metadata.quirk_file_line == 106
 
     ep = quirked.endpoints[1]
 
@@ -1228,11 +1228,11 @@ async def test_quirks_v2_disable_entity_creation(device_mock: Device) -> None:
         .add_to_registry()
     )
 
-    assert entry.prevent_default_entity_creation == {
+    assert entry.disabled_default_entities == (
         PreventDefaultEntityCreationMetadata(
             endpoint_id=1, cluster_id=None, unique_id_suffix="something"
         ),
         PreventDefaultEntityCreationMetadata(
             endpoint_id=1, cluster_id=OnOff.cluster_id, unique_id_suffix=None
         ),
-    }
+    )

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -27,6 +27,7 @@ from zigpy.quirks.v2 import (
     EntityPlatform,
     EntityType,
     NumberMetadata,
+    PreventDefaultEntityCreationMetadata,
     QuirkBuilder,
     SwitchMetadata,
     WriteAttributeButtonMetadata,
@@ -1215,3 +1216,23 @@ async def test_quirks_v2_device_alerts(device_mock: Device) -> None:
             message="This device irreparably crashes the mesh.",
         ),
     )
+
+
+async def test_quirks_v2_disable_entity_creation(device_mock: Device) -> None:
+    registry = DeviceRegistry()
+
+    entry = (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .prevent_default_entity_creation(endpoint_id=1, unique_id_suffix="something")
+        .prevent_default_entity_creation(endpoint_id=1, cluster_id=OnOff.cluster_id)
+        .add_to_registry()
+    )
+
+    assert entry.prevent_default_entity_creation == {
+        PreventDefaultEntityCreationMetadata(
+            endpoint_id=1, cluster_id=None, unique_id_suffix="something"
+        ),
+        PreventDefaultEntityCreationMetadata(
+            endpoint_id=1, cluster_id=OnOff.cluster_id, unique_id_suffix=None
+        ),
+    }

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -436,6 +436,15 @@ class DeviceAlertMetadata:
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
+class PreventDefaultEntityCreationMetadata:
+    """Metadata to prevent the default creation of an entity."""
+
+    endpoint_id: int | None = attrs.field()
+    cluster_id: int | None = attrs.field()
+    unique_id_suffix: str | None = attrs.field()
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class QuirksV2RegistryEntry:
     """Quirks V2 registry entry."""
 
@@ -446,6 +455,9 @@ class QuirksV2RegistryEntry:
     )
     friendly_name: FriendlyNameMetadata | None = attrs.field(default=None)
     device_alerts: tuple[DeviceAlertMetadata] = attrs.field(factory=tuple)
+    prevent_default_entity_creation: tuple[PreventDefaultEntityCreationMetadata] = (
+        attrs.field(factory=tuple)
+    )
     filters: tuple[FilterType] = attrs.field(factory=tuple)
     custom_device_class: type[CustomDeviceV2] | None = attrs.field(default=None)
     device_node_descriptor: NodeDescriptor | None = attrs.field(default=None)
@@ -507,6 +519,9 @@ class QuirkBuilder:
         self.manufacturer_model_metadata: list[ManufacturerModelMetadata] = []
         self.friendly_name_metadata: FriendlyNameMetadata | None = None
         self.device_alerts: list[DeviceAlertMetadata] = []
+        self.prevent_default_entity_creation: list[
+            PreventDefaultEntityCreationMetadata
+        ] = []
         self.filters: list[FilterType] = []
         self.custom_device_class: type[CustomDeviceV2] | None = None
         self.device_node_descriptor: NodeDescriptor | None = None
@@ -1037,6 +1052,23 @@ class QuirkBuilder:
         self.device_alerts.append(DeviceAlertMetadata(level=level, message=message))
         return self
 
+    def prevent_default_entity_creation(
+        self,
+        *,
+        endpoint_id: int | None = None,
+        cluster_id: int | None = None,
+        unique_id_suffix: str | None = None,
+    ) -> QuirkBuilder:
+        """Do not create default entities."""
+        self.prevent_default_entity_creation.append(
+            PreventDefaultEntityCreationMetadata(
+                endpoint_id=endpoint_id,
+                cluster_id=cluster_id,
+                unique_id_suffix=unique_id_suffix,
+            ),
+        )
+        return self
+
     def add_to_registry(self) -> QuirksV2RegistryEntry:
         """Build the quirks v2 registry entry."""
         if not self.manufacturer_model_metadata:
@@ -1047,6 +1079,7 @@ class QuirkBuilder:
             manufacturer_model_metadata=tuple(self.manufacturer_model_metadata),
             friendly_name=self.friendly_name_metadata,
             device_alerts=tuple(self.device_alerts),
+            prevent_default_entity_creation=tuple(self.prevent_default_entity_creation),
             quirk_file=self.quirk_file,
             quirk_file_line=self.quirk_file_line,
             filters=tuple(self.filters),

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -455,7 +455,7 @@ class QuirksV2RegistryEntry:
     )
     friendly_name: FriendlyNameMetadata | None = attrs.field(default=None)
     device_alerts: tuple[DeviceAlertMetadata] = attrs.field(factory=tuple)
-    prevent_default_entity_creation: tuple[PreventDefaultEntityCreationMetadata] = (
+    disabled_default_entities: tuple[PreventDefaultEntityCreationMetadata] = (
         attrs.field(factory=tuple)
     )
     filters: tuple[FilterType] = attrs.field(factory=tuple)
@@ -519,9 +519,7 @@ class QuirkBuilder:
         self.manufacturer_model_metadata: list[ManufacturerModelMetadata] = []
         self.friendly_name_metadata: FriendlyNameMetadata | None = None
         self.device_alerts: list[DeviceAlertMetadata] = []
-        self.prevent_default_entity_creation: list[
-            PreventDefaultEntityCreationMetadata
-        ] = []
+        self.disabled_default_entities: list[PreventDefaultEntityCreationMetadata] = []
         self.filters: list[FilterType] = []
         self.custom_device_class: type[CustomDeviceV2] | None = None
         self.device_node_descriptor: NodeDescriptor | None = None
@@ -1060,7 +1058,7 @@ class QuirkBuilder:
         unique_id_suffix: str | None = None,
     ) -> QuirkBuilder:
         """Do not create default entities."""
-        self.prevent_default_entity_creation.append(
+        self.disabled_default_entities.append(
             PreventDefaultEntityCreationMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
@@ -1079,7 +1077,7 @@ class QuirkBuilder:
             manufacturer_model_metadata=tuple(self.manufacturer_model_metadata),
             friendly_name=self.friendly_name_metadata,
             device_alerts=tuple(self.device_alerts),
-            prevent_default_entity_creation=tuple(self.prevent_default_entity_creation),
+            disabled_default_entities=tuple(self.disabled_default_entities),
             quirk_file=self.quirk_file,
             quirk_file_line=self.quirk_file_line,
             filters=tuple(self.filters),


### PR DESCRIPTION
This should practically replace all uses of `removes`: https://github.com/search?q=repo%3Azigpy%2Fzha-device-handlers+removes&type=code