### PR TITLE
Implement `_find_zcl_cluster` and drop `deserialize` APIs

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1349,7 +1349,7 @@ async def test_device_concurrency(dev: device.Device) -> None:
     ]
 
 
-async def test_duplicate_request_matching(dev: device.Device) -> None:
+async def test_duplicate_request_sending(dev: device.Device) -> None:
     """Test that a device throws an error if requests duplicate."""
 
     ep = dev.add_endpoint(1)
@@ -1373,6 +1373,61 @@ async def test_duplicate_request_matching(dev: device.Device) -> None:
     assert all(isinstance(errors[i], asyncio.TimeoutError) for i in range(256))
     assert isinstance(errors[256], zigpy.exceptions.ControllerException)
     assert str(errors[256]).startswith("Duplicate request key: ")
+
+
+async def test_duplicate_request_matching(dev: device.Device, caplog) -> None:
+    """Test that a device handles duplicate packets matching the same request."""
+    ep = dev.add_endpoint(1)
+    ep.add_input_cluster(Basic.cluster_id)
+
+    def send_responses():
+        packet = t.ZigbeePacket(
+            src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+            src_ep=1,
+            dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+            dst_ep=1,
+            tsn=1,
+            profile_id=260,
+            cluster_id=Basic.cluster_id,
+            data=t.SerializableBytes(
+                foundation.ZCLHeader(
+                    frame_control=foundation.FrameControl(
+                        frame_type=foundation.FrameType.GLOBAL_COMMAND,
+                        is_manufacturer_specific=False,
+                        direction=foundation.Direction.Server_to_Client,
+                        disable_default_response=True,
+                        reserved=0,
+                    ),
+                    tsn=1,
+                    command_id=foundation.GeneralCommand.Default_Response,
+                ).serialize()
+                + (
+                    foundation.GENERAL_COMMANDS[
+                        foundation.GeneralCommand.Default_Response
+                    ]
+                    .schema(
+                        command_id=Basic.ServerCommandDefs.reset_fact_default.id,
+                        status=foundation.Status.SUCCESS,
+                    )
+                    .serialize()
+                )
+            ),
+            lqi=255,
+            rssi=-30,
+        )
+
+        dev.packet_received(packet)
+        dev.packet_received(packet)
+        dev.packet_received(packet)
+
+    with (
+        caplog.at_level(logging.DEBUG),
+        patch.object(dev, "_should_filter_packet", return_value=False),
+    ):
+        asyncio.get_running_loop().call_soon(send_responses)
+        await dev.endpoints[1].basic.reset_fact_default()
+
+    assert "probably duplicate response" in caplog.text
 
 
 @pytest.mark.parametrize("cluster_type", [ClusterType.Server, ClusterType.Client])

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1122,48 +1122,13 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     cluster.image_block_response = image_block_response
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-async def test_deserialize_backwards_compat(dev):
-    """Test that deserialization uses the method if it is overloaded."""
-    dev._packet_debouncer.filter = MagicMock(return_value=False)
-
-    packet = t.ZigbeePacket(
-        profile_id=260,
-        cluster_id=Basic.cluster_id,
-        src_ep=1,
-        dst_ep=1,
-        data=t.SerializableBytes(
-            b"\x18\x56\x09\x00\x00\x00\x00\x25\x1e\x00\x84\x03\x01\x02\x03\x04\x05\x06"
-        ),
-        src=t.AddrModeAddress(
-            addr_mode=t.AddrMode.NWK,
-            address=dev.nwk,
-        ),
-        dst=t.AddrModeAddress(
-            addr_mode=t.AddrMode.NWK,
-            address=0x0000,
-        ),
-    )
-
-    ep = dev.add_endpoint(1)
-    ep.add_input_cluster(Basic.cluster_id)
-
-    dev.packet_received(packet)
-
-    # Replace the method
-    dev.deserialize = MagicMock(side_effect=dev.deserialize)
-    dev.packet_received(packet)
-
-    assert dev.deserialize.call_count == 1
-
-
 async def test_request_exception_propagation(dev):
     """Test that exceptions are propagated to the caller."""
     tsn = 0x12
 
     ep = dev.add_endpoint(1)
     ep.add_input_cluster(Basic.cluster_id)
