### PR TITLE
Allow ZCL command definitions to specify acceptable responses

### DIFF
--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -74,6 +74,7 @@ class ResponseKey:
     cluster_id: int
     direction: foundation.Direction | None
     tsn: int
+    response_command_ids: int | None = None
 
 
 class Status(enum.IntEnum):
@@ -513,14 +514,43 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     cluster_id=cluster ^ 0x8000,
                     direction=None,
                     tsn=sequence,
+                    response_command_ids=None,
                 )
             else:
                 zcl_hdr, _ = foundation.ZCLHeader.deserialize(data)
+
+                # Try to further narrow down the acceptable responses
+                try:
+                    zcl_cluster = self._find_zcl_cluster(
+                        zcl_hdr,
+                        t.ZigbeePacket(
+                            profile_id=profile,
+                            cluster_id=cluster,
+                            src_ep=src_ep,
+                            dst_ep=dst_ep,
+                            data=t.SerializableBytes(data),
+                        ),
+                    )
+                except KeyError:
+                    response_command_ids = None
+                else:
+                    # Find the command definition
+                    if (
+                        zcl_hdr.frame_control.direction
+                        == foundation.Direction.Client_to_Server
+                    ):
+                        zcl_command = zcl_cluster.client_commands[zcl_hdr.command_id]
+                    else:
+                        zcl_command = zcl_cluster.server_commands[zcl_hdr.command_id]
+
+                    response_command_ids = zcl_command.response_command_ids
+
                 rsp_key = ResponseKey(
                     endpoint_id=dst_ep,
                     cluster_id=cluster,
                     direction=zcl_hdr.frame_control.direction.flip(),
                     tsn=sequence,
+                    response_command_ids=response_command_ids,
                 )
 
             if rsp_key in self._requests:

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1116,6 +1116,7 @@ class ZCLCommandDef(t.BaseDataclassMixin):
     schema: CommandSchema = None
     direction: Direction = None
     is_manufacturer_specific: bool = None
+    response_command_ids: tuple[t.uint8_t, ...] | None = None
 
     # set later
     name: str = None
@@ -1177,13 +1178,20 @@ class ZCLCommandDef(t.BaseDataclassMixin):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}("
-            f"id=0x{self.id:02X}, "
-            f"name={self.name!r}, "
-            f"direction={self.direction}, "
-            f"schema={self.schema}, "
-            f"is_manufacturer_specific={self.is_manufacturer_specific}"
-            f")"
+            (
+                f"{self.__class__.__name__}("
+                f"id=0x{self.id:02X}, "
+                f"name={self.name!r}, "
+                f"direction={self.direction}, "
+                f"schema={self.schema}, "
+                f"is_manufacturer_specific={self.is_manufacturer_specific}"
+            )
+            + (
+                f"response_command_ids={self.response_command_ids}"
+                if self.response_command_ids is not None
+                else ""
+            )
+            + ")"
         )
 
 
