### PR TITLE
Remove the `ZCLCommand` `direction` attribute from command definitions

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -987,13 +987,6 @@ async def test_send_broadcast(app, packet):
     )
 
 
-async def test_request_concurrency_duplicate_failure(packet: t.ZigbeePacket) -> None:
-    results = await asyncio.gather(
-        *(app.send_packet(packet) for _ in range(256 + 1)), return_exceptions=True
-    )
-    assert False
-
-
 @pytest.fixture
 def zdo_packet(app, device):
     return t.ZigbeePacket(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -987,6 +987,13 @@ async def test_send_broadcast(app, packet):
     )
 
 
+async def test_request_concurrency_duplicate_failure(packet: t.ZigbeePacket) -> None:
+    results = await asyncio.gather(
+        *(app.send_packet(packet) for _ in range(256 + 1)), return_exceptions=True
+    )
+    assert False
+
+
 @pytest.fixture
 def zdo_packet(app, device):
     return t.ZigbeePacket(

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -318,20 +318,18 @@ def test_custom_cluster_idx():
             server_cmd_0: Final = zcl.foundation.ZCLCommandDef(
                 id=0x00,
                 schema={"param1": t.uint8_t, "param2": t.uint8_t},
-                direction=False,
             )
             server_cmd_2: Final = zcl.foundation.ZCLCommandDef(
                 id=0x01,
                 schema={"param1": t.uint8_t, "param2": t.uint8_t},
-                direction=False,
             )
 
         class ClientCommandDefs(zcl.foundation.BaseCommandDefs):
             client_cmd_0: Final = zcl.foundation.ZCLCommandDef(
-                id=0x00, schema={"param1": t.uint8_t}, direction=True
+                id=0x00, schema={"param1": t.uint8_t}
             )
             client_cmd_1: Final = zcl.foundation.ZCLCommandDef(
-                id=0x01, schema={"param1": t.uint8_t}, direction=True
+                id=0x01, schema={"param1": t.uint8_t}
             )
 
     assert hasattr(TestClusterIdx, "attributes_by_name")
@@ -365,20 +363,18 @@ async def test_read_attributes_uncached():
             server_cmd_0: Final = zcl.foundation.ZCLCommandDef(
                 id=0x00,
                 schema={"param1": t.uint8_t, "param2": t.uint8_t},
-                direction=False,
             )
             server_cmd_2: Final = zcl.foundation.ZCLCommandDef(
                 id=0x01,
                 schema={"param1": t.uint8_t, "param2": t.uint8_t},
-                direction=False,
             )
 
         class ClientCommandDefs(zcl.foundation.BaseCommandDefs):
             client_cmd_0: Final = zcl.foundation.ZCLCommandDef(
-                id=0x00, schema={"param1": t.uint8_t}, direction=True
+                id=0x00, schema={"param1": t.uint8_t}
             )
             client_cmd_1: Final = zcl.foundation.ZCLCommandDef(
-                id=0x01, schema={"param1": t.uint8_t}, direction=True
+                id=0x01, schema={"param1": t.uint8_t}
             )
 
     class TestCluster2(zigpy.quirks.CustomCluster):
@@ -465,20 +461,18 @@ async def test_read_attributes_default_response():
             server_cmd_0: Final = zcl.foundation.ZCLCommandDef(
                 id=0x00,
                 schema={"param1": t.uint8_t, "param2": t.uint8_t},
-                direction=False,
             )
             server_cmd_2: Final = zcl.foundation.ZCLCommandDef(
                 id=0x01,
                 schema={"param1": t.uint8_t, "param2": t.uint8_t},
-                direction=False,
             )
 
         class ClientCommandDefs(zcl.foundation.BaseCommandDefs):
             client_cmd_0: Final = zcl.foundation.ZCLCommandDef(
-                id=0x00, schema={"param1": t.uint8_t}, direction=True
+                id=0x00, schema={"param1": t.uint8_t}
             )
             client_cmd_1: Final = zcl.foundation.ZCLCommandDef(
-                id=0x01, schema={"param1": t.uint8_t}, direction=True
+                id=0x01, schema={"param1": t.uint8_t}
             )
 
     epmock = MagicMock()
@@ -520,19 +514,15 @@ class ManufacturerSpecificCluster(zigpy.quirks.CustomCluster):
         )
 
     class ServerCommandDefs(zcl.foundation.BaseCommandDefs):
-        server_cmd0: Final = zcl.foundation.ZCLCommandDef(
-            id=0x00, schema={}, direction=False
-        )
+        server_cmd0: Final = zcl.foundation.ZCLCommandDef(id=0x00, schema={})
         server_cmd1: Final = zcl.foundation.ZCLCommandDef(
-            id=0x01, schema={}, direction=False, is_manufacturer_specific=True
+            id=0x01, schema={}, is_manufacturer_specific=True
         )
 
     class ClientCommandDefs(zcl.foundation.BaseCommandDefs):
-        client_cmd0: Final = zcl.foundation.ZCLCommandDef(
-            id=0x00, schema={}, direction=False
-        )
+        client_cmd0: Final = zcl.foundation.ZCLCommandDef(id=0x00, schema={})
         client_cmd1: Final = zcl.foundation.ZCLCommandDef(
-            id=0x01, schema={}, direction=False, is_manufacturer_specific=True
+            id=0x01, schema={}, is_manufacturer_specific=True
         )
 
 

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -981,13 +981,11 @@ async def test_quirks_v2_matches_v1(app_mock):
                 0x0007: ZCLCommandDef(
                     "press",
                     {"param1": t.int16s, "param2": t.int8s, "param3": t.int8s},
-                    False,
                     is_manufacturer_specific=True,
                 ),
                 0x0008: ZCLCommandDef(
                     "hold",
                     {"param1": t.int16s, "param2": t.int8s},
-                    False,
                     is_manufacturer_specific=True,
                 ),
                 0x0009: ZCLCommandDef(
@@ -995,7 +993,6 @@ async def test_quirks_v2_matches_v1(app_mock):
                     {
                         "param1": t.int16s,
                     },
-                    False,
                     is_manufacturer_specific=True,
                 ),
             }

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1262,3 +1262,20 @@ async def test_zcl_cluster_definition_invalid_name():
                         "file_version": t.uint32_t,
                     },
                 )
+
+
+async def test_cluster_definition_invalid_direction():
+    # This is fine
+    class TestCluster(zcl.Cluster):
+        cluster_id = 0xABCD
+        ep_attribute = "test_cluster"
+
+        class ServerCommandDefs(zcl.BaseCommandDefs):
+            server_command = foundation.ZCLCommandDef(
+                name="server_command",
+                id=0x00,
+                schema={},
+                direction=foundation.Direction.Server_to_Client,
+            )
+
+    # This is not but will just log a warning

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1036,12 +1036,8 @@ def test_zcl_command_duplicate_name_prevention():
             cluster_id = 0x1234
             ep_attribute = "test_cluster"
             server_commands = {
-                0x00: foundation.ZCLCommandDef(
-                    name="command1", schema={}, direction=False
-                ),
-                0x01: foundation.ZCLCommandDef(
-                    name="command1", schema={}, direction=False
-                ),
+                0x00: foundation.ZCLCommandDef(name="command1", schema={}),
+                0x01: foundation.ZCLCommandDef(name="command1", schema={}),
             }
 
 
@@ -1230,7 +1226,6 @@ async def test_zcl_cluster_definition_invalid_name():
                     "image_type": t.uint16_t,
                     "file_version": t.uint32_t,
                 },
-                direction=foundation.Direction.Client_to_Server,
             )
 
     # This is not
@@ -1266,5 +1261,4 @@ async def test_zcl_cluster_definition_invalid_name():
                         "image_type": t.uint16_t,
                         "file_version": t.uint32_t,
                     },
-                    direction=foundation.Direction.Client_to_Server,
                 )

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1265,17 +1265,50 @@ async def test_zcl_cluster_definition_invalid_name():
 
 
 async def test_cluster_definition_invalid_direction():
-    # This is fine
-    class TestCluster(zcl.Cluster):
-        cluster_id = 0xABCD
-        ep_attribute = "test_cluster"
+    # Test that incorrect direction on server command triggers warning
+    # ServerCommandDefs should have direction Server_to_Client, so Client_to_Server is wrong
+    with pytest.warns(
+        DeprecationWarning, match="Command 'server_command' has an incorrect direction"
+    ):
 
-        class ServerCommandDefs(zcl.BaseCommandDefs):
-            server_command = foundation.ZCLCommandDef(
-                name="server_command",
-                id=0x00,
-                schema={},
-                direction=foundation.Direction.Server_to_Client,
-            )
+        class TestCluster(zcl.Cluster):
+            cluster_id = 0xABCD
+            ep_attribute = "test_cluster"
 
