### PR TITLE
Fix Struct bitwise operations for int subclasses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,7 @@ combine-as-imports = true
 split-on-trailing-comma = false
 
 [tool.codespell]
-ignore-words-list = ["ser", "nd", "hass", "checkin", "socio-economic"]
+ignore-words-list = ["ser", "nd", "hass", "checkin", "socio-economic", "IntStruct"]
 skip = ["./.*", "tests/*", "pyproject.toml"]
 quiet-level = 2
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -888,6 +888,8 @@ def test_int_comparison(expose_global):
     assert (fw_ver | 0b0010101) == (int(fw_ver) | 0b0010101)
     assert (fw_ver >> 3) == (int(fw_ver) >> 3)
     assert (fw_ver << 3) == (int(fw_ver) << 3)
+    assert bool(fw_ver & 0) is False
+    assert bool(fw_ver & 0xFFFF) is True
 
 
 def test_int_comparison_non_int(expose_global):

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -746,6 +746,10 @@ def test_int_struct():
     assert isinstance(IntegralStruct(1909247146), int)
     assert IntegralStruct(1909247146) == IntegralStruct(IntegralStruct(1909247146))
 
+    # We do not accept anything but kwargs
+    with pytest.raises(ValueError):
+        assert IntegralStruct(1909247146, bar=0, baz=0, asd=0)
+
 
 def test_struct_optional():
     class TestStruct(t.Struct):

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -692,6 +692,18 @@ def test_int_struct():
     with pytest.raises(TypeError):
         int(NonIntegralStruct(123))
 
+    # Integer structs must inherit from IntStruct
+    with pytest.raises(TypeError):
+
+        class BadIntegralStruct(t.Struct, t.uint8_t):
+            foo: t.uint8_t
+
+    # Integer structs must inherit from an integer type
+    with pytest.raises(TypeError):
+
+        class BadIntegralStruct2(t.IntStruct):
+            foo: t.uint8_t
+
     class IntegralStruct(t.IntStruct, t.uint32_t):
         foo: t.uint8_t
         bar: t.uint16_t
@@ -732,6 +744,7 @@ def test_int_struct():
 
     assert isinstance(IntegralStruct(1909247146), t.uint32_t)
     assert isinstance(IntegralStruct(1909247146), int)
+    assert IntegralStruct(1909247146) == IntegralStruct(IntegralStruct(1909247146))
 
 
 def test_struct_optional():

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -884,6 +884,11 @@ def test_int_comparison(expose_global):
     assert int(fw_ver) + 1 > fw_ver
     assert fw_ver > int(fw_ver) - 1
 
+    assert (fw_ver & 0b0010101) == (int(fw_ver) & 0b0010101)
+    assert (fw_ver | 0b0010101) == (int(fw_ver) | 0b0010101)
+    assert (fw_ver >> 3) == (int(fw_ver) >> 3)
+    assert (fw_ver << 3) == (int(fw_ver) << 3)
+
 
 def test_int_comparison_non_int(expose_global):
     @expose_global

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -750,6 +750,10 @@ def test_int_struct():
     with pytest.raises(TypeError):
         assert IntegralStruct(1909247146, bar=0, baz=0, asd=0)
 
+    # Or multiple positional arguments
+    with pytest.raises(TypeError):
+        assert IntegralStruct(1909247146, 0)
+
 
 def test_struct_optional():
     class TestStruct(t.Struct):

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -432,22 +432,6 @@ def test_conflicting_types():
             foo: t.uint8_t = t.StructField(type=t.uint16_t)
 
 
-def test_requires_uses_instance_of_struct():
-    class TestStruct(t.Struct):
-        foo: t.uint8_t
-
-        # the first parameter is really an instance of TestStruct
-        bar: t.uint8_t = t.StructField(requires=lambda s: s.test)
-
-        @property
-        def test(self):
-            assert isinstance(self, TestStruct)
-            return self.foo == 0x01
-
-    assert TestStruct.deserialize(b"\x00\x00") == (TestStruct(foo=0x00), b"\x00")
-    assert TestStruct.deserialize(b"\x01\x00") == (TestStruct(foo=0x01, bar=0x00), b"")
-
-
 def test_uppercase_field():
     class Neighbor(t.Struct):
         """Neighbor Descriptor"""
@@ -829,26 +813,6 @@ def test_matching(expose_global):
     assert s.matches(TestStruct(bar=InnerStruct()))
     assert s.matches(TestStruct(bar=InnerStruct(field1=2, field2="asd")))
     assert not s.matches(TestStruct(bar=InnerStruct(field1=3)))
-
-
-def test_dynamic_type():
-    class TestStruct(t.Struct):
-        foo: t.uint8_t
-        baz: None = t.StructField(
-            dynamic_type=lambda s: t.LVBytes if s.foo == 0x00 else t.uint8_t
-        )
-
-    assert TestStruct.deserialize(b"\x00\x04test") == (
-        TestStruct(foo=0x00, baz=b"test"),
-        b"",
-    )
-    assert TestStruct.deserialize(b"\x01\x04test") == (
-        TestStruct(foo=0x01, baz=0x04),
-        b"test",
-    )
-
-    assert TestStruct(foo=0x00, baz=b"test").serialize() == b"\x00\x04test"
-    assert TestStruct(foo=0x01, baz=0x04).serialize() == b"\x01\x04"
 
 
 def test_int_comparison(expose_global):

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -708,7 +708,7 @@ def test_int_struct():
     with pytest.raises(TypeError):
         int(NonIntegralStruct(123))
 
-    class IntegralStruct(t.Struct, t.uint32_t):
+    class IntegralStruct(t.IntStruct, t.uint32_t):
         foo: t.uint8_t
         bar: t.uint16_t
         baz: t.uint7_t
@@ -858,7 +858,7 @@ def test_int_comparison(expose_global):
         Conbee_II = 0x07
         Conbee_III = 0x09
 
-    class FirmwareVersion(t.Struct, t.uint32_t):
+    class FirmwareVersion(t.IntStruct, t.uint32_t):
         reserved: t.uint8_t
         platform: FirmwarePlatform
         minor: t.uint8_t
@@ -890,6 +890,7 @@ def test_int_comparison(expose_global):
     assert (fw_ver << 3) == (int(fw_ver) << 3)
     assert bool(fw_ver & 0) is False
     assert bool(fw_ver & 0xFFFF) is True
