### PR TITLE
Replace deprecated quirks `registry` usage

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -182,7 +182,7 @@ def test_custom_devices():
         return False
 
     # Validate that all CustomDevices look sane
-    reg = zigpy.quirks._DEVICE_REGISTRY.registry
+    reg = zigpy.quirks._DEVICE_REGISTRY.registry_v1
     candidates = list(
         itertools.chain(*itertools.chain(*[m.values() for m in reg.values()]))
     )

--- a/tests/test_quirks_registry.py
+++ b/tests/test_quirks_registry.py
@@ -153,6 +153,7 @@ def test_remove_models_info(fake_dev):
     assert quirk_list.remove.call_args_list[1][0][0] is fake_dev
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_property_accessors():
     reg = DeviceRegistry()
     assert reg.registry is reg._registry_v1

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -50,9 +50,9 @@ def get_quirk_list(
 ):
     """Get the Quirk list for a given manufacturer and model."""
     if registry is None:
-        return _DEVICE_REGISTRY.registry[manufacturer][model]
+        return _DEVICE_REGISTRY.registry_v1[manufacturer][model]
 
-    return registry.registry[manufacturer][model]
+    return registry.registry_v1[manufacturer][model]
 
 
 def register_uninitialized_device_message_handler(handler: typing.Callable) -> None:

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -69,13 +69,13 @@ class DeviceRegistry:
         models_info = custom_device.signature.get(SIG_MODELS_INFO)
         if models_info:
             for manuf, model in models_info:
-                if custom_device not in self.registry[manuf][model]:
-                    self.registry[manuf][model].appendleft(custom_device)
+                if custom_device not in self.registry_v1[manuf][model]:
+                    self.registry_v1[manuf][model].appendleft(custom_device)
         else:
             manufacturer = custom_device.signature.get(SIG_MANUFACTURER)
             model = custom_device.signature.get(SIG_MODEL)
-            if custom_device not in self.registry[manufacturer][model]:
-                self.registry[manufacturer][model].appendleft(custom_device)
+            if custom_device not in self.registry_v1[manufacturer][model]:
+                self.registry_v1[manufacturer][model].appendleft(custom_device)
 
     def add_to_registry_v2(
         self, manufacturer: str, model: str, entry: QuirksV2RegistryEntry
@@ -94,11 +94,11 @@ class DeviceRegistry:
         models_info = custom_device.signature.get(SIG_MODELS_INFO)
         if models_info:
             for manuf, model in models_info:
-                self.registry[manuf][model].remove(custom_device)
+                self.registry_v1[manuf][model].remove(custom_device)
         else:
             manufacturer = custom_device.signature.get(SIG_MANUFACTURER)
             model = custom_device.signature.get(SIG_MODEL)
-            self.registry[manufacturer][model].remove(custom_device)
+            self.registry_v1[manufacturer][model].remove(custom_device)
 
     def get_device(self, device: DeviceType) -> CustomDeviceType | DeviceType:
         """Get a CustomDevice object, if one is available"""
@@ -121,10 +121,10 @@ class DeviceRegistry:
 
         # Then, fall back to v1 quirks
         for candidate in itertools.chain(
-            self.registry[device.manufacturer][device.model],
-            self.registry[device.manufacturer][None],
-            self.registry[None][device.model],
-            self.registry[None][None],
+            self.registry_v1[device.manufacturer][device.model],
+            self.registry_v1[device.manufacturer][None],
+            self.registry_v1[None][device.model],
+            self.registry_v1[None][None],
         ):
             matcher = zigpy.quirks.signature_matches(candidate.signature)
             _LOGGER.debug("Considering %s", candidate)
@@ -173,7 +173,7 @@ class DeviceRegistry:
             ],
         )[0]
         return device in itertools.chain(
-            self.registry[manufacturer][model],
-            self.registry[manufacturer][None],
-            self.registry[None][None],
+            self.registry_v1[manufacturer][model],
+            self.registry_v1[manufacturer][None],
+            self.registry_v1[None][None],
         )


### PR DESCRIPTION
## Proposed change

Since https://github.com/zigpy/zigpy/pull/1534, the quirks `registry` property is deprecated. Zigpy still accessed it internally though, which caused a lot of warnings in test runs of zigpy, quirks, and ZHA.

This PR replaces the access of the deprecated `registry` with `registry_v1`.
In the `test_property_accessors` test where the deprecated `registry` property is explicitly accessed, the `DeprecationWarning` are silenced, so they're not logged. 

## Additional information

<details><summary>Screenshot of a test run</summary>
<p>

😄
![image](https://github.com/user-attachments/assets/01f040c7-50ae-4f77-a194-a597c1e53fad)

</p>
</details> 

From this test run: https://github.com/zigpy/zha/actions/runs/12921479748/job/36035754936)
