### PR TITLE
Bypass request queuing with `CRITICAL` priority

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,6 +266,7 @@ follow_imports = "silent"
 
 [tool.coverage.run]
 source = ["zigpy"]
+omit = ["zigpy/backports/*"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,11 @@ def raise_on_bad_log_formatting():
 
 class App(zigpy.application.ControllerApplication):
     async def send_packet(self, packet):
-        pass
+        async with self._limit_concurrency(priority=packet.priority):
+            return await self._send_packet(packet)
+
+    async def _send_packet(self, packet):
+        await asyncio.sleep(0)
 
     async def connect(self):
         pass

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 import errno
 import logging
 from unittest import mock
-from unittest.mock import ANY, PropertyMock, call
+from unittest.mock import ANY, Mock, PropertyMock, call
 
 import pytest
 
@@ -1614,3 +1614,29 @@ async def test_packet_capture(app) -> None:
     with patch.object(app, "_packet_capture_change_channel"):
         await app.packet_capture_change_channel(channel=25)
         assert app._packet_capture_change_channel.mock_calls == [call(channel=25)]
+
+
+async def test_request_priority(app) -> None:
+    app._concurrent_requests_semaphore.max_value = 1
+
+    with patch.object(app, "_send_packet", wraps=app._send_packet) as mock_send_packet:
+        packet_low = Mock(name="LOW", priority=t.PacketPriority.LOW)
+        packet_normal = Mock(name="NORMAL", priority=t.PacketPriority.NORMAL)
+        packet_high = Mock(name="HIGH", priority=t.PacketPriority.HIGH)
+        packet_critical = Mock(name="CRITICAL", priority=t.PacketPriority.CRITICAL)
+
+        await asyncio.gather(
+            app.send_packet(packet_low),
+            app.send_packet(packet_normal),
+            app.send_packet(packet_high),
+            app.send_packet(packet_critical),
+        )
+
+    assert mock_send_packet.mock_calls == [
+        # The low priority packet made it through first, locking up the queue
+        call(packet_low),
+        # The critical one bypasses all others even though it's sent last
+        call(packet_critical),
+        call(packet_high),
+        call(packet_normal),
+    ]

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -16,7 +16,7 @@ import typing
 from typing import Any, TypeVar
 import warnings
 
-from zigpy.backports import nullcontext
+from zigpy.backports.contextlib import nullcontext
 
 if sys.version_info[:2] < (3, 11):
     from async_timeout import timeout as asyncio_timeout  # pragma: no cover

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -743,10 +743,13 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             await self.add_endpoint(endpoint)
 
     @contextlib.asynccontextmanager
-    async def _limit_concurrency(self, *, priority: int = t.PacketPriority.NORMAL):
+    async def _limit_concurrency(
+        self, *, priority: int = t.PacketPriority.NORMAL
+    ) -> AsyncGenerator[None, None]:
         """Async context manager to limit global coordinator request concurrency."""
 
         start_time = time.monotonic()
+        manager: contextlib.AbstractAsyncContextManager
 
         if priority >= t.PacketPriority.CRITICAL:
             LOGGER.debug(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -16,6 +16,8 @@ import typing
 from typing import Any, TypeVar
 import warnings
 
+from zigpy.backports import nullcontext
+
 if sys.version_info[:2] < (3, 11):
     from async_timeout import timeout as asyncio_timeout  # pragma: no cover
 else:
@@ -752,7 +754,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 priority,
                 self._concurrent_requests_semaphore.num_waiting,
             )
-            manager = contextlib.nullcontext()
+            manager = nullcontext()
             was_locked = False
         else:
             manager = self._concurrent_requests_semaphore(priority=priority)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -744,6 +744,16 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     async def _limit_concurrency(self, *, priority: int = t.PacketPriority.NORMAL):
         """Async context manager to limit global coordinator request concurrency."""
 
+        if priority >= t.PacketPriority.CRITICAL:
+            LOGGER.debug(
+                "Critical priority request received (%s), skipping queue with %d requests",
+                priority,
+                self._concurrent_requests_semaphore.num_waiting,
+            )
+            manager = contextlib.nullcontext()
+        else:
+            manager = self._concurrent_requests_semaphore(priority=priority)
+
         start_time = time.monotonic()
         was_locked = self._concurrent_requests_semaphore.locked()
 
@@ -754,7 +764,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 self._concurrent_requests_semaphore.num_waiting,
             )
 