-    # This is not but will just log a warning
+            class ServerCommandDefs(zcl.BaseCommandDefs):
+                server_command = foundation.ZCLCommandDef(
+                    name="server_command",
+                    id=0x00,
+                    schema={},
+                    direction=foundation.Direction.Client_to_Server,  # Wrong direction
+                )
+
+    # Verify direction was auto-corrected
+    assert (
+        TestCluster.ServerCommandDefs.server_command.direction
+        == foundation.Direction.Server_to_Client
+    )
+
+    # Test that incorrect direction on client command also triggers warning
+    # ClientCommandDefs should have direction Client_to_Server, so Server_to_Client is wrong
+    with pytest.warns(
+        DeprecationWarning, match="Command 'client_command' has an incorrect direction"
+    ):
+
+        class TestCluster2(zcl.Cluster):
+            cluster_id = 0xDEF0
+            ep_attribute = "test_cluster2"
+
+            class ClientCommandDefs(zcl.BaseCommandDefs):
+                client_command = foundation.ZCLCommandDef(
+                    name="client_command",
+                    id=0x00,
+                    schema={},
+                    direction=foundation.Direction.Server_to_Client,  # Wrong direction
+                )
+
+    # Verify direction was auto-corrected
+    assert (
+        TestCluster2.ClientCommandDefs.client_command.direction
+        == foundation.Direction.Client_to_Server
+    )

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -173,6 +173,20 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             for name in dir(defs):
                 definition = getattr(defs, name)
 
+                if isinstance(definition, foundation.ZCLCommandDef):
+                    direction = (
+                        foundation.Direction.Client_to_Server
+                        if defs is cls.ClientCommandDefs
+                        else foundation.Direction.Server_to_Client
+                    )
+
+                    if definition.direction is None:
+                        object.__setattr__(definition, "direction", direction)
+                    elif definition.direction != direction:
+                        raise TypeError(
+                            f"Command {definition.name!r} has an incorrect direction"
+                        )
+
                 if isinstance(
                     definition,
                     (foundation.ZCLCommandDef, foundation.ZCLAttributeDef),

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -180,12 +180,17 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                         else foundation.Direction.Server_to_Client
                     )
 
