### PR TITLE
[WIP] Rework initialization process

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -72,7 +72,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._config = self.SCHEMA(config)
         self._dblistener = None
         self._groups = zigpy.group.Groups(self)
-        self._listeners = {}
         self._send_sequence = 0
         self._tasks: set[asyncio.Future[Any]] = set()
 
@@ -419,9 +418,15 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         if self._watchdog_task is not None:
             self._watchdog_task.cancel()
 
+        for task in self._tasks:
+            task.cancel()
+
         self.ota.stop_periodic_broadcasts()
         self.backups.stop_periodic_backups()
         self.topology.stop_periodic_scans()
+
+        for device in self.devices.values():
+            device.on_remove()
 
         try:
             await self.disconnect()
@@ -1166,6 +1171,32 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         else:
             raise ValueError(f"Invalid address: {address!r}")
 
+    def register_callback_listener(
+        self,
+        src: zigpy.device.Device | zigpy.listeners.ANY_DEVICE,
+        filters: list[zigpy.listeners.MatcherType],
+        callback: typing.Callable[
+            [
+                zigpy.zcl.foundation.ZCLHeader,
+                zigpy.zcl.foundation.CommandSchema,
+            ],
+            typing.Any,
+        ],
+    ) -> typing.Callable[[], None]:
+        listener = zigpy.listeners.CallbackListener(
+            matchers=tuple(filters),
+            callback=callback,
+        )
+
+        self._req_listeners[src].append(listener)
+
+        def cancel_callback() -> None:
+            """Remove the listener."""
+            if listener in self._req_listeners[src]:
+                self._req_listeners[src].remove(listener)
+
+        return cancel_callback
+
     @contextlib.contextmanager
     def callback_for_response(
         self,
@@ -1180,18 +1211,14 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         ],
     ) -> typing.Any:
         """Context manager to create a callback that is passed Zigbee responses."""
-
-        listener = zigpy.listeners.CallbackListener(
-            matchers=tuple(filters),
-            callback=callback,
+        cancel = self.register_callback_listener(
+            src=src, filters=filters, callback=callback
         )
-
-        self._req_listeners[src].append(listener)
 
         try:
             yield
         finally:
-            self._req_listeners[src].remove(listener)
+            cancel()
 
     @contextlib.contextmanager
     def wait_for_response(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -753,6 +753,16 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     ) -> AsyncGenerator[None, None]:
         """Async context manager to limit global coordinator request concurrency."""
 
+        if priority >= t.PacketPriority.CRITICAL:
+            LOGGER.debug(
+                "Critical priority request received (%s), skipping queue with %d requests",
+                priority,
+                self._concurrent_requests_semaphore.num_waiting,
+            )
+            manager = contextlib.nullcontext()
+        else:
+            manager = self._concurrent_requests_semaphore(priority=priority)
+
         start_time = time.monotonic()
         manager: contextlib.AbstractAsyncContextManager
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1088,13 +1088,17 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             or device.all_endpoints_init
             or (
                 device.has_non_zdo_endpoints
-                and packet.cluster_id == zigpy.zcl.clusters.general.Basic.cluster_id
+                and packet.cluster_id
+                in (
+                    zigpy.zcl.clusters.general.Basic.cluster_id,
+                    zigpy.zcl.clusters.general.Ota.cluster_id,
+                )
             )
         ):
             # Allow the following responses:
             #  - any ZDO
             #  - ZCL if endpoints are initialized
-            #  - ZCL from Basic packet.cluster_id if endpoints are initializing
+            #  - ZCL from Basic and OTA clusters if endpoints are initializing
 
             if not device.initializing:
                 device.schedule_initialize()

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -683,7 +683,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         # Next, try to parse the command
         try:
-            cmd, remaining = foundation.GENERAL_COMMANDS.deserialize(command_data)
+            cmd, remaining = foundation.GENERAL_COMMANDS[
+                hdr.command_id
+            ].schema.deserialize(command_data)
         except Exception as exc:  # noqa: BLE001
             error = zigpy.exceptions.ParsingError()
             error.__cause__ = exc

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -11,6 +11,7 @@ import time
 import typing
 import warnings
 
+from zigpy.exceptions import DeliveryError
 from zigpy.ota.manager import update_firmware
 from zigpy.zcl.clusters.general import Ota, PollControl
 
@@ -51,6 +52,7 @@ LOGGER = logging.getLogger(__name__)
 
 PACKET_DEBOUNCE_WINDOW = 10
 MAX_DEVICE_CONCURRENCY = 1
