### PR TITLE
Add `can_write_network_settings` to ControllerApplication API

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1689,3 +1689,10 @@ async def test_request_priority_context_concurrency(app, packet):
         call(packet.replace(data=b"high")),
         call(packet.replace(data=b"normal")),
     ]
+
+
+async def test_can_write_network_settings(app) -> None:
+    # The default is True
+    assert await app.can_write_network_settings(
+        network_info=app.state.network_info, node_info=app.state.node_info
+    )

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1691,11 +1691,6 @@ async def test_request_priority_context_concurrency(app, packet):
     ]
 
 
-async def test_can_read_network_settings(app) -> None:
-    # The default is True
-    assert await app.can_read_network_settings()
-
-
 async def test_can_write_network_settings(app) -> None:
     # The default is True
     assert await app.can_write_network_settings(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1691,6 +1691,11 @@ async def test_request_priority_context_concurrency(app, packet):
     ]
 
 
+async def test_can_read_network_settings(app) -> None:
+    # The default is True
+    assert await app.can_read_network_settings()
+
+
 async def test_can_write_network_settings(app) -> None:
     # The default is True
     assert await app.can_write_network_settings(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1344,12 +1344,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Permit a node to join with the provided link key."""
         raise NotImplementedError  # pragma: no cover
 
-    async def can_read_network_settings(
-        self,
-        *,
-        network_info: zigpy.state.NetworkInfo,
-        node_info: zigpy.state.NodeInfo,
-    ) -> bool:
+    async def can_read_network_settings(self) -> bool:
         """Returns `True` if the radio can read the given network settings.
 
         If reading is not possible, `CannotReadNetworkSettings` is raised.

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -13,7 +13,7 @@ import random
 import sys
 import time
 import typing
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 import warnings
 
 from zigpy.backports.contextlib import nullcontext
@@ -1344,12 +1344,28 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Permit a node to join with the provided link key."""
         raise NotImplementedError  # pragma: no cover
 
+    @overload
     async def can_write_network_settings(
         self,
         network_info: zigpy.state.NetworkInfo,
         node_info: zigpy.state.NodeInfo,
+    ) -> bool: ...
+
+    @overload
+    async def can_write_network_settings(
+        self,
+        network_info: None,
+        node_info: None,
+    ) -> bool: ...
+
+    async def can_write_network_settings(
+        self,
+        network_info: zigpy.state.NetworkInfo | None,
+        node_info: zigpy.state.NodeInfo | None,
     ) -> bool:
         """Returns `True` if the radio can write the given network settings.
+
+        If restoration is not possible, `CannotWriteNetworkSettings` is raised.
 
         Some radio firmwares do not support writing every network setting in a backup
         (ZiGate cannot set the PAN ID, older EZSP can only write the EUI64 once, etc.).

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1351,6 +1351,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     ) -> bool:
         """Returns `True` if the radio can write the given network settings.
 
+        If restoration is not possible, `CannotWriteNetworkSettings` is raised.
+        If restoration is possible in a destructive way (e.g. write-once tokens),
+        `DestructiveWriteNetworkSettings` is raised.
+
         Some radio firmwares do not support writing every network setting in a backup
         (ZiGate cannot set the PAN ID, older EZSP can only write the EUI64 once, etc.).
         Not all situations, however, are critical failures: if we are restoring a

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -13,7 +13,7 @@ import random
 import sys
 import time
 import typing
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar
 import warnings
 
 from zigpy.backports.contextlib import nullcontext
@@ -1344,28 +1344,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Permit a node to join with the provided link key."""
         raise NotImplementedError  # pragma: no cover
 
-    @overload
     async def can_write_network_settings(
         self,
         network_info: zigpy.state.NetworkInfo,
         node_info: zigpy.state.NodeInfo,
-    ) -> bool: ...
-
-    @overload
-    async def can_write_network_settings(
-        self,
-        network_info: None,
-        node_info: None,
-    ) -> bool: ...
-
-    async def can_write_network_settings(
-        self,
-        network_info: zigpy.state.NetworkInfo | None,
-        node_info: zigpy.state.NodeInfo | None,
     ) -> bool:
         """Returns `True` if the radio can write the given network settings.
-
-        If restoration is not possible, `CannotWriteNetworkSettings` is raised.
 
         Some radio firmwares do not support writing every network setting in a backup
         (ZiGate cannot set the PAN ID, older EZSP can only write the EUI64 once, etc.).

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1344,6 +1344,21 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Permit a node to join with the provided link key."""
         raise NotImplementedError  # pragma: no cover
 
