### PR TITLE
Allow changing entity metadata with quirks v2

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -37,7 +37,8 @@ from zigpy.quirks.v2 import (
     ZCLSensorMetadata,
     add_to_registry_v2,
 )
-from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant import EntityType, UnitOfTime
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import (
@@ -1449,9 +1450,9 @@ async def test_quirks_v2_change_entity_metadata(device_mock: Device) -> None:
             endpoint_id=1,
             cluster_id=OnOff.cluster_id,
             cluster_type=ClusterType.Client,
-            new_device_class="custom_device_class",
-            new_state_class="measurement",
-            new_entity_category="config",
+            new_device_class=SensorDeviceClass.POWER,
+            new_state_class=SensorStateClass.MEASUREMENT,
+            new_entity_category=EntityType.CONFIG,
             new_entity_registry_enabled_default=False,
         )
         .change_entity_metadata(
@@ -1499,9 +1500,9 @@ async def test_quirks_v2_change_entity_metadata(device_mock: Device) -> None:
             new_primary=None,
             new_unique_id=None,
             new_translation_key=None,
-            new_device_class="custom_device_class",
-            new_state_class="measurement",
-            new_entity_category="config",
+            new_device_class=SensorDeviceClass.POWER,
+            new_state_class=SensorStateClass.MEASUREMENT,
+            new_entity_category=EntityType.CONFIG,
             new_entity_registry_enabled_default=False,
         ),
         ChangedEntityMetadata(

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -20,6 +20,7 @@ from zigpy.quirks import CustomCluster, CustomDevice, signature_matches
 from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import (
     BinarySensorMetadata,
+    ChangedEntityMetadata,
     CustomDeviceV2,
     DeviceAlertLevel,
     DeviceAlertMetadata,
@@ -1423,3 +1424,98 @@ async def test_quirks_v2_firmware_version_filter_metadata(device_mock):
     assert entry.fw_version_filter.min_version == 10
     assert entry.fw_version_filter.max_version == 50
     assert entry.fw_version_filter.allow_missing is False
+
+
+async def test_quirks_v2_change_entity_metadata(device_mock: Device) -> None:
+    """Test changing entity metadata functionality."""
+    registry = DeviceRegistry()
+
+    def filter_func(entity) -> bool:
+        return True
+
+    entry = (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .change_entity_metadata(
+            endpoint_id=1,
+            unique_id_suffix="something",
+            new_primary=True,
+        )
+        .change_entity_metadata(
+            endpoint_id=1,
+            cluster_id=OnOff.cluster_id,
+            new_translation_key="custom_key",
+        )
+        .change_entity_metadata(
+            endpoint_id=1,
+            cluster_id=OnOff.cluster_id,
+            cluster_type=ClusterType.Client,
+            new_device_class="custom_device_class",
+            new_state_class="measurement",
+            new_entity_category="config",
+            new_entity_registry_enabled_default=False,
+        )
+        .change_entity_metadata(
+            function=filter_func,
+            new_unique_id="custom_unique_id",
+        )
+        .add_to_registry()
+    )
+
+    assert entry.changed_entity_metadata == (
+        ChangedEntityMetadata(
+            endpoint_id=1,
+            cluster_id=None,
+            cluster_type=None,
+            unique_id_suffix="something",
+            function=None,
+            new_primary=True,
+            new_unique_id=None,
+            new_translation_key=None,
+            new_device_class=None,
+            new_state_class=None,
+            new_entity_category=None,
+            new_entity_registry_enabled_default=None,
+        ),
+        ChangedEntityMetadata(
+            endpoint_id=1,
+            cluster_id=OnOff.cluster_id,
+            cluster_type=ClusterType.Server,  # by default
+            unique_id_suffix=None,
+            function=None,
+            new_primary=None,
+            new_unique_id=None,
+            new_translation_key="custom_key",
+            new_device_class=None,
+            new_state_class=None,
+            new_entity_category=None,
+            new_entity_registry_enabled_default=None,
+        ),
+        ChangedEntityMetadata(
+            endpoint_id=1,
+            cluster_id=OnOff.cluster_id,
+            cluster_type=ClusterType.Client,
+            unique_id_suffix=None,
+            function=None,
+            new_primary=None,
+            new_unique_id=None,
+            new_translation_key=None,
+            new_device_class="custom_device_class",
+            new_state_class="measurement",
+            new_entity_category="config",
+            new_entity_registry_enabled_default=False,
+        ),
+        ChangedEntityMetadata(
+            endpoint_id=None,
+            cluster_id=None,
+            cluster_type=None,
+            unique_id_suffix=None,
+            function=filter_func,
+            new_primary=None,
+            new_unique_id="custom_unique_id",
+            new_translation_key=None,
+            new_device_class=None,
+            new_state_class=None,
+            new_entity_category=None,
+            new_entity_registry_enabled_default=None,
+        ),
+    )

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1458,6 +1458,7 @@ async def test_quirks_v2_change_entity_metadata(device_mock: Device) -> None:
         .change_entity_metadata(
             function=filter_func,
             new_unique_id="custom_unique_id",
+            new_fallback_name="Custom Fallback Name",
         )
         .add_to_registry()
     )
@@ -1476,6 +1477,7 @@ async def test_quirks_v2_change_entity_metadata(device_mock: Device) -> None:
             new_state_class=None,
             new_entity_category=None,
             new_entity_registry_enabled_default=None,
+            new_fallback_name=None,
         ),
         ChangedEntityMetadata(
             endpoint_id=1,
@@ -1490,6 +1492,7 @@ async def test_quirks_v2_change_entity_metadata(device_mock: Device) -> None:
             new_state_class=None,
             new_entity_category=None,
             new_entity_registry_enabled_default=None,
+            new_fallback_name=None,
         ),
         ChangedEntityMetadata(
             endpoint_id=1,
@@ -1504,6 +1507,7 @@ async def test_quirks_v2_change_entity_metadata(device_mock: Device) -> None:
             new_state_class=SensorStateClass.MEASUREMENT,
             new_entity_category=EntityType.CONFIG,
             new_entity_registry_enabled_default=False,
+            new_fallback_name=None,
         ),
         ChangedEntityMetadata(
             endpoint_id=None,
@@ -1518,5 +1522,6 @@ async def test_quirks_v2_change_entity_metadata(device_mock: Device) -> None:
             new_state_class=None,
             new_entity_category=None,
             new_entity_registry_enabled_default=None,
+            new_fallback_name="Custom Fallback Name",
         ),
     )

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -458,6 +458,25 @@ class PreventDefaultEntityCreationMetadata:
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
+class ChangedEntityMetadata:
+    """Metadata to change entity metadata for matching entities."""
+
+    endpoint_id: int | None = attrs.field()
+    cluster_id: int | None = attrs.field()
+    cluster_type: ClusterType | None = attrs.field()
+    unique_id_suffix: str | None = attrs.field()
+    function: Callable[[Any], bool] | None = attrs.field()
+    # Entity metadata changes
+    new_primary: bool | None = attrs.field(default=None)
+    new_unique_id: str | None = attrs.field(default=None)
+    new_translation_key: str | None = attrs.field(default=None)
+    new_device_class: str | None = attrs.field(default=None)
+    new_state_class: str | None = attrs.field(default=None)
+    new_entity_category: str | None = attrs.field(default=None)
+    new_entity_registry_enabled_default: bool | None = attrs.field(default=None)
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class FirmwareVersionFilterMetadata:
     """Metadata to only apply the quirk if the device's firmware version matches."""
 
