### PR TITLE
Use `contextvar` to cascade request priority

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1640,3 +1640,34 @@ async def test_request_priority(app) -> None:
         call(packet_high),
         call(packet_normal),
     ]
+
+
+async def test_request_priority_context_concurrency(app, packet):
+    """Test that request_priority contexts work correctly with concurrent tasks."""
+    # Limit concurrency to see priority ordering effects
+    app._concurrent_requests_semaphore.max_value = 1
+
+    with patch.object(app, "_send_packet", wraps=app._send_packet) as mock_send:
+
+        async def task_with_priority(name: str, priority: int):
+            async with app.request_priority(priority):
+                await app.send_packet(packet.replace(data=name.encode()))
+
+        # Start multiple concurrent tasks with different priority contexts
+        await asyncio.gather(
+            asyncio.create_task(task_with_priority("low", t.PacketPriority.LOW)),
+            asyncio.create_task(task_with_priority("normal", t.PacketPriority.NORMAL)),
+            asyncio.create_task(task_with_priority("high", t.PacketPriority.HIGH)),
+            asyncio.create_task(
+                task_with_priority("critical", t.PacketPriority.CRITICAL)
+            ),
+        )
+
+    # Verify packets were processed in priority order, not send order
+    assert mock_send.mock_calls == [
+        # The low priority task started first but gets processed in priority order
+        call(packet.replace(data=b"low")),
+        call(packet.replace(data=b"critical")),
+        call(packet.replace(data=b"high")),
+        call(packet.replace(data=b"normal")),
+    ]

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -794,7 +794,9 @@ async def test_request(app, device, packet):
     assert status == zigpy.zcl.foundation.Status.SUCCESS
     assert isinstance(msg, str)
 
-    app.send_packet.assert_called_once_with(packet)
+    app.send_packet.assert_called_once_with(
+        packet.replace(priority=t.PacketPriority.NORMAL)
+    )
     app.send_packet.reset_mock()
 
     # Test sending with IEEE
@@ -809,6 +811,7 @@ async def test_request(app, device, packet):
                 addr_mode=t.AddrMode.IEEE,
                 address=device.ieee,
             ),
+            priority=t.PacketPriority.NORMAL,
         )
     )
     app.send_packet.reset_mock()
@@ -821,7 +824,7 @@ async def test_request(app, device, packet):
 
     app.build_source_route_to.assert_called_once_with(dest=device)
     app.send_packet.assert_called_once_with(
-        packet.replace(source_route=[0x000A, 0x000B])
+        packet.replace(source_route=[0x000A, 0x000B], priority=t.PacketPriority.NORMAL)
     )
     app.send_packet.reset_mock()
 
@@ -829,7 +832,9 @@ async def test_request(app, device, packet):
     status, msg = await send_request(app, expect_reply=False)
 
     app.send_packet.assert_called_once_with(
-        packet.replace(tx_options=t.TransmitOptions.ACK)
+        packet.replace(
+            tx_options=t.TransmitOptions.ACK, priority=t.PacketPriority.NORMAL
+        )
     )
     app.send_packet.reset_mock()
 
@@ -837,7 +842,9 @@ async def test_request(app, device, packet):
     status, msg = await send_request(app, ask_for_ack=True)
 
     app.send_packet.assert_called_once_with(
-        packet.replace(tx_options=t.TransmitOptions.ACK)
+        packet.replace(
+            tx_options=t.TransmitOptions.ACK, priority=t.PacketPriority.NORMAL
+        )
     )
     app.send_packet.reset_mock()
 
@@ -845,7 +852,9 @@ async def test_request(app, device, packet):
     status, msg = await send_request(app, ask_for_ack=False)
 
     app.send_packet.assert_called_once_with(
-        packet.replace(tx_options=t.TransmitOptions(0))
+        packet.replace(
+            tx_options=t.TransmitOptions(0), priority=t.PacketPriority.NORMAL
+        )
     )
     app.send_packet.reset_mock()
 
@@ -871,15 +880,17 @@ async def test_request_retrying_success(app, device, packet) -> None:
     )
 
     assert app.send_packet.mock_calls == [
-        call(packet),
+        call(packet.replace(priority=t.PacketPriority.NORMAL)),
         call(
             packet.replace(
-                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY,
+                priority=t.PacketPriority.NORMAL,
             )
         ),
         call(
             packet.replace(
-                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY,
+                priority=t.PacketPriority.NORMAL,
             )
         ),
     ]
