### PR TITLE
Do not pass through unknown ZCL commands

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1237,7 +1237,7 @@ async def test_debouncing(dev):
     """Test that request debouncing filters out duplicate packets."""
 
     ep = dev.add_endpoint(1)
-    cluster = ep.add_input_cluster(0xEF00)
+    on_off = ep.add_output_cluster(OnOff.cluster_id)
 
     packet = t.ZigbeePacket(
         src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
@@ -1248,8 +1248,21 @@ async def test_debouncing(dev):
         extended_timeout=False,
         tsn=202,
         profile_id=260,
-        cluster_id=cluster.cluster_id,
-        data=t.SerializableBytes(b"\t6\x02\x00\x89m\x02\x00\x04\x00\x00\x00\x00"),
+        cluster_id=on_off.cluster_id,
+        data=t.SerializableBytes(
+            foundation.ZCLHeader(
+                frame_control=foundation.FrameControl(
+                    frame_type=foundation.FrameType.GLOBAL_COMMAND,
+                    is_manufacturer_specific=False,
+                    direction=foundation.Direction.Client_to_Server,
+                    disable_default_response=True,
+                    reserved=0,
+                ),
+                tsn=1,
+                command_id=OnOff.ServerCommandDefs.toggle.id,
+            ).serialize()
+            + OnOff.ServerCommandDefs.toggle.schema().serialize()
+        ),
         tx_options=t.TransmitOptions.NONE,
         radius=0,
         non_member_radius=0,

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -35,12 +35,8 @@ def test_deserialize_general(endpoint):
 
 
 def test_deserialize_general_unknown(endpoint):
-    hdr, args = endpoint.in_clusters[0].deserialize(b"\x00\x01\xff")
-    assert hdr.tsn == 1
-    assert hdr.frame_control.is_general is True
-    assert hdr.frame_control.is_cluster is False
-    assert hdr.command_id == 255
-    assert hdr.direction == foundation.Direction.Client_to_Server
+    with pytest.raises(ValueError):
+        endpoint.in_clusters[0].deserialize(b"\x00\x01\xff")
 
 
 def test_deserialize_cluster(endpoint):
@@ -68,10 +64,8 @@ def test_deserialize_cluster_unknown(endpoint):
 
 
 def test_deserialize_cluster_command_unknown(endpoint):
-    hdr, args = endpoint.in_clusters[0].deserialize(b"\x01\x01\xff")
-    assert hdr.tsn == 1
-    assert hdr.command_id == 255
-    assert hdr.direction == foundation.Direction.Client_to_Server
+    with pytest.raises(ValueError):
+        endpoint.in_clusters[0].deserialize(b"\x01\x01\xff")
 
 
 def test_unknown_cluster():

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -301,15 +301,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 commands = self.server_commands
 
             if hdr.command_id not in commands:
-                self.debug("Unknown cluster command %s %s", hdr.command_id, data)
-                return hdr, data
+                raise ValueError(f"Unknown cluster command: {hdr} {data!r}")
 
             command = commands[hdr.command_id]
         else:
             # General command
             if hdr.command_id not in foundation.GENERAL_COMMANDS:
-                self.debug("Unknown foundation command %s %s", hdr.command_id, data)
-                return hdr, data
+                raise ValueError(f"Unknown general command: {hdr} {data!r}")
 
             command = foundation.GENERAL_COMMANDS[hdr.command_id]
 


### PR DESCRIPTION
Currently, we pass through unknown ZCL commands by just passing along the raw bytes. This is not ideal. If an application needs access to the raw bytes, we should provide an appropriate hook. This removes warnings such as https://github.com/home-assistant/core/issues/148752#issuecomment-3162079109.