### PR TITLE
Auto correct cluster direction and log a warning

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,7 +15,7 @@ import zigpy.state
 import zigpy.types as t
 import zigpy.util
 from zigpy.zcl import ClusterType, foundation
-from zigpy.zcl.clusters.general import Basic, Ota, PollControl
+from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PollControl
 from zigpy.zdo import types as zdo_t
 
 from .async_mock import AsyncMock, MagicMock, patch, sentinel
@@ -1617,3 +1617,66 @@ async def test_initialize_fast_polling_failure(dev: device.Device) -> None:
 
     # Initialization attempted to fast poll but failure didn't stop it
     assert dev.begin_fast_polling.mock_calls == [call()]
+
+
+async def test_device_flipped_cluster_warning(dev: device.Device, caplog) -> None:
+    """Test that a warning is logged when a cluster is flipped."""
+    ep1 = dev.add_endpoint(1)
+    ep1.add_input_cluster(OnOff.cluster_id)
+
+    ep2 = dev.add_endpoint(2)
+    ep2.add_output_cluster(OnOff.cluster_id)
+
+    zcl_hdr = foundation.ZCLHeader(
+        frame_control=foundation.FrameControl(
+            frame_type=foundation.FrameType.CLUSTER_COMMAND,
+            is_manufacturer_specific=False,
+            direction=foundation.Direction.Client_to_Server,
+            disable_default_response=1,
+            reserved=0,
+        ),
+        tsn=0x12,
+        command_id=OnOff.ServerCommandDefs.on.id,
+    )
+
+    # Correct
+    with caplog.at_level(logging.WARNING):
+        dev.packet_received(
+            t.ZigbeePacket(
+                src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+                src_ep=2,
+                dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+                dst_ep=1,
+                profile_id=260,
+                cluster_id=OnOff.cluster_id,
+                data=t.SerializableBytes(
+                    zcl_hdr.serialize()
+                    + OnOff.ServerCommandDefs.on.schema().serialize()
+                ),
+                lqi=255,
+                rssi=-30,
+            )
+        )
+
+    assert "has incorrect direction" not in caplog.text
+
+    # Incorrect
+    with caplog.at_level(logging.WARNING):
+        dev.packet_received(
+            t.ZigbeePacket(
+                src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+                src_ep=1,
+                dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+                dst_ep=1,
+                profile_id=260,
+                cluster_id=OnOff.cluster_id,
+                data=t.SerializableBytes(
+                    zcl_hdr.serialize()
+                    + OnOff.ServerCommandDefs.on.schema().serialize()
+                ),
+                lqi=255,
+                rssi=-30,
+            )
+        )
+
+    assert "has incorrect direction" in caplog.text

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1639,44 +1639,28 @@ async def test_device_flipped_cluster_warning(dev: device.Device, caplog) -> Non
         command_id=OnOff.ServerCommandDefs.on.id,
     )
 
+    packet = t.ZigbeePacket(
+        src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+        src_ep=1,
+        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+        dst_ep=1,
+        profile_id=260,
+        cluster_id=OnOff.cluster_id,
+        data=t.SerializableBytes(
+            zcl_hdr.serialize() + OnOff.ServerCommandDefs.on.schema().serialize()
+        ),
+        lqi=255,
+        rssi=-30,
+    )
+
     # Correct
     with caplog.at_level(logging.WARNING):
-        dev.packet_received(
-            t.ZigbeePacket(
-                src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
-                src_ep=2,
-                dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
-                dst_ep=1,
-                profile_id=260,
-                cluster_id=OnOff.cluster_id,
-                data=t.SerializableBytes(
-                    zcl_hdr.serialize()
-                    + OnOff.ServerCommandDefs.on.schema().serialize()
-                ),
-                lqi=255,
-                rssi=-30,
-            )
-        )
+        dev.packet_received(packet.replace(src_ep=2))
 
     assert "has incorrect direction" not in caplog.text
 
     # Incorrect
     with caplog.at_level(logging.WARNING):
-        dev.packet_received(
-            t.ZigbeePacket(
-                src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
-                src_ep=1,
-                dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
-                dst_ep=1,
-                profile_id=260,
-                cluster_id=OnOff.cluster_id,
-                data=t.SerializableBytes(
-                    zcl_hdr.serialize()
-                    + OnOff.ServerCommandDefs.on.schema().serialize()
-                ),
-                lqi=255,
-                rssi=-30,
-            )
-        )
+        dev.packet_received(packet.replace(src_ep=1))
 
     assert "has incorrect direction" in caplog.text

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -613,7 +613,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 packet,
             )
             LOGGER.warning(
-                "Cluster 0x%04x on %r has incorrect direction (got %r for %r cluster)",
+                (
+                    "Cluster 0x%04x on %r has incorrect direction (got %r for %r cluster)."
+                    " Please report this here: https://github.com/zigpy/zigpy/issues/1640"
+                ),
                 packet.cluster_id,
                 self,
                 hdr.frame_control.direction,

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -583,10 +583,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
         )
 
-    def _find_zcl_cluster(
+    def _find_zcl_cluster_strict(
         self, hdr: foundation.ZCLHeader, packet: t.ZigbeePacket
     ) -> Cluster:
-        """Find the ZCL cluster for a given header and packet."""
+        """Find the ZCL cluster for a given header and packet, strict."""
         assert packet.src_ep is not None
         ep = self.endpoints[packet.src_ep]
 
@@ -594,6 +594,33 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             return ep.out_clusters[packet.cluster_id]
         else:
             return ep.in_clusters[packet.cluster_id]
+
+    def _find_zcl_cluster(
+        self, hdr: foundation.ZCLHeader, packet: t.ZigbeePacket
+    ) -> Cluster:
+        """Find the ZCL cluster for a given header and packet."""
+        try:
+            return self._find_zcl_cluster_strict(hdr, packet)
+        except KeyError:
+            # If the cluster is not found, try to find it with flipped direction. This
+            # will be removed in 2025.9.0.
+            cluster = self._find_zcl_cluster_strict(
+                hdr.replace(
+                    frame_control=hdr.frame_control.replace(
+                        direction=hdr.frame_control.direction.flip()
+                    )
+                ),
+                packet,
+            )
+            self.warning(
+                "Cluster 0x%04x has incorrect direction (got %r for %r cluster)",
+                self,
+                packet.cluster_id,
+                hdr.frame_control.direction,
+                cluster.cluster_type,
+            )
+
+            return cluster
 
     def custom_profile_packet_received(self, packet: t.ZigbeePacket) -> None:
         """Handle packets with a custom profile ID."""

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -612,10 +612,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 ),
                 packet,
             )
-            self.warning(
-                "Cluster 0x%04x has incorrect direction (got %r for %r cluster)",
-                self,
+            LOGGER.warning(
+                "Cluster 0x%04x on %r has incorrect direction (got %r for %r cluster)",
                 packet.cluster_id,
+                self,
                 hdr.frame_control.direction,
                 cluster.cluster_type,
             )


### PR DESCRIPTION
Strict matching is unfortunately catching too many bad devices, some of which are caused by bad quirks. Instead of failing, we should log a warning but match regardless to figure out which quirks and devices are problematic.