### PR TITLE
Allow testing basic data types for `undefined`

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -830,3 +830,29 @@ def test_serializable_bytes():
 
     with pytest.raises(ValueError):
         t.SerializableBytes([1, 2, 3])
+
+
+def test_is_undefined():
+    # uint8
+    assert t.uint8_t(0xFF).is_undefined() is True
+    assert t.uint8_t(0xFF - 1).is_undefined() is False
+
+    # uint16
+    assert t.uint16_t(0xFFFF).is_undefined() is True
+    assert t.uint16_t(0xFFFF - 1).is_undefined() is False
+
+    # int8
+    assert t.int8s(-128).is_undefined() is True
+    assert t.int8s(-128 + 1).is_undefined() is False
+
+    # int16
+    assert t.int16s(-32768).is_undefined() is True
+    assert t.int16s(-32768 + 1).is_undefined() is False
+
+    # float
+    assert t.Half(float("nan")).is_undefined() is True
+    assert t.Half(0).is_undefined() is False
+    assert t.Single(float("nan")).is_undefined() is True
+    assert t.Single(0).is_undefined() is False
+    assert t.Double(float("nan")).is_undefined() is True
+    assert t.Double(0).is_undefined() is False

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import enum
 import inspect
+import math
 import struct
 import sys
 import typing
@@ -202,13 +203,18 @@ class FixedIntType(int):
         data = data[byte_size:]
         return r, data
 
+    def is_undefined(self) -> bool:
+        raise NotImplementedError
+
 
 class uint_t(FixedIntType, signed=False):
-    pass
+    def is_undefined(self) -> bool:
+        return self == (1 << self._bits) - 1
 
 
 class int_t(FixedIntType, signed=True):
-    pass
+    def is_undefined(self) -> bool:
+        return self == -(1 << (self._bits - 1))
 
 
 class int8s(int_t, bits=8):
@@ -701,6 +707,9 @@ class BaseFloat(float):
         ).to_bytes(Double._size, "little")
 
         return cls(struct.unpack("<d", double_bytes)[0]), data[cls._size :]
+
+    def is_undefined(self) -> bool:
+        return math.isnan(self)
 
 
 class Half(BaseFloat, exponent_bits=5, fraction_bits=10):


### PR DESCRIPTION
Currently only implemented for the numeric types. Character arrays, strings, and lists all implement this as well by setting the length to the undefined value for the length type, but these are not something I've seen in use. These currently are.

<img width="578" alt="image" src="https://github.com/user-attachments/assets/19ad0949-2079-464a-9610-a4f0fd17505a" />

<img width="584" alt="image" src="https://github.com/user-attachments/assets/b9b1a098-0da9-4a14-a407-53d5011b8c1a" />