-    ep.deserialize = MagicMock(side_effect=RuntimeError())
+    ep.basic.deserialize = MagicMock(side_effect=RuntimeError())
 
     dev.get_sequence = MagicMock(return_value=tsn)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -369,6 +369,32 @@ async def test_handle_custom_profile(dev) -> None:
     assert mock_handler.mock_calls == [call(packet)]
 
 
+async def test_handle_unknown_cluster(dev, caplog) -> None:
+    """Test that unknown cluster messages are ignored."""
+    dev.add_endpoint(1)
+
+    with caplog.at_level(logging.DEBUG):
+        dev.packet_received(
+            t.ZigbeePacket(
+                profile_id=260,
+                cluster_id=0x9999,  # Unknown cluster
+                src_ep=1,
+                dst_ep=1,
+                data=t.SerializableBytes(b"unknown cluster data"),
+                src=t.AddrModeAddress(
+                    addr_mode=t.AddrMode.NWK,
+                    address=dev.nwk,
+                ),
+                dst=t.AddrModeAddress(
+                    addr_mode=t.AddrMode.NWK,
+                    address=0x0000,
+                ),
+            )
+        )
+
+    assert "Ignoring message on unknown cluster: 0x9999" in caplog.text
+
+
 async def test_update_device_firmware_no_ota_cluster(dev):
     """Test that device firmware updates fails: no ota cluster."""
     with pytest.raises(ValueError, match="Cluster 0x0019 not found"):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -343,6 +343,32 @@ async def test_ignore_unknown_endpoint(dev, caplog):
     assert "Ignoring message on unknown endpoint" in caplog.text
 
 
+async def test_handle_custom_profile(dev) -> None:
+    """Test that custom profile messages are handled."""
+    dev.add_endpoint(1)
+
+    packet = t.ZigbeePacket(
+        profile_id=0x1234,
+        cluster_id=1,
+        src_ep=1,
+        dst_ep=1,
+        data=t.SerializableBytes(b"custom data"),
+        src=t.AddrModeAddress(
+            addr_mode=t.AddrMode.NWK,
+            address=dev.nwk,
+        ),
+        dst=t.AddrModeAddress(
+            addr_mode=t.AddrMode.NWK,
+            address=0x0000,
+        ),
+    )
+
+    with patch.object(dev, "custom_profile_packet_received") as mock_handler:
+        dev.packet_received(packet)
+
+    assert mock_handler.mock_calls == [call(packet)]
+
+
 async def test_update_device_firmware_no_ota_cluster(dev):
     """Test that device firmware updates fails: no ota cluster."""
     with pytest.raises(ValueError, match="Cluster 0x0019 not found"):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -328,7 +328,7 @@ async def test_ignore_unknown_endpoint(dev, caplog):
                 cluster_id=1,
                 src_ep=2,
                 dst_ep=3,
