### PR TITLE
Quirk v2 firmware version filters

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -26,6 +26,7 @@ from zigpy.quirks.v2 import (
     EntityMetadata,
     EntityPlatform,
     EntityType,
+    FirmwareVersionFilterMetadata,
     NumberMetadata,
     PreventDefaultEntityCreationMetadata,
     QuirkBuilder,
@@ -1321,3 +1322,104 @@ async def test_quirks_v2_primary_entity(device_mock: Device) -> None:
 
     assert len(entry.entity_metadata) == 1
     assert entry.entity_metadata[0].primary is True
+
+
+@pytest.mark.parametrize(
+    ("fw_version", "min_version", "max_version", "allow_missing", "expected_match"),
+    [
+        # Basic version filtering
+        (100, 50, 150, True, True),  # Within range
+        (25, 50, 150, True, False),  # Below min
+        (175, 50, 150, True, False),  # Above/equal max
+        (150, 50, 150, True, False),  # Equal to max (exclusive)
+        (50, 50, 150, True, True),  # Equal to min (inclusive)
+        # Only min version specified
+        (100, 50, None, True, True),  # Above min
+        (25, 50, None, True, False),  # Below min
+        (50, 50, None, True, True),  # Equal to min
+        # Only max version specified
+        (100, None, 150, True, True),  # Below max
+        (175, None, 150, True, False),  # Above/equal max
+        (150, None, 150, True, False),  # Equal to max
+        # Missing firmware version handling
+        (None, 50, 150, True, True),  # Missing allowed
+        (None, 50, 150, False, False),  # Missing not allowed
+        (None, None, None, True, True),  # No constraints, missing allowed
+        (None, None, None, False, False),  # No constraints, missing not allowed
+    ],
+)
+async def test_quirks_v2_firmware_version_filter(
+    device_mock, fw_version, min_version, max_version, allow_missing, expected_match
+):
+    """Test firmware version filtering functionality."""
+    registry = DeviceRegistry()
+
+    # Add OTA cluster to device with firmware version
+    device_mock[1].add_output_cluster(Ota.cluster_id)
+    ota_cluster = device_mock[1].out_clusters[Ota.cluster_id]
+
+    if fw_version is not None:
+        ota_cluster._attr_cache[Ota.AttributeDefs.current_file_version.id] = fw_version
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .firmware_version_filter(
+            min_version=min_version,
+            max_version=max_version,
+            allow_missing=allow_missing,
+        )
+        .adds(Basic.cluster_id)
+        .add_to_registry()
+    )
+
+    quirked = registry.get_device(device_mock)
+    is_quirked = isinstance(quirked, CustomDeviceV2)
+
+    assert is_quirked == expected_match
+
+
+async def test_quirks_v2_firmware_version_filter_no_ota_cluster(device_mock):
+    """Test firmware version filter when device has no OTA cluster."""
+    registry1 = DeviceRegistry()
+
+    # Test with allow_missing=True (should match)
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry1)
+        .firmware_version_filter(min_version=50, max_version=150, allow_missing=True)
+        .adds(Basic.cluster_id)
+        .add_to_registry()
+    )
+
+    quirked = registry1.get_device(device_mock)
+    assert isinstance(quirked, CustomDeviceV2)
+
+    registry2 = DeviceRegistry()
+
+    # Test with allow_missing=False (should not match)
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry2)
+        .firmware_version_filter(min_version=50, max_version=150, allow_missing=False)
+        .adds(Basic.cluster_id)
+        .add_to_registry()
+    )
+
+    quirked = registry2.get_device(device_mock)
+    assert not isinstance(quirked, CustomDeviceV2)
+
+
+async def test_quirks_v2_firmware_version_filter_metadata(device_mock):
+    """Test that firmware version filter metadata is properly set."""
+    registry = DeviceRegistry()
+
+    entry = (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .firmware_version_filter(min_version=10, max_version=50, allow_missing=False)
+        .adds(Basic.cluster_id)
+        .add_to_registry()
+    )
+
+    assert entry.fw_version_filter is not None
+    assert isinstance(entry.fw_version_filter, FirmwareVersionFilterMetadata)
+    assert entry.fw_version_filter.min_version == 10
+    assert entry.fw_version_filter.max_version == 50
+    assert entry.fw_version_filter.allow_missing is False

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -528,7 +528,7 @@ class QuirksV2RegistryEntry:
                 return False
 
             if self.fw_version_filter.max_version is not None and (
-                current_file_version > self.fw_version_filter.max_version
+                current_file_version >= self.fw_version_filter.max_version
             ):
                 return False
 
