### PR TITLE
Read firmware version during initialization

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import copy
 import logging
 import threading
 import typing
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
@@ -22,8 +22,6 @@ from zigpy.config import (
 import zigpy.state as app_state
 import zigpy.types as t
 import zigpy.zdo.types as zdo_t
-
-from .async_mock import AsyncMock, MagicMock
 
 if typing.TYPE_CHECKING:
     import zigpy.device

--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -191,7 +191,10 @@ async def test_ota_manager():
     )
     cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
 
-    await dev.initialize()
+    with patch.object(
+        dev, "get_firmware_version", FW_IMAGE.firmware.header.file_version - 10
+    ):
+        await dev.initialize()
 
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True
@@ -364,7 +367,10 @@ async def test_ota_manager_image_page():
     )
     cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
 
-    await dev.initialize()
+    with patch.object(
+        dev, "get_firmware_version", FW_IMAGE.firmware.header.file_version - 10
+    ):
+        await dev.initialize()
 
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True
@@ -561,7 +567,10 @@ async def test_ota_manager_image_page_invalid_size():
     )
     cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
 
-    await dev.initialize()
+    with patch.object(
+        dev, "get_firmware_version", FW_IMAGE.firmware.header.file_version - 10
+    ):
+        await dev.initialize()
 
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True
@@ -630,7 +639,10 @@ async def test_ota_manager_image_page_failure():
     )
     cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
 
-    await dev.initialize()
+    with patch.object(
+        dev, "get_firmware_version", FW_IMAGE.firmware.header.file_version - 10
+    ):
+        await dev.initialize()
 
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime, timezone
 import logging
-from unittest.mock import call
+from unittest.mock import call, patch
 
 import pytest
 
@@ -52,10 +52,12 @@ async def test_initialize(monkeypatch, dev):
         else:
             return "Model2", "Manufacturer2"
 
-    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
-    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
-    dev.zdo.Active_EP_req = mockrequest
-    await dev.initialize()
+    with (
+        patch.object(endpoint.Endpoint, "initialize", new=mockepinit),
+        patch.object(endpoint.Endpoint, "get_model_info", new=mock_ep_get_model_info),
+        patch.object(dev.zdo, "Active_EP_req", new=mockrequest),
+    ):
+        await dev.initialize()
 
     assert dev.endpoints[0] is dev.zdo
     assert 1 in dev.endpoints
@@ -492,11 +494,10 @@ async def test_update_device_firmware_already_in_progress(dev, caplog):
     "zigpy.device.OTA_RETRY_DECORATOR",
     zigpy.util.retryable_request(tries=1, delay=0.01),
 )
-async def test_update_device_firmware(monkeypatch, dev, caplog):
+async def test_update_device_firmware(dev, caplog):
     """Test that device firmware updates execute the expected calls."""
     ep = dev.add_endpoint(1)
-    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
-    ep.add_output_cluster(Ota.cluster_id, cluster)
+    cluster = ep.add_output_cluster(Ota.cluster_id)
 
     async def mockrequest(nwk, tries=None, delay=None):
         return [0, None, [0, 1, 2, 3, 4]]
@@ -509,10 +510,13 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
         if self.endpoint_id == 1:
             return "Model2", "Manufacturer2"
 
