### PR TITLE
Backport and use `StrEnum` for quirks v2 units

### DIFF
--- a/tests/test_backports.py
+++ b/tests/test_backports.py
@@ -1,0 +1,35 @@
+"""Test zigpy backports."""
+
+from enum import auto
+
+import pytest
+
+from zigpy.backports.enum import StrEnum
+
+
+def test_strenum() -> None:
+    """Test StrEnum."""
+
+    class TestEnum(StrEnum):
+        Test = "test"
+
+    assert str(TestEnum.Test) == "test"
+    assert TestEnum.Test == "test"
+    assert TestEnum("test") is TestEnum.Test
+    assert TestEnum(TestEnum.Test) is TestEnum.Test
+
+    with pytest.raises(ValueError):
+        TestEnum(42)
+
+    with pytest.raises(ValueError):
+        TestEnum("str but unknown")
+
+    with pytest.raises(TypeError):
+
+        class FailEnum(StrEnum):
+            Test = 42
+
+    with pytest.raises(TypeError):
+
+        class FailEnum2(StrEnum):
+            Test = auto()

--- a/zigpy/backports/__init__.py
+++ b/zigpy/backports/__init__.py
@@ -1,0 +1,1 @@
+"""Backports from newer Python versions."""

--- a/zigpy/backports/enum.py
+++ b/zigpy/backports/enum.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Self
+from typing import Any, TypeVar
+
+_StrEnumSelfT = TypeVar("_StrEnumSelfT", bound="StrEnum")
 
 
 class StrEnum(str, Enum):
     """Partial backport of Python 3.11's StrEnum for our basic use cases."""
 
-    value: str
-
-    def __new__(cls, value: str, *args: Any, **kwargs: Any) -> Self:
+    def __new__(
+        cls: type[_StrEnumSelfT], value: str, *args: Any, **kwargs: Any
+    ) -> _StrEnumSelfT:  # noqa: PYI019
         """Create a new StrEnum instance."""
         if not isinstance(value, str):
             raise TypeError(f"{value!r} is not a string")

--- a/zigpy/backports/enum.py
+++ b/zigpy/backports/enum.py
@@ -1,0 +1,33 @@
+"""Enum backports from standard lib."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Self
+
+
+class StrEnum(str, Enum):
+    """Partial backport of Python 3.11's StrEnum for our basic use cases."""
+
+    value: str
+
+    def __new__(cls, value: str, *args: Any, **kwargs: Any) -> Self:
+        """Create a new StrEnum instance."""
+        if not isinstance(value, str):
+            raise TypeError(f"{value!r} is not a string")
+        return super().__new__(cls, value, *args, **kwargs)
+
+    def __str__(self) -> str:
+        """Return self.value."""
+        return self.value
+
+    @staticmethod
+    def _generate_next_value_(
+        name: str, start: int, count: int, last_values: list[Any]
+    ) -> Any:
+        """Make `auto()` explicitly unsupported.
+
+        We may revisit this when it's very clear that Python 3.11's
+        `StrEnum.auto()` behavior will no longer change.
+        """
+        raise TypeError("auto() is not supported by this implementation")

--- a/zigpy/quirks/v2/homeassistant/__init__.py
+++ b/zigpy/quirks/v2/homeassistant/__init__.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Final
 
 
-class EntityType(Enum):
+class EntityType(str, Enum):
     """Entity type."""
 
     CONFIG = "config"
@@ -12,7 +12,7 @@ class EntityType(Enum):
     STANDARD = "standard"
 
 
-class EntityPlatform(Enum):
+class EntityPlatform(str, Enum):
     """Entity platform."""
 
     BINARY_SENSOR = "binary_sensor"
@@ -23,14 +23,14 @@ class EntityPlatform(Enum):
     SWITCH = "switch"
 
 
-class UnitOfApparentPower(Enum):
+class UnitOfApparentPower(str, Enum):
     """Apparent power units."""
 
     VOLT_AMPERE = "VA"
 
 
 # Power units
-class UnitOfPower(Enum):
+class UnitOfPower(str, Enum):
     """Power units."""
 
     WATT = "W"
