### PR TITLE
Reorder quirks v2 metadata processing

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -525,6 +525,52 @@ async def test_quirks_v2_endpoints(device_mock):
     assert quirked.endpoints[4].in_clusters.get(OnOff.cluster_id) is not None
 
 
+async def test_quirks_v2_processing_order(device_mock):
+    """Test quirks v2 metadata processing order."""
+    registry = DeviceRegistry()
+
+    device_mock.add_endpoint(2)
+    device_mock[2].add_input_cluster(Identify.cluster_id)
+    device_mock[2].add_output_cluster(OnOff.cluster_id)
+
+    device_mock.add_endpoint(3)
+    device_mock[3].add_input_cluster(Identify.cluster_id)
+    device_mock[3].add_output_cluster(OnOff.cluster_id)
+
+    class TestCustomIdentifyCluster(CustomCluster, Identify):
+        """Custom identify cluster for testing quirks v2."""
+
+    # the order of operations in the quirk builder below barely matters,
+    # but is laid out in a way that generally follows the expected execution order
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .removes_endpoint(2)  # wipes device reported clusters from endpoint 2
+        .adds_endpoint(2)  # adds a new "blank" endpoint 2 with no clusters
+        .removes(Identify.cluster_id, endpoint_id=3)  # test removing cluster
+        .adds(TestCustomIdentifyCluster, endpoint_id=3)  # then "replacing" it by adds
+        .adds(LevelControl.cluster_id, endpoint_id=2)  # adds one custom cluster to ep 2
+        .add_to_registry()
+    )
+
+    quirked: CustomDeviceV2 = registry.get_device(device_mock)
+    assert isinstance(quirked, CustomDeviceV2)
+
+    # verify endpoint 2 was removed and a new one added with device clusters removed
+    assert 2 in quirked.endpoints
+    assert quirked.endpoints[2].in_clusters.get(Identify.cluster_id) is None
+    assert quirked.endpoints[2].out_clusters.get(OnOff.cluster_id) is None
+
+    # verify endpoint 2 cluster added by quirk is present though
+    assert quirked.endpoints[2].in_clusters.get(LevelControl.cluster_id) is not None
+
+    # verify endpoint 3 cluster was replaced by alternatively using removes and adds
+    # instead of just using replaces directly
+    assert 3 in quirked.endpoints
+    assert isinstance(
+        quirked.endpoints[3].in_clusters[Identify.cluster_id], TestCustomIdentifyCluster
+    )
+
+
 async def test_quirks_v2_apply_custom_configuration(device_mock):
     """Test adding a quirk custom configuration to the registry."""
     registry = DeviceRegistry()

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -89,20 +89,20 @@ class CustomDeviceV2(BaseCustomDevice):
         ] = collections.defaultdict(list)
 
         # endpoints need to be modified before clusters
-        for add_endpoint_meta in quirk_metadata.adds_endpoint_metadata:
-            add_endpoint_meta(self)
-
         for remove_endpoint_meta in quirk_metadata.removes_endpoint_metadata:
             remove_endpoint_meta(self)
+
+        for add_endpoint_meta in quirk_metadata.adds_endpoint_metadata:
+            add_endpoint_meta(self)
 
         for replace_endpoint_meta in quirk_metadata.replaces_endpoint_metadata:
             replace_endpoint_meta(self)
 
-        for add_meta in quirk_metadata.adds_metadata:
-            add_meta(self)
-
         for remove_meta in quirk_metadata.removes_metadata:
             remove_meta(self)
+
+        for add_meta in quirk_metadata.adds_metadata:
+            add_meta(self)
 
         for replace_meta in quirk_metadata.replaces_metadata:
             replace_meta(self)


### PR DESCRIPTION
## Proposed change

Call the metadata processing for `removes` (for clusters) and `removes_endpoint` before calling `adds` and `adds_endpoint`.

A test is also added to verify the new expected execution order for the metadata processing.


### Background

Currently, you never want to remove a cluster/endpoint and also add a cluster/endpoint, as the custom cluster will always be added first (assuming it's not already reported by the device) and then immediately removed again afterwards.

With this PR, we first remove existing clusters/endpoints and then add our custom clusters/endpoints.

### Impact

This behavioral change should have no (negative) impact at all.
There should be no quirks currently calling `removes` and `adds` for the same cluster id (or `adds_endpoint` and `removes_endpoint` for the same endpoint id), as those two calls would cancel each other out.

### Similar to `replaces`

#### 1.

After this PR, calling `removes` and `adds` for the same cluster (id) is the same as `replaces`, just a more verbose way.
In general, this shouldn't need to be used, but we also shouldn't intentionally break it (by having it do nothing, like now).

This new processing order is the same as the one used by `replaces`:
https://github.com/zigpy/zigpy/blob/7fb1b8d207990ba04d14198e45651bdeca120609/zigpy/quirks/v2/__init__.py#L291-L294


Where this makes a difference though—hence changing this in the first place—is with `adds_endpoint`, `removes_endpoint`, and `replaces_endpoint`.

After #1602, the behavior of `replaces_endpoint` is changed to keep existing device reported clusters on the specified endpoint and only have it change the device type/profile of that endpoint. This was not possible before.

With this PR, it will still be possible to completely remove all clusters from a device reported endpoint (by using `removes_endpoint`) and then adding a new "blank" endpoint with no clusters (by using `adds_endpoint`).
Afterwards, custom clusters can be added to the new/wiped endpoint with `adds`.

I'm not sure *why* you would ever want to do that, but we should probably offer a way to do this (instead of individually removing all clusters). Since this fits in with `removes_endpoint` and `adds_endpoint` just fine, I think we can go ahead with this.

#### 2.

Also, with the execution order fixed, we should be able to drop `ReplacesMetadata` (which currently includes `RemovesMetadata` and `AddsMetadata` fields) and just directly add one `RemovesMetadata` and `AddsMetadata`.

I'm not sure we actually need/want to do this, but it would allow for few ZHA and quirks tests to go through added clusters metadata more easily, instead of needing to go through both the `AddsMetadata` in `replaces_metadata` and `adds_metadata` itself.


## Additional information

~~The tests might conflict with #1602. Doesn't really matter which PR is merged first. I'd probably do #1602 first.
Will rebase whatever PR then.~~ I guess not.