@@ -907,15 +918,17 @@ async def test_request_retrying_failure(app, device, packet) -> None:
         )
 
     assert app.send_packet.mock_calls == [
-        call(packet),
+        call(packet.replace(priority=t.PacketPriority.NORMAL)),
         call(
             packet.replace(
-                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY,
+                priority=t.PacketPriority.NORMAL,
             )
         ),
         call(
             packet.replace(
-                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+                tx_options=packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY,
+                priority=t.PacketPriority.NORMAL,
             )
         ),
     ]
@@ -956,6 +969,7 @@ async def test_send_mrequest(app, packet):
             radius=12,
             non_member_radius=34,
             tx_options=t.TransmitOptions.NONE,
+            priority=t.PacketPriority.NORMAL,
         )
     )
 
@@ -983,6 +997,7 @@ async def test_send_broadcast(app, packet):
             ),
             radius=12,
             tx_options=t.TransmitOptions.NONE,
+            priority=t.PacketPriority.NORMAL,
         )
     )
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1327,7 +1327,7 @@ async def test_device_concurrency(dev: device.Device) -> None:
         t.PacketPriority.LOW,  # First one that made it through
         999,  # Super high
         t.PacketPriority.HIGH,
-        t.PacketPriority.NORMAL,
+        None,  # Normal
         t.PacketPriority.LOW,
     ]
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -180,7 +180,7 @@ async def test_reply_change_profile_id(ep):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
-            priority=t.PacketPriority.NORMAL,
+            priority=None,
         )
     ]
 
@@ -198,7 +198,7 @@ async def test_reply_change_profile_id(ep):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
-            priority=t.PacketPriority.NORMAL,
+            priority=None,
         )
     ]
 
@@ -217,7 +217,7 @@ async def test_reply_change_profile_id(ep):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
-            priority=t.PacketPriority.NORMAL,
+            priority=None,
         )
     ]
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -111,14 +111,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         return task
 
     @contextlib.asynccontextmanager
-    async def request_priority(
-        self, priority: int | None = None
-    ) -> AsyncGenerator[None]:
+    async def request_priority(self, priority: int) -> AsyncGenerator[None]:
         """Context manager to set the request priority for the duration of the context."""
-        if priority is None:
-            yield
-            return
-
         token = self._packet_priority_var.set(priority)
 
         try:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -94,7 +94,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         ] = collections.defaultdict(lambda: collections.deque([]))
 
         # Context variable for request priority context manager
-        self._priority_var = contextvars.ContextVar("request_priority", default=None)
+        self._priority_var = contextvars.ContextVar(
+            "request_priority", default=t.PacketPriority.NORMAL
+        )
 
     def create_task(
         self, target: Coroutine[Any, Any, _R], name: str | None = None

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -94,7 +94,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         ] = collections.defaultdict(lambda: collections.deque([]))
 
         # Context variable for request priority context manager
-        self._priority_var = contextvars.ContextVar(
+        self._packet_priority_var = contextvars.ContextVar(
             "request_priority", default=t.PacketPriority.NORMAL
         )
 
@@ -119,12 +119,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             yield
             return
 
-        token = self._priority_var.set(priority)
+        token = self._packet_priority_var.set(priority)
 
         try:
             yield
         finally:
-            self._priority_var.reset(token)
+            self._packet_priority_var.reset(token)
 
     async def _load_db(self) -> None:
         """Restore save state."""
@@ -771,7 +771,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     ) -> AsyncGenerator[None, None]:
         """Async context manager to limit global coordinator request concurrency."""
         if priority is None:
-            priority = self._priority_var.get()
+            priority = self._packet_priority_var.get()
 
         start_time = time.monotonic()
         manager: contextlib.AbstractAsyncContextManager

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -115,6 +115,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self, priority: int | None = None
     ) -> AsyncGenerator[None]:
         """Context manager to set the request priority for the duration of the context."""
+        if priority is None:
+            yield
+            return
+
         token = self._priority_var.set(priority)
 
         try:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -23,6 +23,8 @@ if sys.version_info[:2] < (3, 11):
 else:
     from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
+import contextvars
+
 import zigpy.appdb
 import zigpy.backups
 import zigpy.config as conf
