### PR TITLE
Force route discovery on retries

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -870,7 +870,19 @@ async def test_request_retrying_success(app, device, packet) -> None:
         extended_timeout=False,
     )
 
-    assert app.send_packet.mock_calls == [call(packet), call(packet), call(packet)]
+    assert app.send_packet.mock_calls == [
+        call(packet),
+        call(
+            packet.replace(
+                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+            )
+        ),
+        call(
+            packet.replace(
+                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+            )
+        ),
+    ]
 
 
 async def test_request_retrying_failure(app, device, packet) -> None:
@@ -894,7 +906,19 @@ async def test_request_retrying_failure(app, device, packet) -> None:
             extended_timeout=False,
         )
 
-    assert app.send_packet.mock_calls == [call(packet), call(packet), call(packet)]
+    assert app.send_packet.mock_calls == [
+        call(packet),
+        call(
+            packet.replace(
+                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+            )
+        ),
+        call(
+            packet.replace(
+                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+            )
+        ),
+    ]
 
 
 def test_build_source_route_has_relays(app):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -837,6 +837,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         max_attempts = self._config[conf.CONF_NWK_MAX_RETRIES] + 1
 
         for attempt in range(max_attempts):
+            if attempt > 0:
+                tx_options |= t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+
             try:
                 await self.send_packet(
                     t.ZigbeePacket(

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -566,6 +566,7 @@ class TransmitOptions(enum.Flag):
 
     ACK = 1
     APS_Encryption = 2
+    FORCE_ROUTE_DISCOVERY = 3
 
 
 class PacketPriority(enum.IntEnum):


### PR DESCRIPTION
For radios where we selectively disable firmware retrying (EmberZNet), this forces route discovery on the second packet send attempt. Route discovery for EmberZNet "consumes" one of the three retries so this effectively restores the old behavior of three firmware retries but splits it into two attempts.