@@ -43,7 +43,7 @@ POWER_VOLT_AMPERE_REACTIVE: Final = "var"
 
 
 # Energy units
-class UnitOfEnergy(Enum):
+class UnitOfEnergy(str, Enum):
     """Energy units."""
 
     GIGA_JOULE = "GJ"
@@ -54,7 +54,7 @@ class UnitOfEnergy(Enum):
 
 
 # Electric_current units
-class UnitOfElectricCurrent(Enum):
+class UnitOfElectricCurrent(str, Enum):
     """Electric current units."""
 
     MILLIAMPERE = "mA"
@@ -62,7 +62,7 @@ class UnitOfElectricCurrent(Enum):
 
 
 # Electric_potential units
-class UnitOfElectricPotential(Enum):
+class UnitOfElectricPotential(str, Enum):
     """Electric potential units."""
 
     MILLIVOLT = "mV"
@@ -79,7 +79,7 @@ CURRENCY_CENT: Final = "¢"
 
 
 # Temperature units
-class UnitOfTemperature(Enum):
+class UnitOfTemperature(str, Enum):
     """Temperature units."""
 
     CELSIUS = "°C"
@@ -88,7 +88,7 @@ class UnitOfTemperature(Enum):
 
 
 # Time units
-class UnitOfTime(Enum):
+class UnitOfTime(str, Enum):
     """Time units."""
 
     MICROSECONDS = "μs"
@@ -103,7 +103,7 @@ class UnitOfTime(Enum):
 
 
 # Length units
-class UnitOfLength(Enum):
+class UnitOfLength(str, Enum):
     """Length units."""
 
     MILLIMETERS = "mm"
@@ -117,7 +117,7 @@ class UnitOfLength(Enum):
 
 
 # Frequency units
-class UnitOfFrequency(Enum):
+class UnitOfFrequency(str, Enum):
     """Frequency units."""
 
     HERTZ = "Hz"
@@ -127,7 +127,7 @@ class UnitOfFrequency(Enum):
 
 
 # Pressure units
-class UnitOfPressure(Enum):
+class UnitOfPressure(str, Enum):
     """Pressure units."""
 
     PA = "Pa"
@@ -142,7 +142,7 @@ class UnitOfPressure(Enum):
 
 
 # Sound pressure units
-class UnitOfSoundPressure(Enum):
+class UnitOfSoundPressure(str, Enum):
     """Sound pressure units."""
 
     DECIBEL = "dB"
@@ -150,7 +150,7 @@ class UnitOfSoundPressure(Enum):
 
 
 # Volume units
-class UnitOfVolume(Enum):
+class UnitOfVolume(str, Enum):
     """Volume units."""
 
     CUBIC_FEET = "ft³"
@@ -169,7 +169,7 @@ class UnitOfVolume(Enum):
 
 
 # Volume Flow Rate units
-class UnitOfVolumeFlowRate(Enum):
+class UnitOfVolumeFlowRate(str, Enum):
     """Volume flow rate units."""
 
     CUBIC_METERS_PER_HOUR = "m³/h"
@@ -183,7 +183,7 @@ AREA_SQUARE_METERS: Final = "m²"
 
 
 # Mass units
-class UnitOfMass(Enum):
+class UnitOfMass(str, Enum):
     """Mass units."""
 
     GRAMS = "g"
@@ -212,14 +212,14 @@ REVOLUTIONS_PER_MINUTE: Final = "rpm"
 
 
 # Irradiance units
-class UnitOfIrradiance(Enum):
+class UnitOfIrradiance(str, Enum):
     """Irradiance units."""
 
     WATTS_PER_SQUARE_METER = "W/m²"
     BTUS_PER_HOUR_SQUARE_FOOT = "BTU/(h⋅ft²)"
 
 
-class UnitOfVolumetricFlux(Enum):
+class UnitOfVolumetricFlux(str, Enum):
     """Volumetric flux, commonly used for precipitation intensity.
 
     The derivation of these units is a volume of rain amassing in a container
@@ -239,7 +239,7 @@ class UnitOfVolumetricFlux(Enum):
     """Derived from mm³/(mm²⋅h)"""
 
 
-class UnitOfPrecipitationDepth(Enum):
+class UnitOfPrecipitationDepth(str, Enum):
     """Precipitation depth.
 
     The derivation of these units is a volume of rain amassing in a container
