### PR TITLE
Use `StrEnum` instead of `Enum` for UnitOfConductivity

### DIFF
--- a/zigpy/quirks/v2/homeassistant/__init__.py
+++ b/zigpy/quirks/v2/homeassistant/__init__.py
@@ -197,7 +197,7 @@ class UnitOfMass(StrEnum):
 
 
 # Conductivity units
-class UnitOfConductivity(Enum):
+class UnitOfConductivity(StrEnum):
     """Conductivity units."""
 
     SIEMENS_PER_CM = "S/cm"


### PR DESCRIPTION
Fixes CI, https://github.com/zigpy/zigpy/pull/1543 wasn't up-to-date.