### PR TITLE
fix(zcl): send default response from handle_cluster_request

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -656,6 +656,8 @@ async def test_configure_reporting_manuf():
         expect_reply=True,
         manufacturer=None,
         tsn=mock.ANY,
+        disable_default_response=True,
+        _direction=None,
     )
 
     cluster.request.reset_mock()
@@ -669,6 +671,8 @@ async def test_configure_reporting_manuf():
         expect_reply=True,
         manufacturer=manufacturer_id,
         tsn=mock.ANY,
+        disable_default_response=True,
+        _direction=None,
     )
     assert cluster.request.call_count == 1
 
@@ -756,6 +760,8 @@ def test_general_command(cluster):
         sentinel.start,
         sentinel.items,
         expect_reply=True,
+        disable_default_response=True,
+        _direction=None,
         manufacturer=0x4567,
         tsn=mock.ANY,
     )
@@ -770,7 +776,7 @@ def test_general_command_reply(cluster):
     assert cluster.request.call_count == 0
     assert cluster.reply.call_count == 1
     cluster.reply.assert_called_with(
-        True, cmd_id, mock.ANY, True, [], manufacturer=0x4567, tsn=None
+        True, cmd_id, mock.ANY, True, [], manufacturer=0x4567, tsn=None, disable_default_response=True, _direction=None
     )
 
     cluster.request.reset_mock()
@@ -780,7 +786,7 @@ def test_general_command_reply(cluster):
     assert cluster.request.call_count == 0
     assert cluster.reply.call_count == 1
     cluster.reply.assert_called_with(
-        True, cmd_id, mock.ANY, True, [], manufacturer=0x4567, tsn=sentinel.tsn
+        True, cmd_id, mock.ANY, True, [], manufacturer=0x4567, tsn=sentinel.tsn, disable_default_response=True, _direction=None
     )
 
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1274,3 +1274,48 @@ async def test_zcl_cluster_definition_invalid_name():
                     },
                     direction=foundation.Direction.Client_to_Server,
                 )
+
+async def test_zcl_on_off_default_rsp(app_mock):
+    """Test that the On/Off cluster's default response is sent correctly."""
+    dev = zigpy.device.Device(
+        application=app_mock,
+        ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"),
+        nwk=0x1234,
+    )
+
+    dev._send_sequence = DEFAULT_TSN
+
+    ep = dev.add_endpoint(1)
+    ep.add_input_cluster(zcl.clusters.general.OnOff.cluster_id)
+
+    hdr = foundation.ZCLHeader(
+        frame_control=foundation.FrameControl(
+            frame_type=foundation.FrameType.CLUSTER_COMMAND,
+            is_manufacturer_specific=0,
+            direction=foundation.Direction.Client_to_Server,
+            disable_default_response=0,
+            reserved=0,
+        ),
+        tsn=87,
+        command_id=zcl.clusters.general.OnOff.ClientCommandDefs.toggle.id
+    )
+
+    cmd = zcl.clusters.general.OnOff.ClientCommandDefs.toggle
+
+    ep.handle_message(
+        profile=260,
+        cluster=zcl.clusters.general.OnOff.cluster_id,
+        hdr=hdr,
+        args=cmd,
+    )
+
+    await asyncio.sleep(0.1)
+
+    packet = app_mock.send_packet.mock_calls[0].args[0]
+    assert packet.cluster_id == zcl.clusters.general.OnOff.cluster_id
+
+    # Expect a default response to be sent from server to client
+    packet_hdr, _ = foundation.ZCLHeader.deserialize(packet.data.serialize())
+    assert packet_hdr.command_id == zcl.foundation.GeneralCommand.Default_Response
+    assert packet_hdr.direction == foundation.Direction.Server_to_Client
+

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -400,20 +400,24 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
         priority: int = t.PacketPriority.NORMAL,
+        disable_default_response: bool = True,
+        direction: foundation.Direction | None = None,
         **kwargs,
     ) -> None:
+        if direction is None:
+            direction = (
+                foundation.Direction.Server_to_Client
+                if self.is_client
+                else foundation.Direction.Client_to_Server
+            )
         hdr, request = self._create_request(
             general=general,
             command_id=command_id,
             schema=schema,
             manufacturer=manufacturer,
             tsn=tsn,
-            disable_default_response=True,
-            direction=(
-                foundation.Direction.Server_to_Client
-                if self.is_client
-                else foundation.Direction.Client_to_Server
-            ),
+            disable_default_response=disable_default_response,
+            direction=direction,
             args=args,
             kwargs=kwargs,
         )
@@ -914,6 +918,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         *args,
         manufacturer: int | t.uint16_t | None = None,
         expect_reply: bool = True,
+        disable_default_response: bool = True,
+        direction: foundation.Direction | None = None,
         tsn: int | t.uint8_t | None = None,
         **kwargs,
     ):
@@ -928,6 +934,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 *args,
                 manufacturer=manufacturer,
                 tsn=tsn,
