### PR TITLE
Read hardwareVersionMin from Z2M catalog

### DIFF
--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -572,6 +572,8 @@ class BaseZ2MProvider(BaseOtaProvider):
                 "model_names": tuple([fw["modelId"]] if "modelId" in fw else []),
                 "min_current_file_version": fw.get("minFileVersion"),
                 "max_current_file_version": fw.get("maxFileVersion"),
+                "min_hardware_version": fw.get("hardwareVersionMin"),
+                "max_hardware_version": fw.get("hardwareVersionMax"),
                 "source": "",  # Set in a subclass
             }
 


### PR DESCRIPTION
It appears the root cause for conflicting images from #1566 is that hardware constraints are not taken into account for the Z2M catalog.