### PR TITLE
Active fast poll context manager

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime, timezone
 import logging
+import math
 from unittest.mock import call
 
 import pytest
@@ -1541,7 +1542,9 @@ async def test_begin_fast_polling_with_cluster(dev: device.Device) -> None:
 
         # Verify write_attributes was called with correct timeout
         assert poll_control.write_attributes.mock_calls == [
-            call({PollControl.AttributeDefs.fast_poll_timeout.id: int(timeout * 4)})
+            call(
+                {PollControl.AttributeDefs.fast_poll_timeout.id: math.ceil(timeout * 4)}
+            )
         ]
 
         # Verify we are now fast polling

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1552,6 +1552,30 @@ async def test_begin_fast_polling_with_cluster(dev: device.Device) -> None:
     assert not dev._fast_polling
 
 
+async def test_fast_poll_mode_cancel_old_timer(dev: device.Device) -> None:
+    """Test that multiple fast_poll_mode runs cancel the previous timer."""
+    ep = dev.add_endpoint(1)
+    poll_control = ep.add_input_cluster(PollControl.cluster_id)
+    poll_control.bind = AsyncMock()
+    poll_control.write_attributes = AsyncMock()
+
+    # Start one fast polling session
+    await dev.begin_fast_polling(0.25)
+    assert dev._fast_polling
+
+    # A second run shouldn't be cancelled by the first expiring
+    await dev.begin_fast_polling(0.5)
+    assert dev._fast_polling
+
+    # It would have happened by now
+    await asyncio.sleep(0.3)
+    assert dev._fast_polling
+
+    # The second one resets it
+    await asyncio.sleep(0.3)
+    assert not dev._fast_polling
+
+
 async def test_begin_fast_polling_no_cluster(dev: device.Device) -> None:
     """Test beginning fast polling when PollControl cluster doesn't exist."""
     dev.add_endpoint(1)  # No PollControl cluster

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1534,19 +1534,22 @@ async def test_begin_fast_polling_with_cluster(dev: device.Device) -> None:
     poll_control.bind = AsyncMock()
     poll_control.write_attributes = AsyncMock()
 
-    timeout = 45.0
-    await dev.begin_fast_polling(timeout)
+    timeout = 0.25
+    async with dev.fast_poll_mode(timeout):
+        # Verify bind was called
+        assert poll_control.bind.mock_calls == [call()]
 
-    # Verify bind was called
-    assert poll_control.bind.mock_calls == [call()]
+        # Verify write_attributes was called with correct timeout
+        assert poll_control.write_attributes.mock_calls == [
+            call({PollControl.AttributeDefs.fast_poll_timeout.id: int(timeout * 4)})
+        ]
 
-    # Verify write_attributes was called with correct timeout
-    assert poll_control.write_attributes.mock_calls == [
-        call({PollControl.AttributeDefs.fast_poll_timeout.id: int(timeout * 4)})
-    ]
+        # Verify we are now fast polling
+        assert dev._fast_polling
 
-    # Verify end time was set
-    assert dev._fast_polling_end_time > datetime.now(timezone.utc)
+    # We reset afterwards
+    await asyncio.sleep(0.3)
+    assert not dev._fast_polling
 
 
 async def test_begin_fast_polling_no_cluster(dev: device.Device) -> None:
@@ -1557,19 +1560,7 @@ async def test_begin_fast_polling_no_cluster(dev: device.Device) -> None:
     await dev.begin_fast_polling()
 
     # End time should remain at minimum
-    assert dev._fast_polling_end_time == datetime.min.replace(tzinfo=timezone.utc)
-
-
-async def test_reset_timers(dev: device.Device) -> None:
-    """Test resetting device timers."""
-    # Set a future end time
-    dev._fast_polling_end_time = datetime.now(timezone.utc)
-
-    # Reset timers
-    dev.reset_timers()
-
-    # Verify end time was reset to minimum
-    assert dev._fast_polling_end_time == datetime.min.replace(tzinfo=timezone.utc)
+    assert not dev._fast_polling
 
 
 async def test_on_remove_callbacks(dev: device.Device) -> None:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -591,9 +591,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             zigpy.exceptions.DeliveryError("Device has re-joined the network")
         )
 
-        # Reset all timers related to the device
-        dev.reset_timers()
-
         if new_join:
             self.listener_event("device_joined", dev)
             dev.schedule_initialize()

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -381,24 +381,23 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self._fast_polling_reset_task.cancel()
             self._fast_polling_reset_task = None
 