+                disable_default_response=disable_default_response,
+                direction=direction,
                 **kwargs,
             )
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -352,13 +352,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         ask_for_ack: bool | None = None,
         priority: int = t.PacketPriority.NORMAL,
         disable_default_response: bool = None,
-        direction: foundation.Direction | None = None,
+        _direction: foundation.Direction | None = None,
         tsn: int | t.uint8_t | None = None,
         timeout=APS_REPLY_TIMEOUT,
         **kwargs,
     ):
-        if direction is None:
-            direction = (
+        if _direction is None:
+            _direction = (
                 foundation.Direction.Server_to_Client
                 if self.is_client
                 else foundation.Direction.Client_to_Server
@@ -372,7 +372,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             manufacturer=manufacturer,
             tsn=tsn,
             disable_default_response=disable_default_response,
-            direction=direction,
+            direction=_direction,
             args=args,
             kwargs=kwargs,
         )
@@ -407,11 +407,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         ask_for_ack: bool | None = None,
         priority: int = t.PacketPriority.NORMAL,
         disable_default_response: bool = True,
-        direction: foundation.Direction | None = None,
+        _direction: foundation.Direction | None = None,
         **kwargs,
     ) -> None:
-        if direction is None:
-            direction = (
+        if _direction is None:
+            _direction = (
                 foundation.Direction.Server_to_Client
                 if self.is_client
                 else foundation.Direction.Client_to_Server
@@ -423,7 +423,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             manufacturer=manufacturer,
             tsn=tsn,
             disable_default_response=disable_default_response,
-            direction=direction,
+            direction=_direction,
             args=args,
             kwargs=kwargs,
         )
@@ -926,7 +926,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         manufacturer: int | t.uint16_t | None = None,
         expect_reply: bool = True,
         disable_default_response: bool = True,
-        direction: foundation.Direction | None = None,
+        _direction: foundation.Direction | None = None,
         tsn: int | t.uint8_t | None = None,
         **kwargs,
     ):
@@ -942,7 +942,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 manufacturer=manufacturer,
                 tsn=tsn,
                 disable_default_response=disable_default_response,
-                direction=direction,
+                _direction=_direction,
                 **kwargs,
             )
 
@@ -953,6 +953,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             *args,
             manufacturer=manufacturer,
             expect_reply=expect_reply,
+            disable_default_response=disable_default_response,
+            _direction=_direction,
             tsn=tsn,
             **kwargs,
         )
@@ -991,7 +993,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         command_id: t.uint8_t,
         status: foundation.Status = foundation.Status.SUCCESS,
         disable_default_response: bool = True,
-        direction: foundation.Direction | None = None,
+        _direction: foundation.Direction | None = None,
     ) -> None:
         """Send default response unconditionally."""
         self.create_catching_task(
@@ -1002,7 +1004,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 tsn=tsn,
                 priority=t.PacketPriority.LOW,
                 disable_default_response=disable_default_response,
-                direction=direction,
+                _direction=_direction,
             )
         )
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -351,22 +351,28 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
         priority: int = t.PacketPriority.NORMAL,
+        disable_default_response: bool = None,
+        direction: foundation.Direction | None = None,
         tsn: int | t.uint8_t | None = None,
         timeout=APS_REPLY_TIMEOUT,
         **kwargs,
     ):
+        if direction is None:
+            direction = (
+                foundation.Direction.Server_to_Client
+                if self.is_client
+                else foundation.Direction.Client_to_Server
+            )
+        if disable_default_response is None:
+            disable_default_response = self.is_client
         hdr, request = self._create_request(
             general=general,
             command_id=command_id,
             schema=schema,
             manufacturer=manufacturer,
             tsn=tsn,
-            disable_default_response=self.is_client,
-            direction=(
-                foundation.Direction.Server_to_Client
-                if self.is_client
-                else foundation.Direction.Client_to_Server
-            ),
+            disable_default_response=disable_default_response,
+            direction=direction,
             args=args,
             kwargs=kwargs,
         )
@@ -503,7 +509,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
             if not hdr.frame_control.disable_default_response:
                 self.send_default_rsp(
-                    hdr,
+                    hdr.tsn,
+                    hdr.command_id,
                     foundation.Status.SUCCESS,
                 )
 
@@ -980,17 +987,22 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
     def send_default_rsp(
         self,
-        hdr: foundation.ZCLHeader,
+        tsn: t.uint8_t,
+        command_id: t.uint8_t,
         status: foundation.Status = foundation.Status.SUCCESS,
+        disable_default_response: bool = True,
+        direction: foundation.Direction | None = None,
     ) -> None:
         """Send default response unconditionally."""
         self.create_catching_task(
             self.general_command(
                 foundation.GeneralCommand.Default_Response,
-                hdr.command_id,
+                command_id,
                 status,
-                tsn=hdr.tsn,
+                tsn=tsn,
                 priority=t.PacketPriority.LOW,
+                disable_default_response=disable_default_response,
+                direction=direction,
             )
         )
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -942,6 +942,17 @@ class OnOff(Cluster):
             direction=Direction.Client_to_Server,
         )
 
