### PR TITLE
Add `UnitOfConductivity` to v2 quirks

### DIFF
--- a/zigpy/quirks/v2/homeassistant/__init__.py
+++ b/zigpy/quirks/v2/homeassistant/__init__.py
@@ -203,6 +203,7 @@ class UnitOfConductivity(Enum):
     MICROSIEMENS_PER_CM = "µS/cm"
     MILLISIEMENS_PER_CM = "mS/cm"
 
+
 # Light units
 LIGHT_LUX: Final = "lx"
 

--- a/zigpy/quirks/v2/homeassistant/__init__.py
+++ b/zigpy/quirks/v2/homeassistant/__init__.py
@@ -198,7 +198,7 @@ class UnitOfMass(Enum):
 # Conductivity units
 class UnitOfConductivity(Enum):
     """Conductivity units."""
-    
+
     SIEMENS_PER_CM = "S/cm"
     MICROSIEMENS_PER_CM = "µS/cm"
     MILLISIEMENS_PER_CM = "mS/cm"

--- a/zigpy/quirks/v2/homeassistant/__init__.py
+++ b/zigpy/quirks/v2/homeassistant/__init__.py
@@ -196,7 +196,12 @@ class UnitOfMass(Enum):
 
 
 # Conductivity units
-CONDUCTIVITY: Final = "µS/cm"
+class UnitOfConductivity(Enum):
+    """Conductivity units."""
+    
+    SIEMENS_PER_CM = "S/cm"
+    MICROSIEMENS_PER_CM = "µS/cm"
+    MILLISIEMENS_PER_CM = "mS/cm"
 
 # Light units
 LIGHT_LUX: Final = "lx"


### PR DESCRIPTION
Adds SIEMENS_PER_CM and MILLISIEMENS_PER_CM to the existing uS/cm while changing it from CONDUCTIVITY to MICROSEIMENS_PER_CM