@@ -480,6 +499,7 @@ class QuirksV2RegistryEntry:
     disabled_default_entities: tuple[PreventDefaultEntityCreationMetadata] = (
         attrs.field(factory=tuple)
     )
+    changed_entity_metadata: tuple[ChangedEntityMetadata] = attrs.field(factory=tuple)
     filters: tuple[FilterType] = attrs.field(factory=tuple)
     fw_version_filter: FirmwareVersionFilterMetadata | None = attrs.field(default=None)
     custom_device_class: type[CustomDeviceV2] | None = attrs.field(default=None)
@@ -567,6 +587,7 @@ class QuirkBuilder:
         self.friendly_name_metadata: FriendlyNameMetadata | None = None
         self.device_alerts: list[DeviceAlertMetadata] = []
         self.disabled_default_entities: list[PreventDefaultEntityCreationMetadata] = []
+        self.changed_entity_metadata: list[ChangedEntityMetadata] = []
         self.filters: list[FilterType] = []
         self.fw_version_filter: FirmwareVersionFilterMetadata | None = None
         self.custom_device_class: type[CustomDeviceV2] | None = None
@@ -1183,6 +1204,44 @@ class QuirkBuilder:
         )
         return self
 
+    def change_entity_metadata(
+        self,
+        *,
+        endpoint_id: int | None = None,
+        cluster_id: int | None = None,
+        cluster_type: ClusterType | None = None,
+        unique_id_suffix: str | None = None,
+        function: Callable[[Any], bool] | None = None,
+        new_primary: bool | None = None,
+        new_unique_id: str | None = None,
+        new_translation_key: str | None = None,
+        new_device_class: str | None = None,
+        new_state_class: str | None = None,
+        new_entity_category: str | None = None,
+        new_entity_registry_enabled_default: bool | None = None,
+    ) -> QuirkBuilder:
+        """Change entity metadata for matching entities."""
+        if cluster_id is not None and cluster_type is None:
+            cluster_type = ClusterType.Server
+
+        self.changed_entity_metadata.append(
+            ChangedEntityMetadata(
+                endpoint_id=endpoint_id,
+                cluster_id=cluster_id,
+                cluster_type=cluster_type,
+                unique_id_suffix=unique_id_suffix,
+                function=function,
+                new_primary=new_primary,
+                new_unique_id=new_unique_id,
+                new_translation_key=new_translation_key,
+                new_device_class=new_device_class,
+                new_state_class=new_state_class,
+                new_entity_category=new_entity_category,
+                new_entity_registry_enabled_default=new_entity_registry_enabled_default,
+            ),
+        )
+        return self
+
     def add_to_registry(self) -> QuirksV2RegistryEntry:
         """Build the quirks v2 registry entry."""
         if not self.manufacturer_model_metadata:
