### PR TITLE
Pin pytest-asyncio to < 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ testing = [
     "coveralls",
     "coverage[toml]",
     "pytest",
-    "pytest-asyncio",
+    "pytest-asyncio<1.0.0",
     "pytest-cov",
     "pytest-timeout",
     "freezegun",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ asynctest
 coveralls
 coverage[toml]
 pytest
-pytest-asyncio
+pytest-asyncio<1.0.0
 pytest-cov
 pytest-timeout
 freezegun


### PR DESCRIPTION
pytest-asyncio has incompatible changes. I guess the long-term solution would be to actually update the fixtures/tests to use pytest-asyncio 1.0.0, but this at least allows me to run the tests.