@@ -91,6 +93,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             collections.deque[zigpy.listeners.BaseRequestListener],
         ] = collections.defaultdict(lambda: collections.deque([]))
 
+        # Context variable for request priority context manager
+        self._priority_var = contextvars.ContextVar("request_priority", default=None)
+
     def create_task(
         self, target: Coroutine[Any, Any, _R], name: str | None = None
     ) -> asyncio.Task[_R]:
@@ -102,6 +107,18 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._tasks.add(task)
         task.add_done_callback(self._tasks.remove)
         return task
+
+    @contextlib.asynccontextmanager
+    async def request_priority(
+        self, priority: int | None = None
+    ) -> AsyncGenerator[None]:
+        """Context manager to set the request priority for the duration of the context."""
+        token = self._priority_var.set(priority)
+
+        try:
+            yield
+        finally:
+            self._priority_var.reset(token)
 
     async def _load_db(self) -> None:
         """Restore save state."""
@@ -744,9 +761,11 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     @contextlib.asynccontextmanager
     async def _limit_concurrency(
-        self, *, priority: int = t.PacketPriority.NORMAL
+        self, *, priority: int | None = None
     ) -> AsyncGenerator[None, None]:
         """Async context manager to limit global coordinator request concurrency."""
+        if priority is None:
+            priority = self._priority_var.get()
 
         start_time = time.monotonic()
         manager: contextlib.AbstractAsyncContextManager

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -11,6 +11,7 @@ import time
 import typing
 import warnings
 
+from zigpy.backports.contextlib import nullcontext
 from zigpy.ota.manager import find_ota_cluster, update_firmware
 from zigpy.zcl.clusters.general import Ota
 
@@ -118,11 +119,26 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.status = Status.NEW
 
     @contextlib.asynccontextmanager
-    async def _limit_concurrency(self, *, priority: int = 0):
+    async def _limit_concurrency(self, *, priority: int | None = None):
         """Async context manager to limit device request concurrency."""
+        # Defer to the current app-level priority if not specified
+        if priority is None:
+            priority = self._application._priority_var.get()
 
         start_time = time.monotonic()
-        was_locked = self._concurrent_requests_semaphore.locked()
+        manager: contextlib.AbstractAsyncContextManager
+
+        if priority >= t.PacketPriority.CRITICAL:
+            LOGGER.debug(
+                "Critical priority request received (%s), skipping queue with %d requests",
+                priority,
+                self._concurrent_requests_semaphore.num_waiting,
+            )
+            manager = nullcontext()
+            was_locked = False
+        else:
+            manager = self._concurrent_requests_semaphore(priority=priority)
+            was_locked = self._concurrent_requests_semaphore.locked()
 
         if was_locked:
             LOGGER.debug(
@@ -131,7 +147,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 self._concurrent_requests_semaphore.num_waiting,
             )
 
-        async with self._concurrent_requests_semaphore(priority=priority):
+        async with manager:
             if was_locked:
                 LOGGER.debug(
                     "Previously delayed device request is now running, delayed by %0.2fs",
@@ -357,7 +373,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         timeout=APS_REPLY_TIMEOUT,
         use_ieee=False,
         ask_for_ack: bool | None = None,
-        priority: int = t.PacketPriority.NORMAL,
+        priority: int | None = None,
     ):
         extended_timeout = False
 