+    assert hash(fw_ver) == hash(int(fw_ver))
 
 
 def test_int_comparison_non_int(expose_global):

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -746,8 +746,8 @@ def test_int_struct():
     assert issubclass(IntegralStruct, t.uint32_t)
     assert issubclass(IntegralStruct, int)
 
-    assert isinstance(IntegralStruct(), t.uint32_t)
-    assert isinstance(IntegralStruct(), int)
+    assert isinstance(IntegralStruct(1909247146), t.uint32_t)
+    assert isinstance(IntegralStruct(1909247146), int)
 
 
 def test_struct_optional():

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -747,7 +747,7 @@ def test_int_struct():
     assert IntegralStruct(1909247146) == IntegralStruct(IntegralStruct(1909247146))
 
     # We do not accept anything but kwargs
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         assert IntegralStruct(1909247146, bar=0, baz=0, asd=0)
 
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -806,7 +806,7 @@ async def test_handle_cluster_general_request_disable_default_rsp(endpoint):
         assert general_cmd_mock.call_count == 0
 
     with p1 as attr_lst_mock, p2 as general_cmd_mock:
-        hdr.frame_control.disable_default_response = False
+        hdr.frame_control = hdr.frame_control.replace(disable_default_response=False)
         cluster.handle_cluster_general_request(hdr, values)
         await asyncio.sleep(0)
         assert attr_lst_mock.call_count > 0

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -604,12 +604,12 @@ async def test_ias_zone(send_rsp_mock):
 
     # suppress default response
     hdr, args = t.deserialize(b"\tK\x00&\x00\x00\x00\x00\x00")
-    hdr.frame_control.disable_default_response = True
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
     t.handle_message(hdr, args)
     assert send_rsp_mock.call_count == 0
 
     # this should generate a default response
-    hdr.frame_control.disable_default_response = False
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=False)
     t.handle_message(hdr, args)
     assert send_rsp_mock.call_count == 0
 
@@ -617,12 +617,12 @@ async def test_ias_zone(send_rsp_mock):
 
     # suppress default response
     hdr, args = t.deserialize(b"\tK\x00&\x00\x00\x00\x00\x00")
-    hdr.frame_control.disable_default_response = True
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
     t.handle_message(hdr, args)
     assert send_rsp_mock.call_count == 0
 
     # this should generate a default response
-    hdr.frame_control.disable_default_response = False
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=False)
     t.handle_message(hdr, args)
     assert send_rsp_mock.call_count == 1
 

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -263,9 +263,9 @@ def test_frame_control_general():
 
     assert data == b"\x00"
     assert not frc.is_manufacturer_specific
-    frc.is_manufacturer_specific = False
+    frc = frc.replace(is_manufacturer_specific=False)
     assert frc.serialize() == b"\x00"
-    frc.is_manufacturer_specific = True
+    frc = frc.replace(is_manufacturer_specific=True)
     assert frc.serialize() == b"\x04"
 
     frc = foundation.FrameControl.general(
@@ -273,7 +273,7 @@ def test_frame_control_general():
     )
     assert frc.direction == foundation.Direction.Client_to_Server
     assert frc.serialize() == b"\x00"