+    async def can_write_network_settings(
+        self,
+        network_info: zigpy.state.NetworkInfo,
+        node_info: zigpy.state.NodeInfo,
+    ) -> bool:
+        """Returns `True` if the radio can write the given network settings.
+
+        Some radio firmwares do not support writing every network setting in a backup
+        (ZiGate cannot set the PAN ID, older EZSP can only write the EUI64 once, etc.).
+        Not all situations, however, are critical failures: if we are restoring a
+        backup where the PAN ID does not change or the EUI64 remains the same, we can
+        restore the backup successfully.
+        """
+        return True
+
     @abc.abstractmethod
     async def write_network_info(
         self,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1346,6 +1346,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     async def can_write_network_settings(
         self,
+        *,
         network_info: zigpy.state.NetworkInfo,
         node_info: zigpy.state.NodeInfo,
     ) -> bool:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1344,6 +1344,18 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Permit a node to join with the provided link key."""
         raise NotImplementedError  # pragma: no cover
 
+    async def can_read_network_settings(
+        self,
+        *,
+        network_info: zigpy.state.NetworkInfo,
+        node_info: zigpy.state.NodeInfo,
+    ) -> bool:
+        """Returns `True` if the radio can read the given network settings.
+
+        If reading is not possible, `CannotReadNetworkSettings` is raised.
+        """
+        return True
+
     async def can_write_network_settings(
         self,
         *,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1344,13 +1344,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Permit a node to join with the provided link key."""
         raise NotImplementedError  # pragma: no cover
 
-    async def can_read_network_settings(self) -> bool:
-        """Returns `True` if the radio can read the given network settings.
-
-        If reading is not possible, `CannotReadNetworkSettings` is raised.
-        """
-        return True
-
     async def can_write_network_settings(
         self,
         *,

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -26,10 +26,6 @@ class DestructiveWriteNetworkSettings(ZigbeeException):
     """The provided network settings will be written but in a destructive manner."""
 
 
-class CannotReadNetworkSettings(ZigbeeException):
-    """Adapter network settings cannot be read due to a radio limitation."""
-
-
 class APIException(ZigbeeException):
     """Radio API failed in some way."""
 

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -18,6 +18,10 @@ class ControllerException(ZigbeeException):
     """Application controller failed in some way."""
 
 
+class CannotWriteNetworkSettings(ZigbeeException):
+    """The provided network settings cannot be written due to a radio limitation."""
+
+
 class APIException(ZigbeeException):
     """Radio API failed in some way."""
 

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -22,6 +22,10 @@ class CannotWriteNetworkSettings(ZigbeeException):
     """The provided network settings cannot be written due to a radio limitation."""
 
 
+class DestructiveWriteNetworkSettings(ZigbeeException):
+    """The provided network settings will be written but in a destructive manner."""
+
+
 class APIException(ZigbeeException):
     """Radio API failed in some way."""
 

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -26,6 +26,10 @@ class DestructiveWriteNetworkSettings(ZigbeeException):
     """The provided network settings will be written but in a destructive manner."""
 
 
+class CannotReadNetworkSettings(ZigbeeException):
+    """Adapter network settings cannot be read due to a radio limitation."""
+
+
 class APIException(ZigbeeException):
     """Radio API failed in some way."""
 


### PR DESCRIPTION
This method will be used to raise an exception before migrating, to allow us to bail out of the config flow before we actually start the migration:

> Returns `True` if the radio can write the given network settings.
> 
> If restoration is not possible, `CannotWriteNetworkSettings` is raised.
> If restoration is possible in a destructive way (e.g. write-once tokens),
> `DestructiveWriteNetworkSettings` is raised.
> 
> Some radio firmwares do not support writing every network setting in a backup
> (ZiGate cannot set the PAN ID, older EZSP can only write the EUI64 once, etc.).
> Not all situations, however, are critical failures: if we are restoring a
> backup where the PAN ID does not change or the EUI64 remains the same, we can
> restore the backup successfully.