-                data=t.SerializableBytes(b"data"),
+                data=t.SerializableBytes(b"some data"),
                 src=t.AddrModeAddress(
                     addr_mode=t.AddrMode.NWK,
                     address=dev.nwk,

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -127,12 +127,6 @@ def test_multiple_add_output_cluster(ep):
     assert ep.out_clusters[0].cluster_id == 1
 
 
-def test_handle_request_unknown(ep):
-    hdr = MagicMock()
-    hdr.command_id = sentinel.command_id
-    ep.handle_message(sentinel.profile, 99, hdr, sentinel.args)
-
-
 def test_cluster_attr(ep):
     with pytest.raises(AttributeError):
         ep.basic  # noqa: B018

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -28,14 +28,14 @@ def endpoint():
 
 
 def test_deserialize_general(endpoint):
-    hdr, args = endpoint.deserialize(0, b"\x00\x01\x00")
+    hdr, args = endpoint.in_clusters[0].deserialize(b"\x00\x01\x00")
     assert hdr.tsn == 1
     assert hdr.command_id == 0
     assert hdr.direction == foundation.Direction.Client_to_Server
 
 
 def test_deserialize_general_unknown(endpoint):
-    hdr, args = endpoint.deserialize(0, b"\x00\x01\xff")
+    hdr, args = endpoint.in_clusters[0].deserialize(b"\x00\x01\xff")
     assert hdr.tsn == 1
     assert hdr.frame_control.is_general is True
     assert hdr.frame_control.is_cluster is False
@@ -44,7 +44,7 @@ def test_deserialize_general_unknown(endpoint):
 
 
 def test_deserialize_cluster(endpoint):
-    hdr, args = endpoint.deserialize(0, b"\x01\x01\x00xxx")
+    hdr, args = endpoint.in_clusters[0].deserialize(b"\x01\x01\x00xxx")
     assert hdr.tsn == 1
     assert hdr.frame_control.is_general is False
     assert hdr.frame_control.is_cluster is True
@@ -53,7 +53,7 @@ def test_deserialize_cluster(endpoint):
 
 
 def test_deserialize_cluster_client(endpoint):
-    hdr, args = endpoint.deserialize(3, b"\x09\x01\x00AB")
+    hdr, args = endpoint.in_clusters[3].deserialize(b"\x09\x01\x00AB")
     assert hdr.tsn == 1
     assert hdr.frame_control.is_general is False
     assert hdr.frame_control.is_cluster is True
@@ -64,11 +64,11 @@ def test_deserialize_cluster_client(endpoint):
 
 def test_deserialize_cluster_unknown(endpoint):
     with pytest.raises(KeyError):
-        endpoint.deserialize(0xFF00, b"\x05\x00\x00\x01\x00")
+        endpoint.in_clusters[0xFF00].deserialize(b"\x05\x00\x00\x01\x00")
 
 
 def test_deserialize_cluster_command_unknown(endpoint):
-    hdr, args = endpoint.deserialize(0, b"\x01\x01\xff")
+    hdr, args = endpoint.in_clusters[0].deserialize(b"\x01\x01\xff")
     assert hdr.tsn == 1
     assert hdr.command_id == 255
     assert hdr.direction == foundation.Direction.Client_to_Server
@@ -793,8 +793,7 @@ async def test_handle_cluster_request_handler(cluster):
 
 
 async def test_handle_cluster_general_request_disable_default_rsp(endpoint):
-    hdr, values = endpoint.deserialize(
-        0,
+    hdr, values = endpoint.in_clusters[0].deserialize(
         b"\x18\xcd\x0a\x01\xff\x42\x25\x01\x21\x95\x0b\x04\x21\xa8\x43\x05\x21\x36\x00"
         b"\x06\x24\x02\x00\x05\x00\x00\x64\x29\xf8\x07\x65\x21\xd9\x0e\x66\x2b\x84\x87"
         b"\x01\x00\x0a\x21\x00\x00",
@@ -1149,12 +1148,7 @@ async def test_zcl_reply_direction(app_mock):
         foundation.GeneralCommand.Report_Attributes
     ].schema([attr])
 
-    ep.handle_message(
-        profile=260,
-        cluster=zcl.clusters.general.OnOff.cluster_id,
-        hdr=hdr,
-        args=cmd,
-    )
+    ep.on_off.handle_message(hdr, cmd)
 
     await asyncio.sleep(0.1)
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -88,7 +88,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.topology: zigpy.topology.Topology = zigpy.topology.Topology(self)
 
         self._req_listeners: collections.defaultdict[
-            zigpy.device.Device,
+            zigpy.device.Device | zigpy.listeners.Singleton,
             collections.deque[zigpy.listeners.BaseRequestListener],
         ] = collections.defaultdict(lambda: collections.deque([]))
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -711,6 +711,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         # Finally, pass it off to the cluster message handler. This will be removed.
         if zcl_cluster is not None:
             zcl_cluster.handle_message(hdr, args)
+        else:
+            assert isinstance(endpoint, zdo.ZDO)
+            endpoint.handle_message(packet.profile_id, packet.cluster_id, hdr, args)
 
     async def reply(
         self,

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -598,7 +598,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def custom_profile_packet_received(self, packet: t.ZigbeePacket) -> None:
         """Handle packets with a custom profile ID."""
         self.debug(
-            "Received packet with custom profile %04x, ignoring",
+            "Received packet with custom profile 0x%04x, ignoring",
             packet.profile_id,
         )
 
@@ -658,7 +658,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 zcl_cluster = self._find_zcl_cluster(hdr, packet)
             except KeyError:
                 self.debug(
-                    "Ignoring message on unknown cluster: %04x",
+                    "Ignoring message on unknown cluster: 0x%04x",
                     packet.cluster_id,
                 )
                 return None, None
@@ -680,7 +680,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return cmd
 
     def _maybe_match_response(
-        self, rsp_key: ResponseKey, cmd: typing.Any, error: Exception | None
+        self, rsp_key: ResponseKey, cmd: typing.Any | None, error: Exception | None
     ) -> bool:
         """Handle response matching for pending requests, returns True if packet was matched."""
         future = self._requests.get(rsp_key)
@@ -742,6 +742,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         try:
             cmd = self._parse_packet_command(packet, endpoint, zcl_cluster)
         except Exception as exc:  # noqa: BLE001
+            cmd = None
             error = zigpy.exceptions.ParsingError()
             error.__cause__ = exc
             self.debug("Failed to parse packet %r", packet, exc_info=error)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -756,7 +756,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         if error is not None:
             return
 
-        # Notify registered listeners
+        # Pass the request off to a listener, if one is registered
         for listener in itertools.chain(
             self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
             self._application._req_listeners[self],
@@ -767,7 +767,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             ):
                 break
 
-        # Dispatch to appropriate message handler
+        # Finally, pass it off to the cluster message handler. This will be removed.
         if zcl_cluster is not None:
             zcl_cluster.handle_message(hdr, cmd)
         else:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -602,25 +602,18 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             packet.profile_id,
         )
 
-    def packet_received(self, packet: t.ZigbeePacket) -> None:
-        # Set radio details that can be read from any type of packet
-        self.last_seen = packet.timestamp
-
-        if packet.lqi is not None:
-            self.lqi = packet.lqi
-
-        if packet.rssi is not None:
-            self.rssi = packet.rssi
-
-        if self._packet_debouncer.filter(
+    def _should_filter_packet(self, packet: t.ZigbeePacket) -> bool:
+        """Check if packet should be filtered as duplicate."""
+        return self._packet_debouncer.filter(
             # Be conservative with deduplication
             obj=packet.replace(timestamp=None, tsn=None, lqi=None, rssi=None),
             expire_in=PACKET_DEBOUNCE_WINDOW,
-        ):
-            self.debug("Filtering duplicate packet")
-            return
+        )
 
-        # Parse the ZCL/ZDO header first. This should never fail.
+    def _parse_packet_header(
+        self, packet: t.ZigbeePacket
+    ) -> tuple[zdo_t.ZDOHeader | foundation.ZCLHeader, ResponseKey] | tuple[None, None]:
+        """Parse packet header and create response key."""
         data = packet.data.serialize()
 
         if packet.src_ep == zdo.ZDO_ENDPOINT:
@@ -631,6 +624,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 direction=None,
                 tsn=hdr.tsn,
             )
+            return hdr, rsp_key
         elif packet.profile_id in (zha.PROFILE_ID, zll.PROFILE_ID):
             hdr, _ = foundation.ZCLHeader.deserialize(data)
             rsp_key = ResponseKey(
@@ -639,23 +633,26 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 direction=hdr.frame_control.direction,
                 tsn=hdr.tsn,
             )
+            return hdr, rsp_key
         else:
-            self.custom_profile_packet_received(packet)
-            return
+            return None, None
 
-        # Filter out packets that refer to unknown endpoints or clusters
+    def _match_packet_endpoint_cluster(
+        self, packet: t.ZigbeePacket, hdr: zdo_t.ZDOHeader | foundation.ZCLHeader
+    ) -> tuple[typing.Any, Cluster | None] | tuple[None, None]:
+        """Validate packet routing and find target endpoint and cluster."""
         if packet.src_ep not in self.endpoints:
             self.debug(
                 "Ignoring message on unknown endpoint %s (expected one of %s)",
                 packet.src_ep,
                 self.endpoints,
             )
-            return
+            return None, None
 
         endpoint = self.endpoints[packet.src_ep]
 
         if packet.src_ep == zdo.ZDO_ENDPOINT:
-            zcl_cluster = None
+            return endpoint, None
         else:
             try:
                 zcl_cluster = self._find_zcl_cluster(hdr, packet)
@@ -664,56 +661,118 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     "Ignoring message on unknown cluster: %04x",
                     packet.cluster_id,
                 )