@@ -1194,6 +1253,7 @@ class QuirkBuilder:
             friendly_name=self.friendly_name_metadata,
             device_alerts=tuple(self.device_alerts),
             disabled_default_entities=tuple(self.disabled_default_entities),
+            changed_entity_metadata=tuple(self.changed_entity_metadata),
             quirk_file=self.quirk_file,
             quirk_file_line=self.quirk_file_line,
             filters=tuple(self.filters),

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -470,9 +470,11 @@ class ChangedEntityMetadata:
     new_primary: bool | None = attrs.field(default=None)
     new_unique_id: str | None = attrs.field(default=None)
     new_translation_key: str | None = attrs.field(default=None)
-    new_device_class: str | None = attrs.field(default=None)
-    new_state_class: str | None = attrs.field(default=None)
-    new_entity_category: str | None = attrs.field(default=None)
+    new_device_class: (
+        BinarySensorDeviceClass | NumberDeviceClass | SensorDeviceClass | None
+    ) = attrs.field(default=None)
+    new_state_class: SensorStateClass | None = attrs.field(default=None)
+    new_entity_category: EntityType | None = attrs.field(default=None)
     new_entity_registry_enabled_default: bool | None = attrs.field(default=None)
 
 
@@ -1215,9 +1217,11 @@ class QuirkBuilder:
         new_primary: bool | None = None,
         new_unique_id: str | None = None,
         new_translation_key: str | None = None,
-        new_device_class: str | None = None,
-        new_state_class: str | None = None,
-        new_entity_category: str | None = None,
+        new_device_class: (
+            BinarySensorDeviceClass | NumberDeviceClass | SensorDeviceClass | None
+        ) = None,
+        new_state_class: SensorStateClass | None = None,
+        new_entity_category: EntityType | None = None,
         new_entity_registry_enabled_default: bool | None = None,
     ) -> QuirkBuilder:
         """Change entity metadata for matching entities."""

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -476,6 +476,7 @@ class ChangedEntityMetadata:
     new_state_class: SensorStateClass | None = attrs.field(default=None)
     new_entity_category: EntityType | None = attrs.field(default=None)
     new_entity_registry_enabled_default: bool | None = attrs.field(default=None)
+    new_fallback_name: str | None = attrs.field(default=None)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -1223,6 +1224,7 @@ class QuirkBuilder:
         new_state_class: SensorStateClass | None = None,
         new_entity_category: EntityType | None = None,
         new_entity_registry_enabled_default: bool | None = None,
+        new_fallback_name: str | None = None,
     ) -> QuirkBuilder:
         """Change entity metadata for matching entities."""
         if cluster_id is not None and cluster_type is None:
@@ -1242,6 +1244,7 @@ class QuirkBuilder:
                 new_state_class=new_state_class,
                 new_entity_category=new_entity_category,
                 new_entity_registry_enabled_default=new_entity_registry_enabled_default,
+                new_fallback_name=new_fallback_name,
             ),
         )
         return self


### PR DESCRIPTION
This will allow us to re-categorize existing entities, update translation strings, and so on:

```python
QuirkBuilder("manufacturer", "model")
.change_entity_metadata(
    endpoint_id=1,
    unique_id_suffix="something",
    new_primary=True,
)
.change_entity_metadata(
    endpoint_id=1,
    cluster_id=OnOff.cluster_id,
    new_translation_key="custom_key",
    new_fallback_name="Custom translation string",
)
```