### PR TITLE
Match incoming cluster commands based on `direction`

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -127,24 +127,6 @@ def test_multiple_add_output_cluster(ep):
     assert ep.out_clusters[0].cluster_id == 1
 
 
-def test_handle_message(ep):
-    c = ep.add_input_cluster(0)
-    c.handle_message = MagicMock()
-    ep.handle_message(sentinel.profile, 0, sentinel.hdr, sentinel.data)
-    c.handle_message.assert_called_once_with(
-        sentinel.hdr, sentinel.data, dst_addressing=None
-    )
-
-
-def test_handle_message_output(ep):
-    c = ep.add_output_cluster(0)
-    c.handle_message = MagicMock()
-    ep.handle_message(sentinel.profile, 0, sentinel.hdr, sentinel.data)
-    c.handle_message.assert_called_once_with(
-        sentinel.hdr, sentinel.data, dst_addressing=None
-    )
-
-
 def test_handle_request_unknown(ep):
     hdr = MagicMock()
     hdr.command_id = sentinel.command_id

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -15,6 +15,7 @@ import zigpy.zcl
 from zigpy.zcl.foundation import (
     GENERAL_COMMANDS,
     CommandSchema,
+    Direction,
     GeneralCommand,
     Status as ZCLStatus,
     ZCLHeader,
@@ -236,16 +237,17 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         *,
         dst_addressing: AddressingMode | None = None,
     ) -> None:
-        if cluster in self.in_clusters:
-            handler = self.in_clusters[cluster].handle_message
-        elif cluster in self.out_clusters:
-            handler = self.out_clusters[cluster].handle_message
-        else:
+        try:
+            if hdr.direction == Direction.Client_to_Server:
+                cluster = self.out_clusters[cluster]
+            else:
+                cluster = self.in_clusters[cluster]
+        except KeyError:
             self.debug("Message on unknown cluster 0x%04x", cluster)
             self.listener_event("unknown_cluster_message", hdr.command_id, args)
             return
 
-        handler(hdr, args, dst_addressing=dst_addressing)
+        cluster.handle_message(hdr, args, dst_addressing=dst_addressing)
 
     async def request(
         self,

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -239,15 +239,15 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     ) -> None:
         try:
             if hdr.direction == Direction.Client_to_Server:
-                cluster = self.out_clusters[cluster]
+                zcl_cluster = self.out_clusters[cluster]
             else:
-                cluster = self.in_clusters[cluster]
+                zcl_cluster = self.in_clusters[cluster]
         except KeyError:
             self.debug("Message on unknown cluster 0x%04x", cluster)
             self.listener_event("unknown_cluster_message", hdr.command_id, args)
             return
 
-        cluster.handle_message(hdr, args, dst_addressing=dst_addressing)
+        zcl_cluster.handle_message(hdr, args, dst_addressing=dst_addressing)
 
     async def request(
         self,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -289,7 +289,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
             command = foundation.GENERAL_COMMANDS[hdr.command_id]
 
-        hdr.frame_control = hdr.frame_control.replace(direction=command.direction)
         response, data = command.schema.deserialize(data)
 
         self.debug("Decoded ZCL frame: %s:%r", type(self).__name__, response)


### PR DESCRIPTION
Related to #1612 / #1599.

We currently match clusters by ID alone, preferring server over client. This surprisingly works for most devices but a few have both server and client clusters of the same type on the same endpoint. For them, this breaks things.

I've also removed a hack that I can't track down the source of:

https://github.com/zigpy/zigpy/blob/cb5f0f7725433c2f801ecd0ffd563f72ebb45bdf/zigpy/zcl/__init__.py#L292

It really frustrated debugging efforts for the `Ota` cluster when coupled with the `direction` mistake fixed in https://github.com/zigpy/zigpy/pull/1614.