-        LOGGER.debug("Beginning fast polling for %0.2fs", timeout)
+        # The units are quarter seconds, we round up to the nearest one
+        adjusted_timeout = math.ceil(timeout * 4) / 4
+        LOGGER.debug("Beginning fast polling for %0.2fs", adjusted_timeout)
 
         # We must first bind to the cluster, otherwise the device will not send a check-
         # in command
         await poll_control.bind()
         await poll_control.write_attributes(
-            {
-                # The units are quarter seconds, we round up
-                PollControl.AttributeDefs.fast_poll_timeout.id: math.ceil(timeout * 4),
-            }
+            {PollControl.AttributeDefs.fast_poll_timeout.id: int(4 * adjusted_timeout)}
         )
 
         self._fast_polling = True
 
         if reset_after:
 
-            async def reset_fast_polling():
-                await asyncio.sleep(math.ceil(timeout * 4) / 4)
+            async def reset_fast_polling() -> None:
+                await asyncio.sleep(adjusted_timeout)
                 self._fast_polling = False
 
             self._fast_polling_reset_task = self.create_task(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import enum
 import itertools
 import logging
+import math
 import sys
 import time
 import typing
@@ -386,9 +387,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         # in command
         await poll_control.bind()
         await poll_control.write_attributes(
-            # The units are quarter seconds
             {
-                PollControl.AttributeDefs.fast_poll_timeout.id: int(timeout * 4),
+                # The units are quarter seconds, we round up
+                PollControl.AttributeDefs.fast_poll_timeout.id: math.ceil(timeout * 4),
             }
         )
 
@@ -397,6 +398,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         if reset_after:
 
             async def reset_fast_polling():
+                await asyncio.sleep(math.ceil(timeout * 4) / 4)
                 self._fast_polling = False
 
             self._fast_polling_reset_task = self.create_task(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
 import contextlib
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import enum
 import itertools
 import logging
 import sys
 import time
 import typing
+from typing import Any, TypeVar
 import warnings
 
 from zigpy.backports.contextlib import nullcontext
@@ -49,6 +51,8 @@ from zigpy.zcl import Cluster, ClusterType, foundation
 import zigpy.zdo.types as zdo_t
 
 if typing.TYPE_CHECKING:
+    _R = TypeVar("_R")
+
     from zigpy.application import ControllerApplication
     from zigpy.ota.providers import OtaImageWithMetadata
 
@@ -102,8 +106,11 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.rssi: int | None = None
         self.ota_in_progress: bool = False
         self._last_seen: datetime | None = None
+
         self._initialize_task: asyncio.Task | None = None
         self._group_scan_task: asyncio.Task | None = None
+        self._fast_polling_reset_task: asyncio.Task | None = None
+
         self._listeners = {}
         self._manufacturer: str | None = None
         self._model: str | None = None
@@ -113,8 +120,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._skip_configuration: bool = False
         self._send_sequence: int = 0
 
-        self._fast_polling_end_time = datetime.min.replace(tzinfo=timezone.utc)
+        self._fast_polling = False
         self._on_remove_callbacks: list[typing.Callable[[], None]] = []
+        self._tasks: set[asyncio.Future[Any]] = set()
 
         self._packet_debouncer = zigpy.datastructures.Debouncer()
         self._concurrent_requests_semaphore = (
@@ -132,12 +140,29 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
         )
 
+    def create_task(
+        self, target: Coroutine[Any, Any, _R], name: str | None = None
+    ) -> asyncio.Task[_R]:
+        """Create a task and store a reference to it until the task completes.
+
+        target: target to call.
+        """
+        task = asyncio.get_running_loop().create_task(target, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.remove)
+        return task
+
     def on_remove(self) -> None:
         """Call on remove callbacks."""
         for callback in self._on_remove_callbacks:
             callback()
 
         self._on_remove_callbacks.clear()
+
+        for task in self._tasks:
+            task.cancel()
+
+        self._tasks.clear()
 
     @contextlib.asynccontextmanager
     async def _limit_concurrency(self, *, priority: int | None = None):
@@ -232,7 +257,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.debug("Cancelling old group rescan")
             self._group_scan_task.cancel()
 
-        self._group_scan_task = asyncio.create_task(self.group_membership_scan())
+        self._group_scan_task = self.create_task(
+            self.group_membership_scan(), name="group_membership_scan"
+        )
         return self._group_scan_task
 
     async def group_membership_scan(self) -> None:
@@ -261,7 +288,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.debug("Scheduling initialization")
 
         self.cancel_initialization()
-        self._initialize_task = asyncio.create_task(self.initialize())
+        self._initialize_task = self.create_task(self.initialize(), name="initialize")
 
         return self._initialize_task
 
@@ -318,9 +345,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         poll_control = self.find_cluster(cluster_id=PollControl.cluster_id)
 
         async with self._application.request_priority(t.PacketPriority.CRITICAL):
-            if self.initializing or self._concurrent_requests_semaphore.locked():
-                # Initiate fast polling mode if we are initializing or waiting for
-                # requests to be sent
+            # Initiate fast polling mode if we are initializing or waiting for requests
+            # to be sent
+            if (
+                self.initializing
+                or self._concurrent_requests_semaphore.locked()
+                or self._fast_polling
+            ):
                 await poll_control.checkin_response(
                     start_fast_polling=True,
                     fast_poll_timeout=int(DEFAULT_FAST_POLL_TIMEOUT * 4),
@@ -334,14 +365,20 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 )
 
     async def begin_fast_polling(
-        self, timeout: float = DEFAULT_FAST_POLL_TIMEOUT
+        self, timeout: float = DEFAULT_FAST_POLL_TIMEOUT, *, reset_after: bool = True
     ) -> None:
         """Ask the device to enter fast polling mode."""
         try:
             poll_control = self.find_cluster(cluster_id=PollControl.cluster_id)
         except ValueError:
+            LOGGER.debug("Device does not support fast polling")
             # The device doesn't have the cluster, there's nothing more we can do
             return
+
+        # Cancel any fast poll reset tasks
+        if self._fast_polling_reset_task is not None:
+            self._fast_polling_reset_task.cancel()
+            self._fast_polling_reset_task = None
 
         LOGGER.debug("Beginning fast polling for %0.2fs", timeout)
 
@@ -355,13 +392,29 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             }
         )
 