-                return
+                return None, None
+            else:
+                return endpoint, zcl_cluster
+
+    def _parse_packet_command(
+        self, packet: t.ZigbeePacket, endpoint: typing.Any, zcl_cluster: Cluster | None
+    ) -> typing.Any:
+        """Deserialize packet data."""
+        data = packet.data.serialize()
+
+        if packet.src_ep == zdo.ZDO_ENDPOINT:
+            _, cmd = endpoint.deserialize(packet.cluster_id, data)
+        else:
+            assert zcl_cluster is not None
+            _, cmd = zcl_cluster.deserialize(data)
+
+        return cmd
+
+    def _maybe_match_response(
+        self, rsp_key: ResponseKey, cmd: typing.Any, error: Exception | None
+    ) -> bool:
+        """Handle response matching for pending requests, returns True if packet was matched."""
+        future = self._requests.get(rsp_key)
+        if future is None:
+            return False
 
         try:
-            if packet.src_ep == zdo.ZDO_ENDPOINT:
-                _, args = endpoint.deserialize(packet.cluster_id, data)
+            if error is not None:
+                future.set_exception(error)
             else:
-                assert zcl_cluster is not None
-                _, args = zcl_cluster.deserialize(data)
-        except Exception as exc:  # noqa: BLE001
-            error = zigpy.exceptions.ParsingError()
-            error.__cause__ = exc
+                future.set_result(cmd)
+        except asyncio.InvalidStateError:
+            self.debug(
+                "Invalid state on future for %s -- probably duplicate response",
+                rsp_key,
+            )
 