@@ -266,7 +266,7 @@ CONCENTRATION_PARTS_PER_BILLION: Final = "ppb"
 
 
 # Speed units
-class UnitOfSpeed(Enum):
+class UnitOfSpeed(str, Enum):
     """Speed units."""
 
     FEET_PER_SECOND = "ft/s"
@@ -282,7 +282,7 @@ SIGNAL_STRENGTH_DECIBELS_MILLIWATT: Final = "dBm"
 
 
 # Data units
-class UnitOfInformation(Enum):
+class UnitOfInformation(str, Enum):
     """Information units."""
 
     BITS = "bit"
@@ -309,7 +309,7 @@ class UnitOfInformation(Enum):
 
 
 # Data_rate units
-class UnitOfDataRate(Enum):
+class UnitOfDataRate(str, Enum):
     """Data rate units."""
 
     BITS_PER_SECOND = "bit/s"

--- a/zigpy/quirks/v2/homeassistant/__init__.py
+++ b/zigpy/quirks/v2/homeassistant/__init__.py
@@ -1,10 +1,11 @@
 """Homeassistant specific quirks v2 things."""
 
-from enum import Enum
 from typing import Final
 
+from zigpy.backports.enum import StrEnum
 
-class EntityType(str, Enum):
+
+class EntityType(StrEnum):
     """Entity type."""
 
     CONFIG = "config"
@@ -12,7 +13,7 @@ class EntityType(str, Enum):
     STANDARD = "standard"
 
 
-class EntityPlatform(str, Enum):
+class EntityPlatform(StrEnum):
     """Entity platform."""
 
     BINARY_SENSOR = "binary_sensor"
@@ -23,14 +24,14 @@ class EntityPlatform(str, Enum):
     SWITCH = "switch"
 
 
-class UnitOfApparentPower(str, Enum):
+class UnitOfApparentPower(StrEnum):
     """Apparent power units."""
 
     VOLT_AMPERE = "VA"
 
 
 # Power units
-class UnitOfPower(str, Enum):
+class UnitOfPower(StrEnum):
     """Power units."""
 
     WATT = "W"
@@ -43,7 +44,7 @@ POWER_VOLT_AMPERE_REACTIVE: Final = "var"
 
 
 # Energy units
-class UnitOfEnergy(str, Enum):
+class UnitOfEnergy(StrEnum):
     """Energy units."""
 
     GIGA_JOULE = "GJ"
@@ -54,7 +55,7 @@ class UnitOfEnergy(str, Enum):
 
 
 # Electric_current units
-class UnitOfElectricCurrent(str, Enum):
+class UnitOfElectricCurrent(StrEnum):
     """Electric current units."""
 
     MILLIAMPERE = "mA"
@@ -62,7 +63,7 @@ class UnitOfElectricCurrent(str, Enum):
 
 
 # Electric_potential units
-class UnitOfElectricPotential(str, Enum):
+class UnitOfElectricPotential(StrEnum):
     """Electric potential units."""
 
     MILLIVOLT = "mV"
@@ -79,7 +80,7 @@ CURRENCY_CENT: Final = "¢"
 
 
 # Temperature units
-class UnitOfTemperature(str, Enum):
+class UnitOfTemperature(StrEnum):
     """Temperature units."""
 
     CELSIUS = "°C"
@@ -88,7 +89,7 @@ class UnitOfTemperature(str, Enum):
 
 
 # Time units
-class UnitOfTime(str, Enum):
+class UnitOfTime(StrEnum):
     """Time units."""
 
     MICROSECONDS = "μs"
@@ -103,7 +104,7 @@ class UnitOfTime(str, Enum):
 
 
 # Length units
-class UnitOfLength(str, Enum):
+class UnitOfLength(StrEnum):
     """Length units."""
 
     MILLIMETERS = "mm"
@@ -117,7 +118,7 @@ class UnitOfLength(str, Enum):
 
 
 # Frequency units
-class UnitOfFrequency(str, Enum):
+class UnitOfFrequency(StrEnum):
     """Frequency units."""
 
     HERTZ = "Hz"