-        self._fast_polling_end_time = datetime.now(timezone.utc) + timedelta(
-            seconds=timeout
-        )
+        self._fast_polling = True
 
-    def reset_timers(self) -> None:
-        """Reset timers if we suspect a device has rebooted or reset."""
-        self._fast_polling_end_time = datetime.min.replace(tzinfo=timezone.utc)
+        if reset_after:
+
+            async def reset_fast_polling():
+                self._fast_polling = False
+
+            self._fast_polling_reset_task = self.create_task(
+                reset_fast_polling(), name="reset_fast_polling"
+            )
+
+    @contextlib.asynccontextmanager
+    async def fast_poll_mode(
+        self, initial_timeout: float = DEFAULT_FAST_POLL_TIMEOUT
+    ) -> None:
+        """Ask the device to enter fast polling mode."""
+        await self.begin_fast_polling(timeout=initial_timeout, reset_after=False)
+
+        try:
+            yield
+        finally:
+            LOGGER.debug("Stopping fast polling on next device check-in")
+            self._fast_polling = False
 
     @zigpy.util.retryable_request(tries=5, delay=0.5)
     async def _initialize(self) -> None:
@@ -396,9 +449,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.status = Status.ZDO_INIT
 
         # Initialize all of the discovered endpoints
-        initiated_fast_polling = self._fast_polling_end_time > datetime.now(
-            timezone.utc
-        )
+        initiated_fast_polling = self._fast_polling
 
         if self.all_endpoints_init:
             self.info(

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -319,6 +319,8 @@ async def update_firmware(
         if progress_callback is not None:
             progress_callback(current, total, progress)
 
-    with OTAManager(device, image, progress_callback=progress, force=force) as ota:
-        await ota.notify()
-        return await ota.wait()
+    # Ask the device to start fast polling before we send the OTA image
+    async with device.fast_poll_mode():
+        with OTAManager(device, image, progress_callback=progress, force=force) as ota:
+            await ota.notify()
+            return await ota.wait()


### PR DESCRIPTION
For use with OTA, I've created an active fast poll context manager. This responds to all check-in requests for the duration of the context manager lifetime to maintain the device in fast poll mode. This theoretically will speed up OTA for some slow devices, eventually.

I'm not seeing a consistent way to *enter* fast poll mode for devices, however: on some, writing to the fast poll timeout attribute works. On others, it does not. Others do not respond to an unsolicited checkin response.