-            self.debug("Failed to parse packet %r", packet, exc_info=error)
-        else:
-            error = None
+        return True
 
-        future = self._requests.get(rsp_key)
-        if future is not None:
-            try:
-                if error is not None:
-                    future.set_exception(error)
-                else:
-                    future.set_result(args)
-            except asyncio.InvalidStateError:
-                self.debug(
-                    "Invalid state on future for %s -- probably duplicate response",
-                    rsp_key,
-                )
-            return
-
-        if error is not None:
-            return
-
-        # Pass the request off to a listener, if one is registered
+    def _notify_listeners(self, hdr: typing.Any, cmd: typing.Any) -> None:
+        """Notify registered listeners of the packet."""
         for listener in itertools.chain(
             self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
             self._application._req_listeners[self],
         ):
             # Resolve only until the first future listener
-            if listener.resolve(hdr, args) and isinstance(
+            if listener.resolve(hdr, cmd) and isinstance(
                 listener, zigpy.listeners.FutureListener
             ):
                 break
 
-        # Finally, pass it off to the cluster message handler. This will be removed.
+    def packet_received(self, packet: t.ZigbeePacket) -> None:
+        """Process received packet through the device's packet handling pipeline."""
+        self.last_seen = packet.timestamp
+
+        if packet.lqi is not None:
+            self.lqi = packet.lqi
+
+        if packet.rssi is not None:
+            self.rssi = packet.rssi
+
+        # Filter duplicate packets
+        if self._should_filter_packet(packet):
+            self.debug("Filtering duplicate packet")
+            return
+
+        # Parse packet header and create response key
+        hdr, rsp_key = self._parse_packet_header(packet)
+        if hdr is None:
+            self.custom_profile_packet_received(packet)
+            return
+
+        # Validate packet routing and find target endpoint/cluster
+        endpoint, zcl_cluster = self._match_packet_endpoint_cluster(packet, hdr)
+        if endpoint is None:
+            return
+
+        # Deserialize packet data
+        try:
+            cmd = self._parse_packet_command(packet, endpoint, zcl_cluster)
+        except Exception as exc:  # noqa: BLE001
+            error = zigpy.exceptions.ParsingError()
+            error.__cause__ = exc
+            self.debug("Failed to parse packet %r", packet, exc_info=error)
+        else:
+            error = None
+
+        # Handle response matching for pending requests
+        if self._maybe_match_response(rsp_key, cmd, error):
+            return
+
+        # Skip further processing if there was a parsing error
+        if error is not None:
+            return
+
+        # Notify registered listeners
+        for listener in itertools.chain(
+            self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
+            self._application._req_listeners[self],
+        ):
+            # Resolve only until the first future listener
+            if listener.resolve(hdr, cmd) and isinstance(
+                listener, zigpy.listeners.FutureListener
+            ):
+                break
+
+        # Dispatch to appropriate message handler
         if zcl_cluster is not None:
-            zcl_cluster.handle_message(hdr, args)
+            zcl_cluster.handle_message(hdr, cmd)
         else:
             assert isinstance(endpoint, zdo.ZDO)
-            endpoint.handle_message(packet.profile_id, packet.cluster_id, hdr, args)
+            endpoint.handle_message(packet.profile_id, packet.cluster_id, hdr, cmd)
 
     async def reply(
         self,

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -582,13 +582,17 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
         )
 
-    def deserialize(self, endpoint_id, cluster_id, data):
-        """Deprecated compatibility function."""
-        warnings.warn(
-            "`deserialize` is deprecated, avoid rewriting packet structures this way",
-            DeprecationWarning,
-        )
-        return self.endpoints[endpoint_id].deserialize(cluster_id, data)
+    def _find_zcl_cluster(
+        self, hdr: foundation.ZCLHeader, packet: t.ZigbeePacket
+    ) -> Cluster:
+        """Find the ZCL cluster for a given header and packet."""
+        assert packet.src_ep is not None
+        ep = self.endpoints[packet.src_ep]
+
+        if hdr.frame_control.direction == foundation.Direction.Client_to_Server:
+            return ep.out_clusters[packet.cluster_id]
+        else:
+            return ep.in_clusters[packet.cluster_id]
 
     def packet_received(self, packet: t.ZigbeePacket) -> None:
         # Set radio details that can be read from any type of packet
@@ -617,22 +621,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
             return
 
-        endpoint = self.endpoints[packet.src_ep]
-
-        # Ignore packets that do not match the endpoint's clusters.
-        # TODO: this isn't actually necessary, we can parse most packets by cluster ID.
-        if (
-            packet.dst_ep != zdo.ZDO_ENDPOINT
-            and packet.cluster_id not in endpoint.in_clusters
-            and packet.cluster_id not in endpoint.out_clusters
-        ):
-            self.debug(
-                "Ignoring message on unknown cluster %s for endpoint %s",
-                packet.cluster_id,
-                endpoint,
-            )
-            return
-
         # Parse the ZCL/ZDO header first. This should never fail.
         data = packet.data.serialize()
 
@@ -653,17 +641,26 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 tsn=hdr.tsn,
             )
 
