### PR TITLE
Read OTA info for newly joining devices

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 import copy
 import logging
 import threading
 import typing
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -21,6 +22,7 @@ from zigpy.config import (
 )
 import zigpy.state as app_state
 import zigpy.types as t
+from zigpy.zcl import Cluster
 import zigpy.zdo.types as zdo_t
 
 from .async_mock import AsyncMock, MagicMock
@@ -336,3 +338,30 @@ def verify_cleanup(
     threads = frozenset(threading.enumerate()) - threads_before
     for thread in threads:
         assert isinstance(thread, threading._DummyThread)
+
+
+@contextmanager
+def mock_attribute_reads(
+    cluster: Cluster, mock_attributes: dict[int, typing.Any]
+) -> typing.Generator[tuple[AsyncMock, dict[str | int, AsyncMock]], None, None]:
+    """Mock attribute reads on a cluster."""
+    for key, value in mock_attributes.items():
+        if not callable(value):
+            mock_attributes[key] = AsyncMock(return_value=value)
+
+    async def read_attributes(attributes, *args, **kwargs):
+        success = {}
+        failure = {}
+
+        for attribute in attributes:
+            if attribute in mock_attributes:
+                success[attribute] = await mock_attributes[attribute]()
+            else:
+                failure[attribute] = Cluster.Status.UNSUPPORTED_ATTRIBUTE
+
+        return success, failure
+
+    with patch.object(
+        cluster, "read_attributes", autospec=True, side_effect=read_attributes
+    ) as mock_read:
+        yield mock_read, mock_attributes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ from zigpy.config import (
 )
 import zigpy.state as app_state
 import zigpy.types as t
-from zigpy.zcl import Cluster
+from zigpy.zcl import Cluster, foundation
 import zigpy.zdo.types as zdo_t
 
 from .async_mock import AsyncMock, MagicMock
@@ -342,26 +342,37 @@ def verify_cleanup(
 
 @contextmanager
 def mock_attribute_reads(
-    cluster: Cluster, mock_attributes: dict[int, typing.Any]
+    cluster: Cluster, mock_attributes: dict[str | int, typing.Any]
 ) -> typing.Generator[tuple[AsyncMock, dict[str | int, AsyncMock]], None, None]:
     """Mock attribute reads on a cluster."""
+    mock_reads = {}
+
     for key, value in mock_attributes.items():
         if not callable(value):
-            mock_attributes[key] = AsyncMock(return_value=value)
+            value = Mock(return_value=value)
 
-    async def read_attributes(attributes, *args, **kwargs):
-        success = {}
-        failure = {}
+        mock_reads[cluster.find_attribute(key)] = value
 
-        for attribute in attributes:
-            if attribute in mock_attributes:
-                success[attribute] = await mock_attributes[attribute]()
+    async def read_attributes_raw(attributes, *args, **kwargs):
+        records = []
+
+        for attrid in attributes:
+            record = foundation.ReadAttributeRecord(attrid=attrid)
+            attr_def = cluster.find_attribute(attrid)
+
+            if attr_def in mock_reads:
+                record.status = foundation.Status.SUCCESS
+                record.value = foundation.TypeValue(
+                    type=attr_def.zcl_type, value=mock_reads[attr_def]()
+                )
             else:
-                failure[attribute] = Cluster.Status.UNSUPPORTED_ATTRIBUTE
+                record.status = foundation.Status.UNSUPPORTED_ATTRIBUTE
 
-        return success, failure
+            records.append(record)
+
+        return [records]
 
     with patch.object(
-        cluster, "read_attributes", autospec=True, side_effect=read_attributes
+        cluster, "read_attributes_raw", autospec=True, side_effect=read_attributes_raw
     ) as mock_read:
         yield mock_read, mock_attributes

--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -3,7 +3,12 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
-from tests.conftest import add_initialized_device, make_app, make_node_desc
+from tests.conftest import (
+    add_initialized_device,
+    make_app,
+    make_node_desc,
+    mock_attribute_reads,
+)
 from tests.ota.test_ota_metadata import image_with_metadata  # noqa: F401
 import zigpy.application
 import zigpy.device
@@ -191,7 +196,10 @@ async def test_ota_manager():
     )
     cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
 
-    await dev.initialize()
+    with mock_attribute_reads(
+        cluster, {"current_file_version": FW_IMAGE.firmware.header.file_version - 10}
+    ):
+        await dev.initialize()
 
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True
@@ -364,7 +372,10 @@ async def test_ota_manager_image_page():
     )
     cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
 
-    await dev.initialize()
+    with mock_attribute_reads(
+        cluster, {"current_file_version": FW_IMAGE.firmware.header.file_version - 10}
+    ):
+        await dev.initialize()
 
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True
@@ -561,7 +572,10 @@ async def test_ota_manager_image_page_invalid_size():
     )
     cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
 
-    await dev.initialize()
+    with mock_attribute_reads(
+        cluster, {"current_file_version": FW_IMAGE.firmware.header.file_version - 10}
+    ):
+        await dev.initialize()
 
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True
@@ -631,7 +645,10 @@ async def test_ota_manager_image_page_failure():
     )
     cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
 