-    frc.direction = foundation.Direction.Server_to_Client
+    frc = frc.replace(direction=foundation.Direction.Server_to_Client)
     assert frc.serialize() == b"\x08"
     assert (
         foundation.FrameControl.general(
@@ -287,9 +287,9 @@ def test_frame_control_general():
     )
     assert not frc.disable_default_response
     assert frc.serialize() == b"\x00"
-    frc.disable_default_response = False
+    frc = frc.replace(disable_default_response=False)
     assert frc.serialize() == b"\x00"
-    frc.disable_default_response = True
+    frc = frc.replace(disable_default_response=True)
     assert frc.serialize() == b"\x10"
 
 
@@ -303,9 +303,9 @@ def test_frame_control_cluster():
 
     assert data == b"\x01"
     assert not frc.is_manufacturer_specific
-    frc.is_manufacturer_specific = False
+    frc = frc.replace(is_manufacturer_specific=False)
     assert frc.serialize() == b"\x01"
-    frc.is_manufacturer_specific = True
+    frc = frc.replace(is_manufacturer_specific=True)
     assert frc.serialize() == b"\x05"
 
     frc = foundation.FrameControl.cluster(
@@ -313,9 +313,9 @@ def test_frame_control_cluster():
     )
     assert frc.direction == foundation.Direction.Client_to_Server
     assert frc.serialize() == b"\x01"
-    frc.direction = foundation.Direction.Client_to_Server
+    frc = frc.replace(direction=foundation.Direction.Client_to_Server)
     assert frc.serialize() == b"\x01"
-    frc.direction = foundation.Direction.Server_to_Client
+    frc = frc.replace(direction=foundation.Direction.Server_to_Client)
     assert frc.serialize() == b"\x09"
     assert (
         foundation.FrameControl.cluster(
@@ -329,9 +329,9 @@ def test_frame_control_cluster():
     )
     assert not frc.disable_default_response
     assert frc.serialize() == b"\x01"
-    frc.disable_default_response = False
+    frc = frc.replace(disable_default_response=False)
     assert frc.serialize() == b"\x01"
-    frc.disable_default_response = True
+    frc = frc.replace(disable_default_response=True)
     assert frc.serialize() == b"\x11"
 
 
@@ -350,7 +350,7 @@ def test_frame_header():
     assert hdr.serialize() == data
 
     # check no manufacturer
-    hdr.frame_control.is_manufacturer_specific = False
+    hdr.frame_control = hdr.frame_control.replace(is_manufacturer_specific=False)
     assert hdr.serialize() == b"\x18\xc0\n"
 
     r = repr(hdr)
@@ -366,11 +366,11 @@ def test_frame_header_general():
     assert hdr.command_id == cmd_id
     assert hdr.tsn == tsn
     assert hdr.manufacturer == manufacturer
-    assert hdr.frame_control.is_manufacturer_specific is True
+    assert hdr.frame_control.is_manufacturer_specific
 
     hdr.manufacturer = None
     assert hdr.manufacturer is None
-    assert hdr.frame_control.is_manufacturer_specific is False
+    assert not hdr.frame_control.is_manufacturer_specific
 
 
 def test_frame_header_cluster():
@@ -384,11 +384,11 @@ def test_frame_header_cluster():
     assert hdr.command_id == cmd_id
     assert hdr.tsn == tsn
     assert hdr.manufacturer == manufacturer
-    assert hdr.frame_control.is_manufacturer_specific is True
+    assert hdr.frame_control.is_manufacturer_specific
 
     hdr.manufacturer = None
     assert hdr.manufacturer is None
-    assert hdr.frame_control.is_manufacturer_specific is False
+    assert not hdr.frame_control.is_manufacturer_specific
 
 
 def test_frame_header_disable_manufacturer_id():

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -83,16 +83,20 @@ class OTAImageHeader(t.Struct):
     image_size: t.uint32_t
 
     security_credential_version: t.uint8_t = t.StructField(
-        requires=lambda s: s.security_credential_version_present
+        requires=lambda s: s.field_control is not None
+        and FieldControl.SECURITY_CREDENTIAL_VERSION_PRESENT in s.field_control
     )
     upgrade_file_destination: t.EUI64 = t.StructField(
-        requires=lambda s: s.device_specific_file
+        requires=lambda s: s.field_control is not None
+        and FieldControl.DEVICE_SPECIFIC_FILE_PRESENT in s.field_control
     )
     minimum_hardware_version: HWVersion = t.StructField(
-        requires=lambda s: s.hardware_versions_present
+        requires=lambda s: s.field_control is not None
+        and FieldControl.HARDWARE_VERSIONS_PRESENT in s.field_control
     )
     maximum_hardware_version: HWVersion = t.StructField(
-        requires=lambda s: s.hardware_versions_present
+        requires=lambda s: s.field_control is not None
+        and FieldControl.HARDWARE_VERSIONS_PRESENT in s.field_control
     )
 
     @property

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -469,12 +469,14 @@ class IntStruct(Struct, IntMixin):
         except StopIteration:
             raise TypeError("Integer structs must be an integer subclasses") from None
 
-    def __new__(cls: type[Self], *args, **kwargs) -> Self:
+    def __new__(
+        cls: type[Self], *args, _underlying_int: int | None = None, **kwargs
+    ) -> Self:
         # Integers are immutable in Python so we need to know, at creation time, what
         # the integer value of this object will be. This means that these structs *must*
         # also be immutable.
-        underlying_int = None
         cls = cls._real_cls()  # noqa: PLW0642
+        underlying_int = _underlying_int
 
         # Like a copy constructor
         if len(args) == 1 and isinstance(args[0], int):
@@ -537,3 +539,15 @@ class IntStruct(Struct, IntMixin):
             raise NotImplementedError
 
         return int(self) == int(other)
+
+    @classmethod
+    def deserialize(cls: type[Self], data: bytes) -> tuple[Self, bytes]:
+        fields, remaining = cls._deserialize_internal(cls.fields, data)
+        underlying_int, _ = cls._int_type.deserialize(
+            data[: len(data) - len(remaining)]
+        )
+
+        # We overload deserialization to avoid an unnecessary serialize-deserialize
+        # during `cls.__new__` to compute the underlying integer, since we have all the
+        # data here already
+        return cls(_underlying_int=underlying_int, **fields), remaining

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -81,6 +81,7 @@ class Struct:
         cls._frozen = False
 
     def __new__(cls: type[Self], *args, **kwargs) -> Self:
+        orig_cls = cls
         cls = cls._real_cls()  # noqa: PLW0642
 
         if len(args) == 1 and isinstance(args[0], cls):
@@ -90,9 +91,17 @@ class Struct:
 
             kwargs = args[0].as_dict()
             args = ()
+
+            instance = super().__new__(cls)
         elif len(args) == 1 and cls._int_type is not None and isinstance(args[0], int):
-            # Integer constructor
-            return cls.deserialize(cls._int_type(args[0]).serialize())[0]
+            # The Python `int` constructor needs to be passed the real integer
+            instance = super().__new__(cls, args[0])  # type:ignore[call-arg]
+            data = cls._int_type(args[0]).serialize()
+            cls._deserialize_internal(instance, data)
+
+            return instance
+        else:
+            instance = super().__new__(cls)
 
         # Pretend our signature is `__new__(cls, p1: t1, p2: t2, ...)`
         signature = inspect.Signature(
@@ -110,12 +119,17 @@ class Struct:
         bound = signature.bind(*args, **kwargs)
         bound.apply_defaults()
 
-        instance = super().__new__(cls)
-
         # Set each attributes on the instance
         for name, value in bound.arguments.items():
             field = getattr(cls.fields, name)
             setattr(instance, name, field._convert_type(value, struct=instance))
+
+        if cls._int_type is not None:
+            # For integral types, we really need a reference to the underlying integer!
+            # Jump back to the "single integer" constructor to finish things off.
+            # This is not very efficient.
+            value = cls._int_type.deserialize(instance.serialize())[0]
+            return orig_cls(value)
 
         return instance
 
@@ -269,14 +283,12 @@ class Struct:
 
         return b"".join(chunks)
 
-    @classmethod
-    def deserialize(cls: type[Self], data: bytes) -> tuple[Self, bytes]:
-        instance = cls()
-
+    @staticmethod
+    def _deserialize_internal(instance: Self, data: bytes) -> tuple[Self, bytes]:
         bit_length = 0
         bitfields = []
 
-        for field in cls.fields:
+        for field in instance.fields:
             if (
                 field.requires is not None
                 and not field.requires(instance)
@@ -327,6 +339,13 @@ class Struct:
 
         return instance, data
 
+    @classmethod
+    def deserialize(cls: type[Self], data: bytes) -> tuple[Self, bytes]:
+        instance = cls()
+        instance, data = cls._deserialize_internal(instance, data)
+
+        return instance, data
+
     def replace(self, **kwargs: dict[str, typing.Any]) -> Struct:
         d = self.as_dict().copy()
         d.update(kwargs)
@@ -340,44 +359,11 @@ class Struct:
 
     def __eq__(self, other: object) -> bool:
         if self._int_type is not None and isinstance(other, int):
-            return int(self) == other
+            return int(self) == other  # type:ignore[call-overload]
         elif not isinstance(self, type(other)) and not isinstance(other, type(self)):
             return NotImplemented
 
         return self.as_dict() == other.as_dict()
-
-    def __int__(self) -> int:
-        if self._int_type is None:
-            return NotImplemented
-
-        n, remaining = self._int_type.deserialize(self.serialize())
-        assert not remaining
-
-        return int(n)
-
-    def __lt__(self, other: object) -> bool:
-        if self._int_type is None or not isinstance(other, int):
-            return NotImplemented
-
-        return int(self) < int(other)
-
-    def __le__(self, other: object) -> bool:
-        if self._int_type is None or not isinstance(other, int):
-            return NotImplemented
-
-        return int(self) <= int(other)
-
-    def __gt__(self, other: object) -> bool:
-        if self._int_type is None or not isinstance(other, int):
-            return NotImplemented
-
-        return int(self) > int(other)
-
-    def __ge__(self, other: object) -> bool:
-        if self._int_type is None or not isinstance(other, int):
-            return NotImplemented
-
-        return int(self) >= int(other)
 
     def __repr__(self) -> str:
         fields = []
@@ -403,7 +389,7 @@ class Struct:
         extra_parts = []
 
         if self._int_type is not None:
-            extra_parts.append(f"{self._int_type(int(self))._hex_repr()}")
+            extra_parts.append(f"{self._int_type(int(self))._hex_repr()}")  # type:ignore[call-overload]
 
         if self._frozen:
             extra_parts.append("frozen")

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -69,19 +69,20 @@ class Struct:
         cls.fields = cls._real_cls()._get_fields()
 
         # Check to see if the Struct is also an integer
-        cls._int_type = next(
+        if next(
             (
                 c
                 for c in cls.__mro__[1:]
                 if issubclass(c, t.FixedIntType) and not issubclass(c, Struct)
             ),
             None,
-        )
+        ) is not None and not issubclass(cls, IntStruct):
+            raise TypeError("Integer structs must be subclasses of `IntStruct`")
+
         cls._hash = -1
         cls._frozen = False
 
     def __new__(cls: type[Self], *args, **kwargs) -> Self:
-        orig_cls = cls
         cls = cls._real_cls()  # noqa: PLW0642
 
         if len(args) == 1 and isinstance(args[0], cls):
@@ -91,17 +92,6 @@ class Struct:
 
             kwargs = args[0].as_dict()
             args = ()
-
-            instance = super().__new__(cls)
-        elif len(args) == 1 and cls._int_type is not None and isinstance(args[0], int):
-            # The Python `int` constructor needs to be passed the real integer
-            instance = super().__new__(cls, args[0])  # type:ignore[call-arg]
-            data = cls._int_type(args[0]).serialize()
-            cls._deserialize_internal(instance, data)
-
-            return instance
-        else:
-            instance = super().__new__(cls)
 
         # Pretend our signature is `__new__(cls, p1: t1, p2: t2, ...)`
         signature = inspect.Signature(
@@ -119,17 +109,12 @@ class Struct:
         bound = signature.bind(*args, **kwargs)
         bound.apply_defaults()
 
+        instance = super().__new__(cls)
+
         # Set each attributes on the instance
         for name, value in bound.arguments.items():
             field = getattr(cls.fields, name)
             setattr(instance, name, field._convert_type(value, struct=instance))
-
-        if cls._int_type is not None:
-            # For integral types, we really need a reference to the underlying integer!
-            # Jump back to the "single integer" constructor to finish things off.
-            # This is not very efficient.
-            value = cls._int_type.deserialize(instance.serialize())[0]
-            return orig_cls(value)
 
         return instance
 
@@ -358,9 +343,7 @@ class Struct:
         return instance
 
     def __eq__(self, other: object) -> bool:
-        if self._int_type is not None and isinstance(other, int):
-            return int(self) == other  # type:ignore[call-overload]
-        elif not isinstance(self, type(other)) and not isinstance(other, type(self)):
+        if not isinstance(self, type(other)) and not isinstance(other, type(self)):
             return NotImplemented
 
         return self.as_dict() == other.as_dict()
@@ -387,9 +370,6 @@ class Struct:
                 fields.append(f"*{attr}={value!r}")
 
         extra_parts = []
-
-        if self._int_type is not None:
-            extra_parts.append(f"{self._int_type(int(self))._hex_repr()}")  # type:ignore[call-overload]
 
         if self._frozen:
             extra_parts.append("frozen")
@@ -464,3 +444,89 @@ class Struct:
         instance._frozen = True
 
         return instance
+
+
+class IntStruct(Struct):
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+
+        try:
+            cls._int_type: type[t.FixedIntType] = next(
+                c
+                for c in cls.__mro__[1:]
+                if issubclass(c, t.FixedIntType) and not issubclass(c, Struct)
+            )
+        except StopIteration:
+            raise TypeError("Integer structs must be an integer subclasses") from None
+
+    def __new__(
+        cls: type[Self], *args, _underlying_int: int | None = None, **kwargs
+    ) -> Self:
+        orig_cls = cls
+        cls = cls._real_cls()  # noqa: PLW0642
+
+        if len(args) == 1 and isinstance(args[0], int):
+            # Like a copy constructor
+            if kwargs:
+                raise ValueError(f"Cannot use copy constructor with kwargs: {kwargs!r}")
+
+            _underlying_int = args[0]
+            kwargs = {}
+            args = ()
+
+        # Pretend our signature is `__new__(cls, p1: t1, p2: t2, ...)`
+        signature = inspect.Signature(
+            parameters=[
+                inspect.Parameter(
+                    name=f.name,
+                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=None,
+                    annotation=f.type,
+                )
+                for f in cls.fields
+            ]
+        )
+
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+
+        if _underlying_int is None:
+            temp_instance = super(Struct, cls).__new__(cls, 0)  # type:ignore[call-arg]
+        else:
+            temp_instance = super(Struct, cls).__new__(cls, _underlying_int)  # type:ignore[call-arg]
+
+        # Set each attributes on the instance
+        for name, value in bound.arguments.items():
+            field = getattr(cls.fields, name)
+            setattr(
+                temp_instance, name, field._convert_type(value, struct=temp_instance)
+            )
+
+        # If we have computed the underlying integer, we can finish
+        if _underlying_int is not None:
+            temp_instance._frozen = True
+            return temp_instance
+
+        # Otherwise, we need to re-initialize with the correct underlying integer
+        underlying_int, _ = cls._int_type.deserialize(temp_instance.serialize())
+        return orig_cls.__new__(
+            orig_cls, *args, _underlying_int=underlying_int, **kwargs
+        )
+
+    __hash__ = int.__hash__
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, int):
+            raise NotImplementedError
+
+        return int(self) == int(other)  # type:ignore[call-overload]
+
+    @classmethod
+    def deserialize(cls: type[Self], data: bytes) -> tuple[Self, bytes]:
+        temp_instance = cls(0)
+        object.__setattr__(temp_instance, "_frozen", False)
+        _, data = cls._deserialize_internal(temp_instance, data)
+        object.__setattr__(temp_instance, "_frozen", True)
+
+        real_instance = cls(**temp_instance.as_dict())
+        return real_instance, data

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -63,6 +63,17 @@ class Struct:
 
         # We generate fields up here to fail early and cache it
         cls.fields = cls._real_cls()._get_fields()
+        cls._signature = inspect.Signature(
+            parameters=[
+                inspect.Parameter(
+                    name=f.name,
+                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=None,
+                    annotation=f.type,
+                )
+                for f in cls.fields
+            ]
+        )
 
         # Check to see if the Struct is also an integer
         if next(
@@ -90,19 +101,7 @@ class Struct:
             args = ()
 
         # Pretend our signature is `__new__(cls, p1: t1, p2: t2, ...)`
-        signature = inspect.Signature(
-            parameters=[
-                inspect.Parameter(
-                    name=f.name,
-                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    default=None,
-                    annotation=f.type,
-                )
-                for f in cls.fields
-            ]
-        )
-
-        bound = signature.bind(*args, **kwargs)
+        bound = cls._signature.bind(*args, **kwargs)
         bound.apply_defaults()
 
         instance = super().__new__(cls)
@@ -347,6 +346,14 @@ class Struct:
 
         return self.as_dict() == other.as_dict()
 
+    def _repr_extra_parts(self) -> list[str]:
+        extra_parts = []
+
+        if self._frozen:
+            extra_parts.append("frozen")
+
+        return extra_parts
+
     def __repr__(self) -> str:
         fields = []
 
@@ -368,11 +375,7 @@ class Struct:
             if value is not None:
                 fields.append(f"*{attr}={value!r}")
 
-        extra_parts = []
-
-        if self._frozen:
-            extra_parts.append("frozen")
-
+        extra_parts = self._repr_extra_parts()
         if extra_parts:
             extra = f"<{', '.join(extra_parts)}>"
         else:
@@ -445,7 +448,7 @@ class Struct:
         return instance
 
 
-class IntStruct(Struct):
+class IntStruct(Struct, int):
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
 
@@ -458,62 +461,71 @@ class IntStruct(Struct):
         except StopIteration:
             raise TypeError("Integer structs must be an integer subclasses") from None
 
-    def __new__(
-        cls: type[Self], *args, _underlying_int: int | None = None, **kwargs
-    ) -> Self:
-        orig_cls = cls
+    def __new__(cls: type[Self], *args, **kwargs) -> Self:
+        # Integers are immutable in Python so we need to know, at creation time, what
+        # the integer value of this object will be. This means that these structs *must*
+        # also be immutable.
+        underlying_int = None
         cls = cls._real_cls()  # noqa: PLW0642
 
+        # Like a copy constructor
         if len(args) == 1 and isinstance(args[0], int):
-            # Like a copy constructor
             if kwargs:
                 raise ValueError(f"Cannot use copy constructor with kwargs: {kwargs!r}")
 
-            _underlying_int = args[0]
-            kwargs = {}
+            if isinstance(args[0], cls):
+                kwargs = args[0].as_dict()
+                args = ()
+            else:
+                underlying_int = args[0]
+
+                data = cls._int_type(underlying_int).serialize()
+                args = ()
+                kwargs, _ = cls._deserialize_internal(cls.fields, data)
+
+        if underlying_int is None:
+            # To compute the underlying integer, we create a temp instance and serialize
+            temp_instance = super(Struct, cls).__new__(cls, 0)
+
+            # Set the correct attributes on the instance so we can serialize
+            bound = cls._signature.bind(*args, **kwargs)
+            bound.apply_defaults()
+
+            for name, value in bound.arguments.items():
+                field = getattr(cls.fields, name)
+                setattr(temp_instance, name, value)
+
+            # Finally, serialize
+            underlying_int, rest = cls._int_type.deserialize(temp_instance.serialize())
+            assert not rest
+
+            # Pretend we were called with the correct kwargs
             args = ()
+            kwargs = temp_instance.as_dict()
 
-        # Pretend our signature is `__new__(cls, p1: t1, p2: t2, ...)`
-        signature = inspect.Signature(
-            parameters=[
-                inspect.Parameter(
-                    name=f.name,
-                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    default=None,
-                    annotation=f.type,
-                )
-                for f in cls.fields
-            ]
-        )
-
-        bound = signature.bind(*args, **kwargs)
+        bound = cls._signature.bind(*args, **kwargs)
         bound.apply_defaults()
 
-        if _underlying_int is None:
-            temp_instance = super(Struct, cls).__new__(cls, 0)  # type:ignore[call-arg]
-        else:
-            temp_instance = super(Struct, cls).__new__(cls, _underlying_int)  # type:ignore[call-arg]
+        instance = super(Struct, cls).__new__(cls, underlying_int)
 
-        # Set attributes on the instance so we can serialize
+        # Set attributes on the final instance
         for name, value in bound.arguments.items():
             field = getattr(cls.fields, name)
-            setattr(temp_instance, name, field._convert_type(value))
+            setattr(instance, name, field._convert_type(value))
 
-        # If we have computed the underlying integer, we can finish up
-        if _underlying_int is not None:
-            temp_instance._frozen = True
-            return temp_instance
+        # Freeze it
+        instance._frozen = True
 
-        # Otherwise, we need to re-initialize with the correct underlying integer
-        underlying_int, _ = cls._int_type.deserialize(temp_instance.serialize())
-        return orig_cls.__new__(
-            orig_cls, *args, _underlying_int=underlying_int, **kwargs
-        )
+        return instance
 
     __hash__ = int.__hash__
+
+    def _repr_extra_parts(self) -> list[str]:
+        # We override this method to omit the unnecessary `<frozen>`
+        return [f"{self._int_type(int(self))._hex_repr()}"]
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, int):
             raise NotImplementedError
 
-        return int(self) == int(other)  # type:ignore[call-overload]
+        return int(self) == int(other)

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -11,6 +11,14 @@ import zigpy.types as t
 NoneType = type(None)
 
 
+# To make sure mypy is aware that `IntStruct` is technically a mixin, we need to
+# convince it that it really is an integer at runtime
+if typing.TYPE_CHECKING:
+    IntMixin = int
+else:
+    IntMixin = object
+
+
 class ListSubclass(list):
     # So we can call `setattr()` on it
     pass
@@ -448,7 +456,7 @@ class Struct:
         return instance
 
 
-class IntStruct(Struct, int):
+class IntStruct(Struct, IntMixin):
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
 

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -16,11 +16,15 @@ class ListSubclass(list):
     pass
 
 
+class EmptyObject:
+    # So we can call `setattr()` on it
+    pass
+
+
 @dataclasses.dataclass(frozen=True)
 class StructField:
     name: str | None = None
-    type: type | None = None
-    dynamic_type: typing.Callable[[Struct], type] | None = None
+    type: type = None
 
     requires: typing.Callable[[Struct], bool] | None = dataclasses.field(
         default=None, repr=False
@@ -34,24 +38,16 @@ class StructField:
     def replace(self, **kwargs) -> StructField:
         return dataclasses.replace(self, **kwargs)
 
-    def get_type(self, struct: Struct) -> type:
-        if self.dynamic_type is not None:
-            return self.dynamic_type(struct)
-
-        return self.type
-
-    def _convert_type(self, value, struct: Struct):
-        field_type = self.get_type(struct)
-
-        if value is None or isinstance(value, field_type):
+    def _convert_type(self, value):
+        if value is None or isinstance(value, self.type):
             return value
 
         try:
-            return field_type(value)
+            return self.type(value)
         except Exception as e:  # noqa: BLE001
             raise ValueError(
                 f"Failed to convert {self.name}={value!r} from type"
-                f" {type(value)} to {field_type}"
+                f" {type(value)} to {self.type}"
             ) from e
 
 
@@ -114,7 +110,7 @@ class Struct:
         # Set each attributes on the instance
         for name, value in bound.arguments.items():
             field = getattr(cls.fields, name)
-            setattr(instance, name, field._convert_type(value, struct=instance))
+            setattr(instance, name, field._convert_type(value))
 
         return instance
 
@@ -155,7 +151,7 @@ class Struct:
                     )
 
                 field = field.replace(type=annotation)
-            elif field.type is None and field.dynamic_type is None:
+            elif field.type is None:
                 raise TypeError(f"Field {name!r} has no type")
 
             fields.append(field)
@@ -194,10 +190,9 @@ class Struct:
 
         for key, value in obj.items():
             field = getattr(cls.fields, key)
-            field_type = field.get_type(instance)
 
-            if issubclass(field_type, Struct):
-                setattr(instance, field.name, field_type.from_dict(value))
+            if issubclass(field.type, Struct):
+                setattr(instance, field.name, field.type.from_dict(value))
             else:
                 setattr(instance, field.name, value)
 
@@ -235,12 +230,11 @@ class Struct:
             if value is None and field.optional:
                 continue
 
-            value = field._convert_type(value, struct=self)
-            field_type = field.get_type(struct=self)
+            value = field._convert_type(value)
 
             # All integral types are compacted into one chunk, unless they start and end
             # on a byte boundary.
-            if issubclass(field_type, t.FixedIntType) and not (
+            if issubclass(field.type, t.FixedIntType) and not (
                 value._bits % 8 == 0 and bit_offset % 8 == 0
             ):
                 bit_offset += value._bits
@@ -269,25 +263,30 @@ class Struct:
         return b"".join(chunks)
 
     @staticmethod
-    def _deserialize_internal(instance: Self, data: bytes) -> tuple[Self, bytes]:
+    def _deserialize_internal(
+        fields: list[StructField], data: bytes
+    ) -> tuple[dict[str, typing.Any], bytes]:
         bit_length = 0
         bitfields = []
+        result = {}
 
-        for field in instance.fields:
-            if (
-                field.requires is not None
-                and not field.requires(instance)
-                or not data
-                and field.optional
+        # We need to create a temporary instance to call the field's `requires` method,
+        # which expects a struct-like object
+        temp_instance = EmptyObject()
+
+        for field in fields:
+            setattr(temp_instance, field.name, None)
+
+        for field in fields:
+            if (field.requires is not None and not field.requires(temp_instance)) or (
+                not data and field.optional
             ):
                 continue
 
-            field_type = field.get_type(struct=instance)
-
-            if issubclass(field_type, t.FixedIntType) and not (
-                field_type._bits % 8 == 0 and bit_length % 8 == 0
+            if issubclass(field.type, t.FixedIntType) and not (
+                field.type._bits % 8 == 0 and bit_length % 8 == 0
             ):
-                bit_length += field_type._bits
+                bit_length += field.type._bits
                 bitfields.append(field)
 
                 if bit_length % 8 == 0:
@@ -299,7 +298,8 @@ class Struct:
 
                     for f in bitfields:
                         value, bits = f.type.from_bits(bits)
-                        setattr(instance, f.name, value)
+                        result[f.name] = value
+                        setattr(temp_instance, f.name, value)
 
                     assert not bits
 
@@ -313,8 +313,9 @@ class Struct:
                     f" {bitfields}"
                 )
 
-            value, data = field_type.deserialize(data)
-            setattr(instance, field.name, value)
+            value, data = field.type.deserialize(data)
+            result[field.name] = value
+            setattr(temp_instance, field.name, value)
 
         if bitfields:
             raise ValueError(
@@ -322,14 +323,12 @@ class Struct:
                 f" {bitfields}"
             )
 
-        return instance, data
+        return result, data
 
     @classmethod
     def deserialize(cls: type[Self], data: bytes) -> tuple[Self, bytes]:
-        instance = cls()
-        instance, data = cls._deserialize_internal(instance, data)
-
-        return instance, data
+        fields, data = cls._deserialize_internal(cls.fields, data)
+        return cls(**fields), data
 
     def replace(self, **kwargs: dict[str, typing.Any]) -> Struct:
         d = self.as_dict().copy()
@@ -495,14 +494,12 @@ class IntStruct(Struct):
         else:
             temp_instance = super(Struct, cls).__new__(cls, _underlying_int)  # type:ignore[call-arg]
 
-        # Set each attributes on the instance
+        # Set attributes on the instance so we can serialize
         for name, value in bound.arguments.items():
             field = getattr(cls.fields, name)
-            setattr(
-                temp_instance, name, field._convert_type(value, struct=temp_instance)
-            )
+            setattr(temp_instance, name, field._convert_type(value))
 
-        # If we have computed the underlying integer, we can finish
+        # If we have computed the underlying integer, we can finish up
         if _underlying_int is not None:
             temp_instance._frozen = True
             return temp_instance
@@ -520,13 +517,3 @@ class IntStruct(Struct):
             raise NotImplementedError
 
         return int(self) == int(other)  # type:ignore[call-overload]
-
-    @classmethod
-    def deserialize(cls: type[Self], data: bytes) -> tuple[Self, bytes]:
-        temp_instance = cls(0)
-        object.__setattr__(temp_instance, "_frozen", False)
-        _, data = cls._deserialize_internal(temp_instance, data)
-        object.__setattr__(temp_instance, "_frozen", True)
-
-        real_instance = cls(**temp_instance.as_dict())
-        return real_instance, data

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -483,9 +483,10 @@ class IntStruct(Struct, IntMixin):
 
         # Like a copy constructor
         if len(args) == 1:
-            if not isinstance(args[0], int):
+            if not isinstance(args[0], int) or kwargs:
                 raise TypeError(
-                    f"{cls} can only be constructed from an integer or with keyword arguments"
+                    f"{cls} can only be constructed from an integer"
+                    f" or with just keyword arguments"
                 )
 
             underlying_int = args[0]

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -478,20 +478,21 @@ class IntStruct(Struct, IntMixin):
         cls = cls._real_cls()  # noqa: PLW0642
         underlying_int = _underlying_int
 
+        if len(args) > 1:
+            raise TypeError(f"{cls} takes no positional arguments")
+
         # Like a copy constructor
-        if len(args) == 1 and isinstance(args[0], int):
-            if kwargs:
-                raise ValueError(f"Cannot use copy constructor with kwargs: {kwargs!r}")
+        if len(args) == 1:
+            if not isinstance(args[0], int):
+                raise TypeError(
+                    f"{cls} can only be constructed from an integer or with keyword arguments"
+                )
 
-            if isinstance(args[0], cls):
-                kwargs = args[0].as_dict()
-                args = ()
-            else:
-                underlying_int = args[0]
+            underlying_int = args[0]
 
-                data = cls._int_type(underlying_int).serialize()
-                args = ()
-                kwargs, _ = cls._deserialize_internal(cls.fields, data)
+            data = cls._int_type(underlying_int).serialize()
+            kwargs, _ = cls._deserialize_internal(cls.fields, data)
+            args = ()
 
         if underlying_int is None:
             # To compute the underlying integer, we create a temp instance and serialize

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -289,7 +289,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
             command = foundation.GENERAL_COMMANDS[hdr.command_id]
 
-        hdr.frame_control.direction = command.direction
+        hdr.frame_control = hdr.frame_control.replace(direction=command.direction)
         response, data = command.schema.deserialize(data)
 
         self.debug("Decoded ZCL frame: %s:%r", type(self).__name__, response)

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1972,71 +1972,89 @@ class UpgradeTimeoutPolicy(t.enum8):
     Do_not_apply_after_timeout = 0x01
 
 
-class ImageNotifyCommand(foundation.CommandSchema):
-    class PayloadType(t.enum8):
-        QueryJitter = 0x00
-        QueryJitter_ManufacturerCode = 0x01
-        QueryJitter_ManufacturerCode_ImageType = 0x02
-        QueryJitter_ManufacturerCode_ImageType_NewFileVersion = 0x03
+class ImageNotifyPayloadType(t.enum8):
+    QueryJitter = 0x00
+    QueryJitter_ManufacturerCode = 0x01
+    QueryJitter_ManufacturerCode_ImageType = 0x02
+    QueryJitter_ManufacturerCode_ImageType_NewFileVersion = 0x03
 
-    payload_type: None = t.StructField(type=PayloadType)
+
+class ImageNotifyCommand(foundation.CommandSchema):
+    PayloadType = ImageNotifyPayloadType
+
+    payload_type: ImageNotifyPayloadType
     query_jitter: t.uint8_t
     manufacturer_code: t.uint16_t = t.StructField(
         requires=(
-            lambda s: s.payload_type >= s.PayloadType.QueryJitter_ManufacturerCode
+            lambda s: s.payload_type
+            >= ImageNotifyPayloadType.QueryJitter_ManufacturerCode
         )
     )
     image_type: t.uint16_t = t.StructField(
         requires=(
             lambda s: s.payload_type
-            >= s.PayloadType.QueryJitter_ManufacturerCode_ImageType
+            >= ImageNotifyPayloadType.QueryJitter_ManufacturerCode_ImageType
         )
     )
     new_file_version: t.uint32_t = t.StructField(
         requires=(
             lambda s: s.payload_type
-            >= s.PayloadType.QueryJitter_ManufacturerCode_ImageType_NewFileVersion
+            >= ImageNotifyPayloadType.QueryJitter_ManufacturerCode_ImageType_NewFileVersion
         )
     )
 
 
-class QueryNextImageCommand(foundation.CommandSchema):
-    class FieldControl(t.bitmap8):
-        HardwareVersion = 0b00000001
+class QueryNextImageCommandFieldControl(t.bitmap8):
+    HardwareVersion = 0b00000001
 
-    field_control: None = t.StructField(type=FieldControl)
+
+class QueryNextImageCommand(foundation.CommandSchema):
+    FieldControl = QueryNextImageCommandFieldControl
+
+    field_control: QueryNextImageCommandFieldControl
     manufacturer_code: t.uint16_t
     image_type: t.uint16_t
     current_file_version: t.uint32_t
     hardware_version: t.uint16_t = t.StructField(
-        requires=(lambda s: s.field_control & s.FieldControl.HardwareVersion)
+        requires=(
+            lambda s: s.field_control
+            & QueryNextImageCommandFieldControl.HardwareVersion
+        )
     )
 
 
-class ImageBlockCommand(foundation.CommandSchema):
-    class FieldControl(t.bitmap8):
-        RequestNodeAddr = 0b00000001
-        MinimumBlockPeriod = 0b00000010
+class ImageBlockCommandFieldControl(t.bitmap8):
+    RequestNodeAddr = 0b00000001
+    MinimumBlockPeriod = 0b00000010
 
-    field_control: None = t.StructField(type=FieldControl)
+
+class ImageBlockCommand(foundation.CommandSchema):
+    FieldControl = ImageBlockCommandFieldControl
+
+    field_control: ImageBlockCommandFieldControl
     manufacturer_code: t.uint16_t
     image_type: t.uint16_t
     file_version: t.uint32_t
     file_offset: t.uint32_t
     maximum_data_size: t.uint8_t
     request_node_addr: t.EUI64 = t.StructField(
-        requires=(lambda s: s.field_control & s.FieldControl.RequestNodeAddr)
+        requires=(
+            lambda s: s.field_control & ImageBlockCommandFieldControl.RequestNodeAddr
+        )
     )
     minimum_block_period: t.uint16_t = t.StructField(
-        requires=(lambda s: s.field_control & s.FieldControl.MinimumBlockPeriod)
+        requires=(
+            lambda s: s.field_control & ImageBlockCommandFieldControl.MinimumBlockPeriod
+        )
     )
+
+
+class ImagePageCommandFieldControl(t.bitmap8):
+    RequestNodeAddr = 0b00000001
 
 
 class ImagePageCommand(foundation.CommandSchema):
-    class FieldControl(t.bitmap8):
-        RequestNodeAddr = 0b00000001
-
-    field_control: None = t.StructField(type=FieldControl)
+    field_control: ImagePageCommandFieldControl
     manufacturer_code: t.uint16_t
     image_type: t.uint16_t
     file_version: t.uint32_t
@@ -2045,7 +2063,9 @@ class ImagePageCommand(foundation.CommandSchema):
     page_size: t.uint16_t
     response_spacing: t.uint16_t
     request_node_addr: t.EUI64 = t.StructField(
-        requires=lambda s: s.field_control & s.FieldControl.RequestNodeAddr
+        requires=lambda s: (
+            s.field_control & ImagePageCommandFieldControl.RequestNodeAddr
+        )
     )
 
 

--- a/zigpy/zcl/clusters/general_const.py
+++ b/zigpy/zcl/clusters/general_const.py
@@ -262,7 +262,7 @@ ANALOG_INPUT_TYPES = {
 }
 
 
-class ApplicationType(t.Struct, t.uint32_t):
+class ApplicationType(t.IntStruct, t.uint32_t):
     # Index = Bits 0 to 15
     index: t.uint16_t
     # Type = Bits 16 to 23

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -153,7 +153,9 @@ class IasZone(Cluster):
             and self.is_server
             and not hdr.frame_control.disable_default_response
         ):
-            hdr.frame_control.is_reply = False  # this is a client -> server cmd
+            hdr.frame_control = hdr.frame_control.replace(
+                direction=Direction.Client_to_Server
+            )  # this is a client -> server cmd
             self.send_default_rsp(hdr, foundation.Status.SUCCESS)
 
 

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -115,7 +115,7 @@ class MeteringUnitofMeasure(t.enum8):
     Kvar_and_Kvarh_bcd = 0x8D
 
 
-class NumberFormatting(t.Struct, t.uint8_t):
+class NumberFormatting(t.IntStruct, t.uint8_t):
     """Number formatting."""
 
     num_digits_right_of_decimal: t.uint3_t

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -970,7 +970,7 @@ class Direction(t.enum1):
         return cls.Server_to_Client if is_reply else cls.Client_to_Server
 
 
-class FrameControl(t.Struct, t.uint8_t):
+class FrameControl(t.IntStruct, t.uint8_t):
     """The frame control field contains information defining the command type
     and other control flags.
     """
@@ -1042,7 +1042,7 @@ class ZCLHeader(t.Struct):
             manufacturer = None
 
         if frame_control is not None and manufacturer is not None:
-            frame_control.is_manufacturer_specific = True
+            frame_control = frame_control.replace(is_manufacturer_specific=True)
 
         return super().__new__(cls, frame_control, manufacturer, tsn, command_id)
 
@@ -1062,7 +1062,9 @@ class ZCLHeader(t.Struct):
         super().__setattr__(name, value)
 
         if name == "manufacturer" and self.frame_control is not None:
-            self.frame_control.is_manufacturer_specific = value is not None
+            self.frame_control = self.frame_control.replace(
+                is_manufacturer_specific=value is not None
+            )
 
     @classmethod
     def general(

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -369,19 +369,23 @@ class Routes(t.Struct):
     RoutingTableList: t.LVList[Route]
 
 
+CHANNEL_CHANGE_REQ = 0xFE
+CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ = 0xFF
+
+
 class NwkUpdate(t.Struct):
-    CHANNEL_CHANGE_REQ = 0xFE
-    CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ = 0xFF
+    CHANNEL_CHANGE_REQ = CHANNEL_CHANGE_REQ
+    CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ = CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ
 
     ScanChannels: t.Channels
     ScanDuration: t.uint8_t
     ScanCount: t.uint8_t = t.StructField(requires=lambda s: s.ScanDuration <= 0x05)
     nwkUpdateId: t.uint8_t = t.StructField(  # noqa: N815
         requires=lambda s: s.ScanDuration
-        in (s.CHANNEL_CHANGE_REQ, s.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ)
+        in (CHANNEL_CHANGE_REQ, CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ)
     )
     nwkManagerAddr: t.NWK = t.StructField(  # noqa: N815
-        requires=lambda s: s.ScanDuration == s.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ
+        requires=lambda s: s.ScanDuration == CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ
     )
 
 


### PR DESCRIPTION
This is a pretty insidious bug. We were essentially were creating integer struct objects with an "internal" value of `0` via the `int()` object constructor but were overloading enough operations to make it *seem* like the object was correctly set.

Unfortunately, this is going to be a breaking change: integer structs *must* now be immutable because they truly are integers. I've looked through quirks and ZHA and we really don't rely on integer structs outside of zigpy, making this an internal change.

I've taken this opportunity to remove now-unused features from the struct module. Due to implementation constraints:
- Integer structs are now 1.8x slower to create or deserialize
- Due to micro-optimizations, however, deserialization is now on average 1.5x *faster*