+        endpoint = self.endpoints[packet.src_ep]
+
+        if packet.src_ep == zdo.ZDO_ENDPOINT:
+            zcl_cluster = None
+        else:
+            try:
+                zcl_cluster = self._find_zcl_cluster(hdr, packet)
+            except KeyError:
+                self.debug(
+                    "Ignoring message on unknown cluster: %04x",
+                    packet.cluster_id,
+                )
+                return
+
         try:
-            if (
-                type(self).deserialize is not Device.deserialize
-                or getattr(self.deserialize, "__func__", None) is not Device.deserialize
-            ):
-                # XXX: support for custom deserialization will be removed
-                _, args = self.deserialize(packet.src_ep, packet.cluster_id, data)
-            else:
-                # Next, parse the ZCL/ZDO payload
-                # FIXME: ZCL deserialization mutates the header!
+            if packet.src_ep == zdo.ZDO_ENDPOINT:
                 _, args = endpoint.deserialize(packet.cluster_id, data)
+            else:
+                assert zcl_cluster is not None
+                _, args = zcl_cluster.deserialize(data)
         except Exception as exc:  # noqa: BLE001
             error = zigpy.exceptions.ParsingError()
             error.__cause__ = exc
@@ -700,14 +697,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             ):
                 break
 
-        # Finally, pass it off to the endpoint message handler. This will be removed.
-        endpoint.handle_message(
-            packet.profile_id,
-            packet.cluster_id,
-            hdr,
-            args,
-            dst_addressing=packet.dst.addr_mode if packet.dst is not None else None,
-        )
+        # Finally, pass it off to the cluster message handler. This will be removed.
+        if zcl_cluster is not None:
+            zcl_cluster.handle_message(hdr, args)
 
     async def reply(
         self,

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -639,7 +639,11 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
     def _match_packet_endpoint_cluster(
         self, packet: t.ZigbeePacket, hdr: zdo_t.ZDOHeader | foundation.ZCLHeader
-    ) -> tuple[typing.Any, Cluster | None] | tuple[None, None]:
+    ) -> (
+        tuple[zigpy.endpoint.Endpoint, Cluster]
+        | tuple[zigpy.zdo.ZDO, None]
+        | tuple[None, None]
+    ):
         """Validate packet routing and find target endpoint and cluster."""
         if packet.src_ep not in self.endpoints:
             self.debug(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -700,18 +700,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         return True
 
-    def _notify_listeners(self, hdr: typing.Any, cmd: typing.Any) -> None:
-        """Notify registered listeners of the packet."""
-        for listener in itertools.chain(
-            self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
-            self._application._req_listeners[self],
-        ):
-            # Resolve only until the first future listener
-            if listener.resolve(hdr, cmd) and isinstance(
-                listener, zigpy.listeners.FutureListener
-            ):
-                break
-
     def packet_received(self, packet: t.ZigbeePacket) -> None:
         """Process received packet through the device's packet handling pipeline."""
         self.last_seen = packet.timestamp

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -14,6 +14,7 @@ import warnings
 from zigpy.backports.contextlib import nullcontext
 from zigpy.exceptions import DeliveryError
 from zigpy.ota.manager import update_firmware
+from zigpy.profiles import zha, zll
 from zigpy.zcl.clusters.general import Ota, PollControl
 
 if sys.version_info[:2] < (3, 11):
@@ -594,6 +595,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         else:
             return ep.in_clusters[packet.cluster_id]
 
+    def custom_profile_packet_received(self, packet: t.ZigbeePacket) -> None:
+        """Handle packets with a custom profile ID."""
+        self.debug(
+            "Received packet with custom profile %04x, ignoring",
+            packet.profile_id,
+        )
+
     def packet_received(self, packet: t.ZigbeePacket) -> None:
         # Set radio details that can be read from any type of packet
         self.last_seen = packet.timestamp
@@ -612,15 +620,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.debug("Filtering duplicate packet")
             return
 
-        # Filter out packets that refer to unknown endpoints or clusters
-        if packet.src_ep not in self.endpoints:
-            self.debug(
-                "Ignoring message on unknown endpoint %s (expected one of %s)",
-                packet.src_ep,
-                self.endpoints,
-            )
-            return
-
         # Parse the ZCL/ZDO header first. This should never fail.
         data = packet.data.serialize()
 
@@ -632,7 +631,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 direction=None,
                 tsn=hdr.tsn,
             )