@@ -1341,16 +1349,30 @@ GENERAL_COMMANDS = COMMANDS = {
     GeneralCommand.Read_Attributes: ZCLCommandDef(
         schema={"attribute_ids": t.List[t.uint16_t]},
         direction=Direction.Client_to_Server,
+        response_command_ids=(
+            GeneralCommand.Read_Attributes_rsp,
+            GeneralCommand.Default_Response,
+        ),
     ),
     GeneralCommand.Read_Attributes_rsp: ZCLCommandDef(
         schema={"status_records": t.List[ReadAttributeRecord]},
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Write_Attributes: ZCLCommandDef(
-        schema={"attributes": t.List[Attribute]}, direction=Direction.Client_to_Server
+        schema={"attributes": t.List[Attribute]},
+        direction=Direction.Client_to_Server,
+        response_command_ids=(
+            GeneralCommand.Write_Attributes_rsp,
+            GeneralCommand.Default_Response,
+        ),
     ),
     GeneralCommand.Write_Attributes_Undivided: ZCLCommandDef(
-        schema={"attributes": t.List[Attribute]}, direction=Direction.Client_to_Server
+        schema={"attributes": t.List[Attribute]},
+        direction=Direction.Client_to_Server,
+        response_command_ids=(
+            GeneralCommand.Write_Attributes_rsp,
+            GeneralCommand.Default_Response,
+        ),
     ),
     GeneralCommand.Write_Attributes_rsp: ZCLCommandDef(
         schema={"status_records": WriteAttributesResponse},
@@ -1362,6 +1384,10 @@ GENERAL_COMMANDS = COMMANDS = {
     GeneralCommand.Configure_Reporting: ZCLCommandDef(
         schema={"config_records": t.List[AttributeReportingConfig]},
         direction=Direction.Client_to_Server,
+        response_command_ids=(
+            GeneralCommand.Configure_Reporting_rsp,
+            GeneralCommand.Default_Response,
+        ),
     ),
     GeneralCommand.Configure_Reporting_rsp: ZCLCommandDef(
         schema={"status_records": ConfigureReportingResponse},
@@ -1370,6 +1396,10 @@ GENERAL_COMMANDS = COMMANDS = {
     GeneralCommand.Read_Reporting_Configuration: ZCLCommandDef(
         schema={"attribute_records": t.List[ReadReportingConfigRecord]},
         direction=Direction.Client_to_Server,
+        response_command_ids=(
+            GeneralCommand.Read_Reporting_Configuration_rsp,
+            GeneralCommand.Default_Response,
+        ),
     ),
     GeneralCommand.Read_Reporting_Configuration_rsp: ZCLCommandDef(
         schema={"attribute_configs": t.List[AttributeReportingConfigWithStatus]},
@@ -1386,6 +1416,10 @@ GENERAL_COMMANDS = COMMANDS = {
     GeneralCommand.Discover_Attributes: ZCLCommandDef(
         schema={"start_attribute_id": t.uint16_t, "max_attribute_ids": t.uint8_t},
         direction=Direction.Client_to_Server,
+        response_command_ids=(
+            GeneralCommand.Discover_Attributes_rsp,
+            GeneralCommand.Default_Response,
+        ),
     ),
     GeneralCommand.Discover_Attributes_rsp: ZCLCommandDef(
         schema={
@@ -1400,6 +1434,10 @@ GENERAL_COMMANDS = COMMANDS = {
     GeneralCommand.Discover_Commands_Received: ZCLCommandDef(
         schema={"start_command_id": t.uint8_t, "max_command_ids": t.uint8_t},
         direction=Direction.Client_to_Server,
+        response_command_ids=(
+            GeneralCommand.Discover_Commands_Received_rsp,
+            GeneralCommand.Default_Response,
+        ),
     ),
     GeneralCommand.Discover_Commands_Received_rsp: ZCLCommandDef(
         schema={"discovery_complete": t.Bool, "command_ids": t.List[t.uint8_t]},
@@ -1408,6 +1446,10 @@ GENERAL_COMMANDS = COMMANDS = {
     GeneralCommand.Discover_Commands_Generated: ZCLCommandDef(
         schema={"start_command_id": t.uint8_t, "max_command_ids": t.uint8_t},
         direction=Direction.Client_to_Server,
+        response_command_ids=(
+            GeneralCommand.Discover_Commands_Generated_rsp,
+            GeneralCommand.Default_Response,
+        ),
     ),
     GeneralCommand.Discover_Commands_Generated_rsp: ZCLCommandDef(
         schema={"discovery_complete": t.Bool, "command_ids": t.List[t.uint8_t]},
@@ -1416,6 +1458,10 @@ GENERAL_COMMANDS = COMMANDS = {
     GeneralCommand.Discover_Attribute_Extended: ZCLCommandDef(
         schema={"start_attribute_id": t.uint16_t, "max_attribute_ids": t.uint8_t},
         direction=Direction.Client_to_Server,
+        response_command_ids=(
+            GeneralCommand.Discover_Attribute_Extended_rsp,
+            GeneralCommand.Default_Response,
+        ),
     ),
     GeneralCommand.Discover_Attribute_Extended_rsp: ZCLCommandDef(
         schema={


### PR DESCRIPTION
WIP.

This may fix a race condition where an attribute report and an attribute read arrive at the same time, sharing the same TSN.