@@ -603,7 +619,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         expect_reply: bool = False,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
-        priority: int = t.PacketPriority.NORMAL,
+        priority: int | None = None,
     ):
         return await self.request(
             profile=profile,

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -247,10 +247,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     async def get_node_descriptor(self) -> zdo_t.NodeDescriptor:
         self.info("Requesting 'Node Descriptor'")
 
-        status, _, node_desc = await self.zdo.Node_Desc_req(
-            self.nwk,
-            priority=t.PacketPriority.CRITICAL,
-        )
+        status, _, node_desc = await self.zdo.Node_Desc_req(self.nwk)
 
         if status != zdo_t.Status.SUCCESS:
             raise zigpy.exceptions.InvalidResponse(
@@ -264,7 +261,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     async def initialize(self) -> None:
         try:
-            await self._initialize()
+            # Perform initialization with critical priority
+            async with self._application.request_priority(t.PacketPriority.CRITICAL):
+                await self._initialize()
         except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
             self.application.listener_event("device_init_failure", self)
         except Exception:  # noqa: BLE001
@@ -293,9 +292,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         else:
             self.info("Discovering endpoints")
 
-            status, _, endpoints = await self.zdo.Active_EP_req(
-                self.nwk, priority=t.PacketPriority.CRITICAL
-            )
+            status, _, endpoints = await self.zdo.Active_EP_req(self.nwk)
 
             if status != zdo_t.Status.SUCCESS:
                 raise zigpy.exceptions.InvalidResponse(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -123,7 +123,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         """Async context manager to limit device request concurrency."""
         # Defer to the current app-level priority if not specified
         if priority is None:
-            priority = self._application._priority_var.get()
+            priority = self._application._packet_priority_var.get()
 
         start_time = time.monotonic()
         manager: contextlib.AbstractAsyncContextManager

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -63,7 +63,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.info("Endpoint descriptor already queried")
         else:
             status, _, sd = await self._device.zdo.Simple_Desc_req(
-                self._device.nwk, self._endpoint_id, priority=t.PacketPriority.CRITICAL
+                self._device.nwk, self._endpoint_id
             )
 
             if status == ZDOStatus.NOT_ACTIVE:
@@ -201,7 +201,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         for names in (["manufacturer", "model"], ["manufacturer"], ["model"]):
             try:
                 success, failure = await self.basic.read_attributes(
-                    names, allow_cache=True, priority=t.PacketPriority.CRITICAL
+                    names, allow_cache=True
                 )
             except asyncio.TimeoutError:
                 # Only swallow the `TimeoutError` on the double attribute read

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -259,7 +259,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         expect_reply: bool = True,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
-        priority: int = t.PacketPriority.NORMAL,
+        priority: int | None = None,
     ):
         if self.profile_id == zigpy.profiles.zll.PROFILE_ID and not (
             cluster == zigpy.zcl.clusters.lightlink.LightLink.cluster_id
@@ -293,7 +293,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         expect_reply: bool = False,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
-        priority: int = t.PacketPriority.NORMAL,
+        priority: int | None = None,
     ) -> None:
         if self.profile_id == zigpy.profiles.zll.PROFILE_ID and not (
             cluster == zigpy.zcl.clusters.lightlink.LightLink.cluster_id

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -591,7 +591,7 @@ class ZigbeePacket(BaseDataclassMixin):
     )
 
     # Higher priority will try to be sent before lower
-    priority: int = dataclasses.field(default=0)
+    priority: int | None = dataclasses.field(default=None)
 
     # Set to `None` when the packet is outgoing
     src: AddrModeAddress | None = dataclasses.field(default=None)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -373,7 +373,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         expect_reply: bool = True,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
-        priority: int = t.PacketPriority.NORMAL,
+        priority: int | None = None,
         tsn: int | t.uint8_t | None = None,
         timeout=APS_REPLY_TIMEOUT,
         **kwargs,
@@ -422,7 +422,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         expect_reply: bool = False,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
-        priority: int = t.PacketPriority.NORMAL,
+        priority: int | None = None,
         **kwargs,
     ) -> None:
         hdr, request = self._create_request(

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -59,7 +59,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         expect_reply: bool = True,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
-        priority: int = t.PacketPriority.NORMAL,
+        priority: int | None = None,
         **kwargs,
     ):
         data = self._serialize(command, *args, **kwargs)
@@ -87,7 +87,7 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         expect_reply: bool = False,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
-        priority: int = t.PacketPriority.NORMAL,
+        priority: int | None = None,
         **kwargs,
     ):
         data = self._serialize(command, *args, **kwargs)


### PR DESCRIPTION
This is mostly a cleanup PR that can be used from within ZHA in the future. Instead of this:

```python
await dev.endpoints[1].on_off.on(priority=t.PacketPriority.CRITICAL) 
```

You can now do this:

```python
async with app.request_priority(t.PacketPriority.CRITICAL):
    await dev.endpoints[1].on_off.on()
```

With a simple example the use may not be apparent but the real benefit comes from cascading it to *existing* operations:

```python
async def do_something_with_device():
    await dev.endpoints[1].on_off.on()
    await dev.endpoints[1].on_off.off()

async with app.request_priority(t.PacketPriority.CRITICAL):
    await do_something_with_device()
    await do_something_with_device()
```

This will allow ZHA to easily wrap its own binding and initialization code into critical or high priority contexts.