### PR TITLE
Fix sqlite module attribute deprecation warnings

### DIFF
--- a/tests/test_appdb_pysqlite.py
+++ b/tests/test_appdb_pysqlite.py
@@ -17,8 +17,8 @@ else:
             target=sqlite3,
             **{
                 attr: getattr(pysqlite3, attr)
-                for attr in dir(pysqlite3)
-                if hasattr(sqlite3, attr)
+                for attr in dir(sqlite3)
+                if hasattr(pysqlite3, attr)
             },
         ):
             # Ensure the module was patched


### PR DESCRIPTION
pysqlite3 at this point is a little old, we may want to drop it. Right now, it has attributes that the normal `sqlite3` module has marked as deprecated. To fix this, we can pull the list of patched attributes from the built-in module, not the other way around.