### PR TITLE
Provide better error messages when the serial port is in use

### DIFF
--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import fcntl
 import pathlib
 from unittest.mock import AsyncMock, Mock, call, patch
 
@@ -126,6 +127,19 @@ async def test_pyserial_error_remapping(tmp_path: pathlib.Path) -> None:
         await zigpy.serial.create_serial_connection(
             loop, protocol_factory, url=a_folder
         )
+
+    # Locked
+    locked_port = tmp_path / "locked"
+    with locked_port.open("w") as f:
+        # Lock the file
+        fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        with pytest.raises(
+            PermissionError, match="The serial port is locked by another application"
+        ):
+            await zigpy.serial.create_serial_connection(
+                loop, protocol_factory, url=locked_port
+            )
 
 
 async def test_serial_protocol() -> None:

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -121,21 +121,27 @@ async def create_serial_connection(
             )
     else:
         try:
-            transport, protocol = await pyserial_asyncio.create_serial_connection(
-                loop,
-                protocol_factory,
-                url=url,
-                baudrate=baudrate,
-                exclusive=exclusive,
-                xonxoff=xonxoff,
-                rtscts=rtscts,
-                **kwargs,
-            )
-        except pyserial.SerialException as exc:
-            # Unwrap unnecessarily wrapped PySerial exceptions
-            if exc.__context__ is not None:
-                raise exc.__context__ from None
+            try:
+                transport, protocol = await pyserial_asyncio.create_serial_connection(
+                    loop,
+                    protocol_factory,
+                    url=url,
+                    baudrate=baudrate,
+                    exclusive=exclusive,
+                    xonxoff=xonxoff,
+                    rtscts=rtscts,
+                    **kwargs,
+                )
+            except pyserial.SerialException as exc:
+                # Unwrap unnecessarily wrapped PySerial exceptions
+                if exc.__context__ is not None:
+                    raise exc.__context__ from None
 
-            raise
+                raise
+        except BlockingIOError as exc:
+            # Re-raise a more useful exception
+            raise PermissionError(
+                "The serial port is locked by another application"
+            ) from exc
 
     return transport, protocol


### PR DESCRIPTION
Before:

```python
Traceback (most recent call last):
  File "~/Projects/zigpy-cli/.venv/bin/zigpy", line 10, in <module>
    sys.exit(cli())
             ~~~^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/decorators.py", line 45, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "~/Projects/zigpy-cli/zigpy_cli/cli.py", line 20, in inner
    return loop.run_until_complete(cmd(*args, **kwargs))
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "~/Library/Application Support/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/asyncio/base_events.py", line 720, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "~/Projects/zigpy-cli/zigpy_cli/radio.py", line 281, in packet_capture
    await app.connect()
  File "~/Projects/bellows/bellows/zigbee/application.py", line 154, in connect
    await self._ezsp.connect(use_thread=self.config[CONF_USE_THREAD])
  File "~/Projects/bellows/bellows/ezsp/__init__.py", line 134, in connect
    self._gw = await bellows.uart.connect(self._config, self, use_thread=use_thread)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/Projects/bellows/bellows/uart.py", line 154, in connect
    protocol, _ = await _connect(config, api)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/Projects/bellows/bellows/uart.py", line 125, in _connect
    transport, _ = await zigpy.serial.create_serial_connection(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "~/Projects/zigpy/zigpy/serial.py", line 137, in create_serial_connection
    raise exc.__context__ from None
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/serial/serialposix.py", line 385, in _reconfigure_port
    fcntl.flock(self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
BlockingIOError: [Errno 35] Resource temporarily unavailable
```

After:

```python
Traceback (most recent call last):
  File "~/Projects/zigpy/zigpy/serial.py", line 138, in create_serial_connection
    raise exc.__context__ from None
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/serial/serialposix.py", line 385, in _reconfigure_port
    fcntl.flock(self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
BlockingIOError: [Errno 35] Resource temporarily unavailable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "~/Projects/zigpy-cli/.venv/bin/zigpy", line 10, in <module>
    sys.exit(cli())
             ~~~^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "~/Projects/zigpy-cli/.venv/lib/python3.13/site-packages/click/decorators.py", line 45, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "~/Projects/zigpy-cli/zigpy_cli/cli.py", line 20, in inner
    return loop.run_until_complete(cmd(*args, **kwargs))
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "~/Library/Application Support/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/asyncio/base_events.py", line 720, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "~/Projects/zigpy-cli/zigpy_cli/radio.py", line 281, in packet_capture
    await app.connect()
  File "~/Projects/bellows/bellows/zigbee/application.py", line 154, in connect
    await self._ezsp.connect(use_thread=self.config[CONF_USE_THREAD])
  File "~/Projects/bellows/bellows/ezsp/__init__.py", line 134, in connect
    self._gw = await bellows.uart.connect(self._config, self, use_thread=use_thread)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/Projects/bellows/bellows/uart.py", line 154, in connect
    protocol, _ = await _connect(config, api)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/Projects/bellows/bellows/uart.py", line 125, in _connect
    transport, _ = await zigpy.serial.create_serial_connection(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "~/Projects/zigpy/zigpy/serial.py", line 143, in create_serial_connection
    raise PermissionError(
        "The serial port is locked by another application"
    ) from exc
PermissionError: The serial port is locked by another application
```