### PR TITLE
Fix ZCL type autodetection for enum factories in ZCL

### DIFF
--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -671,3 +671,9 @@ def test_general_analog_in_application_type():
         app_type.index
         == zcl.clusters.general_const.RelativeHumidityPercent.Space_Humidity
     )
+
+
+def test_ias_zone_enum_subclass_zcl_type():
+    """Test `IasZone.zone_type` is an enum16, not a uint16."""
+
+    assert sec.IasZone.AttributeDefs.zone_type.zcl_type == foundation.DataTypeId.enum16

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -19,7 +19,7 @@ class ZoneState(t.enum8):
     Enrolled = 0x01
 
 
-class ZoneType(t.enum_factory(t.uint16_t, "manufacturer_specific")):
+class ZoneType(t.enum_factory(t.uint16_t, "manufacturer_specific"), t.enum16):
     """Zone type enum."""
 
     Standard_CIE = 0x0000
@@ -170,7 +170,7 @@ class ArmNotification(t.enum8):
     Already_Disarmed = 0x06
 
 
-class AudibleNotification(t.enum_factory(t.uint8_t, "manufacturer_specific")):
+class AudibleNotification(t.enum_factory(t.uint8_t, "manufacturer_specific"), t.enum8):
     """IAS ACE audible notification enum."""
 
     Mute = 0x00


### PR DESCRIPTION
We use the base enum factory when creating `ZoneType`, I assume to allow `manufacturer_specific_0x1234` attributes to show up. Since these technically are not subclasses of `enum16` and `enum8`, the ZCL data type detection did not work properly for them and mistakenly classified them as `uint16` and `uint8`. This fixes it.

I don't think this had any practical impact but we'll need to regenerate ZHA diagnostics after this change.