### PR TITLE
Fix `Callable` typing

### DIFF
--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -448,7 +448,7 @@ class PreventDefaultEntityCreationMetadata:
     cluster_id: int | None = attrs.field()
     cluster_type: ClusterType | None = attrs.field()
     unique_id_suffix: str | None = attrs.field()
-    function: Callable[Any, bool] | None = attrs.field()
+    function: Callable[[Any], bool] | None = attrs.field()
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -1108,7 +1108,7 @@ class QuirkBuilder:
         cluster_id: int | None = None,
         cluster_type: ClusterType | None = None,
         unique_id_suffix: str | None = None,
-        function: Callable[Any, bool] | None = None,
+        function: Callable[[Any], bool] | None = None,
     ) -> QuirkBuilder:
         """Do not create default entities."""
         if cluster_id is not None and cluster_type is None:

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -10,7 +10,6 @@ import inspect
 import logging
 import pathlib
 from types import FrameType
-import typing
 from typing import TYPE_CHECKING, Any, Callable
 
 import attrs
@@ -166,7 +165,7 @@ class AddsMetadata:
     cluster: int | type[Cluster | CustomCluster] = attrs.field()
     endpoint_id: int = attrs.field(default=1)
     cluster_type: ClusterType = attrs.field(default=ClusterType.Server)
-    constant_attributes: frozendict[ZCLAttributeDef, typing.Any] = attrs.field(
+    constant_attributes: frozendict[ZCLAttributeDef, Any] = attrs.field(
         factory=frozendict, converter=deepfreeze
     )
 
@@ -344,7 +343,7 @@ class ZCLSensorMetadata(EntityMetadata):
     """Metadata for exposed ZCL attribute based sensor entity."""
 
     attribute_name: str | None = attrs.field(default=None)
-    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
+    attribute_converter: Callable[[Any], Any] | None = attrs.field(default=None)
     reporting_config: ReportingConfig | None = attrs.field(default=None)
     divisor: int | None = attrs.field(default=None)
     multiplier: int | None = attrs.field(default=None)
@@ -386,7 +385,7 @@ class BinarySensorMetadata(EntityMetadata):
     """Metadata for exposed binary sensor entity."""
 
     attribute_name: str = attrs.field()
-    attribute_converter: typing.Callable[[Any], Any] | None = attrs.field(default=None)
+    attribute_converter: Callable[[Any], Any] | None = attrs.field(default=None)
     reporting_config: ReportingConfig | None = attrs.field(default=None)
     device_class: BinarySensorDeviceClass | None = attrs.field(default=None)
 
@@ -629,7 +628,7 @@ class QuirkBuilder:
         cluster: int | type[Cluster | CustomCluster],
         cluster_type: ClusterType = ClusterType.Server,
         endpoint_id: int = 1,
-        constant_attributes: dict[ZCLAttributeDef, typing.Any] | None = None,
+        constant_attributes: dict[ZCLAttributeDef, Any] | None = None,
     ) -> QuirkBuilder:
         """Add an AddsMetadata entry and returns self.
 
@@ -826,7 +825,7 @@ class QuirkBuilder:
         unit: str | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        attribute_converter: typing.Callable[[Any], Any] | None = None,
+        attribute_converter: Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         unique_id_suffix: str | None = None,
         translation_key: str | None = None,
@@ -972,7 +971,7 @@ class QuirkBuilder:
         device_class: BinarySensorDeviceClass | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
-        attribute_converter: typing.Callable[[Any], Any] | None = None,
+        attribute_converter: Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         unique_id_suffix: str | None = None,
         translation_key: str | None = None,


### PR DESCRIPTION
## Proposed change

This fixes the typing of `Callable` for `PreventDefaultEntityCreationMetadata` and `prevent_default_entity_creation`.

The first parameter of `Callable` are the actual parameters of the callable with `[]` meaning no parameters.
For more info, see https://docs.python.org/3.12/library/typing.html#annotating-callables.
So, the fix is to just wrap `Any` in brackets here.


Furthermore, `typing.Callable` is replaced with just `Callable` and `typing.Any` with just `Any` in the quirks v2 module.


## Additional information

We also use both `typing.Callable` and just `Callable` (with `from` import), and `typing.Any` and `Any` in the quirks v2 module. Do we want to standardize on one? 😄 