### PR TITLE
Allow passing a function to `prevent_default_entity_creation`

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1189,7 +1189,7 @@ async def test_quirks_v2_device_alerts(device_mock: Device) -> None:
 async def test_quirks_v2_disable_entity_creation(device_mock: Device) -> None:
     registry = DeviceRegistry()
 
-    def filter_func(device, entity) -> bool:
+    def filter_func(entity) -> bool:
         return True
 
     entry = (

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1189,18 +1189,34 @@ async def test_quirks_v2_device_alerts(device_mock: Device) -> None:
 async def test_quirks_v2_disable_entity_creation(device_mock: Device) -> None:
     registry = DeviceRegistry()
 
+    def filter_func(device, entity) -> bool:
+        return True
+
     entry = (
         QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .prevent_default_entity_creation(endpoint_id=1, unique_id_suffix="something")
         .prevent_default_entity_creation(endpoint_id=1, cluster_id=OnOff.cluster_id)
+        .prevent_default_entity_creation(function=filter_func)
         .add_to_registry()
     )
 
     assert entry.disabled_default_entities == (
         PreventDefaultEntityCreationMetadata(
-            endpoint_id=1, cluster_id=None, unique_id_suffix="something"
+            endpoint_id=1,
+            cluster_id=None,
+            unique_id_suffix="something",
+            function=None,
         ),
         PreventDefaultEntityCreationMetadata(
-            endpoint_id=1, cluster_id=OnOff.cluster_id, unique_id_suffix=None
+            endpoint_id=1,
+            cluster_id=OnOff.cluster_id,
+            unique_id_suffix=None,
+            function=None,
+        ),
+        PreventDefaultEntityCreationMetadata(
+            endpoint_id=None,
+            cluster_id=None,
+            unique_id_suffix=None,
+            function=filter_func,
         ),
     )

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1,5 +1,6 @@
 """Tests for the quirks v2 module."""
 
+import pathlib
 from typing import Final
 from unittest.mock import AsyncMock
 
@@ -103,6 +104,7 @@ async def test_quirks_v2(device_mock):
             report: Final = ZCLAttributeDef(id=0x0000, type=t.uint8_t)
 
     entry = (
+        # Quirk builder creation line, this comment is read by this unit test
         QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .filter(signature_matches(signature))
         .adds(
@@ -132,7 +134,15 @@ async def test_quirks_v2(device_mock):
     assert str(quirked.quirk_metadata.quirk_file).endswith(
         "zigpy/tests/test_quirks_v2.py"
     )
-    assert quirked.quirk_metadata.quirk_file_line == 106
+
+    # To avoid having to rewrite this test every time quirks change, we read the current
+    # file to find the line number
+    quirk_builder_line = next(
+        index
+        for index, line in enumerate(pathlib.Path(__file__).read_text().splitlines())
+        if "# Quirk builder creation line" in line
+    )
+    assert quirked.quirk_metadata.quirk_file_line == quirk_builder_line + 2
 
     ep = quirked.endpoints[1]
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -1081,16 +1081,6 @@ class QuirkBuilder:
         function: Callable[[Any, Any], bool] | None = None,
     ) -> QuirkBuilder:
         """Do not create default entities."""
-
-        if (function is not None) ^ (
-            endpoint_id is not None
-            or cluster_id is not None
-            or unique_id_suffix is not None
-        ):
-            raise ValueError(
-                "function is mutually exclusive with the other filter kwargs"
-            )
-
         self.disabled_default_entities.append(
             PreventDefaultEntityCreationMetadata(
                 endpoint_id=endpoint_id,

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -445,7 +445,7 @@ class PreventDefaultEntityCreationMetadata:
     endpoint_id: int | None = attrs.field()
     cluster_id: int | None = attrs.field()
     unique_id_suffix: str | None = attrs.field()
-    function: Callable[[Any, Any], bool] | None = attrs.field()
+    function: Callable[Any, bool] | None = attrs.field()
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -1078,7 +1078,7 @@ class QuirkBuilder:
         endpoint_id: int | None = None,
         cluster_id: int | None = None,
         unique_id_suffix: str | None = None,
-        function: Callable[[Any, Any], bool] | None = None,
+        function: Callable[Any, bool] | None = None,
     ) -> QuirkBuilder:
         """Do not create default entities."""
         self.disabled_default_entities.append(

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -11,7 +11,7 @@ import logging
 import pathlib
 from types import FrameType
 import typing
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import attrs
 from frozendict import deepfreeze, frozendict
@@ -445,6 +445,7 @@ class PreventDefaultEntityCreationMetadata:
     endpoint_id: int | None = attrs.field()
     cluster_id: int | None = attrs.field()
     unique_id_suffix: str | None = attrs.field()
+    function: Callable[[Any, Any], bool] | None = attrs.field()
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -1077,13 +1078,25 @@ class QuirkBuilder:
         endpoint_id: int | None = None,
         cluster_id: int | None = None,
         unique_id_suffix: str | None = None,
+        function: Callable[[Any, Any], bool] | None = None,
     ) -> QuirkBuilder:
         """Do not create default entities."""
+
+        if (function is not None) ^ (
+            endpoint_id is not None
+            or cluster_id is not None
+            or unique_id_suffix is not None
+        ):
+            raise ValueError(
+                "function is mutually exclusive with the other filter kwargs"
+            )
+
         self.disabled_default_entities.append(
             PreventDefaultEntityCreationMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
                 unique_id_suffix=unique_id_suffix,
+                function=function,
             ),
         )
         return self


### PR DESCRIPTION
This somewhat violates the isolation between quirks v2 and ZHA by allowing quirks to opt out of default entity creation via a callable accepting a ZHA `Entity` object.

Here is a working quirk that cleans up a real device ([with a small change to ZHA](https://github.com/puddly/zha/compare/puddly/explicit-entity-registry...puddly:zha:puddly/ignore-entity-creation)):

```python
from zigpy.quirks.v2 import QuirkBuilder
from zigpy.zcl.clusters.general import BinaryInput

(
    QuirkBuilder("frient A/S", "MOSZB-153")
    # An endpoint with an OnOff server cluster is present on every frient device, causing an
    # erroneous switch entity to be created
    .prevent_default_entity_creation(
        function=lambda entity: entity.endpoint.zigpy_endpoint.profile_id == 0xC0C9
    )
    # This entity does not do anything
    .prevent_default_entity_creation(endpoint_id=35, cluster_id=BinaryInput.cluster_id)
    # These endpoints are duplicates of 35 and do not create useful entities
    .prevent_default_entity_creation(endpoint_id=40)
    .prevent_default_entity_creation(endpoint_id=41)
    .add_to_registry()
)
```

Before:
<img width="561" alt="image" src="https://github.com/user-attachments/assets/c4e55cd1-a927-48c6-9be4-a71a753963d5" />

After:
<img width="542" alt="image" src="https://github.com/user-attachments/assets/5223203f-8b84-4f18-a91b-6f7f5613cc3c" />