-        else:
+        elif packet.profile_id in (zha.PROFILE_ID, zll.PROFILE_ID):
             hdr, _ = foundation.ZCLHeader.deserialize(data)
             rsp_key = ResponseKey(
                 endpoint_id=packet.src_ep,
@@ -640,6 +639,18 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 direction=hdr.frame_control.direction,
                 tsn=hdr.tsn,
             )
+        else:
+            self.custom_profile_packet_received(packet)
+            return
+
+        # Filter out packets that refer to unknown endpoints or clusters
+        if packet.src_ep not in self.endpoints:
+            self.debug(
+                "Ignoring message on unknown endpoint %s (expected one of %s)",
+                packet.src_ep,
+                self.endpoints,
+            )
+            return
 
         endpoint = self.endpoints[packet.src_ep]
 

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -9,17 +9,10 @@ from zigpy.const import APS_REPLY_TIMEOUT
 import zigpy.exceptions
 import zigpy.profiles
 import zigpy.types as t
-from zigpy.typing import AddressingMode, DeviceType
+from zigpy.typing import DeviceType
 import zigpy.util
 import zigpy.zcl
-from zigpy.zcl.foundation import (
-    GENERAL_COMMANDS,
-    CommandSchema,
-    Direction,
-    GeneralCommand,
-    Status as ZCLStatus,
-    ZCLHeader,
-)
+from zigpy.zcl.foundation import GENERAL_COMMANDS, GeneralCommand, Status as ZCLStatus
 from zigpy.zdo.types import Status as ZDOStatus
 
 LOGGER = logging.getLogger(__name__)
