### PR TITLE
Fix quirks v2 `replaces_endpoint` removing existing clusters

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -497,6 +497,7 @@ async def test_quirks_v2_endpoints(device_mock):
         .replaces_endpoint(3, profile_id=260, device_type=260)
         .adds_endpoint(4)
         .adds(OnOff.cluster_id, endpoint_id=4)
+        .replaces_endpoint(5)
         .add_to_registry()
     )
 
@@ -516,13 +517,22 @@ async def test_quirks_v2_endpoints(device_mock):
     assert quirked.endpoints[3].profile_id == 260
     assert quirked.endpoints[3].device_type == 260
 
-    # verify endpoint 4 was added with default profile id and device type
+    # verify original clusters still exist on endpoint 3 where id and type were replaced
+    assert quirked.endpoints[3].in_clusters.get(Identify.cluster_id) is not None
+    assert quirked.endpoints[3].out_clusters.get(OnOff.cluster_id) is not None
+
+    # verify endpoint 4 was added with default profile id and device type using adds
     assert 4 in quirked.endpoints
     assert quirked.endpoints[4].profile_id == 260
     assert quirked.endpoints[4].device_type == 255
 
     # verify cluster was added to endpoint 4
     assert quirked.endpoints[4].in_clusters.get(OnOff.cluster_id) is not None
+
+    # verify endpoint 5 was added with default profile id and device type using replaces
+    assert 5 in quirked.endpoints
+    assert quirked.endpoints[5].profile_id == 260
+    assert quirked.endpoints[5].device_type == 255
 
 
 async def test_quirks_v2_apply_custom_configuration(device_mock):

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -285,13 +285,15 @@ class RemovesEndpointMetadata:
 class ReplacesEndpointMetadata:
     """Replaces metadata for replacing an endpoint on a device."""
 
-    remove: RemovesEndpointMetadata = attrs.field()
     add: AddsEndpointMetadata = attrs.field()
 
     def __call__(self, device: CustomDeviceV2) -> None:
         """Process the replace."""
-        self.remove(device)
-        self.add(device)
+        if isinstance(ep := device.endpoints.get(self.add.endpoint_id), Endpoint):
+            ep.profile_id = self.add.profile_id
+            ep.device_type = self.add.device_type
+        else:
+            self.add(device)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -762,11 +764,10 @@ class QuirkBuilder:
         device_type: int = 0xFF,
     ) -> QuirkBuilder:
         """Add a ReplacesEndpointMetadata entry and return self."""
-        remove = RemovesEndpointMetadata(endpoint_id=endpoint_id)
         add = AddsEndpointMetadata(
             endpoint_id=endpoint_id, profile_id=profile_id, device_type=device_type
         )
-        replace = ReplacesEndpointMetadata(remove=remove, add=add)
+        replace = ReplacesEndpointMetadata(add=add)
         self.replaces_endpoint_metadata.append(replace)
         return self
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -285,15 +285,18 @@ class RemovesEndpointMetadata:
 class ReplacesEndpointMetadata:
     """Replaces metadata for replacing an endpoint on a device."""
 
-    add: AddsEndpointMetadata = attrs.field()
+    endpoint_id: int = attrs.field()
+    profile_id: int = attrs.field()
+    device_type: int = attrs.field()
 
     def __call__(self, device: CustomDeviceV2) -> None:
         """Process the replace."""
-        if isinstance(ep := device.endpoints.get(self.add.endpoint_id), Endpoint):
-            ep.profile_id = self.add.profile_id
-            ep.device_type = self.add.device_type
+        if self.endpoint_id in device.endpoints:
+            ep: Endpoint = device.endpoints[self.endpoint_id]
         else:
-            self.add(device)
+            ep = device.add_endpoint(self.endpoint_id)
+        ep.profile_id = self.profile_id
+        ep.device_type = self.device_type
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -764,10 +767,9 @@ class QuirkBuilder:
         device_type: int = 0xFF,
     ) -> QuirkBuilder:
         """Add a ReplacesEndpointMetadata entry and return self."""
-        add = AddsEndpointMetadata(
+        replace = ReplacesEndpointMetadata(
             endpoint_id=endpoint_id, profile_id=profile_id, device_type=device_type
         )
-        replace = ReplacesEndpointMetadata(add=add)
         self.replaces_endpoint_metadata.append(replace)
         return self
 


### PR DESCRIPTION
## Proposed change

This fixes unexpected behavior of `replaces_endpoint` deleting all device reported clusters, instead of just replacing the device type and profile and keeping the clusters reported by the device itself.

A test is also added to verify for that expected behavior.


### Background

This hasn't been an issue so far, as we've only used this for endpoints where we add custom clusters with quirks v2, ignoring ones possibly reported by the device. Due to the ordering of quirks v2 metadata processing, this has worked fine.

But even in those cases, we do want to keep the clusters reported by the device, even if they're not used currently.
For the Inovelli quirks v2 PR linked below, we do need to keep existing clusters on the endpoint and just replace the type/profile (due to a bug with older firmware versions reporting the wrong type, causing a switch entity instead of a dimmable light entity in HA).

### Naming

I'm aware `replaces_endpoint` might not be the the most intuitive name. Since an endpoint is only an integer (here), I hope it's somewhat clear that it's only supposed to replace the type/id.
I'd still like to keep that name to avoid a breaking change and since it closes aligns with the `adds`, `removes`, and `replaces` methods for cluster replacement.

### Removed functionality?

If there's a rare case where you want to remove all clusters from an endpoint and then re-add the endpoint to add your own clusters via quirks v2, this would be possible with calling `removes_endpoint` and `adds_endpoint` after #1603 is merged.

There's more info in that PR.


## Additional information

Usage in related quirks PR: https://github.com/zigpy/zha-device-handlers/pull/3232#discussion_r2106058344

Follow-up PR to:
- https://github.com/zigpy/zigpy/pull/1524