+    class ClientCommandDefs(BaseCommandDefs):
+        off: Final = ZCLCommandDef(
+            id=0x00, schema={}, direction=Direction.Server_to_Client
+        )
+        on: Final = ZCLCommandDef(
+            id=0x01, schema={}, direction=Direction.Server_to_Client
+        )
+        toggle: Final = ZCLCommandDef(
+            id=0x02, schema={}, direction=Direction.Server_to_Client
+        )
+
     def handle_cluster_request(
             self,
             hdr: foundation.ZCLHeader,

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -15,6 +15,8 @@ from zigpy.zcl.foundation import (
     ZCLAttributeDef,
     ZCLCommandDef,
 )
+import logging
+_LOGGER = logging.getLogger(__name__)
 
 ZIGBEE_EPOCH = datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
 
@@ -941,6 +943,29 @@ class OnOff(Cluster):
             },
             direction=Direction.Client_to_Server,
         )
+
+    def handle_cluster_request(
+            self,
+            hdr: foundation.ZCLHeader,
+            args: list[Any],
+            *,
+            dst_addressing=None,
+    ) -> None:
+        _LOGGER.info(f"handle_cluster_request: {hdr.command_id} {hdr.frame_control.disable_default_response}")
+
+        if not hdr.frame_control.disable_default_response:
+            _LOGGER.info(f"sending default response")
+            self.create_catching_task(
+                self.general_command(
+                    foundation.GeneralCommand.Default_Response,
+                    hdr.command_id,
+                    foundation.Status.SUCCESS,
+                    tsn=hdr.tsn,
+                    priority=t.PacketPriority.LOW,
+                    disable_default_response=False,
+                    direction=Direction.Server_to_Client,
+                )
+            )
 
 
 class SwitchType(t.enum8):

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -15,8 +15,6 @@ from zigpy.zcl.foundation import (
     ZCLAttributeDef,
     ZCLCommandDef,
 )
-import logging
-_LOGGER = logging.getLogger(__name__)
 
 ZIGBEE_EPOCH = datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
 
@@ -951,21 +949,8 @@ class OnOff(Cluster):
             *,
             dst_addressing=None,
     ) -> None:
-        _LOGGER.info(f"handle_cluster_request: {hdr.command_id} {hdr.frame_control.disable_default_response}")
-
         if not hdr.frame_control.disable_default_response:
-            _LOGGER.info(f"sending default response")
-            self.create_catching_task(
-                self.general_command(
-                    foundation.GeneralCommand.Default_Response,
-                    hdr.command_id,
-                    foundation.Status.SUCCESS,
-                    tsn=hdr.tsn,
-                    priority=t.PacketPriority.LOW,
-                    disable_default_response=False,
-                    direction=Direction.Server_to_Client,
-                )
-            )
+            self.send_default_rsp(hdr.tsn, hdr.command_id, disable_default_response=False, direction=Direction.Server_to_Client)
 
 
 class SwitchType(t.enum8):

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -950,7 +950,7 @@ class OnOff(Cluster):
             dst_addressing=None,
     ) -> None:
         if not hdr.frame_control.disable_default_response:
-            self.send_default_rsp(hdr.tsn, hdr.command_id, disable_default_response=False, direction=Direction.Server_to_Client)
+            self.send_default_rsp(hdr.tsn, hdr.command_id, disable_default_response=False, _direction=Direction.Server_to_Client)
 
 
 class SwitchType(t.enum8):

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -153,10 +153,7 @@ class IasZone(Cluster):
             and self.is_server
             and not hdr.frame_control.disable_default_response
         ):
-            hdr.frame_control = hdr.frame_control.replace(
-                direction=Direction.Client_to_Server
-            )  # this is a client -> server cmd
-            self.send_default_rsp(hdr, foundation.Status.SUCCESS)
+            self.send_default_rsp(hdr.tsn, hdr.command_id, foundation.Status.SUCCESS, direction=Direction.Client_to_Server)
 
 
 class AlarmStatus(t.enum8):

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -153,7 +153,7 @@ class IasZone(Cluster):
             and self.is_server
             and not hdr.frame_control.disable_default_response
         ):
-            self.send_default_rsp(hdr.tsn, hdr.command_id, foundation.Status.SUCCESS, direction=Direction.Client_to_Server)
+            self.send_default_rsp(hdr.tsn, hdr.command_id, foundation.Status.SUCCESS, _direction=Direction.Client_to_Server)
 
 
 class AlarmStatus(t.enum8):


### PR DESCRIPTION
This PR addresses an issue for Sonoff ZMBINIR2, discussed here: https://github.com/zigpy/zha-device-handlers/issues/3579

In short, this device expects a default response on some of its commands in order to function properly, and ZHA currently does not send default response packets in general cluster implementations.

I am default response to `OnOff` cluster, however, it may be sensible to have this in some other clusters as well