### PR TITLE
Reverse the field order of the `ApplicationType` int struct

### DIFF
--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -655,7 +655,7 @@ def test_ota_image_block_field_control():
 def test_general_analog_in_application_type():
     """Test AnalogInput General Cluster, Application Type Attribute."""
     app_type = zcl.clusters.general_const.ApplicationType(
-        0x00070100
+        0x00_01_0007
     )  # Group 0x00, Type 0x01, Application 0x0007
 
     assert app_type.group == 0x00

--- a/zigpy/zcl/clusters/general_const.py
+++ b/zigpy/zcl/clusters/general_const.py
@@ -263,6 +263,9 @@ ANALOG_INPUT_TYPES = {
 
 
 class ApplicationType(t.Struct, t.uint32_t):
-    group: t.uint8_t
-    type: AnalogInputType
+    # Index = Bits 0 to 15
     index: t.uint16_t
+    # Type = Bits 16 to 23
+    type: AnalogInputType
+    # Group = Bits 24 to 31
+    group: t.uint8_t


### PR DESCRIPTION
I believe our field order may be backwards. From the spec, the `index` should be the lowest-order 16 bits:

<img width="867" alt="image" src="https://github.com/user-attachments/assets/56600911-b7f5-494f-954b-34ec0e00f03b" />