@@ -127,7 +128,7 @@ class UnitOfFrequency(str, Enum):
 
 
 # Pressure units
-class UnitOfPressure(str, Enum):
+class UnitOfPressure(StrEnum):
     """Pressure units."""
 
     PA = "Pa"
@@ -142,7 +143,7 @@ class UnitOfPressure(str, Enum):
 
 
 # Sound pressure units
-class UnitOfSoundPressure(str, Enum):
+class UnitOfSoundPressure(StrEnum):
     """Sound pressure units."""
 
     DECIBEL = "dB"
@@ -150,7 +151,7 @@ class UnitOfSoundPressure(str, Enum):
 
 
 # Volume units
-class UnitOfVolume(str, Enum):
+class UnitOfVolume(StrEnum):
     """Volume units."""
 
     CUBIC_FEET = "ft³"
@@ -169,7 +170,7 @@ class UnitOfVolume(str, Enum):
 
 
 # Volume Flow Rate units
-class UnitOfVolumeFlowRate(str, Enum):
+class UnitOfVolumeFlowRate(StrEnum):
     """Volume flow rate units."""
 
     CUBIC_METERS_PER_HOUR = "m³/h"
@@ -183,7 +184,7 @@ AREA_SQUARE_METERS: Final = "m²"
 
 
 # Mass units
-class UnitOfMass(str, Enum):
+class UnitOfMass(StrEnum):
     """Mass units."""
 
     GRAMS = "g"
@@ -212,14 +213,14 @@ REVOLUTIONS_PER_MINUTE: Final = "rpm"
 
 
 # Irradiance units
-class UnitOfIrradiance(str, Enum):
+class UnitOfIrradiance(StrEnum):
     """Irradiance units."""
 
     WATTS_PER_SQUARE_METER = "W/m²"
     BTUS_PER_HOUR_SQUARE_FOOT = "BTU/(h⋅ft²)"
 
 
-class UnitOfVolumetricFlux(str, Enum):
+class UnitOfVolumetricFlux(StrEnum):
     """Volumetric flux, commonly used for precipitation intensity.
 
     The derivation of these units is a volume of rain amassing in a container
@@ -239,7 +240,7 @@ class UnitOfVolumetricFlux(str, Enum):
     """Derived from mm³/(mm²⋅h)"""
 
 
-class UnitOfPrecipitationDepth(str, Enum):
+class UnitOfPrecipitationDepth(StrEnum):
     """Precipitation depth.
 
     The derivation of these units is a volume of rain amassing in a container
@@ -266,7 +267,7 @@ CONCENTRATION_PARTS_PER_BILLION: Final = "ppb"
 
 
 # Speed units
-class UnitOfSpeed(str, Enum):
+class UnitOfSpeed(StrEnum):
     """Speed units."""
 
     FEET_PER_SECOND = "ft/s"
@@ -282,7 +283,7 @@ SIGNAL_STRENGTH_DECIBELS_MILLIWATT: Final = "dBm"
 
 
 # Data units
-class UnitOfInformation(str, Enum):
+class UnitOfInformation(StrEnum):
     """Information units."""
 
     BITS = "bit"
@@ -309,7 +310,7 @@ class UnitOfInformation(str, Enum):
 
 
 # Data_rate units
-class UnitOfDataRate(str, Enum):
+class UnitOfDataRate(StrEnum):
     """Data rate units."""
 
     BITS_PER_SECOND = "bit/s"


### PR DESCRIPTION
## Proposed change

We need the quirks v2 unit enum members to be strings, similar to the unit implementation in ZHA and HA Core, so this PR backports `StrEnum` and adds test coverage for the backport.
We can't use the native `StrEnum` implementation due to needing to support older Python versions with zigpy.

The fix is confirmed working in ZHA.

## Additional information

This issue wasn't caught in ZHA tests, because they mistakenly imported ZHA units (which are `StrEnum`) and not zigpy's quirks v2 unit enums. The ZHA test fix is linked below.

With https://github.com/zigpy/zigpy/pull/1547, we'll also have a regression test for this in zigpy and with https://github.com/zigpy/zha/pull/371, we'll have one in ZHA too.