### PR TITLE
Open serial ports exclusively by default

### DIFF
--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -81,7 +81,7 @@ async def create_serial_connection(
     url: pathlib.Path | str,
     *,
     baudrate: int = 115200,  # We default to 115200 instead of 9600
-    exclusive: bool | None = None,
+    exclusive: bool | None = True,
     xonxoff: bool | UndefinedType = UNDEFINED,
     rtscts: bool | UndefinedType = UNDEFINED,
     flow_control: Literal["hardware", "software", None] | UndefinedType = UNDEFINED,


### PR DESCRIPTION
The issue that caused us to revert in the past (https://github.com/zigpy/zigpy/pull/1422) is now fixed so I think this is safe to merge.