-    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
-    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
-    dev.zdo.Active_EP_req = mockrequest
-    await dev.initialize()
+    with (
+        patch.object(endpoint.Endpoint, "initialize", new=mockepinit),
+        patch.object(endpoint.Endpoint, "get_model_info", new=mock_ep_get_model_info),
+        patch.object(dev.zdo, "Active_EP_req", new=mockrequest),
+        patch.object(dev, "get_firmware_version", return_value=0x12345678 - 100),
+    ):
+        await dev.initialize()
 
     fw_image = zigpy.ota.OtaImageWithMetadata(
         metadata=zigpy.ota.providers.BaseOtaImageMetadata(
@@ -871,11 +875,10 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     "zigpy.device.OTA_RETRY_DECORATOR",
     zigpy.util.retryable_request(tries=1, delay=0.01),
 )
-async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
+async def test_update_legrand_device_firmware(dev, caplog):
     """Legrand device (manufacturer_code == 4129) firmware update expects the "image_block" command "maximum_data_size" to be complied with."""
     ep = dev.add_endpoint(1)
-    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
-    ep.add_output_cluster(Ota.cluster_id, cluster)
+    cluster = ep.add_output_cluster(Ota.cluster_id)
 
     async def mockrequest(nwk, tries=None, delay=None):
         return [0, None, [0, 1, 2, 3, 4]]
@@ -888,10 +891,13 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
         if self.endpoint_id == 1:
             return "SomeModel", "Legrand"
 
-    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
-    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
-    dev.zdo.Active_EP_req = mockrequest
-    await dev.initialize()
+    with (
+        patch.object(endpoint.Endpoint, "initialize", new=mockepinit),
+        patch.object(endpoint.Endpoint, "get_model_info", new=mock_ep_get_model_info),
+        patch.object(dev.zdo, "Active_EP_req", new=mockrequest),
+        patch.object(dev, "get_firmware_version", return_value=0x12345678 - 100),
+    ):
+        await dev.initialize()
 
     fw_image = zigpy.ota.OtaImageWithMetadata(
         metadata=zigpy.ota.providers.BaseOtaImageMetadata(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -311,6 +311,16 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     if manufacturer is not None:
                         self.manufacturer = manufacturer
 
+        # Query firmware version
+        if self.firmware_version is not None:
+            self.info("Already have firmware version")
+        else:
+            ota = find_ota_cluster(self)
+            if ota is not None:
+                await OTA_RETRY_DECORATOR(ota.read_attributes)(
+                    [Ota.AttributeDefs.current_file_version.name]
+                )
+
         self.status = Status.ENDPOINTS_INIT
 
         self.info("Discovered basic device information for %s", self)
@@ -655,6 +665,15 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def model(self, value) -> None:
         if isinstance(value, str):
             self._model = value
+
+    @property
+    def firmware_version(self) -> int | None:
+        try:
+            ota = find_ota_cluster(self)
+        except KeyError:
+            return None
+        else:
+            return ota.get(Ota.AttributeDefs.current_file_version.id)
 
     @property
     def skip_configuration(self) -> bool:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -232,6 +232,21 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         return node_desc
 
+    async def get_firmware_version(self) -> int | None:
+        try:
+            ota = find_ota_cluster(self)
+        except ValueError:
+            return None
+        else:
+            success, _failure = await OTA_RETRY_DECORATOR(ota.read_attributes)(
+                [Ota.AttributeDefs.current_file_version.name]
+            )
+
+        if Ota.AttributeDefs.current_file_version.name in success:
+            return success[Ota.AttributeDefs.current_file_version.name]
+
+        return None
+
     async def initialize(self) -> None:
         try:
             await self._initialize()
@@ -315,11 +330,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         if self.firmware_version is not None:
             self.info("Already have firmware version")
         else:
-            ota = find_ota_cluster(self)
-            if ota is not None:
-                await OTA_RETRY_DECORATOR(ota.read_attributes)(
-                    [Ota.AttributeDefs.current_file_version.name]
-                )
+            # The `firmware_version` property uses the attribute cache so this doesn't
+            # need to be stored explicitly
+            await self.get_firmware_version()
 
         self.status = Status.ENDPOINTS_INIT
 
@@ -670,7 +683,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def firmware_version(self) -> int | None:
         try:
             ota = find_ota_cluster(self)
-        except KeyError:
+        except ValueError:
             return None
         else:
             return ota.get(Ota.AttributeDefs.current_file_version.id)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -753,6 +753,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             f" manuf={self.manufacturer!r}"
             f" nwk={t.NWK(self.nwk)}"
             f" ieee={self.ieee}"
+            f" firmware_version={f'{self.firmware_version:#08x}' if self.firmware_version is not None else None}"
             f" is_initialized={self.is_initialized}"
             f">"
         )


### PR DESCRIPTION
This PR adds a new `Device.get_firmware_version` method that polls the current firmware version and will be called during initialization. This will allow all new devices with an OTA cluster to have this information available *before* quirks are applied.

Question: are there any devices without an OTA cluster that require version-dependent quirks and also expose the current firmware version as just `sw_build_id`? My assumption right now is that all firmware versions are integers and we will at some point in the future support custom, per-manufacturer/device formatters for them.