@@ -217,37 +210,6 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 self._manufacturer = success["manufacturer"]
 
         return self._model, self._manufacturer
-
-    def deserialize(
-        self, cluster_id: t.ClusterId, data: bytes
-    ) -> tuple[ZCLHeader, CommandSchema]:
-        """Deserialize data for ZCL"""
-        if cluster_id not in self.in_clusters and cluster_id not in self.out_clusters:
-            raise KeyError(f"No cluster ID 0x{cluster_id:04x} on {self.unique_id}")
-
-        cluster = self.in_clusters.get(cluster_id, self.out_clusters.get(cluster_id))
-        return cluster.deserialize(data)
-
-    def handle_message(
-        self,
-        profile: int,
-        cluster: int,
-        hdr: ZCLHeader,
-        args: list,
-        *,
-        dst_addressing: AddressingMode | None = None,
-    ) -> None:
-        try:
-            if hdr.direction == Direction.Client_to_Server:
-                zcl_cluster = self.out_clusters[cluster]
-            else:
-                zcl_cluster = self.in_clusters[cluster]
-        except KeyError:
-            self.debug("Message on unknown cluster 0x%04x", cluster)
-            self.listener_event("unknown_cluster_message", hdr.command_id, args)
-            return
-
-        zcl_cluster.handle_message(hdr, args, dst_addressing=dst_addressing)
 
     async def request(
         self,


### PR DESCRIPTION
For https://github.com/zigpy/zha-device-handlers/pull/4193, we need an API for devices to be able to "fix" broken ZCL cluster matching. The current API of cascading `deserialize` methods will be replaced with methods on `Device`.