-        async with self._concurrent_requests_semaphore(priority=priority):
+        async with manager:
             if was_locked:
                 LOGGER.debug(
                     "Previously delayed request is now running, delayed by %0.2fs",

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -744,6 +744,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     async def _limit_concurrency(self, *, priority: int = t.PacketPriority.NORMAL):
         """Async context manager to limit global coordinator request concurrency."""
 
+        start_time = time.monotonic()
+
         if priority >= t.PacketPriority.CRITICAL:
             LOGGER.debug(
                 "Critical priority request received (%s), skipping queue with %d requests",
@@ -751,11 +753,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 self._concurrent_requests_semaphore.num_waiting,
             )
             manager = contextlib.nullcontext()
+            was_locked = False
         else:
             manager = self._concurrent_requests_semaphore(priority=priority)
-
-        start_time = time.monotonic()
-        was_locked = self._concurrent_requests_semaphore.locked()
+            was_locked = self._concurrent_requests_semaphore.locked()
 
         if was_locked:
             LOGGER.debug(

--- a/zigpy/backports/contextlib.py
+++ b/zigpy/backports/contextlib.py
@@ -1,4 +1,10 @@
-class nullcontext:
+from types import TracebackType
+from typing import Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class nullcontext(Generic[T]):
     """Context manager that does no additional processing.
 
     Used as a stand-in for a normal context manager, when a particular
@@ -9,17 +15,27 @@ class nullcontext:
         # Perform operation, using optional_cm if condition is True
     """
 
-    def __init__(self, enter_result=None):
+    def __init__(self, enter_result: T | None = None) -> None:
         self.enter_result = enter_result
 
-    def __enter__(self):
+    def __enter__(self) -> T:
         return self.enter_result
 
-    def __exit__(self, *excinfo):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         pass
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> T:
         return self.enter_result
 
-    async def __aexit__(self, *excinfo):
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         pass

--- a/zigpy/backports/contextlib.py
+++ b/zigpy/backports/contextlib.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from types import TracebackType
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 
@@ -23,9 +25,9 @@ class nullcontext(Generic[T]):
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         pass
 
@@ -34,8 +36,8 @@ class nullcontext(Generic[T]):
 
     async def __aexit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         pass

--- a/zigpy/backports/contextlib.py
+++ b/zigpy/backports/contextlib.py
@@ -1,0 +1,25 @@
+class nullcontext:
+    """Context manager that does no additional processing.
+
+    Used as a stand-in for a normal context manager, when a particular
+    block of code is only sometimes used with a normal context manager:
+
+    cm = optional_cm if condition else nullcontext()
+    with cm:
+        # Perform operation, using optional_cm if condition is True
+    """
+
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
+
+    def __enter__(self):
+        return self.enter_result
+
+    def __exit__(self, *excinfo):
+        pass
+
+    async def __aenter__(self):
+        return self.enter_result
+
+    async def __aexit__(self, *excinfo):
+        pass

--- a/zigpy/backports/enum.py
+++ b/zigpy/backports/enum.py
@@ -33,31 +33,3 @@ class StrEnum(str, Enum):
         `StrEnum.auto()` behavior will no longer change.
         """
         raise TypeError("auto() is not supported by this implementation")
-
-
-# Taken straight from CPython 3.12
-class nullcontext:
-    """Context manager that does no additional processing.
-
-    Used as a stand-in for a normal context manager, when a particular
-    block of code is only sometimes used with a normal context manager:
-
-    cm = optional_cm if condition else nullcontext()
-    with cm:
-        # Perform operation, using optional_cm if condition is True
-    """
-
-    def __init__(self, enter_result=None):
-        self.enter_result = enter_result
-
-    def __enter__(self):
-        return self.enter_result
-
-    def __exit__(self, *excinfo):
-        pass
-
-    async def __aenter__(self):
-        return self.enter_result
-
-    async def __aexit__(self, *excinfo):
-        pass

--- a/zigpy/backports/enum.py
+++ b/zigpy/backports/enum.py
@@ -33,3 +33,31 @@ class StrEnum(str, Enum):
         `StrEnum.auto()` behavior will no longer change.
         """
         raise TypeError("auto() is not supported by this implementation")
+
+
+# Taken straight from CPython 3.12
+class nullcontext:
+    """Context manager that does no additional processing.
+
+    Used as a stand-in for a normal context manager, when a particular
+    block of code is only sometimes used with a normal context manager:
+
+    cm = optional_cm if condition else nullcontext()
+    with cm:
+        # Perform operation, using optional_cm if condition is True
+    """
+
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
+
+    def __enter__(self):
+        return self.enter_result
+
+    def __exit__(self, *excinfo):
+        pass
+
+    async def __aenter__(self):
+        return self.enter_result
+
+    async def __aexit__(self, *excinfo):
+        pass

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -219,7 +219,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         status, _, node_desc = await self.zdo.Node_Desc_req(
             self.nwk,
-            priority=t.PacketPriority.HIGH,
+            priority=t.PacketPriority.CRITICAL,
         )
 
         if status != zdo_t.Status.SUCCESS:
@@ -264,7 +264,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.info("Discovering endpoints")
 
             status, _, endpoints = await self.zdo.Active_EP_req(
-                self.nwk, priority=t.PacketPriority.HIGH
+                self.nwk, priority=t.PacketPriority.CRITICAL
             )
 
             if status != zdo_t.Status.SUCCESS:

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -63,7 +63,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.info("Endpoint descriptor already queried")
         else:
             status, _, sd = await self._device.zdo.Simple_Desc_req(
-                self._device.nwk, self._endpoint_id, priority=t.PacketPriority.HIGH
+                self._device.nwk, self._endpoint_id, priority=t.PacketPriority.CRITICAL
             )
 
             if status == ZDOStatus.NOT_ACTIVE:
@@ -201,7 +201,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         for names in (["manufacturer", "model"], ["manufacturer"], ["model"]):
             try:
                 success, failure = await self.basic.read_attributes(
-                    names, allow_cache=True, priority=t.PacketPriority.HIGH
+                    names, allow_cache=True, priority=t.PacketPriority.CRITICAL
                 )
             except asyncio.TimeoutError:
                 # Only swallow the `TimeoutError` on the double attribute read


### PR DESCRIPTION
Taken from https://github.com/zigpy/zigpy/pull/1618.

During device joining, we should communicate with the joining device as fast as possible to finish initialization before it goes to sleep. A follow-up PR will bring in the poll control handling functionality from the above PR to finish this process off.