-                    if definition.direction is None:
-                        object.__setattr__(definition, "direction", direction)
-                    elif definition.direction != direction:
-                        raise TypeError(
-                            f"Command {definition.name!r} has an incorrect direction"
+                    if definition.direction != direction:
+                        warnings.warn(
+                            f"Command {definition.name!r} has an incorrect direction, please remove the definition",
+                            DeprecationWarning,
                         )
+                        LOGGER.warning(
+                            "Command %r has an incorrect direction, please remove the definition",
+                            definition.name,
+                        )
+
+                    object.__setattr__(definition, "direction", direction)
 
                 if isinstance(
                     definition,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -180,14 +180,19 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                         else foundation.Direction.Server_to_Client
                     )
 
-                    if definition.direction != direction:
+                    if (
+                        definition.direction is not None
+                        and definition.direction != direction
+                    ):
                         warnings.warn(
-                            f"Command {definition.name!r} has an incorrect direction, please remove the definition",
+                            f"Command {definition.name!r} has an incorrect direction, please remove the `direction` kwarg",
                             DeprecationWarning,
+                            stacklevel=2,
                         )
                         LOGGER.warning(
-                            "Command %r has an incorrect direction, please remove the definition",
+                            "Command %r has an incorrect direction, please remove the `direction` kwarg",
                             definition.name,
+                            stacklevel=2,
                         )
 
                     object.__setattr__(definition, "direction", direction)

--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -9,7 +9,6 @@ from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
-    Direction,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
@@ -410,27 +409,22 @@ class DoorLock(Cluster):
         lock_door: Final = ZCLCommandDef(
             id=0x00,
             schema={"pin_code?": t.CharacterString},
-            direction=Direction.Client_to_Server,
         )
         unlock_door: Final = ZCLCommandDef(
             id=0x01,
             schema={"pin_code?": t.CharacterString},
-            direction=Direction.Client_to_Server,
         )
         toggle_door: Final = ZCLCommandDef(
             id=0x02,
             schema={"pin_code?": t.CharacterString},
-            direction=Direction.Client_to_Server,
         )
         unlock_with_timeout: Final = ZCLCommandDef(
             id=0x03,
             schema={"timeout": t.uint16_t, "pin_code?": t.CharacterString},
-            direction=Direction.Client_to_Server,
         )
         get_log_record: Final = ZCLCommandDef(
             id=0x04,
             schema={"log_index": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         set_pin_code: Final = ZCLCommandDef(
             id=0x05,
@@ -440,30 +434,23 @@ class DoorLock(Cluster):
                 "user_type": UserType,
                 "pin_code": t.CharacterString,
             },
-            direction=Direction.Client_to_Server,
         )
         get_pin_code: Final = ZCLCommandDef(
             id=0x06,
             schema={"user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         clear_pin_code: Final = ZCLCommandDef(
             id=0x07,
             schema={"user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
-        clear_all_pin_codes: Final = ZCLCommandDef(
-            id=0x08, schema={}, direction=Direction.Client_to_Server
-        )
+        clear_all_pin_codes: Final = ZCLCommandDef(id=0x08, schema={})
         set_user_status: Final = ZCLCommandDef(
             id=0x09,
             schema={"user_id": t.uint16_t, "user_status": UserStatus},
-            direction=Direction.Client_to_Server,
         )
         get_user_status: Final = ZCLCommandDef(
             id=0x0A,
             schema={"user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         set_week_day_schedule: Final = ZCLCommandDef(
             id=0x0B,
@@ -476,17 +463,14 @@ class DoorLock(Cluster):
                 "end_hour": t.uint8_t,
                 "end_minute": t.uint8_t,
             },
-            direction=Direction.Client_to_Server,
         )
         get_week_day_schedule: Final = ZCLCommandDef(
             id=0x0C,
             schema={"schedule_id": t.uint8_t, "user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         clear_week_day_schedule: Final = ZCLCommandDef(
             id=0x0D,
             schema={"schedule_id": t.uint8_t, "user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         set_year_day_schedule: Final = ZCLCommandDef(
             id=0x0E,
@@ -496,17 +480,14 @@ class DoorLock(Cluster):
                 "local_start_time": t.LocalTime,
                 "local_end_time": t.LocalTime,
             },
-            direction=Direction.Client_to_Server,
         )
         get_year_day_schedule: Final = ZCLCommandDef(
             id=0x0F,
             schema={"schedule_id": t.uint8_t, "user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         clear_year_day_schedule: Final = ZCLCommandDef(
             id=0x10,
             schema={"schedule_id": t.uint8_t, "user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         set_holiday_schedule: Final = ZCLCommandDef(
             id=0x11,
@@ -516,27 +497,22 @@ class DoorLock(Cluster):
                 "local_end_time": t.LocalTime,
                 "operating_mode_during_holiday": OperatingMode,
             },
-            direction=Direction.Client_to_Server,
         )
         get_holiday_schedule: Final = ZCLCommandDef(
             id=0x12,
             schema={"holiday_schedule_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         clear_holiday_schedule: Final = ZCLCommandDef(
             id=0x13,
             schema={"holiday_schedule_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         set_user_type: Final = ZCLCommandDef(
             id=0x14,
             schema={"user_id": t.uint16_t, "user_type": UserType},
-            direction=Direction.Client_to_Server,
         )
         get_user_type: Final = ZCLCommandDef(
             id=0x15,
             schema={"user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         set_rfid_code: Final = ZCLCommandDef(
             id=0x16,
@@ -546,42 +522,33 @@ class DoorLock(Cluster):
                 "user_type": UserType,
                 "rfid_code": t.CharacterString,
             },
-            direction=Direction.Client_to_Server,
         )
         get_rfid_code: Final = ZCLCommandDef(
             id=0x17,
             schema={"user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         clear_rfid_code: Final = ZCLCommandDef(
             id=0x18,
             schema={"user_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
-        clear_all_rfid_codes: Final = ZCLCommandDef(
-            id=0x19, schema={}, direction=Direction.Client_to_Server
-        )
+        clear_all_rfid_codes: Final = ZCLCommandDef(id=0x19, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
         lock_door_response: Final = ZCLCommandDef(
             id=0x00,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         unlock_door_response: Final = ZCLCommandDef(
             id=0x01,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         toggle_door_response: Final = ZCLCommandDef(
             id=0x02,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         unlock_with_timeout_response: Final = ZCLCommandDef(
             id=0x03,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         get_log_record_response: Final = ZCLCommandDef(
             id=0x04,
@@ -594,12 +561,10 @@ class DoorLock(Cluster):
                 "user_id": t.uint16_t,
                 "pin?": t.CharacterString,
             },
-            direction=Direction.Server_to_Client,
         )
         set_pin_code_response: Final = ZCLCommandDef(
             id=0x05,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         get_pin_code_response: Final = ZCLCommandDef(
             id=0x06,
@@ -609,32 +574,26 @@ class DoorLock(Cluster):
                 "user_type": UserType,
                 "code": t.CharacterString,
             },
-            direction=Direction.Server_to_Client,
         )
         clear_pin_code_response: Final = ZCLCommandDef(
             id=0x07,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         clear_all_pin_codes_response: Final = ZCLCommandDef(
             id=0x08,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         set_user_status_response: Final = ZCLCommandDef(
             id=0x09,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         get_user_status_response: Final = ZCLCommandDef(
             id=0x0A,
             schema={"user_id": t.uint16_t, "user_status": UserStatus},
-            direction=Direction.Server_to_Client,
         )
         set_week_day_schedule_response: Final = ZCLCommandDef(
             id=0x0B,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         get_week_day_schedule_response: Final = ZCLCommandDef(
             id=0x0C,
@@ -648,17 +607,14 @@ class DoorLock(Cluster):
                 "end_hour?": t.uint8_t,
                 "end_minute?": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         clear_week_day_schedule_response: Final = ZCLCommandDef(
             id=0x0D,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         set_year_day_schedule_response: Final = ZCLCommandDef(
             id=0x0E,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         get_year_day_schedule_response: Final = ZCLCommandDef(
             id=0x0F,
@@ -669,17 +625,14 @@ class DoorLock(Cluster):
                 "local_start_time?": t.LocalTime,
                 "local_end_time?": t.LocalTime,
             },
-            direction=Direction.Server_to_Client,
         )
         clear_year_day_schedule_response: Final = ZCLCommandDef(
             id=0x10,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         set_holiday_schedule_response: Final = ZCLCommandDef(
             id=0x11,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         get_holiday_schedule_response: Final = ZCLCommandDef(
             id=0x12,
@@ -690,27 +643,22 @@ class DoorLock(Cluster):
                 "local_end_time?": t.LocalTime,
                 "operating_mode_during_holiday?": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         clear_holiday_schedule_response: Final = ZCLCommandDef(
             id=0x13,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         set_user_type_response: Final = ZCLCommandDef(
             id=0x14,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         get_user_type_response: Final = ZCLCommandDef(
             id=0x15,
             schema={"user_id": t.uint16_t, "user_type": UserType},
-            direction=Direction.Server_to_Client,
         )
         set_rfid_code_response: Final = ZCLCommandDef(
             id=0x16,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         get_rfid_code_response: Final = ZCLCommandDef(
             id=0x17,
@@ -720,17 +668,14 @@ class DoorLock(Cluster):
                 "user_type": UserType,
                 "rfid_code": t.CharacterString,
             },
-            direction=Direction.Server_to_Client,
         )
         clear_rfid_code_response: Final = ZCLCommandDef(
             id=0x18,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         clear_all_rfid_codes_response: Final = ZCLCommandDef(
             id=0x19,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         operation_event_notification: Final = ZCLCommandDef(
             id=0x20,
@@ -742,7 +687,6 @@ class DoorLock(Cluster):
                 "local_time": t.LocalTime,
                 "data?": t.CharacterString,
             },
-            direction=Direction.Server_to_Client,
         )
         programming_event_notification: Final = ZCLCommandDef(
             id=0x21,
@@ -756,7 +700,6 @@ class DoorLock(Cluster):
                 "local_time": t.LocalTime,
                 "data?": t.CharacterString,
             },
-            direction=Direction.Server_to_Client,
         )
 
 
@@ -863,34 +806,24 @@ class WindowCovering(Cluster):
         )
 
     class ServerCommandDefs(BaseCommandDefs):
-        up_open: Final = ZCLCommandDef(
-            id=0x00, schema={}, direction=Direction.Client_to_Server
-        )
-        down_close: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
-        stop: Final = ZCLCommandDef(
-            id=0x02, schema={}, direction=Direction.Client_to_Server
-        )
+        up_open: Final = ZCLCommandDef(id=0x00, schema={})
+        down_close: Final = ZCLCommandDef(id=0x01, schema={})
+        stop: Final = ZCLCommandDef(id=0x02, schema={})
         go_to_lift_value: Final = ZCLCommandDef(
             id=0x04,
             schema={"lift_value": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         go_to_lift_percentage: Final = ZCLCommandDef(
             id=0x05,
             schema={"percentage_lift_value": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         go_to_tilt_value: Final = ZCLCommandDef(
             id=0x07,
             schema={"tilt_value": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         go_to_tilt_percentage: Final = ZCLCommandDef(
             id=0x08,
             schema={"percentage_tilt_value": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
 
 
@@ -944,11 +877,8 @@ class BarrierControl(Cluster):
         go_to_percent: Final = ZCLCommandDef(
             id=0x00,
             schema={"percent_open": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
-        stop: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
+        stop: Final = ZCLCommandDef(id=0x01, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
         pass

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -11,7 +11,6 @@ from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
-    Direction,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
@@ -279,9 +278,7 @@ class Basic(Cluster):
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
 
     class ServerCommandDefs(BaseCommandDefs):
-        reset_fact_default: Final = ZCLCommandDef(
-            id=0x00, schema={}, direction=Direction.Client_to_Server
-        )
+        reset_fact_default: Final = ZCLCommandDef(id=0x00, schema={})
 
     def handle_read_attribute_zcl_version(self) -> t.uint8_t:
         return t.uint8_t(8)
@@ -582,24 +579,19 @@ class Identify(Cluster):
         identify: Final = ZCLCommandDef(
             id=0x00,
             schema={"identify_time": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
-        identify_query: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
+        identify_query: Final = ZCLCommandDef(id=0x01, schema={})
         # 0x02: ("ezmode_invoke", (t.bitmap8,), False),
         # 0x03: ("update_commission_state", (t.bitmap8,), False),
         trigger_effect: Final = ZCLCommandDef(
             id=0x40,
             schema={"effect_id": EffectIdentifier, "effect_variant": EffectVariant},
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
         identify_query_response: Final = ZCLCommandDef(
             id=0x00,
             schema={"timeout": t.uint16_t},
-            direction=Direction.Server_to_Client,
         )
 
 
@@ -628,33 +620,23 @@ class Groups(Cluster):
         add: Final = ZCLCommandDef(
             id=0x00,
             schema={"group_id": t.Group, "group_name": t.LimitedCharString(16)},
-            direction=Direction.Client_to_Server,
         )
-        view: Final = ZCLCommandDef(
-            id=0x01, schema={"group_id": t.Group}, direction=Direction.Client_to_Server
-        )
+        view: Final = ZCLCommandDef(id=0x01, schema={"group_id": t.Group})
         get_membership: Final = ZCLCommandDef(
             id=0x02,
             schema={"groups": t.LVList[t.Group]},
-            direction=Direction.Client_to_Server,
         )
-        remove: Final = ZCLCommandDef(
-            id=0x03, schema={"group_id": t.Group}, direction=Direction.Client_to_Server
-        )
-        remove_all: Final = ZCLCommandDef(
-            id=0x04, schema={}, direction=Direction.Client_to_Server
-        )
+        remove: Final = ZCLCommandDef(id=0x03, schema={"group_id": t.Group})
+        remove_all: Final = ZCLCommandDef(id=0x04, schema={})
         add_if_identifying: Final = ZCLCommandDef(
             id=0x05,
             schema={"group_id": t.Group, "group_name": t.LimitedCharString(16)},
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
         add_response: Final = ZCLCommandDef(
             id=0x00,
             schema={"status": foundation.Status, "group_id": t.Group},
-            direction=Direction.Server_to_Client,
         )
         view_response: Final = ZCLCommandDef(
             id=0x01,
@@ -663,17 +645,14 @@ class Groups(Cluster):
                 "group_id": t.Group,
                 "group_name": t.LimitedCharString(16),
             },
-            direction=Direction.Server_to_Client,
         )
         get_membership_response: Final = ZCLCommandDef(
             id=0x02,
             schema={"capacity": t.uint8_t, "groups": t.LVList[t.Group]},
-            direction=Direction.Server_to_Client,
         )
         remove_response: Final = ZCLCommandDef(
             id=0x03,
             schema={"status": foundation.Status, "group_id": t.Group},
-            direction=Direction.Server_to_Client,
         )
 
 
@@ -717,26 +696,20 @@ class Scenes(Cluster):
                 "transition_time": t.uint16_t,
                 "scene_name": t.LimitedCharString(16),
             },
-            direction=Direction.Client_to_Server,
         )
         # TODO: + extension field sets
         view: Final = ZCLCommandDef(
             id=0x01,
             schema={"group_id": t.Group, "scene_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         remove: Final = ZCLCommandDef(
             id=0x02,
             schema={"group_id": t.Group, "scene_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
-        remove_all: Final = ZCLCommandDef(
-            id=0x03, schema={"group_id": t.Group}, direction=Direction.Client_to_Server
-        )
+        remove_all: Final = ZCLCommandDef(id=0x03, schema={"group_id": t.Group})
         store: Final = ZCLCommandDef(
             id=0x04,
             schema={"group_id": t.Group, "scene_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         recall: Final = ZCLCommandDef(
             id=0x05,
@@ -745,10 +718,9 @@ class Scenes(Cluster):
                 "scene_id": t.uint8_t,
                 "transition_time?": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
         get_scene_membership: Final = ZCLCommandDef(
-            id=0x06, schema={"group_id": t.Group}, direction=Direction.Client_to_Server
+            id=0x06, schema={"group_id": t.Group}
         )
         enhanced_add: Final = ZCLCommandDef(
             id=0x40,
@@ -758,12 +730,10 @@ class Scenes(Cluster):
                 "transition_time": t.uint16_t,
                 "scene_name": t.LimitedCharString(16),
             },
-            direction=Direction.Client_to_Server,
         )
         enhanced_view: Final = ZCLCommandDef(
             id=0x41,
             schema={"group_id": t.Group, "scene_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         copy: Final = ZCLCommandDef(
             id=0x42,
@@ -774,7 +744,6 @@ class Scenes(Cluster):
                 "group_id_to": t.uint16_t,
                 "scene_id_to": t.uint8_t,
             },
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
@@ -785,7 +754,6 @@ class Scenes(Cluster):
                 "group_id": t.Group,
                 "scene_id": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         view_response: Final = ZCLCommandDef(
             id=0x01,
@@ -796,7 +764,6 @@ class Scenes(Cluster):
                 "transition_time?": t.uint16_t,
                 "scene_name?": t.LimitedCharString(16),
             },
-            direction=Direction.Server_to_Client,
         )
         # TODO: + extension field sets
         remove_scene_response: Final = ZCLCommandDef(
@@ -806,12 +773,10 @@ class Scenes(Cluster):
                 "group_id": t.Group,
                 "scene_id": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         remove_all_scenes_response: Final = ZCLCommandDef(
             id=0x03,
             schema={"status": foundation.Status, "group_id": t.Group},
-            direction=Direction.Server_to_Client,
         )
         store_scene_response: Final = ZCLCommandDef(
             id=0x04,
@@ -820,7 +785,6 @@ class Scenes(Cluster):
                 "group_id": t.Group,
                 "scene_id": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         get_scene_membership_response: Final = ZCLCommandDef(
             id=0x06,
@@ -830,7 +794,6 @@ class Scenes(Cluster):
                 "group_id": t.Group,
                 "scenes?": t.LVList[t.uint8_t],
             },
-            direction=Direction.Server_to_Client,
         )
         enhanced_add_response: Final = ZCLCommandDef(
             id=0x40,
@@ -839,7 +802,6 @@ class Scenes(Cluster):
                 "group_id": t.Group,
                 "scene_id": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         enhanced_view_response: Final = ZCLCommandDef(
             id=0x41,
@@ -850,7 +812,6 @@ class Scenes(Cluster):
                 "transition_time?": t.uint16_t,
                 "scene_name?": t.LimitedCharString(16),
             },
-            direction=Direction.Server_to_Client,
         )
         # TODO: + extension field sets
         copy_response: Final = ZCLCommandDef(
@@ -860,7 +821,6 @@ class Scenes(Cluster):
                 "group_id": t.Group,
                 "scene_id": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
 
 
@@ -915,23 +875,14 @@ class OnOff(Cluster):
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
 
     class ServerCommandDefs(BaseCommandDefs):
-        off: Final = ZCLCommandDef(
-            id=0x00, schema={}, direction=Direction.Client_to_Server
-        )
-        on: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
-        toggle: Final = ZCLCommandDef(
-            id=0x02, schema={}, direction=Direction.Client_to_Server
-        )
+        off: Final = ZCLCommandDef(id=0x00, schema={})
+        on: Final = ZCLCommandDef(id=0x01, schema={})
+        toggle: Final = ZCLCommandDef(id=0x02, schema={})
         off_with_effect: Final = ZCLCommandDef(
             id=0x40,
             schema={"effect_id": OffEffectIdentifier, "effect_variant": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
-        on_with_recall_global_scene: Final = ZCLCommandDef(
-            id=0x41, schema={}, direction=Direction.Client_to_Server
-        )
+        on_with_recall_global_scene: Final = ZCLCommandDef(id=0x41, schema={})
         on_with_timed_off: Final = ZCLCommandDef(
             id=0x42,
             schema={
@@ -939,7 +890,6 @@ class OnOff(Cluster):
                 "on_time": t.uint16_t,
                 "off_wait_time": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
 
 
@@ -1051,7 +1001,6 @@ class LevelControl(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=Direction.Client_to_Server,
         )
         move: Final = ZCLCommandDef(
             id=0x01,
@@ -1061,7 +1010,6 @@ class LevelControl(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=Direction.Client_to_Server,
         )
         step: Final = ZCLCommandDef(
             id=0x02,
@@ -1072,7 +1020,6 @@ class LevelControl(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=Direction.Client_to_Server,
         )
         stop: Final = ZCLCommandDef(
             id=0x03,
@@ -1080,17 +1027,14 @@ class LevelControl(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=Direction.Client_to_Server,
         )
         move_to_level_with_on_off: Final = ZCLCommandDef(
             id=0x04,
             schema={"level": t.uint8_t, "transition_time": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         move_with_on_off: Final = ZCLCommandDef(
             id=0x05,
             schema={"move_mode": MoveMode, "rate": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         step_with_on_off: Final = ZCLCommandDef(
             id=0x06,
@@ -1099,15 +1043,11 @@ class LevelControl(Cluster):
                 "step_size": t.uint8_t,
                 "transition_time": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
-        stop_with_on_off: Final = ZCLCommandDef(
-            id=0x07, schema={}, direction=Direction.Client_to_Server
-        )
+        stop_with_on_off: Final = ZCLCommandDef(id=0x07, schema={})
         move_to_closest_frequency: Final = ZCLCommandDef(
             id=0x08,
             schema={"frequency": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
 
 
@@ -1128,24 +1068,16 @@ class Alarms(Cluster):
         reset_alarm: Final = ZCLCommandDef(
             id=0x00,
             schema={"alarm_code": t.uint8_t, "cluster_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
-        reset_all_alarms: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
-        get_alarm: Final = ZCLCommandDef(
-            id=0x02, schema={}, direction=Direction.Client_to_Server
-        )
-        reset_alarm_log: Final = ZCLCommandDef(
-            id=0x03, schema={}, direction=Direction.Client_to_Server
-        )
+        reset_all_alarms: Final = ZCLCommandDef(id=0x01, schema={})
+        get_alarm: Final = ZCLCommandDef(id=0x02, schema={})
+        reset_alarm_log: Final = ZCLCommandDef(id=0x03, schema={})
         # 0x04: ("publish_event_log", {}, False),
 
     class ClientCommandDefs(BaseCommandDefs):
         alarm: Final = ZCLCommandDef(
             id=0x00,
             schema={"alarm_code": t.uint8_t, "cluster_id": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
         get_alarm_response: Final = ZCLCommandDef(
             id=0x01,
@@ -1155,7 +1087,6 @@ class Alarms(Cluster):
                 "cluster_id?": t.uint16_t,
                 "timestamp?": t.uint32_t,
             },
-            direction=Direction.Server_to_Client,
         )
         # 0x02: ("get_event_log", {}, False),
 
@@ -1300,7 +1231,6 @@ class RSSILocation(Cluster):
                 "power": t.int16s,
                 "path_loss_exponent": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
         set_dev_config: Final = ZCLCommandDef(
             id=0x01,
@@ -1311,12 +1241,10 @@ class RSSILocation(Cluster):
                 "num_rssi_measurements": t.uint8_t,
                 "reporting_period": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
         get_dev_config: Final = ZCLCommandDef(
             id=0x02,
             schema={"target_addr": t.EUI64},
-            direction=Direction.Client_to_Server,
         )
         get_location_data: Final = ZCLCommandDef(
             id=0x03,
@@ -1325,7 +1253,6 @@ class RSSILocation(Cluster):
                 "num_responses": t.uint8_t,
                 "target_addr": t.EUI64,
             },
-            direction=Direction.Client_to_Server,
         )
         rssi_response: Final = ZCLCommandDef(
             id=0x04,
@@ -1337,7 +1264,6 @@ class RSSILocation(Cluster):
                 "rssi": t.int8s,
                 "num_rssi_measurements": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         send_pings: Final = ZCLCommandDef(
             id=0x05,
@@ -1346,7 +1272,6 @@ class RSSILocation(Cluster):
                 "num_rssi_measurements": t.uint8_t,
                 "calculation_period": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
         anchor_node_announce: Final = ZCLCommandDef(
             id=0x06,
@@ -1356,7 +1281,6 @@ class RSSILocation(Cluster):
                 "y": t.int16s,
                 "z": t.int16s,
             },
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
@@ -1370,7 +1294,6 @@ class RSSILocation(Cluster):
                 "num_rssi_measurements?": t.uint8_t,
                 "reporting_period?": t.uint16_t,
             },
-            direction=Direction.Server_to_Client,
         )
         location_data_response: Final = ZCLCommandDef(
             id=0x01,
@@ -1386,34 +1309,24 @@ class RSSILocation(Cluster):
                 "quality_measure?": t.uint8_t,
                 "location_age?": t.uint16_t,
             },
-            direction=Direction.Server_to_Client,
         )
-        location_data_notification: Final = ZCLCommandDef(
-            id=0x02, schema={}, direction=Direction.Client_to_Server
-        )
-        compact_location_data_notification: Final = ZCLCommandDef(
-            id=0x03, schema={}, direction=Direction.Client_to_Server
-        )
+        location_data_notification: Final = ZCLCommandDef(id=0x02, schema={})
+        compact_location_data_notification: Final = ZCLCommandDef(id=0x03, schema={})
         rssi_ping: Final = ZCLCommandDef(
             id=0x04,
             schema={"location_type": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
-        rssi_req: Final = ZCLCommandDef(
-            id=0x05, schema={}, direction=Direction.Client_to_Server
-        )
+        rssi_req: Final = ZCLCommandDef(id=0x05, schema={})
         report_rssi_measurements: Final = ZCLCommandDef(
             id=0x06,
             schema={
                 "measuring_device": t.EUI64,
                 "neighbors": t.LVList[NeighborInfo],
             },
-            direction=Direction.Client_to_Server,
         )
         request_own_location: Final = ZCLCommandDef(
             id=0x07,
             schema={"ieee_of_blind_node": t.EUI64},
-            direction=Direction.Client_to_Server,
         )
 
 
@@ -1866,44 +1779,36 @@ class Commissioning(Cluster):
         restart_device: Final = ZCLCommandDef(
             id=0x00,
             schema={"options": t.bitmap8, "delay": t.uint8_t, "jitter": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         save_startup_parameters: Final = ZCLCommandDef(
             id=0x01,
             schema={"options": t.bitmap8, "index": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         restore_startup_parameters: Final = ZCLCommandDef(
             id=0x02,
             schema={"options": t.bitmap8, "index": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         reset_startup_parameters: Final = ZCLCommandDef(
             id=0x03,
             schema={"options": t.bitmap8, "index": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
         restart_device_response: Final = ZCLCommandDef(
             id=0x00,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         save_startup_params_response: Final = ZCLCommandDef(
             id=0x01,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         restore_startup_params_response: Final = ZCLCommandDef(
             id=0x02,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
         reset_startup_params_response: Final = ZCLCommandDef(
             id=0x03,
             schema={"status": foundation.Status},
-            direction=Direction.Server_to_Client,
         )
 
 
@@ -2151,15 +2056,9 @@ class Ota(Cluster):
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
 
     class ServerCommandDefs(BaseCommandDefs):
-        query_next_image: Final = ZCLCommandDef(
-            id=0x01, schema=QueryNextImageCommand, direction=Direction.Client_to_Server
-        )
-        image_block: Final = ZCLCommandDef(
-            id=0x03, schema=ImageBlockCommand, direction=Direction.Client_to_Server
-        )
-        image_page: Final = ZCLCommandDef(
-            id=0x04, schema=ImagePageCommand, direction=Direction.Client_to_Server
-        )
+        query_next_image: Final = ZCLCommandDef(id=0x01, schema=QueryNextImageCommand)
+        image_block: Final = ZCLCommandDef(id=0x03, schema=ImageBlockCommand)
+        image_page: Final = ZCLCommandDef(id=0x04, schema=ImagePageCommand)
         upgrade_end: Final = ZCLCommandDef(
             id=0x06,
             schema={
@@ -2168,7 +2067,6 @@ class Ota(Cluster):
                 "image_type": t.uint16_t,
                 "file_version": t.uint32_t,
             },
-            direction=Direction.Client_to_Server,
         )
         query_specific_file: Final = ZCLCommandDef(
             id=0x08,
@@ -2179,13 +2077,10 @@ class Ota(Cluster):
                 "file_version": t.uint32_t,
                 "current_zigbee_stack_version": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
-        image_notify: Final = ZCLCommandDef(
-            id=0x00, schema=ImageNotifyCommand, direction=Direction.Client_to_Server
-        )
+        image_notify: Final = ZCLCommandDef(id=0x00, schema=ImageNotifyCommand)
         query_next_image_response: Final = ZCLCommandDef(
             id=0x02,
             schema={
@@ -2195,12 +2090,10 @@ class Ota(Cluster):
                 "file_version?": t.uint32_t,
                 "image_size?": t.uint32_t,
             },
-            direction=Direction.Server_to_Client,
         )
         image_block_response: Final = ZCLCommandDef(
             id=0x05,
             schema=ImageBlockResponseCommand,
-            direction=Direction.Server_to_Client,
         )
         upgrade_end_response: Final = ZCLCommandDef(
             id=0x07,
@@ -2211,7 +2104,6 @@ class Ota(Cluster):
                 "current_time": t.UTCTime,
                 "upgrade_time": t.UTCTime,
             },
-            direction=Direction.Server_to_Client,
         )
         query_specific_file_response: Final = ZCLCommandDef(
             id=0x09,
@@ -2222,7 +2114,6 @@ class Ota(Cluster):
                 "file_version?": t.uint32_t,
                 "image_size?": t.uint32_t,
             },
-            direction=Direction.Server_to_Client,
         )
 
     def handle_cluster_request(
@@ -2324,11 +2215,8 @@ class PowerProfile(Cluster):
         power_profile_request: Final = ZCLCommandDef(
             id=0x00,
             schema={"power_profile_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
-        power_profile_state_request: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
+        power_profile_state_request: Final = ZCLCommandDef(id=0x01, schema={})
         get_power_profile_price_response: Final = ZCLCommandDef(
             id=0x02,
             schema={
@@ -2337,7 +2225,6 @@ class PowerProfile(Cluster):
                 "price": t.uint32_t,
                 "price_trailing_digit": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         get_overall_schedule_price_response: Final = ZCLCommandDef(
             id=0x03,
@@ -2346,7 +2233,6 @@ class PowerProfile(Cluster):
                 "price": t.uint32_t,
                 "price_trailing_digit": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         energy_phases_schedule_notification: Final = ZCLCommandDef(
             id=0x04,
@@ -2354,7 +2240,6 @@ class PowerProfile(Cluster):
                 "power_profile_id": t.uint8_t,
                 "scheduled_phases": t.LVList[ScheduleRecord],
             },
-            direction=Direction.Client_to_Server,
         )
         energy_phases_schedule_response: Final = ZCLCommandDef(
             id=0x05,
@@ -2362,17 +2247,14 @@ class PowerProfile(Cluster):
                 "power_profile_id": t.uint8_t,
                 "scheduled_phases": t.LVList[ScheduleRecord],
             },
-            direction=Direction.Server_to_Client,
         )
         power_profile_schedule_constraints_request: Final = ZCLCommandDef(
             id=0x06,
             schema={"power_profile_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         energy_phases_schedule_state_request: Final = ZCLCommandDef(
             id=0x07,
             schema={"power_profile_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         get_power_profile_price_extended_response: Final = ZCLCommandDef(
             id=0x08,
@@ -2382,7 +2264,6 @@ class PowerProfile(Cluster):
                 "price": t.uint32_t,
                 "price_trailing_digit": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
@@ -2393,7 +2274,6 @@ class PowerProfile(Cluster):
                 "power_profile_id": t.uint8_t,
                 "transfer_phases": t.LVList[PowerProfilePhase],
             },
-            direction=Direction.Client_to_Server,
         )
         power_profile_response: Final = ZCLCommandDef(
             id=0x01,
@@ -2402,30 +2282,23 @@ class PowerProfile(Cluster):
                 "power_profile_id": t.uint8_t,
                 "transfer_phases": t.LVList[PowerProfilePhase],
             },
-            direction=Direction.Server_to_Client,
         )
         power_profile_state_response: Final = ZCLCommandDef(
             id=0x02,
             schema={"power_profiles": t.LVList[PowerProfileType]},
-            direction=Direction.Server_to_Client,
         )
         get_power_profile_price: Final = ZCLCommandDef(
             id=0x03,
             schema={"power_profile_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         power_profile_state_notification: Final = ZCLCommandDef(
             id=0x04,
             schema={"power_profiles": t.LVList[PowerProfileType]},
-            direction=Direction.Client_to_Server,
         )
-        get_overall_schedule_price: Final = ZCLCommandDef(
-            id=0x05, schema={}, direction=Direction.Client_to_Server
-        )
+        get_overall_schedule_price: Final = ZCLCommandDef(id=0x05, schema={})
         energy_phases_schedule_request: Final = ZCLCommandDef(
             id=0x06,
             schema={"power_profile_id": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         energy_phases_schedule_state_response: Final = ZCLCommandDef(
             id=0x07,
@@ -2433,7 +2306,6 @@ class PowerProfile(Cluster):
                 "power_profile_id": t.uint8_t,
                 "num_scheduled_energy_phases": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         energy_phases_schedule_state_notification: Final = ZCLCommandDef(
             id=0x08,
@@ -2441,7 +2313,6 @@ class PowerProfile(Cluster):
                 "power_profile_id": t.uint8_t,
                 "num_scheduled_energy_phases": t.uint8_t,
             },
-            direction=Direction.Client_to_Server,
         )
         power_profile_schedule_constraints_notification: Final = ZCLCommandDef(
             id=0x09,
@@ -2450,7 +2321,6 @@ class PowerProfile(Cluster):
                 "start_after": t.uint16_t,
                 "stop_before": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
         power_profile_schedule_constraints_response: Final = ZCLCommandDef(
             id=0x0A,
@@ -2459,7 +2329,6 @@ class PowerProfile(Cluster):
                 "start_after": t.uint16_t,
                 "stop_before": t.uint16_t,
             },
-            direction=Direction.Server_to_Client,
         )
         get_power_profile_price_extended: Final = ZCLCommandDef(
             id=0x0B,
@@ -2468,7 +2337,6 @@ class PowerProfile(Cluster):
                 "power_profile_id": t.uint8_t,
                 "power_profile_start_time?": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
 
 
@@ -2522,26 +2390,19 @@ class PollControl(Cluster):
         checkin_response: Final = ZCLCommandDef(
             id=0x00,
             schema={"start_fast_polling": t.Bool, "fast_poll_timeout": t.uint16_t},
-            direction=Direction.Server_to_Client,
         )
-        fast_poll_stop: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
+        fast_poll_stop: Final = ZCLCommandDef(id=0x01, schema={})
         set_long_poll_interval: Final = ZCLCommandDef(
             id=0x02,
             schema={"new_long_poll_interval": t.uint32_t},
-            direction=Direction.Client_to_Server,
         )
         set_short_poll_interval: Final = ZCLCommandDef(
             id=0x03,
             schema={"new_short_poll_interval": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
-        checkin: Final = ZCLCommandDef(
-            id=0x0000, schema={}, direction=Direction.Client_to_Server
-        )
+        checkin: Final = ZCLCommandDef(id=0x0000, schema={})
 
 
 class GreenPowerProxy(Cluster):

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -104,12 +104,12 @@ class ApplianceEventAlerts(Cluster):
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
 
     class ServerCommandDefs(BaseCommandDefs):
-        get_alerts: Final = ZCLCommandDef(id=0x00, schema={}, direction=False)
+        get_alerts: Final = ZCLCommandDef(id=0x00, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
-        get_alerts_response: Final = ZCLCommandDef(id=0x00, schema={}, direction=True)
-        alerts_notification: Final = ZCLCommandDef(id=0x01, schema={}, direction=False)
-        event_notification: Final = ZCLCommandDef(id=0x02, schema={}, direction=False)
+        get_alerts_response: Final = ZCLCommandDef(id=0x00, schema={})
+        alerts_notification: Final = ZCLCommandDef(id=0x01, schema={})
+        event_notification: Final = ZCLCommandDef(id=0x02, schema={})
 
 
 class ApplianceStatistics(Cluster):
@@ -128,14 +128,14 @@ class ApplianceStatistics(Cluster):
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
 
     class ServerCommandDefs(BaseCommandDefs):
-        log: Final = ZCLCommandDef(id=0x00, schema={}, direction=False)
-        log_queue: Final = ZCLCommandDef(id=0x01, schema={}, direction=False)
+        log: Final = ZCLCommandDef(id=0x00, schema={})
+        log_queue: Final = ZCLCommandDef(id=0x01, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
-        log_notification: Final = ZCLCommandDef(id=0x00, schema={}, direction=False)
-        log_response: Final = ZCLCommandDef(id=0x01, schema={}, direction=True)
-        log_queue_response: Final = ZCLCommandDef(id=0x02, schema={}, direction=True)
-        statistics_available: Final = ZCLCommandDef(id=0x03, schema={}, direction=False)
+        log_notification: Final = ZCLCommandDef(id=0x00, schema={})
+        log_response: Final = ZCLCommandDef(id=0x01, schema={})
+        log_queue_response: Final = ZCLCommandDef(id=0x02, schema={})
+        statistics_available: Final = ZCLCommandDef(id=0x03, schema={})
 
 
 class MeasurementType(t.bitmap32):
@@ -528,18 +528,12 @@ class ElectricalMeasurement(Cluster):
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
 
     class ServerCommandDefs(BaseCommandDefs):
-        get_profile_info: Final = ZCLCommandDef(id=0x00, schema={}, direction=False)
-        get_measurement_profile: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=False
-        )
+        get_profile_info: Final = ZCLCommandDef(id=0x00, schema={})
+        get_measurement_profile: Final = ZCLCommandDef(id=0x01, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
-        get_profile_info_response: Final = ZCLCommandDef(
-            id=0x00, schema={}, direction=True
-        )
-        get_measurement_profile_response: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=True
-        )
+        get_profile_info_response: Final = ZCLCommandDef(id=0x00, schema={})
+        get_measurement_profile_response: Final = ZCLCommandDef(id=0x01, schema={})
 
 
 class Diagnostic(Cluster):

--- a/zigpy/zcl/clusters/hvac.py
+++ b/zigpy/zcl/clusters/hvac.py
@@ -9,7 +9,6 @@ from zigpy.zcl import Cluster
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
-    Direction,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
@@ -499,9 +498,7 @@ class Thermostat(Cluster):
 
     class ServerCommandDefs(BaseCommandDefs):
         setpoint_raise_lower: Final = ZCLCommandDef(
-            id=0x00,
-            schema={"mode": SetpointMode, "amount": t.int8s},
-            direction=Direction.Client_to_Server,
+            id=0x00, schema={"mode": SetpointMode, "amount": t.int8s}
         )
         set_weekly_schedule: Final = ZCLCommandDef(
             id=0x01,
@@ -511,19 +508,12 @@ class Thermostat(Cluster):
                 "mode_for_sequence": SeqMode,
                 "values": t.List[t.int16s],
             },
-            direction=Direction.Client_to_Server,
         )
         get_weekly_schedule: Final = ZCLCommandDef(
-            id=0x02,
-            schema={"days_to_return": SeqDayOfWeek, "mode_to_return": SeqMode},
-            direction=Direction.Client_to_Server,
+            id=0x02, schema={"days_to_return": SeqDayOfWeek, "mode_to_return": SeqMode}
         )
-        clear_weekly_schedule: Final = ZCLCommandDef(
-            id=0x03, schema={}, direction=Direction.Client_to_Server
-        )
-        get_relay_status_log: Final = ZCLCommandDef(
-            id=0x04, schema={}, direction=Direction.Client_to_Server
-        )
+        clear_weekly_schedule: Final = ZCLCommandDef(id=0x03, schema={})
+        get_relay_status_log: Final = ZCLCommandDef(id=0x04, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
         get_weekly_schedule_response: Final = ZCLCommandDef(
@@ -534,7 +524,6 @@ class Thermostat(Cluster):
                 "mode_for_sequence": SeqMode,
                 "values": t.List[t.int16s],
             },
-            direction=Direction.Server_to_Client,
         )
         get_relay_status_log_response: Final = ZCLCommandDef(
             id=0x01,
@@ -546,7 +535,6 @@ class Thermostat(Cluster):
                 "set_point": t.int16s,
                 "unread_entries": t.uint16_t,
             },
-            direction=Direction.Server_to_Client,
         )
 
 

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -9,7 +9,6 @@ from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
-    Direction as CommandDirection,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
@@ -234,7 +233,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         move_hue: Final = ZCLCommandDef(
             id=0x01,
@@ -244,7 +242,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         step_hue: Final = ZCLCommandDef(
             id=0x02,
@@ -255,7 +252,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         move_to_saturation: Final = ZCLCommandDef(
             id=0x03,
@@ -265,7 +261,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         move_saturation: Final = ZCLCommandDef(
             id=0x04,
@@ -275,7 +270,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         step_saturation: Final = ZCLCommandDef(
             id=0x05,
@@ -286,7 +280,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         move_to_hue_and_saturation: Final = ZCLCommandDef(
             id=0x06,
@@ -297,7 +290,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         move_to_color: Final = ZCLCommandDef(
             id=0x07,
@@ -308,7 +300,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         move_color: Final = ZCLCommandDef(
             id=0x08,
@@ -318,7 +309,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         step_color: Final = ZCLCommandDef(
             id=0x09,
@@ -329,7 +319,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         move_to_color_temp: Final = ZCLCommandDef(
             id=0x0A,
@@ -339,7 +328,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         enhanced_move_to_hue: Final = ZCLCommandDef(
             id=0x40,
@@ -350,7 +338,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         enhanced_move_hue: Final = ZCLCommandDef(
             id=0x41,
@@ -360,7 +347,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         enhanced_step_hue: Final = ZCLCommandDef(
             id=0x42,
@@ -371,7 +357,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         enhanced_move_to_hue_and_saturation: Final = ZCLCommandDef(
             id=0x43,
@@ -382,7 +367,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         color_loop_set: Final = ZCLCommandDef(
             id=0x44,
@@ -395,7 +379,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         stop_move_step: Final = ZCLCommandDef(
             id=0x47,
@@ -403,7 +386,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         move_color_temp: Final = ZCLCommandDef(
             id=0x4B,
@@ -415,7 +397,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
         step_color_temp: Final = ZCLCommandDef(
             id=0x4C,
@@ -428,7 +409,6 @@ class Color(Cluster):
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
-            direction=CommandDirection.Client_to_Server,
         )
 
 

--- a/zigpy/zcl/clusters/lightlink.py
+++ b/zigpy/zcl/clusters/lightlink.py
@@ -4,7 +4,7 @@ from typing import Final
 
 import zigpy.types as t
 from zigpy.zcl import Cluster
-from zigpy.zcl.foundation import BaseCommandDefs, Direction, ZCLCommandDef
+from zigpy.zcl.foundation import BaseCommandDefs, ZCLCommandDef
 
 
 class LogicalType(t.enum2):
@@ -89,12 +89,10 @@ class LightLink(Cluster):
                 "zigbee_information": ZigbeeInformation,
                 "touchlink_information": ScanRequestInformation,
             },
-            direction=Direction.Client_to_Server,
         )
         device_info: Final = ZCLCommandDef(
             id=0x02,
             schema={"inter_pan_transaction_id": t.uint32_t, "start_index": t.uint8_t},
-            direction=Direction.Client_to_Server,
         )
         identify: Final = ZCLCommandDef(
             id=0x06,
@@ -102,12 +100,10 @@ class LightLink(Cluster):
                 "inter_pan_transaction_id": t.uint32_t,
                 "identify_duration": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
         reset_to_factory_new: Final = ZCLCommandDef(
             id=0x07,
             schema={"inter_pan_transaction_id": t.uint32_t},
-            direction=Direction.Client_to_Server,
         )
         network_start: Final = ZCLCommandDef(
             id=0x10,
@@ -128,7 +124,6 @@ class LightLink(Cluster):
                 "initiator_ieee": t.EUI64,
                 "initiator_nwk": t.NWK,
             },
-            direction=Direction.Client_to_Server,
         )
         network_join_router: Final = ZCLCommandDef(
             id=0x12,
@@ -148,7 +143,6 @@ class LightLink(Cluster):
                 "free_group_id_range_begin": t.Group,
                 "free_group_id_range_end": t.Group,
             },
-            direction=Direction.Client_to_Server,
         )
         network_join_end_device: Final = ZCLCommandDef(
             id=0x14,
@@ -168,7 +162,6 @@ class LightLink(Cluster):
                 "free_group_id_range_begin": t.Group,
                 "free_group_id_range_end": t.Group,
             },
-            direction=Direction.Client_to_Server,
         )
         network_update: Final = ZCLCommandDef(
             id=0x16,
@@ -180,7 +173,6 @@ class LightLink(Cluster):
                 "pan_id": t.PanId,
                 "nwk_addr": t.NWK,
             },
-            direction=Direction.Client_to_Server,
         )
         # Utility
         get_group_identifiers: Final = ZCLCommandDef(
@@ -188,14 +180,12 @@ class LightLink(Cluster):
             schema={
                 "start_index": t.uint8_t,
             },
-            direction=Direction.Client_to_Server,
         )
         get_endpoint_list: Final = ZCLCommandDef(
             id=0x42,
             schema={
                 "start_index": t.uint8_t,
             },
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
@@ -221,7 +211,6 @@ class LightLink(Cluster):
                 "version?": t.uint8_t,
                 "group_id_count?": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         device_info_rsp: Final = ZCLCommandDef(
             id=0x03,
@@ -231,7 +220,6 @@ class LightLink(Cluster):
                 "start_index": t.uint8_t,
                 "device_info_records": t.LVList[DeviceInfoRecord],
             },
-            direction=Direction.Server_to_Client,
         )
         network_start_rsp: Final = ZCLCommandDef(
             id=0x11,
@@ -243,7 +231,6 @@ class LightLink(Cluster):
                 "logical_channel": t.uint8_t,
                 "pan_id": t.PanId,
             },
-            direction=Direction.Server_to_Client,
         )
         network_join_router_rsp: Final = ZCLCommandDef(
             id=0x13,
@@ -251,7 +238,6 @@ class LightLink(Cluster):
                 "inter_pan_transaction_id": t.uint32_t,
                 "status": Status,
             },
-            direction=Direction.Server_to_Client,
         )
         network_join_end_device_rsp: Final = ZCLCommandDef(
             id=0x15,
@@ -259,7 +245,6 @@ class LightLink(Cluster):
                 "inter_pan_transaction_id": t.uint32_t,
                 "status": Status,
             },
-            direction=Direction.Server_to_Client,
         )
         # Utility
         endpoint_info: Final = ZCLCommandDef(
@@ -272,7 +257,6 @@ class LightLink(Cluster):
                 "device_id": t.uint16_t,
                 "version": t.uint8_t,
             },
-            direction=Direction.Server_to_Client,
         )
         get_group_identifiers_rsp: Final = ZCLCommandDef(
             id=0x41,
@@ -281,7 +265,6 @@ class LightLink(Cluster):
                 "start_index": t.uint8_t,
                 "group_info_records": t.LVList[GroupInfoRecord],
             },
-            direction=Direction.Server_to_Client,
         )
         get_endpoint_list_rsp: Final = ZCLCommandDef(
             id=0x42,
@@ -290,5 +273,4 @@ class LightLink(Cluster):
                 "start_index": t.uint8_t,
                 "endpoint_info_records": t.LVList[EndpointInfoRecord],
             },
-            direction=Direction.Server_to_Client,
         )

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -9,7 +9,6 @@ from zigpy.zcl import Cluster
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
-    Direction,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
@@ -30,17 +29,11 @@ class GenericTunnel(Cluster):
         protocol_addr: Final = ZCLAttributeDef(id=0x0003, type=t.LVBytes)
 
     class ServerCommandDefs(BaseCommandDefs):
-        match_protocol_addr: Final = ZCLCommandDef(
-            id=0x00, schema={}, direction=Direction.Client_to_Server
-        )
+        match_protocol_addr: Final = ZCLCommandDef(id=0x00, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
-        match_protocol_addr_response: Final = ZCLCommandDef(
-            id=0x00, schema={}, direction=Direction.Server_to_Client
-        )
-        advertise_protocol_address: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
+        match_protocol_addr_response: Final = ZCLCommandDef(id=0x00, schema={})
+        advertise_protocol_address: Final = ZCLCommandDef(id=0x01, schema={})
 
 
 class BacnetProtocolTunnel(Cluster):
@@ -48,9 +41,7 @@ class BacnetProtocolTunnel(Cluster):
     ep_attribute: Final = "bacnet_tunnel"
 
     class ServerCommandDefs(BaseCommandDefs):
-        transfer_npdu: Final = ZCLCommandDef(
-            id=0x00, schema={"npdu": t.LVBytes}, direction=Direction.Client_to_Server
-        )
+        transfer_npdu: Final = ZCLCommandDef(id=0x00, schema={"npdu": t.LVBytes})
 
 
 class AnalogInputRegular(Cluster):
@@ -86,18 +77,10 @@ class AnalogInputExtended(Cluster):
         # integer, time of day, or structure of (date, time of day))
 
     class ServerCommandDefs(BaseCommandDefs):
-        transfer_apdu: Final = ZCLCommandDef(
-            id=0x00, schema={}, direction=Direction.Client_to_Server
-        )
-        connect_req: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
-        disconnect_req: Final = ZCLCommandDef(
-            id=0x02, schema={}, direction=Direction.Client_to_Server
-        )
-        connect_status_noti: Final = ZCLCommandDef(
-            id=0x03, schema={}, direction=Direction.Client_to_Server
-        )
+        transfer_apdu: Final = ZCLCommandDef(id=0x00, schema={})
+        connect_req: Final = ZCLCommandDef(id=0x01, schema={})
+        disconnect_req: Final = ZCLCommandDef(id=0x02, schema={})
+        connect_status_noti: Final = ZCLCommandDef(id=0x03, schema={})
 
 
 class AnalogOutputRegular(Cluster):

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -10,6 +10,7 @@ from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
+    Direction,
     ZCLAttributeDef,
     ZCLCommandDef,
 )

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -10,7 +10,6 @@ from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
-    Direction,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
@@ -110,10 +109,10 @@ class IasZone(Cluster):
         enroll_response: Final = ZCLCommandDef(
             id=0x00,
             schema={"enroll_response_code": EnrollResponse, "zone_id": t.uint8_t},
-            direction=Direction.Server_to_Client,
         )
         init_normal_op_mode: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
+            id=0x01,
+            schema={},
         )
         init_test_mode: Final = ZCLCommandDef(
             id=0x02,
@@ -121,7 +120,6 @@ class IasZone(Cluster):
                 "test_mode_duration": t.uint8_t,
                 "current_zone_sensitivity_level": t.uint8_t,
             },
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
@@ -133,12 +131,10 @@ class IasZone(Cluster):
                 "zone_id": t.uint8_t,
                 "delay": t.uint16_t,
             },
-            direction=Direction.Client_to_Server,
         )
         enroll: Final = ZCLCommandDef(
             id=0x01,
             schema={"zone_type": ZoneType, "manufacturer_code": t.uint16_t},
-            direction=Direction.Client_to_Server,
         )
 
     def handle_cluster_request(
@@ -262,7 +258,6 @@ class IasAce(Cluster):
                 "arm_disarm_code": t.CharacterString,
                 "zone_id": t.uint8_t,
             },
-            direction=Direction.Client_to_Server,
         )
         bypass: Final = ZCLCommandDef(
             id=0x01,
@@ -270,28 +265,34 @@ class IasAce(Cluster):
                 "zones_ids": t.LVList[t.uint8_t],
                 "arm_disarm_code": t.CharacterString,
             },
-            direction=Direction.Client_to_Server,
         )
         emergency: Final = ZCLCommandDef(
-            id=0x02, schema={}, direction=Direction.Client_to_Server
+            id=0x02,
+            schema={},
         )
         fire: Final = ZCLCommandDef(
-            id=0x03, schema={}, direction=Direction.Client_to_Server
+            id=0x03,
+            schema={},
         )
         panic: Final = ZCLCommandDef(
-            id=0x04, schema={}, direction=Direction.Client_to_Server
+            id=0x04,
+            schema={},
         )
         get_zone_id_map: Final = ZCLCommandDef(
-            id=0x05, schema={}, direction=Direction.Client_to_Server
+            id=0x05,
+            schema={},
         )
         get_zone_info: Final = ZCLCommandDef(
-            id=0x06, schema={"zone_id": t.uint8_t}, direction=Direction.Client_to_Server
+            id=0x06,
+            schema={"zone_id": t.uint8_t},
         )
         get_panel_status: Final = ZCLCommandDef(
-            id=0x07, schema={}, direction=Direction.Client_to_Server
+            id=0x07,
+            schema={},
         )
         get_bypassed_zone_list: Final = ZCLCommandDef(
-            id=0x08, schema={}, direction=Direction.Client_to_Server
+            id=0x08,
+            schema={},
         )
         get_zone_status: Final = ZCLCommandDef(
             id=0x09,
@@ -301,19 +302,16 @@ class IasAce(Cluster):
                 "zone_status_mask_flag": t.Bool,
                 "zone_status_mask": ZoneStatus,
             },
-            direction=Direction.Client_to_Server,
         )
 
     class ClientCommandDefs(BaseCommandDefs):
         arm_response: Final = ZCLCommandDef(
             id=0x00,
             schema={"arm_notification": ArmNotification},
-            direction=Direction.Server_to_Client,
         )
         get_zone_id_map_response: Final = ZCLCommandDef(
             id=0x01,
             schema={"zone_id_map_sections": t.List[t.bitmap16]},
-            direction=Direction.Server_to_Client,
         )
         get_zone_info_response: Final = ZCLCommandDef(
             id=0x02,
@@ -323,7 +321,6 @@ class IasAce(Cluster):
                 "ieee": t.EUI64,
                 "zone_label": t.CharacterString,
             },
-            direction=Direction.Server_to_Client,
         )
         zone_status_changed: Final = ZCLCommandDef(
             id=0x03,
@@ -333,7 +330,6 @@ class IasAce(Cluster):
                 "audible_notification": AudibleNotification,
                 "zone_label": t.CharacterString,
             },
-            direction=Direction.Client_to_Server,
         )
         panel_status_changed: Final = ZCLCommandDef(
             id=0x04,
@@ -343,7 +339,6 @@ class IasAce(Cluster):
                 "audible_notification": AudibleNotification,
                 "alarm_status": AlarmStatus,
             },
-            direction=Direction.Client_to_Server,
         )
         panel_status_response: Final = ZCLCommandDef(
             id=0x05,
@@ -353,17 +348,14 @@ class IasAce(Cluster):
                 "audible_notification": AudibleNotification,
                 "alarm_status": AlarmStatus,
             },
-            direction=Direction.Server_to_Client,
         )
         set_bypassed_zone_list: Final = ZCLCommandDef(
             id=0x06,
             schema={"zone_ids": t.LVList[t.uint8_t]},
-            direction=Direction.Client_to_Server,
         )
         bypass_response: Final = ZCLCommandDef(
             id=0x07,
             schema={"bypass_results": t.LVList[BypassResponse]},
-            direction=Direction.Server_to_Client,
         )
         get_zone_status_response: Final = ZCLCommandDef(
             id=0x08,
@@ -371,7 +363,6 @@ class IasAce(Cluster):
                 "zone_status_complete": t.Bool,
                 "zone_statuses": t.LVList[ZoneStatusRsp],
             },
-            direction=Direction.Server_to_Client,
         )
 
 
@@ -525,8 +516,8 @@ class IasWd(Cluster):
                 "strobe_duty_cycle": t.uint8_t,
                 "stobe_level": StrobeLevel,
             },
-            direction=Direction.Client_to_Server,
         )
         squawk: Final = ZCLCommandDef(
-            id=0x01, schema={"squawk": Squawk}, direction=Direction.Client_to_Server
+            id=0x01,
+            schema={"squawk": Squawk},
         )

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -8,7 +8,6 @@ from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
     DataType,
-    Direction,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
@@ -584,44 +583,20 @@ class Metering(Cluster):
         )
 
     class ServerCommandDefs(BaseCommandDefs):
-        get_profile: Final = ZCLCommandDef(
-            id=0x00, schema={}, direction=Direction.Client_to_Server
-        )
-        req_mirror: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Client_to_Server
-        )
-        mirror_rem: Final = ZCLCommandDef(
-            id=0x02, schema={}, direction=Direction.Client_to_Server
-        )
-        req_fast_poll_mode: Final = ZCLCommandDef(
-            id=0x03, schema={}, direction=Direction.Client_to_Server
-        )
-        get_snapshot: Final = ZCLCommandDef(
-            id=0x04, schema={}, direction=Direction.Client_to_Server
-        )
-        take_snapshot: Final = ZCLCommandDef(
-            id=0x05, schema={}, direction=Direction.Client_to_Server
-        )
-        mirror_report_attr_response: Final = ZCLCommandDef(
-            id=0x06, schema={}, direction=Direction.Server_to_Client
-        )
+        get_profile: Final = ZCLCommandDef(id=0x00, schema={})
+        req_mirror: Final = ZCLCommandDef(id=0x01, schema={})
+        mirror_rem: Final = ZCLCommandDef(id=0x02, schema={})
+        req_fast_poll_mode: Final = ZCLCommandDef(id=0x03, schema={})
+        get_snapshot: Final = ZCLCommandDef(id=0x04, schema={})
+        take_snapshot: Final = ZCLCommandDef(id=0x05, schema={})
+        mirror_report_attr_response: Final = ZCLCommandDef(id=0x06, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
-        get_profile_response: Final = ZCLCommandDef(
-            id=0x00, schema={}, direction=Direction.Server_to_Client
-        )
-        req_mirror_response: Final = ZCLCommandDef(
-            id=0x01, schema={}, direction=Direction.Server_to_Client
-        )
-        mirror_rem_response: Final = ZCLCommandDef(
-            id=0x02, schema={}, direction=Direction.Server_to_Client
-        )
-        req_fast_poll_mode_response: Final = ZCLCommandDef(
-            id=0x03, schema={}, direction=Direction.Server_to_Client
-        )
-        get_snapshot_response: Final = ZCLCommandDef(
-            id=0x04, schema={}, direction=Direction.Server_to_Client
-        )
+        get_profile_response: Final = ZCLCommandDef(id=0x00, schema={})
+        req_mirror_response: Final = ZCLCommandDef(id=0x01, schema={})
+        mirror_rem_response: Final = ZCLCommandDef(id=0x02, schema={})
+        req_fast_poll_mode_response: Final = ZCLCommandDef(id=0x03, schema={})
+        get_snapshot_response: Final = ZCLCommandDef(id=0x04, schema={})
 
 
 class Messaging(Cluster):


### PR DESCRIPTION
I've been investigating #1612 / #1599 and have run across a few bugs. This is a fairly simple change but more than a few commands (including commonly-used ones!) have bad `direction` fields, including the `Time` cluster and a few `Ota` commands. We weren't really using the `direction` for much but it definitely impacts the generation of default replies.

This will likely have to be downgraded to a loud warning instead of a hard error due to custom quirks likely existing with this bug. Alternatively, we can break compatibility, since custom quirks are entirely the responsibility of the person using them.