### PR TITLE
Fix OTA file checksum validation error message formatting. 

### DIFF
--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -76,8 +76,8 @@ class BaseOtaImageMetadata(t.BaseDataclassMixin):
 
             if hasher.hexdigest() != checksum:
                 raise ValueError(
-                    f"Image checksum is invalid: expected {checksum},"
-                    f" got {hasher.hexdigest()}"
+                    f"Image checksum is invalid: expected {hasher.hexdigest()},"
+                    f" got {checksum}"
                 )
 
     async def fetch(self) -> BaseOTAImage:


### PR DESCRIPTION
When the OTA image has an incorrect checksum, an exception is raised: *Image checksum is invalid: expected AAAAAAA, got BBBBBBBBB*.  

The expected value comes from the JSON file, but it should be the computed value instead.  

This patch swaps the A and B values in the error message.