### PR TITLE
Add `cluster_type` to `prevent_default_entity_creation`

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1196,6 +1196,9 @@ async def test_quirks_v2_disable_entity_creation(device_mock: Device) -> None:
         QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .prevent_default_entity_creation(endpoint_id=1, unique_id_suffix="something")
         .prevent_default_entity_creation(endpoint_id=1, cluster_id=OnOff.cluster_id)
+        .prevent_default_entity_creation(
+            endpoint_id=1, cluster_id=OnOff.cluster_id, cluster_type=ClusterType.Client
+        )
         .prevent_default_entity_creation(function=filter_func)
         .add_to_registry()
     )
@@ -1204,18 +1207,28 @@ async def test_quirks_v2_disable_entity_creation(device_mock: Device) -> None:
         PreventDefaultEntityCreationMetadata(
             endpoint_id=1,
             cluster_id=None,
+            cluster_type=None,
             unique_id_suffix="something",
             function=None,
         ),
         PreventDefaultEntityCreationMetadata(
             endpoint_id=1,
             cluster_id=OnOff.cluster_id,
+            cluster_type=ClusterType.Server,  # by default
+            unique_id_suffix=None,
+            function=None,
+        ),
+        PreventDefaultEntityCreationMetadata(
+            endpoint_id=1,
+            cluster_id=OnOff.cluster_id,
+            cluster_type=ClusterType.Client,
             unique_id_suffix=None,
             function=None,
         ),
         PreventDefaultEntityCreationMetadata(
             endpoint_id=None,
             cluster_id=None,
+            cluster_type=None,
             unique_id_suffix=None,
             function=filter_func,
         ),

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -445,6 +445,7 @@ class PreventDefaultEntityCreationMetadata:
 
     endpoint_id: int | None = attrs.field()
     cluster_id: int | None = attrs.field()
+    cluster_type: ClusterType | None = attrs.field()
     unique_id_suffix: str | None = attrs.field()
     function: Callable[Any, bool] | None = attrs.field()
 
@@ -1102,14 +1103,19 @@ class QuirkBuilder:
         *,
         endpoint_id: int | None = None,
         cluster_id: int | None = None,
+        cluster_type: ClusterType | None = None,
         unique_id_suffix: str | None = None,
         function: Callable[Any, bool] | None = None,
     ) -> QuirkBuilder:
         """Do not create default entities."""
+        if cluster_id is not None and cluster_type is None:
+            cluster_type = ClusterType.Server
+
         self.disabled_default_entities.append(
             PreventDefaultEntityCreationMetadata(
                 endpoint_id=endpoint_id,
                 cluster_id=cluster_id,
+                cluster_type=cluster_type,
                 unique_id_suffix=unique_id_suffix,
                 function=function,
             ),


### PR DESCRIPTION
This allows client cluster entities to be excluded from ZHA. Requires a small ZHA patch:

```diff
diff --git a/zha/zigbee/device.py b/zha/zigbee/device.py
index 4e3da83..317ea46 100644
--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -793,7 +793,11 @@ class Device(LogMixin, EventBase):
 
             if meta.cluster_id is not None and not any(
                 cluster_handler.cluster.cluster_id == meta.cluster_id
-                for cluster_handler in entity.cluster_handlers.values()
+                for cluster_handler in (
+                    entity.cluster_handlers
+                    if meta.cluster_type == ClusterType.Server
+                    else entity.client_cluster_handlers
+                ).values()
             ):
                 continue
```