### PR TITLE
Make OTA more robust for battery powered devices

### DIFF
--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -19,7 +19,10 @@ if TYPE_CHECKING:
 
 # Devices often ask for bigger blocks than radios can send
 MAXIMUM_IMAGE_BLOCK_SIZE = 40
-MAX_TIME_WITHOUT_PROGRESS = 30
+# Wait up to a day to timeout an upgrade process. This will
+# allow battery powered devices to start fetching the image when 
+# they check in.
+MAX_TIME_WITHOUT_PROGRESS = 86400
 
 
 def find_ota_cluster(device: Device) -> Ota:
@@ -140,6 +143,7 @@ class OTAManager:
             status = foundation.Status.FAILURE
 
         if status != foundation.Status.SUCCESS:
+            # When querying an image fails, stop the upgrade process.
             self._finish(status)
 
     async def _finish_malformed_image_block_response(self, handler: str, tsn: int):
@@ -198,8 +202,9 @@ class OTAManager:
                     command.file_offset + len(block), len(self._image_data)
                 )
         except Exception as ex:  # noqa: BLE001
+            # Do NOT finish the OTA process upon exceptions. The radio may be 
+            # congested and devices may (will?) retry fetching the block.
             self.device.debug("OTA image_block handler exception", exc_info=ex)
-            self._finish(foundation.Status.FAILURE)
 
     async def _image_page_req(
         self, hdr: foundation.ZCLHeader, command: Ota.ImagePageCommand
@@ -254,8 +259,9 @@ class OTAManager:
                         offset - block_size + len(block), len(self._image_data)
                     )
             except Exception as ex:  # noqa: BLE001
+                # Do NOT finish the OTA process upon exceptions. The radio may be 
+                # congested and devices may (will?) retry fetching the page.
                 self.device.debug("OTA image_page handler exception", exc_info=ex)
-                self._finish(foundation.Status.FAILURE)
                 return
 
             # Delay according to what the device asks
@@ -290,8 +296,13 @@ class OTAManager:
                 query_jitter=100,
             )
         except Exception as ex:  # noqa: BLE001
+            # While mains powered devices will respond to this,
+            # battery powered ones will not (unless interacted with or not 
+            # at all, for example RWL021). By not failing, we give battery
+            # powered devices an opportunity to check for new images when
+            # they checkin.
             self.device.debug("OTA image_notify handler exception", exc_info=ex)
-            self._finish(foundation.Status.FAILURE)
+            
         else:
             self._stall_timer.reschedule(MAX_TIME_WITHOUT_PROGRESS)
 


### PR DESCRIPTION
Two issues are addressed:

(1) On congested networks, the upgrade process may fail because the radio fails delivery of a message (page or block request, of which there are potentially thousands for a new image). Instead of stopping the upgrade process right away, we let it run to allow the devices to retry fetching the page or block.  

(2) There are battery powered devices that need to be interacted with in a short time window to kick off the upgrade process. Not all battery powered devices do this (famous RWL021 at least in my network), but instead query for new images themselves. By not failing the initial notification AND by extending the timeout for the OTA, we give these devices an opportunity to query for this upgrade when they check in. At least for RWL021, this approach has worked for me.

When used in HA, this appears to improve how OTA can be done for battery powered devices. E.g. this one is a RWL021 that refused to upgrade. With the change, it started fetching a new image when it checked in (hours after I started the upgrade in HA).

![image](https://github.com/user-attachments/assets/97a95159-a6fb-446f-9cab-20d9de685bee)

While the upgrade did not finish due to an issue on the radio, I see that it at least will retry fetching the block for three times (this is with modified logging so I can observe what is happening for this device):

2025-02-12 09:44:10.967 INFO (MainThread) [zigpy.device] [0x2722] OTA upgrade progress: (78296 / 240760): 32.5204%
2025-02-12 09:44:11.585 INFO (MainThread) [zigpy.device] [0x2722] OTA upgrade progress: (78336 / 240760): 32.5370%
2025-02-12 09:44:26.158 INFO (MainThread) [zigpy.device] [0x2722] OTA image_block handler exception
zigpy.exceptions.DeliveryError: Failed to deliver message: <sl_Status.ZIGBEE_DELIVERY_FAILED: 3074>
2025-02-12 09:44:31.303 INFO (MainThread) [zigpy.device] [0x2722] OTA image_block handler exception
zigpy.exceptions.DeliveryError: Failed to deliver message: <sl_Status.ZIGBEE_DELIVERY_FAILED: 3074>
2025-02-12 09:44:41.091 INFO (MainThread) [zigpy.device] [0x2722] OTA image_block handler exception
zigpy.exceptions.DeliveryError: Failed to deliver message: <sl_Status.ZIGBEE_DELIVERY_FAILED: 3074>
2025-02-12 09:44:51.092 INFO (MainThread) [zigpy.device] [0x2722] OTA image_block handler exception

It then stopped requesting new blocks. It remains to be seen whether it will resume downloading the image from where it left it or if it will restart the transfer. Either way, the chances of an successful upgrade are greatly increased, I have succesfully upgraded two IKEA tradfri switches using these modifications that refused to complete the uprade process previously.