### PR TITLE
Add `attribute_converter` to quirks v2 sensors

### DIFF
--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -335,7 +335,6 @@ class ZCLEnumMetadata(EntityMetadata):
     enum: type[Enum] = attrs.field()
     attribute_name: str = attrs.field()
     reporting_config: ReportingConfig | None = attrs.field(default=None)
-    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -370,7 +369,6 @@ class NumberMetadata(EntityMetadata):
     """Metadata for exposed number entity."""
 
     attribute_name: str = attrs.field()
-    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
     reporting_config: ReportingConfig | None = attrs.field(default=None)
     min: float | None = attrs.field(default=None)
     max: float | None = attrs.field(default=None)
@@ -769,7 +767,6 @@ class QuirkBuilder:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        attribute_converter: typing.Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
@@ -788,7 +785,6 @@ class QuirkBuilder:
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
                 reporting_config=reporting_config,
-                attribute_converter=attribute_converter,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 enum=enum_class,
@@ -904,7 +900,6 @@ class QuirkBuilder:
         device_class: NumberDeviceClass | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        attribute_converter: typing.Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
@@ -926,7 +921,6 @@ class QuirkBuilder:
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
-                attribute_converter=attribute_converter,
                 min=min_value,
                 max=max_value,
                 step=step,

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -335,6 +335,7 @@ class ZCLEnumMetadata(EntityMetadata):
     enum: type[Enum] = attrs.field()
     attribute_name: str = attrs.field()
     reporting_config: ReportingConfig | None = attrs.field(default=None)
+    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -342,6 +343,7 @@ class ZCLSensorMetadata(EntityMetadata):
     """Metadata for exposed ZCL attribute based sensor entity."""
 
     attribute_name: str | None = attrs.field(default=None)
+    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
     reporting_config: ReportingConfig | None = attrs.field(default=None)
     divisor: int | None = attrs.field(default=None)
     multiplier: int | None = attrs.field(default=None)
@@ -355,6 +357,7 @@ class SwitchMetadata(EntityMetadata):
     """Metadata for exposed switch entity."""
 
     attribute_name: str = attrs.field()
+    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
     reporting_config: ReportingConfig | None = attrs.field(default=None)
     force_inverted: bool = attrs.field(default=False)
     invert_attribute_name: str | None = attrs.field(default=None)
@@ -367,6 +370,7 @@ class NumberMetadata(EntityMetadata):
     """Metadata for exposed number entity."""
 
     attribute_name: str = attrs.field()
+    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
     reporting_config: ReportingConfig | None = attrs.field(default=None)
     min: float | None = attrs.field(default=None)
     max: float | None = attrs.field(default=None)
@@ -382,6 +386,7 @@ class BinarySensorMetadata(EntityMetadata):
     """Metadata for exposed binary sensor entity."""
 
     attribute_name: str = attrs.field()
+    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
     reporting_config: ReportingConfig | None = attrs.field(default=None)
     device_class: BinarySensorDeviceClass | None = attrs.field(default=None)
 
@@ -764,6 +769,7 @@ class QuirkBuilder:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        attribute_converter: typing.Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
@@ -782,6 +788,7 @@ class QuirkBuilder:
                 initially_disabled=initially_disabled,
                 attribute_initialized_from_cache=attribute_initialized_from_cache,
                 reporting_config=reporting_config,
+                attribute_converter=attribute_converter,
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 enum=enum_class,
@@ -804,6 +811,7 @@ class QuirkBuilder:
         unit: str | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        attribute_converter: typing.Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
@@ -825,6 +833,7 @@ class QuirkBuilder:
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
+                attribute_converter=attribute_converter,
                 divisor=divisor,
                 multiplier=multiplier,
                 unit=unit,
@@ -848,6 +857,7 @@ class QuirkBuilder:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        attribute_converter: typing.Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
@@ -869,6 +879,7 @@ class QuirkBuilder:
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
+                attribute_converter=attribute_converter,
                 force_inverted=force_inverted,
                 invert_attribute_name=invert_attribute_name,
                 off_value=off_value,
@@ -893,6 +904,7 @@ class QuirkBuilder:
         device_class: NumberDeviceClass | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        attribute_converter: typing.Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
@@ -914,6 +926,7 @@ class QuirkBuilder:
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
+                attribute_converter=attribute_converter,
                 min=min_value,
                 max=max_value,
                 step=step,
@@ -935,6 +948,7 @@ class QuirkBuilder:
         device_class: BinarySensorDeviceClass | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        attribute_converter: typing.Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
@@ -956,6 +970,7 @@ class QuirkBuilder:
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
+                attribute_converter=attribute_converter,
                 device_class=device_class,
             )
         )

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -356,7 +356,6 @@ class SwitchMetadata(EntityMetadata):
     """Metadata for exposed switch entity."""
 
     attribute_name: str = attrs.field()
-    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
     reporting_config: ReportingConfig | None = attrs.field(default=None)
     force_inverted: bool = attrs.field(default=False)
     invert_attribute_name: str | None = attrs.field(default=None)
@@ -853,7 +852,6 @@ class QuirkBuilder:
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        attribute_converter: typing.Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         translation_key: str | None = None,
         fallback_name: str | None = None,
@@ -875,7 +873,6 @@ class QuirkBuilder:
                 translation_key=translation_key,
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
-                attribute_converter=attribute_converter,
                 force_inverted=force_inverted,
                 invert_attribute_name=invert_attribute_name,
                 off_value=off_value,


### PR DESCRIPTION
## Proposed change

This adds an `attribute_converter` to the following quirk v2 platforms:
- binary sensor
- sensor

This will allow us to parse a ZCL attribute value in quirks, before passing it to the HA state.

## Additional information

If we also add a "unique id suffix suffix" in a future PR, we can even parse the same ZCL attribute in different ways with multiple entities.

Corresponding ZHA PR:
- https://github.com/zigpy/zha/pull/360