### PR TITLE
Add `CONDUCTIVITY` sensor device class to v2 quirks

### DIFF
--- a/zigpy/quirks/v2/homeassistant/sensor.py
+++ b/zigpy/quirks/v2/homeassistant/sensor.py
@@ -67,6 +67,12 @@ class SensorDeviceClass(Enum):
 
     Unit of measurement: `ppm` (parts per million)
     """
+    
+    CONDUCTIVITY = "conductivity"
+    """Conductivity.
+
+    Unit of measurement: 'S/cm', 'µS/cm', 'mS/cm'
+    """
 
     CURRENT = "current"
     """Current.

--- a/zigpy/quirks/v2/homeassistant/sensor.py
+++ b/zigpy/quirks/v2/homeassistant/sensor.py
@@ -67,7 +67,7 @@ class SensorDeviceClass(Enum):
 
     Unit of measurement: `ppm` (parts per million)
     """
-    
+
     CONDUCTIVITY = "conductivity"
     """Conductivity.
 


### PR DESCRIPTION
Adds the CONDUCTIVITY SensorDeviceClass from https://developers.home-assistant.io/docs/core/entity/sensor/