### PR TITLE
Make OTA more robust V2

### DIFF
--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -621,6 +621,7 @@ async def test_ota_manager_image_page_invalid_size():
     assert result == foundation.Status.MALFORMED_COMMAND
 
 
+@patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
 async def test_ota_manager_image_page_failure():
     """Test that the OTA manager fails properly with invalid image page requests."""
 
@@ -696,4 +697,4 @@ async def test_ota_manager_image_page_failure():
     progress_callback = MagicMock()
     result = await update_firmware(dev, FW_IMAGE, progress_callback)
 
-    assert result == foundation.Status.FAILURE
+    assert result != foundation.Status.SUCCESS

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -487,6 +487,7 @@ async def test_update_device_firmware_already_in_progress(dev, caplog):
     assert "OTA already in progress" in caplog.text
 
 
+@patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
 @patch("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0.01)
 @patch(
     "zigpy.device.OTA_RETRY_DECORATOR",
@@ -761,7 +762,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     assert dev.application.send_packet.await_count == 0
     assert progress_callback.call_count == 0
     assert "OTA image_notify handler exception" in caplog.text
-    assert result == foundation.Status.FAILURE
+    assert result != foundation.Status.SUCCESS
     cluster.image_notify = image_notify
     caplog.clear()
 
@@ -776,7 +777,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     assert dev.application.send_packet.await_count == 1  # just image notify
     assert progress_callback.call_count == 0
     assert "OTA query_next_image handler exception" in caplog.text
-    assert result == foundation.Status.FAILURE
+    assert result != foundation.Status.SUCCESS
     cluster.query_next_image_response = query_next_image_response
     caplog.clear()
 
@@ -793,7 +794,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     )  # just image notify + query next image
     assert progress_callback.call_count == 0
     assert "OTA image_block handler exception" in caplog.text
-    assert result == foundation.Status.FAILURE
+    assert result != foundation.Status.SUCCESS
     cluster.image_block_response = image_block_response
     caplog.clear()
 
@@ -810,7 +811,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     )  # just image notify, qne, and 2 img blocks
     assert progress_callback.call_count == 2
     assert "OTA upgrade_end handler exception" in caplog.text
-    assert result == foundation.Status.FAILURE
+    assert result != foundation.Status.SUCCESS
     cluster.upgrade_end_response = upgrade_end_response
     caplog.clear()
 
@@ -866,6 +867,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     cluster.image_block_response = image_block_response
 
 
+@patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
 @patch("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0.01)
 @patch(
     "zigpy.device.OTA_RETRY_DECORATOR",
@@ -1140,7 +1142,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     assert dev.application.send_packet.await_count == 0
     assert progress_callback.call_count == 0
     assert "OTA image_notify handler exception" in caplog.text
-    assert result == foundation.Status.FAILURE
+    assert result != foundation.Status.SUCCESS
     cluster.image_notify = image_notify
     caplog.clear()
 
@@ -1155,7 +1157,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     assert dev.application.send_packet.await_count == 1  # just image notify
     assert progress_callback.call_count == 0
     assert "OTA query_next_image handler exception" in caplog.text
-    assert result == foundation.Status.FAILURE
+    assert result != foundation.Status.SUCCESS
     cluster.query_next_image_response = query_next_image_response
     caplog.clear()
 
@@ -1172,7 +1174,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     )  # just image notify + query next image
     assert progress_callback.call_count == 0
     assert "OTA image_block handler exception" in caplog.text
-    assert result == foundation.Status.FAILURE
+    assert result != foundation.Status.SUCCESS
     cluster.image_block_response = image_block_response
     caplog.clear()
 
@@ -1189,7 +1191,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     )  # just image notify, qne, and 2 img blocks
     assert progress_callback.call_count == 2
     assert "OTA upgrade_end handler exception" in caplog.text
-    assert result == foundation.Status.FAILURE
+    assert result != foundation.Status.SUCCESS
     cluster.upgrade_end_response = upgrade_end_response
     caplog.clear()
 

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -199,7 +199,6 @@ class OTAManager:
                 )
         except Exception as ex:  # noqa: BLE001
             self.device.debug("OTA image_block handler exception", exc_info=ex)
-            self._finish(foundation.Status.FAILURE)
 
     async def _image_page_req(
         self, hdr: foundation.ZCLHeader, command: Ota.ImagePageCommand
@@ -255,7 +254,6 @@ class OTAManager:
                     )
             except Exception as ex:  # noqa: BLE001
                 self.device.debug("OTA image_page handler exception", exc_info=ex)
-                self._finish(foundation.Status.FAILURE)
                 return
 
             # Delay according to what the device asks


### PR DESCRIPTION
This PR only changes the image transfer to not stop the upgrade process when a page or block transfer fails with an error on the stack.

The devices I have tested with re-request blocks if they are not received on the device after some time.

see #1552 for a more detailed discussion, this PR contains just a subset of the changes suggested there.