@@ -641,8 +641,8 @@ class QuirkBuilder:
         """Add a firmware version filter and returns self.
 
         The min_version and max_version are integers representing the firmware version,
-        inclusive. If allow_missing is True, the filter will pass if the device does
-        not have a firmware version.
+        minimum inclusive but maximum exclusive. If allow_missing is True, the filter
+        will pass if the device does not have a firmware version.
         """
         self.fw_version_filter = FirmwareVersionFilterMetadata(
             min_version=min_version,

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -517,6 +517,9 @@ class QuirksV2RegistryEntry:
 
         if self.fw_version_filter is not None:
             ota = find_ota_cluster(device)
+            if ota is None:
+                return self.fw_version_filter.allow_missing
+
             current_file_version = ota.get(Ota.AttributeDefs.current_file_version.id)
 
             if current_file_version is None:

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -516,8 +516,9 @@ class QuirksV2RegistryEntry:
             return False
 
         if self.fw_version_filter is not None:
-            ota = find_ota_cluster(device)
-            if ota is None:
+            try:
+                ota = find_ota_cluster(device)
+            except ValueError:
                 return self.fw_version_filter.allow_missing
 
             current_file_version = ota.get(Ota.AttributeDefs.current_file_version.id)
@@ -1196,6 +1197,7 @@ class QuirkBuilder:
             quirk_file=self.quirk_file,
             quirk_file_line=self.quirk_file_line,
             filters=tuple(self.filters),
+            fw_version_filter=self.fw_version_filter,
             custom_device_class=self.custom_device_class,
             device_node_descriptor=self.device_node_descriptor,
             skip_device_configuration=self.skip_device_configuration,

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -24,6 +24,7 @@ from zigpy.const import (
     SIG_NODE_DESC,
     SIG_SKIP_CONFIG,
 )
+from zigpy.ota.manager import find_ota_cluster
 import zigpy.profiles.zha
 from zigpy.quirks import _DEVICE_REGISTRY, BaseCustomDevice, CustomCluster, FilterType
 from zigpy.quirks.registry import DeviceRegistry
@@ -33,6 +34,7 @@ from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.general import Ota
 from zigpy.zdo import ZDO
 from zigpy.zdo.types import NodeDescriptor
 
@@ -456,6 +458,15 @@ class PreventDefaultEntityCreationMetadata:
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
+class FirmwareVersionFilterMetadata:
+    """Metadata to only apply the quirk if the device's firmware version matches."""
+
+    min_version: int | None = attrs.field(default=None)
+    max_version: int | None = attrs.field(default=None)
+    allow_missing: bool = attrs.field(default=True)
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class QuirksV2RegistryEntry:
     """Quirks V2 registry entry."""
 
@@ -470,6 +481,7 @@ class QuirksV2RegistryEntry:
         attrs.field(factory=tuple)
     )
     filters: tuple[FilterType] = attrs.field(factory=tuple)
+    fw_version_filter: FirmwareVersionFilterMetadata | None = attrs.field(default=None)
     custom_device_class: type[CustomDeviceV2] | None = attrs.field(default=None)
     device_node_descriptor: NodeDescriptor | None = attrs.field(default=None)
     skip_device_configuration: bool = attrs.field(default=False)
@@ -500,7 +512,27 @@ class QuirksV2RegistryEntry:
 
     def matches_device(self, device: Device) -> bool:
         """Determine if this quirk should be applied to the passed in device."""
-        return all(_filter(device) for _filter in self.filters)
+        if not all(_filter(device) for _filter in self.filters):
+            return False
+
+        if self.fw_version_filter is not None:
+            ota = find_ota_cluster(device)
+            current_file_version = ota.get(Ota.AttributeDefs.current_file_version.id)
+
+            if current_file_version is None:
+                return self.fw_version_filter.allow_missing
+
+            if self.fw_version_filter.min_version is not None and (
+                current_file_version < self.fw_version_filter.min_version
+            ):
+                return False
+
+            if self.fw_version_filter.max_version is not None and (
+                current_file_version > self.fw_version_filter.max_version
+            ):
+                return False
+
+        return True
 
     def create_device(self, device: Device) -> CustomDeviceV2:
         """Create the quirked device."""
@@ -532,6 +564,7 @@ class QuirkBuilder:
         self.device_alerts: list[DeviceAlertMetadata] = []
         self.disabled_default_entities: list[PreventDefaultEntityCreationMetadata] = []
         self.filters: list[FilterType] = []
+        self.fw_version_filter: FirmwareVersionFilterMetadata | None = None
         self.custom_device_class: type[CustomDeviceV2] | None = None
         self.device_node_descriptor: NodeDescriptor | None = None
         self.skip_device_configuration: bool = False
@@ -597,6 +630,25 @@ class QuirkBuilder:
         Ex: def some_filter(device: zigpy.device.Device) -> bool:
         """
         self.filters.append(filter_function)
+        return self
+
+    def firmware_version_filter(
+        self,
+        min_version: int | None = None,
+        max_version: int | None = None,
+        allow_missing: bool = True,
+    ) -> QuirkBuilder:
+        """Add a firmware version filter and returns self.
+
+        The min_version and max_version are integers representing the firmware version,
+        inclusive. If allow_missing is True, the filter will pass if the device does
+        not have a firmware version.
+        """
+        self.fw_version_filter = FirmwareVersionFilterMetadata(
+            min_version=min_version,
+            max_version=max_version,
+            allow_missing=allow_missing,
+        )
         return self
 
     def device_class(self, custom_device_class: type[CustomDeviceV2]) -> QuirkBuilder:


### PR DESCRIPTION
Related: https://github.com/zigpy/zha-device-handlers/issues/3857

This would allow quirks to filter compatible firmware versions. As an example, here is the quirk for the above device rewritten to be a v2 quirk and using this proposed API:

```python
"""Innr SP 240 plug."""

from zigpy.quirks.v2 import QuirkBuilder
from zigpy.quirks import CustomCluster
from zhaquirks.innr import MeteringClusterInnr


class InnrCluster(CustomCluster):
    """Innr manufacturer specific cluster."""

    cluster_id = 0xE001

(
    QuirkBuilder(manufacturer="innr", model="SP 240")
    # Firmware version `421410437` fixed the divisor and multiplier bug
    .firmware_version_filter(max_version=0x191E3685)
    .replaces(MeteringClusterInnr, endpoint_id=1)
    .replaces(InnrCluster, endpoint_id=1)
    .add_to_registry()
)
```