-    await dev.initialize()
+    with mock_attribute_reads(
+        cluster, {"current_file_version": FW_IMAGE.firmware.header.file_version - 10}
+    ):
+        await dev.initialize()
 
     # Stop the general cluster handler from interfering
     dev.ota_in_progress = True

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -7,7 +7,7 @@ from unittest.mock import call
 
 import pytest
 
-from tests.conftest import mock_attribute_reads
+from tests.conftest import make_node_desc, mock_attribute_reads
 from zigpy import device, endpoint
 import zigpy.application
 from zigpy.datastructures import RequestLimiter
@@ -78,6 +78,34 @@ async def test_initialize(monkeypatch, dev):
 
     await dev.initialize()
     assert dev._application.device_initialized.call_count == 3
+
+
+async def test_initialize_read_ota(
+    app: zigpy.application.ControllerApplication,
+) -> None:
+    # We skip over endpoint and node descriptor initialization and instead focus on
+    # attribute reading
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
+    dev.node_desc = make_node_desc()
+
+    ep = dev.add_endpoint(1)
+    ep.status = endpoint.Status.ZDO_INIT
+
+    basic = ep.add_input_cluster(Basic.cluster_id)
+    ota = ep.add_output_cluster(Ota.cluster_id)
+
+    with (
+        mock_attribute_reads(basic, {"model": "Model", "manufacturer": "Manufacturer"}),
+        mock_attribute_reads(ota, {"current_file_version": 0x12345678}),
+    ):
+        await dev.initialize()
+
+    assert dev.model == "Model"
+    assert dev.manufacturer == "Manufacturer"
+    success, _ = await ota.read_attributes(
+        [Ota.AttributeDefs.current_file_version.id], only_cache=True
+    )
+    assert success[Ota.AttributeDefs.current_file_version.id] == 0x12345678
 
 
 async def test_initialize_fail(dev):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -108,6 +108,29 @@ async def test_initialize_read_ota(
     assert success[Ota.AttributeDefs.current_file_version.id] == 0x12345678
 
 
+async def test_initialize_read_ota_unsupported(
+    app: zigpy.application.ControllerApplication,
+) -> None:
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
+    dev.node_desc = make_node_desc()
+
+    ep = dev.add_endpoint(1)
+    ep.status = endpoint.Status.ZDO_INIT
+
+    basic = ep.add_input_cluster(Basic.cluster_id)
+    ota = ep.add_output_cluster(Ota.cluster_id)
+
+    with (
+        mock_attribute_reads(basic, {"model": "Model", "manufacturer": "Manufacturer"}),
+        mock_attribute_reads(ota, {}),  # No attributes are supported
+    ):
+        await dev.initialize()
+
+    # Initialization succeeds
+    assert dev.model == "Model"
+    assert dev.manufacturer == "Manufacturer"
+
+
 async def test_initialize_fail(dev):
     async def mockrequest(nwk, tries=None, delay=None):
         return [1, dev.nwk, []]

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -7,6 +7,7 @@ from unittest.mock import call
 
 import pytest
 
+from tests.conftest import mock_attribute_reads
 from zigpy import device, endpoint
 import zigpy.application
 from zigpy.datastructures import RequestLimiter
@@ -442,7 +443,9 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
     monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
     dev.zdo.Active_EP_req = mockrequest
-    await dev.initialize()
+
+    with mock_attribute_reads(cluster, {"current_file_version": 0x00000001}):
+        await dev.initialize()
 
     fw_image = zigpy.ota.OtaImageWithMetadata(
         metadata=zigpy.ota.providers.BaseOtaImageMetadata(
@@ -823,7 +826,9 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
     monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
     dev.zdo.Active_EP_req = mockrequest
-    await dev.initialize()
+
+    with mock_attribute_reads(cluster, {"current_file_version": 0x00000001}):
+        await dev.initialize()
 
     fw_image = zigpy.ota.OtaImageWithMetadata(
         metadata=zigpy.ota.providers.BaseOtaImageMetadata(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1235,6 +1235,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 and packet.cluster_id
                 in (
                     zigpy.zcl.clusters.general.Basic.cluster_id,
+                    zigpy.zcl.clusters.general.Ota.cluster_id,
                     zigpy.zcl.clusters.general.PollControl.cluster_id,
                 )
             )
@@ -1242,7 +1243,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             # Allow the following responses:
             #  - any ZDO
             #  - ZCL if endpoints are initialized
-            #  - ZCL from Basic or PollControl clusters, if endpoints are initializing
+            #  - ZCL from Basic, OTA, or PollControl clusters, if endpoints are initializing
 
             if not device.initializing:
                 device.schedule_initialize()

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -497,6 +497,15 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     if manufacturer is not None:
                         self.manufacturer = manufacturer
 
+        try:
+            ota = self.find_cluster(
+                cluster_id=Ota.cluster_id, cluster_type=ClusterType.Client
+            )
+        except ValueError:
+            self.debug("Device does not support OTA cluster")
+        else:
+            await ota.read_attributes([Ota.AttributeDefs.current_file_version.name])
+
         self.status = Status.ENDPOINTS_INIT
 
         self.info("Discovered basic device information for %s", self)


### PR DESCRIPTION
This will allow ZHA to immediately show an update entity for the device and allow us to use firmware version filtering for quirks v2.