+FAST_POLL_TIMEOUT = 30
 
 AFTER_OTA_ATTR_READ_DELAY = 10
 OTA_RETRY_DECORATOR = zigpy.util.retryable_request(
@@ -108,7 +110,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._on_remove_callbacks.append(
             self._application.register_callback_listener(
                 src=self,
-                filters=PollControl.ClientCommandDefs.checkin.schema,
+                filters=[PollControl.ClientCommandDefs.checkin.schema()],
                 callback=self.poll_control_checkin_callback,
             )
         )
@@ -282,12 +284,33 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         command: foundation.CommandSchema,
     ) -> None:
         """Handle Poll Control check-in callback."""
-        poll_control_cluster = self.find_cluster(cluster_id=PollControl.id)
+        poll_control = self.find_cluster(cluster_id=PollControl.id)
 
-        await poll_control_cluster.checkin_response(
-            start_fast_polling=False,
-            fast_poll_timeout=0,
-            tsn=hdr.tsn,
+        if self.initializing or self._concurrent_requests_semaphore.locked():
+            # Initiate fast polling mode if we are initializing or waiting for requests
+            # to be sent
+            await poll_control.checkin_response(
+                start_fast_polling=True,
+                fast_poll_timeout=int(FAST_POLL_TIMEOUT * 4),
+                tsn=hdr.tsn,
+                priority=t.PacketPriority.CRITICAL,
+            )
+        else:
+            await poll_control.checkin_response(
+                start_fast_polling=False,
+                fast_poll_timeout=0,
+                tsn=hdr.tsn,
+                priority=t.PacketPriority.CRITICAL,
+            )
+
+    async def begin_fast_polling(self, timeout: float) -> None:
+        poll_control = self.find_cluster(cluster_id=PollControl.cluster_id)
+
+        await poll_control.bind()
+        await poll_control.write_attributes(
+            # The units for the fast poll timeout are quarter seconds
+            {PollControl.AttributeDefs.fast_poll_timeout.id: int(timeout * 4)},
+            priority=t.PacketPriority.CRITICAL,
         )
 
     @zigpy.util.retryable_request(tries=5, delay=0.5)
@@ -324,30 +347,34 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         self.status = Status.ZDO_INIT
 
+        initiated_fast_polling = False
+
         # Initialize all of the discovered endpoints
         if self.all_endpoints_init:
             self.info(
                 "All endpoints are already initialized: %s", self.non_zdo_endpoints
             )
+
+            # Begin fast polling if we are re-initializing
+            with contextlib.suppress(ValueError):
+                await self.begin_fast_polling(FAST_POLL_TIMEOUT)
         else:
             self.info("Initializing endpoints %s", self.non_zdo_endpoints)
+
             initiated_fast_polling = False
 
             for ep in self.non_zdo_endpoints:
                 await ep.initialize()
 
-                if (
-                    initiated_fast_polling
-                    or PollControl.cluster_id not in ep.in_clusters
-                ):
-                    continue
-
-                await ep.poll_control.checkin_response(
-                    start_fast_polling=True,
-                    # The timeout is measured in quarter seconds
-                    fast_poll_timeout=30 * 4,
-                )
-                initiated_fast_polling = True
+                if not initiated_fast_polling:
+                    # Ask the device to enter fast polling mode mode as soon as we are
+                    # aware of a PollControl cluster
+                    try:
+                        await self.begin_fast_polling(FAST_POLL_TIMEOUT)
+                    except (ValueError, asyncio.TimeoutError, DeliveryError):
+                        pass
+                    else:
+                        initiated_fast_polling = True
 
         # Query model info
         if self.model is not None and self.manufacturer is not None:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -11,8 +11,8 @@ import time
 import typing
 import warnings
 
-from zigpy.ota.manager import find_ota_cluster, update_firmware
-from zigpy.zcl.clusters.general import Ota
+from zigpy.ota.manager import update_firmware
+from zigpy.zcl.clusters.general import Ota, PollControl
 
 if sys.version_info[:2] < (3, 11):
     from async_timeout import timeout as asyncio_timeout  # pragma: no cover
@@ -39,7 +39,7 @@ import zigpy.listeners
 import zigpy.types as t
 from zigpy.typing import AddressingMode
 import zigpy.util
-from zigpy.zcl import foundation
+from zigpy.zcl import Cluster, ClusterType, foundation
 import zigpy.zdo.types as zdo_t
 
 if typing.TYPE_CHECKING:
@@ -95,6 +95,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._skip_configuration: bool = False
         self._send_sequence: int = 0
 
+        self._on_remove_callbacks: list[typing.Callable[[], None]] = []
+
         self._packet_debouncer = zigpy.datastructures.Debouncer()
         self._concurrent_requests_semaphore = (
             zigpy.datastructures.PriorityDynamicBoundedSemaphore(MAX_DEVICE_CONCURRENCY)
@@ -102,6 +104,21 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         # Retained for backwards compatibility, will be removed in a future release
         self.status = Status.NEW
+
+        self._on_remove_callbacks.append(
+            self._application.register_callback_listener(
+                src=self,
+                filters=PollControl.ClientCommandDefs.checkin.schema,
+                callback=self.poll_control_checkin_callback,
+            )
+        )
+
+    def on_remove(self) -> None:
+        """Call on remove callbacks."""
+        for callback in self._on_remove_callbacks:
+            callback()
+
+        self._on_remove_callbacks.clear()
 
     @contextlib.asynccontextmanager
     async def _limit_concurrency(self, *, priority: int = 0):
@@ -246,6 +263,33 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
             self.application.listener_event("device_init_failure", self)
 
+    def find_cluster(
+        self, cluster_id: int, cluster_type: ClusterType = ClusterType.Server
+    ) -> Cluster:
+        """Find a cluster by its ID and type on any endpoint."""
+        for ep in self.non_zdo_endpoints:
+            if cluster_type == ClusterType.Server and cluster_id in ep.in_clusters:
+                return ep.in_clusters[cluster_id]
+            elif cluster_type == ClusterType.Client and cluster_id in ep.out_clusters:
+                return ep.out_clusters[cluster_id]
+        raise ValueError(
+            f"Cluster {cluster_id:#04x} not found in any endpoint of device {self}"
+        )
+
+    async def poll_control_checkin_callback(
+        self,
+        hdr: foundation.ZCLHeader,
+        command: foundation.CommandSchema,
+    ) -> None:
+        """Handle Poll Control check-in callback."""
+        poll_control_cluster = self.find_cluster(cluster_id=PollControl.id)
+
+        await poll_control_cluster.checkin_response(
+            start_fast_polling=False,
+            fast_poll_timeout=0,
+            tsn=hdr.tsn,
+        )
+
     @zigpy.util.retryable_request(tries=5, delay=0.5)
     async def _initialize(self) -> None:
         """Attempts multiple times to discover all basic information about a device: namely
@@ -287,9 +331,23 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
         else:
             self.info("Initializing endpoints %s", self.non_zdo_endpoints)
+            initiated_fast_polling = False
 
             for ep in self.non_zdo_endpoints:
                 await ep.initialize()
+
+                if (
+                    initiated_fast_polling
+                    or PollControl.cluster_id not in ep.in_clusters
+                ):
+                    continue
+
+                await ep.poll_control.checkin_response(
+                    start_fast_polling=True,
+                    # The timeout is measured in quarter seconds
+                    fast_poll_timeout=30 * 4,
+                )
+                initiated_fast_polling = True
 
         # Query model info
         if self.model is not None and self.manufacturer is not None:
@@ -599,7 +657,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             return result
 
         # Clear the current file version when the update succeeds
-        ota = find_ota_cluster(self)
+        ota = self.find_cluster(
+            cluster_id=Ota.cluster_id, cluster_type=ClusterType.Client
+        )
         ota.update_attribute(Ota.AttributeDefs.current_file_version.id, None)
 
         await asyncio.sleep(AFTER_OTA_ATTR_READ_DELAY)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -369,6 +369,20 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     if manufacturer is not None:
                         self.manufacturer = manufacturer
 
+        # Query current OTA info
+        try:
+            ota = self.find_cluster(
+                cluster_id=Ota.cluster_id, cluster_type=ClusterType.Client
+            )
+        except ValueError:
+            pass
+        else:
+            if ota.get(Ota.AttributeDefs.current_file_version.id) is None:
+                self.info("Reading current OTA file version")
+                await ota.read_attributes(
+                    [Ota.AttributeDefs.current_file_version.name],
+                )
+
         self.status = Status.ENDPOINTS_INIT
 
         self.info("Discovered basic device information for %s", self)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -280,7 +280,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     async def poll_control_checkin_callback(
         self,
-        hdr: foundation.ZCLHeader,
+        zcl_hdr: foundation.ZCLHeader,
         command: foundation.CommandSchema,
     ) -> None:
         """Handle Poll Control check-in callback."""
@@ -292,14 +292,14 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             await poll_control.checkin_response(
                 start_fast_polling=True,
                 fast_poll_timeout=int(FAST_POLL_TIMEOUT * 4),
-                tsn=hdr.tsn,
+                tsn=zcl_hdr.tsn,
                 priority=t.PacketPriority.CRITICAL,
             )
         else:
             await poll_control.checkin_response(
                 start_fast_polling=False,
                 fast_poll_timeout=0,
-                tsn=hdr.tsn,
+                tsn=zcl_hdr.tsn,
                 priority=t.PacketPriority.CRITICAL,
             )
 
@@ -516,13 +516,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         )
 
     def _find_zcl_cluster_for_packet(
-        self, hdr: foundation.ZCLHeader, packet: t.ZigbeePacket
+        self, zcl_hdr: foundation.ZCLHeader, packet: t.ZigbeePacket
     ) -> Cluster:
         """Find a cluster for the packet."""
         assert packet.src_ep is not None
         endpoint = self.endpoints[packet.src_ep]
 
-        if hdr.direction == foundation.Direction.Client_to_Server:
+        if zcl_hdr.direction == foundation.Direction.Client_to_Server:
             return endpoint.out_clusters[packet.cluster_id]
         else:
             return endpoint.in_clusters[packet.cluster_id]
@@ -554,35 +554,98 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
             return
 
-        # ZDO packets are simple
         if packet.dst_ep == zdo.ZDO_ENDPOINT:
             self.zdo_packet_received(packet)
-            return
+        else:
+            self.zcl_packet_received(packet)
 
-        self.zcl_packet_received(packet)
+    def _parse_zcl_command(
+        self, zcl_cluster: Cluster, zcl_hdr: foundation.ZCLHeader, command_data: bytes
+    ) -> tuple[typing.Any, bytes]:
+        """Parse a ZCL command from the data."""
+        if zcl_hdr.frame_control.frame_type == foundation.FrameType.GLOBAL_COMMAND:
+            cmd, remaining = foundation.GENERAL_COMMANDS[
+                zcl_hdr.command_id
+            ].schema.deserialize(command_data)
+        else:
+            if zcl_hdr.direction == foundation.Direction.Server_to_Client:
+                commands = zcl_cluster.client_commands
+            else:
+                commands = zcl_cluster.server_commands
+
+            cmd, remaining = commands[zcl_hdr.command_id].deserialize(command_data)
+
+        return cmd, remaining
 
     def zcl_packet_received(self, packet: t.ZigbeePacket) -> None:
         # ZCL packets need to be parsed a little to determine where they go
         data = packet.data.serialize()
-        zcl_hdr, _ = foundation.ZCLHeader.deserialize(data)
+        zcl_hdr, command_data = foundation.ZCLHeader.deserialize(data)
 
         try:
-            self._find_zcl_cluster_for_packet(zcl_hdr, packet)
+            zcl_cluster = self._find_zcl_cluster_for_packet(zcl_hdr, packet)
         except KeyError:
             self.debug("Ignoring message on an unexpected cluster", packet.cluster_id)
             return
 
-        if zcl_hdr.frame_control.frame_type == foundation.FrameType.GLOBAL_COMMAND:
-            self.zcl_global_packet_received(packet)
+        try:
+            cmd, remaining = self._parse_zcl_command(zcl_cluster, zcl_hdr, command_data)
+        except Exception as exc:  # noqa: BLE001
+            error = zigpy.exceptions.ParsingError()
+            error.__cause__ = exc
+
+            self.debug("Failed to parse packet %r", packet, exc_info=error)
         else:
-            self.zcl_cluster_packet_received(packet)
+            error = None
+            self.debug("Decoded ZCL frame: %s:%r", type(zcl_cluster).__name__, cmd)
+
+            if remaining:
+                self.debug(
+                    "Data remains after deserializing ZCL command: %r", remaining
+                )
+
+        # Resolve the future if this is a response to a request
+        # TODO: this needs to be further narrowed down by cluster ID and endpoint ID
+        if zcl_hdr.tsn in self._pending:
+            future = self._pending[zcl_hdr.tsn]
+
+            if error is not None:
+                future.result.set_exception(error)
+            else:
+                future.result.set_result(cmd)
+
+            return
+
+        if error is not None:
+            return
+
+        # Pass the request off to a listener, if one is registered
+        for listener in itertools.chain(
+            self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
+            self._application._req_listeners[self],
+        ):
+            # Resolve only until the first future listener
+            if listener.resolve(zcl_hdr, cmd) and isinstance(
+                listener, zigpy.listeners.FutureListener
+            ):
+                break
+
+        # Finally, pass it off to a cluster to generate events
+        if zcl_hdr.frame_control.frame_type == foundation.FrameType.GLOBAL_COMMAND:
+            zcl_cluster.handle_cluster_general_request(zcl_hdr, cmd)
+            zcl_cluster.listener_event("general_command", zcl_hdr, cmd)
+        else:
+            zcl_cluster.handle_cluster_request(zcl_hdr, cmd)
+            zcl_cluster.listener_event(
+                "cluster_command", zcl_hdr.tsn, zcl_hdr.command_id, cmd
+            )
 
     def zdo_packet_received(self, packet: t.ZigbeePacket) -> None:
         assert packet.src_ep is not None
         zdo_endpoint = self.endpoints[packet.src_ep]
         data = packet.data.serialize()
 
-        hdr, _ = zdo_t.ZDOHeader.deserialize(packet.cluster_id, data)
+        zdo_hdr, _ = zdo_t.ZDOHeader.deserialize(packet.cluster_id, data)
 
         # Next, try to parse the command
         try:
@@ -596,8 +659,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             error = None
 
         # Resolve the future if this is a response to a request
-        if hdr.tsn in self._pending and hdr.is_reply:
-            future = self._pending[hdr.tsn]
+        if zdo_hdr.tsn in self._pending and zdo_hdr.is_reply:
+            future = self._pending[zdo_hdr.tsn]
 
             if error is not None:
                 future.result.set_exception(error)
@@ -615,90 +678,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self._application._req_listeners[self],
         ):
             # Resolve only until the first future listener
-            if listener.resolve(hdr, cmd) and isinstance(
+            if listener.resolve(zdo_hdr, cmd) and isinstance(
                 listener, zigpy.listeners.FutureListener
             ):
                 break
-
-    def zcl_cluster_packet_received(self, packet: t.ZigbeePacket) -> None:
-        data = packet.data.serialize()
-        hdr, command_data = foundation.ZCLHeader.deserialize(data)
-        zcl_cluster = self._find_zcl_cluster_for_packet(hdr, packet)
-
-        # Next, try to parse the command
-        try:
-            if hdr.direction == foundation.Direction.Server_to_Client:
-                commands = zcl_cluster.client_commands
-            else:
-                commands = zcl_cluster.server_commands
-
-            cmd, remaining = commands[hdr.command_id].deserialize(command_data)
-        except Exception as exc:  # noqa: BLE001
-            error = zigpy.exceptions.ParsingError()
-            error.__cause__ = exc
-
-            self.debug("Failed to parse packet %r", packet, exc_info=error)
-        else:
-            error = None
-
-            if remaining:
-                self.debug(
-                    "Data remains after deserializing ZCL command: %r", remaining
-                )
-
-        # Resolve the future if this is a response to a request
-        # TODO: this needs to be further narrowed down by cluster ID and endpoint ID
-        if hdr.tsn in self._pending:
-            future = self._pending[hdr.tsn]
-
-            if error is not None:
-                future.result.set_exception(error)
-            else:
-                future.result.set_result(cmd)
-
-            return
-
-        if error is not None:
-            return
-
-        # Pass the request off to a listener, if one is registered
-        for listener in itertools.chain(
-            self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
-            self._application._req_listeners[self],
-        ):
-            # Resolve only until the first future listener
-            if listener.resolve(hdr, cmd) and isinstance(
-                listener, zigpy.listeners.FutureListener
-            ):
-                break
-
-        # Finally, pass it off to a cluster to generate events
-        zcl_cluster.handle_cluster_request(hdr, cmd)
-        zcl_cluster.listener_event("cluster_command", hdr.tsn, hdr.command_id, cmd)
-
-    def zcl_global_packet_received(self, packet: t.ZigbeePacket) -> None:
-        data = packet.data.serialize()
-        hdr, command_data = foundation.ZCLHeader.deserialize(data)
-        zcl_cluster = self._find_zcl_cluster_for_packet(hdr, packet)
-
-        # Next, try to parse the command
-        try:
-            cmd, remaining = foundation.GENERAL_COMMANDS[
-                hdr.command_id
-            ].schema.deserialize(command_data)
-        except Exception as exc:  # noqa: BLE001
-            error = zigpy.exceptions.ParsingError()
-            error.__cause__ = exc
-
-            self.debug("Failed to parse packet %r", packet, exc_info=error)
-            return
-
-        if remaining:
-            self.debug("Data remains after deserializing ZCL command: %r", remaining)
-
-        # Finally, pass it off to a cluster to generate events
-        zcl_cluster.handle_cluster_general_request(hdr, cmd)
-        zcl_cluster.listener_event("general_command", hdr, cmd)
 
     async def reply(
         self,

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -595,9 +595,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         # Resolve the future if this is a response to a request
         if hdr.tsn in self._pending and (
-            hdr.direction == foundation.Direction.Server_to_Client
-            if isinstance(hdr, foundation.ZCLHeader)
-            else hdr.is_reply
+            True if isinstance(hdr, foundation.ZCLHeader) else hdr.is_reply
         ):
             future = self._pending[hdr.tsn]
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -515,13 +515,17 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
         )
 
-    def deserialize(self, endpoint_id, cluster_id, data):
-        """Deprecated compatibility function."""
-        warnings.warn(
-            "`deserialize` is deprecated, avoid rewriting packet structures this way",
-            DeprecationWarning,
-        )
-        return self.endpoints[endpoint_id].deserialize(cluster_id, data)
+    def _find_zcl_cluster_for_packet(
+        self, hdr: foundation.ZCLHeader, packet: t.ZigbeePacket
+    ) -> Cluster:
+        """Find a cluster for the packet."""
+        assert packet.src_ep is not None
+        endpoint = self.endpoints[packet.src_ep]
+
+        if hdr.direction == foundation.Direction.Client_to_Server:
+            return endpoint.out_clusters[packet.cluster_id]
+        else:
+            return endpoint.in_clusters[packet.cluster_id]
 
     def packet_received(self, packet: t.ZigbeePacket) -> None:
         # Set radio details that can be read from any type of packet
@@ -541,7 +545,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.debug("Filtering duplicate packet")
             return
 
-        # Filter out packets that refer to unknown endpoints or clusters
+        # Filter out packets that come from unregistered endpoints
         if packet.src_ep not in self.endpoints:
             self.debug(
                 "Ignoring message on unknown endpoint %s (expected one of %s)",
@@ -550,41 +554,39 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
             return
 
-        endpoint = self.endpoints[packet.src_ep]
-
-        # Ignore packets that do not match the endpoint's clusters.
-        # TODO: this isn't actually necessary, we can parse most packets by cluster ID.
-        if (
-            packet.dst_ep != zdo.ZDO_ENDPOINT
-            and packet.cluster_id not in endpoint.in_clusters
-            and packet.cluster_id not in endpoint.out_clusters
-        ):
-            self.debug(
-                "Ignoring message on unknown cluster %s for endpoint %s",
-                packet.cluster_id,
-                endpoint,
-            )
+        # ZDO packets are simple
+        if packet.dst_ep == zdo.ZDO_ENDPOINT:
+            self.zdo_packet_received(packet)
             return
 
-        # Parse the ZCL/ZDO header first. This should never fail.
-        data = packet.data.serialize()
+        self.zcl_packet_received(packet)
 
-        if packet.dst_ep == zdo.ZDO_ENDPOINT:
-            hdr, _ = zdo_t.ZDOHeader.deserialize(packet.cluster_id, data)
-        else:
-            hdr, _ = foundation.ZCLHeader.deserialize(data)
+    def zcl_packet_received(self, packet: t.ZigbeePacket) -> None:
+        # ZCL packets need to be parsed a little to determine where they go
+        data = packet.data.serialize()
+        zcl_hdr, _ = foundation.ZCLHeader.deserialize(data)
 
         try:
-            if (
-                type(self).deserialize is not Device.deserialize
-                or getattr(self.deserialize, "__func__", None) is not Device.deserialize
-            ):
-                # XXX: support for custom deserialization will be removed
-                hdr, args = self.deserialize(packet.src_ep, packet.cluster_id, data)
-            else:
-                # Next, parse the ZCL/ZDO payload
-                # FIXME: ZCL deserialization mutates the header!
-                hdr, args = endpoint.deserialize(packet.cluster_id, data)
+            self._find_zcl_cluster_for_packet(zcl_hdr, packet)
+        except KeyError:
+            self.debug("Ignoring message on an unexpected cluster", packet.cluster_id)
+            return
+
+        if zcl_hdr.frame_control.frame_type == foundation.FrameType.GLOBAL_COMMAND:
+            self.zcl_global_packet_received(packet)
+        else:
+            self.zcl_cluster_packet_received(packet)
+
+    def zdo_packet_received(self, packet: t.ZigbeePacket) -> None:
+        assert packet.src_ep is not None
+        zdo_endpoint = self.endpoints[packet.src_ep]
+        data = packet.data.serialize()
+
+        hdr, _ = zdo_t.ZDOHeader.deserialize(packet.cluster_id, data)
+
+        # Next, try to parse the command
+        try:
+            _, cmd = zdo_endpoint.deserialize(packet.cluster_id, data)
         except Exception as exc:  # noqa: BLE001
             error = zigpy.exceptions.ParsingError()
             error.__cause__ = exc
@@ -594,24 +596,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             error = None
 
         # Resolve the future if this is a response to a request
-        if hdr.tsn in self._pending and (
-            True if isinstance(hdr, foundation.ZCLHeader) else hdr.is_reply
-        ):
+        if hdr.tsn in self._pending and hdr.is_reply:
             future = self._pending[hdr.tsn]
 
-            try:
-                if error is not None:
-                    future.result.set_exception(error)
-                else:
-                    future.result.set_result(args)
-            except asyncio.InvalidStateError:
-                self.debug(
-                    (
-                        "Invalid state on future for 0x%02x seq "
-                        "-- probably duplicate response"
-                    ),
-                    hdr.tsn,
-                )
+            if error is not None:
+                future.result.set_exception(error)
+            else:
+                future.result.set_result(cmd)
 
             return
 
@@ -624,19 +615,88 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self._application._req_listeners[self],
         ):
             # Resolve only until the first future listener
-            if listener.resolve(hdr, args) and isinstance(
+            if listener.resolve(hdr, cmd) and isinstance(
                 listener, zigpy.listeners.FutureListener
             ):
                 break
 
-        # Finally, pass it off to the endpoint message handler. This will be removed.
-        endpoint.handle_message(
-            packet.profile_id,
-            packet.cluster_id,
-            hdr,
-            args,
-            dst_addressing=packet.dst.addr_mode if packet.dst is not None else None,
-        )
+    def zcl_cluster_packet_received(self, packet: t.ZigbeePacket) -> None:
+        data = packet.data.serialize()
+        hdr, command_data = foundation.ZCLHeader.deserialize(data)
+        zcl_cluster = self._find_zcl_cluster_for_packet(hdr, packet)
+
+        # Next, try to parse the command
+        try:
+            if hdr.direction == foundation.Direction.Server_to_Client:
+                commands = zcl_cluster.client_commands
+            else:
+                commands = zcl_cluster.server_commands
+
+            cmd, remaining = commands[hdr.command_id].deserialize(command_data)
+        except Exception as exc:  # noqa: BLE001
+            error = zigpy.exceptions.ParsingError()
+            error.__cause__ = exc
+
+            self.debug("Failed to parse packet %r", packet, exc_info=error)
+        else:
+            error = None
+
+            if remaining:
+                self.debug(
+                    "Data remains after deserializing ZCL command: %r", remaining
+                )
+
+        # Resolve the future if this is a response to a request
+        # TODO: this needs to be further narrowed down by cluster ID and endpoint ID
+        if hdr.tsn in self._pending:
+            future = self._pending[hdr.tsn]
+
+            if error is not None:
+                future.result.set_exception(error)
+            else:
+                future.result.set_result(cmd)
+
+            return
+
+        if error is not None:
+            return
+
+        # Pass the request off to a listener, if one is registered
+        for listener in itertools.chain(
+            self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
+            self._application._req_listeners[self],
+        ):
+            # Resolve only until the first future listener
+            if listener.resolve(hdr, cmd) and isinstance(
+                listener, zigpy.listeners.FutureListener
+            ):
+                break
+
+        # Finally, pass it off to a cluster to generate events
+        zcl_cluster.handle_cluster_request(hdr, cmd)
+        zcl_cluster.listener_event("cluster_command", hdr.tsn, hdr.command_id, cmd)
+
+    def zcl_global_packet_received(self, packet: t.ZigbeePacket) -> None:
+        data = packet.data.serialize()
+        hdr, command_data = foundation.ZCLHeader.deserialize(data)
+        zcl_cluster = self._find_zcl_cluster_for_packet(hdr, packet)
+
+        # Next, try to parse the command
+        try:
+            cmd, remaining = foundation.GENERAL_COMMANDS.deserialize(command_data)
+        except Exception as exc:  # noqa: BLE001
+            error = zigpy.exceptions.ParsingError()
+            error.__cause__ = exc
+
+            self.debug("Failed to parse packet %r", packet, exc_info=error)
+            return
+
+        if remaining:
+            self.debug("Data remains after deserializing ZCL command: %r", remaining)
+
+        # Finally, pass it off to a cluster to generate events
+        zcl_cluster.handle_cluster_general_request(hdr, cmd)
+        zcl_cluster.listener_event("general_command", hdr, cmd)
 
     async def reply(
         self,

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -9,17 +9,10 @@ from zigpy.const import APS_REPLY_TIMEOUT
 import zigpy.exceptions
 import zigpy.profiles
 import zigpy.types as t
-from zigpy.typing import AddressingMode, DeviceType
+from zigpy.typing import DeviceType
 import zigpy.util
 import zigpy.zcl
-from zigpy.zcl.foundation import (
-    GENERAL_COMMANDS,
-    CommandSchema,
-    Direction,
-    GeneralCommand,
-    Status as ZCLStatus,
-    ZCLHeader,
-)
+from zigpy.zcl.foundation import GENERAL_COMMANDS, GeneralCommand, Status as ZCLStatus
 from zigpy.zdo.types import Status as ZDOStatus
 
 LOGGER = logging.getLogger(__name__)
@@ -217,37 +210,6 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 self._manufacturer = success["manufacturer"]
 
         return self._model, self._manufacturer
-
-    def deserialize(
-        self, cluster_id: t.ClusterId, data: bytes
-    ) -> tuple[ZCLHeader, CommandSchema]:
-        """Deserialize data for ZCL"""
-        if cluster_id not in self.in_clusters and cluster_id not in self.out_clusters:
-            raise KeyError(f"No cluster ID 0x{cluster_id:04x} on {self.unique_id}")
-
-        cluster = self.in_clusters.get(cluster_id, self.out_clusters.get(cluster_id))
-        return cluster.deserialize(data)
-
-    def handle_message(
-        self,
-        profile: int,
-        cluster: int,
-        hdr: ZCLHeader,
-        args: list,
-        *,
-        dst_addressing: AddressingMode | None = None,
-    ) -> None:
-        try:
-            if hdr.direction == Direction.Client_to_Server:
-                zcl_cluster = self.out_clusters[cluster]
-            else:
-                zcl_cluster = self.in_clusters[cluster]
-        except KeyError:
-            self.debug("Message on unknown cluster 0x%04x", cluster)
-            self.listener_event("unknown_cluster_message", hdr.command_id, args)
-            return
-
-        zcl_cluster.handle_message(hdr, args, dst_addressing=dst_addressing)
 
     async def request(
         self,

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -7,7 +7,7 @@ import contextlib
 from typing import TYPE_CHECKING
 
 import zigpy.datastructures
-from zigpy.zcl import foundation
+from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import Ota
 
 if TYPE_CHECKING:
@@ -22,14 +22,6 @@ MAXIMUM_IMAGE_BLOCK_SIZE = 40
 MAX_TIME_WITHOUT_PROGRESS = 30
 
 
-def find_ota_cluster(device: Device) -> Ota:
-    """Finds the first OTA cluster available on the device."""
-    for ep in device.non_zdo_endpoints:
-        if Ota.cluster_id in ep.out_clusters:
-            return ep.out_clusters[Ota.cluster_id]
-    raise ValueError("Device has no OTA cluster")
-
-
 class OTAManager:
     """Class to manage OTA updates for a device."""
 
@@ -41,7 +33,9 @@ class OTAManager:
         force: bool = False,
     ) -> None:
         self.device = device
-        self.ota_cluster = find_ota_cluster(device)
+        self.ota_cluster = device.find_cluster(
+            cluster_id=Ota.cluster_id, cluster_type=ClusterType.Client
+        )
 
         self.image = image
         self._image_data = image.firmware.serialize()

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -263,41 +263,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         cluster.cluster_id = cluster_id
         return cluster
 
-    def deserialize(self, data: bytes) -> tuple[foundation.ZCLHeader, ...]:
-        self.debug("Received ZCL frame: %r", data)
-
-        hdr, data = foundation.ZCLHeader.deserialize(data)
-        self.debug("Decoded ZCL frame header: %r", hdr)
-
-        if hdr.frame_control.frame_type == foundation.FrameType.CLUSTER_COMMAND:
-            # Cluster command
-            if hdr.direction == foundation.Direction.Server_to_Client:
-                commands = self.client_commands
-            else:
-                commands = self.server_commands
-
-            if hdr.command_id not in commands:
-                self.debug("Unknown cluster command %s %s", hdr.command_id, data)
-                return hdr, data
-
-            command = commands[hdr.command_id]
-        else:
-            # General command
-            if hdr.command_id not in foundation.GENERAL_COMMANDS:
-                self.debug("Unknown foundation command %s %s", hdr.command_id, data)
-                return hdr, data
-
-            command = foundation.GENERAL_COMMANDS[hdr.command_id]
-
-        response, data = command.schema.deserialize(data)
-
-        self.debug("Decoded ZCL frame: %s:%r", type(self).__name__, response)
-
-        if data:
-            self.debug("Data remains after deserializing ZCL frame: %r", data)
-
-        return hdr, response
-
     def _create_request(
         self,
         *,
@@ -432,23 +397,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             ask_for_ack=ask_for_ack,
             priority=priority,
         )
-
-    def handle_message(
-        self,
-        hdr: foundation.ZCLHeader,
-        args: list[Any],
-        *,
-        dst_addressing: AddressingMode | None = None,
-    ) -> None:
-        self.debug(
-            "Received command 0x%02X (TSN %d): %s", hdr.command_id, hdr.tsn, args
-        )
-        if hdr.frame_control.is_cluster:
-            self.handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
-            self.listener_event("cluster_command", hdr.tsn, hdr.command_id, args)
-            return
-        self.listener_event("general_command", hdr, args)
-        self.handle_cluster_general_request(hdr, args, dst_addressing=dst_addressing)
 
     def handle_cluster_request(
         self,


### PR DESCRIPTION
This PR aggregates a bunch of features and fixes I'm making to clean up and speed up device joining. It will be split up.

- [x] Enable `CRITICAL` priority requests to bypass the request queue: https://github.com/zigpy/zigpy/pull/1619
- [x] Read the OTA `current_file_version` during initialization: https://github.com/zigpy/zigpy/pull/1631
- [x] Implement fast polling: we try to enable it for 30s upon joining if it is available: https://github.com/zigpy/zigpy/pull/1621
- [x] Disable ZHA handling of the poll control cluster and do it within zigpy: if we are trying to communicate with a device and the device checks in, we should ask it to start fast polling. Otherwise, we ask it to stop. https://github.com/zigpy/zha/pull/478
- [x] Fix ZCL attribute read response matching when reading from client clusters (e.g. OTA).