### PR TITLE
Use unit enums in quirks v2 test

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -34,6 +34,7 @@ from zigpy.quirks.v2 import (
     ZCLSensorMetadata,
     add_to_registry_v2,
 )
+from zigpy.quirks.v2.homeassistant import UnitOfTime
 import zigpy.types as t
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import (
@@ -131,7 +132,7 @@ async def test_quirks_v2(device_mock):
     assert str(quirked.quirk_metadata.quirk_file).endswith(
         "zigpy/tests/test_quirks_v2.py"
     )
-    assert quirked.quirk_metadata.quirk_file_line == 105
+    assert quirked.quirk_metadata.quirk_file_line == 106
 
     ep = quirked.endpoints[1]
 
@@ -661,7 +662,7 @@ async def test_quirks_v2_number(device_mock):
             min_value=0,
             max_value=100,
             step=1,
-            unit="s",
+            unit=UnitOfTime.SECONDS,
             translation_key="on_time",
             fallback_name="On time",
         )


### PR DESCRIPTION
## Proposed change

Small follow-up to regression test `StrEnum` for unit enums from this PR in zigpy:
- https://github.com/zigpy/zigpy/pull/1546

We didn't actually use the unit enums in zigpy before. With this PR, we do.
A few lines below, we check that the unit is `"s"` then: https://github.com/TheJulianJES/zigpy/blob/04552d6c8fe6123b581dd878f6209d3af8a70807/tests/test_quirks_v2.py#L691
That check fails before the changes of the `StrEnum` PR (#1546).

## Additional information

This is very similar to the test PR on the ZHA side that will confirm the same thing, but it's also good to directly test here:
- https://github.com/zigpy/zha/pull/371