### PR TITLE
Add packet reception API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ ENV/
 
 # Don't keep track of downloaded OTA files
 tests/ota/files/external/dl
+
+# VS Code workspace files
+*.code-workspace

--- a/tests/test_packet_callbacks.py
+++ b/tests/test_packet_callbacks.py
@@ -1,5 +1,7 @@
 import pytest
+
 import zigpy.types as t
+
 from .async_mock import MagicMock, call
 from .conftest import make_ieee
 
@@ -46,7 +48,9 @@ async def test_packet_callback_register_cancel(app, filter_address):
         (t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x5678), False),
     ],
 )
-async def test_packet_callback_address_filter(app, base_packet, src_address, should_trigger):
+async def test_packet_callback_address_filter(
+    app, base_packet, src_address, should_trigger
+):
     """Source address match."""
     filt = t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234)
     cb = MagicMock()
@@ -83,8 +87,8 @@ async def test_packet_callback_multiple_same_filter(app, base_packet):
     cancel1()
     pkt2 = base_packet.replace(src=addr, tsn=201)
     app.notify_packet_callbacks(pkt2)
-    assert cb1.mock_calls == [call(pkt1)] 
-    assert cb2.mock_calls == [call(pkt1), call(pkt2)] 
+    assert cb1.mock_calls == [call(pkt1)]
+    assert cb2.mock_calls == [call(pkt1), call(pkt2)]
 
 
 async def test_packet_callback_exception_global(app, base_packet, caplog):

--- a/tests/test_packet_callbacks.py
+++ b/tests/test_packet_callbacks.py
@@ -1,0 +1,105 @@
+import pytest
+import zigpy.types as t
+from .async_mock import MagicMock
+from .conftest import make_ieee
+
+
+def make_packet(src_address=None, **overrides):
+    """Build a packet."""
+    defaults = {
+        "src": src_address
+        or t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234),
+        "src_ep": 1,
+        "dst": t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+        "dst_ep": 1,
+        "tsn": 123,
+        "profile_id": 0x0104,
+        "cluster_id": 0x0006,
+        "data": t.SerializableBytes(b"test"),
+        "lqi": 255,
+        "rssi": -30,
+    }
+    defaults.update(overrides)
+    return t.ZigbeePacket(**defaults)
+
+
+@pytest.mark.parametrize(
+    "filter_address",
+    [
+        None,
+        t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234),
+        t.AddrModeAddress(addr_mode=t.AddrMode.IEEE, address=make_ieee()),
+    ],
+)
+async def test_packet_callback_register_cancel(app, filter_address):
+    """Register and cancel packet callback."""
+    cb = MagicMock()
+    cancel = app.register_packet_callback(filter_address, cb)
+    assert cb in app._packet_callbacks[filter_address]
+    cancel()
+    assert cb not in app._packet_callbacks[filter_address]
+    cancel()
+
+
+@pytest.mark.parametrize(
+    ("src_address", "should_trigger"),
+    [
+        (t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234), True),
+        (t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x5678), False),
+    ],
+)
+async def test_packet_callback_address_filter(app, src_address, should_trigger):
+    """Source address match."""
+    filt = t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234)
+    cb = MagicMock()
+    app.register_packet_callback(filt, cb)
+    pkt = make_packet(src_address=src_address)
+    app.notify_packet_callbacks(pkt)
+    if should_trigger:
+        cb.assert_called_once_with(pkt)
+    else:
+        cb.assert_not_called()
+
+
+async def test_packet_callback_addr_mode_mismatch(app):
+    """Address mode mismatch."""
+    ieee = make_ieee()
+    filt = t.AddrModeAddress(addr_mode=t.AddrMode.IEEE, address=ieee)
+    cb = MagicMock()
+    app.register_packet_callback(filt, cb)
+    pkt = make_packet(
+        src_address=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234)
+    )
+    app.notify_packet_callbacks(pkt)
+    cb.assert_not_called()
+
+
+async def test_packet_callback_multiple_same_filter(app):
+    """Multiple callbacks, cancel one."""
+    addr = t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x9ABC)
+    cb1 = MagicMock()
+    cb2 = MagicMock()
+    cancel1 = app.register_packet_callback(addr, cb1)
+    app.register_packet_callback(addr, cb2)
+    pkt1 = make_packet(src_address=addr)
+    app.notify_packet_callbacks(pkt1)
+    cb1.assert_called_once_with(pkt1)
+    cb2.assert_called_once_with(pkt1)
+    cancel1()
+    pkt2 = make_packet(src_address=addr, tsn=124)
+    app.notify_packet_callbacks(pkt2)
+    cb1.assert_called_once()
+    assert cb2.call_count == 2
+    cb2.assert_called_with(pkt2)
+
+
+async def test_packet_callback_exception_global(app, caplog):
+    """Exception isolation."""
+    failing = MagicMock(side_effect=ValueError("boom"))
+    ok = MagicMock()
+    app.register_packet_callback(None, failing)
+    app.register_packet_callback(None, ok)
+    pkt = make_packet()
+    app.notify_packet_callbacks(pkt)
+    ok.assert_called_once_with(pkt)
+    assert any("packet callback" in r.message.lower() for r in caplog.records)

--- a/tests/test_packet_callbacks.py
+++ b/tests/test_packet_callbacks.py
@@ -1,26 +1,24 @@
 import pytest
 import zigpy.types as t
-from .async_mock import MagicMock
+from .async_mock import MagicMock, call
 from .conftest import make_ieee
 
 
-def make_packet(src_address=None, **overrides):
-    """Build a packet."""
-    defaults = {
-        "src": src_address
-        or t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234),
-        "src_ep": 1,
-        "dst": t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
-        "dst_ep": 1,
-        "tsn": 123,
-        "profile_id": 0x0104,
-        "cluster_id": 0x0006,
-        "data": t.SerializableBytes(b"test"),
-        "lqi": 255,
-        "rssi": -30,
-    }
-    defaults.update(overrides)
-    return t.ZigbeePacket(**defaults)
+@pytest.fixture
+def base_packet():
+    """Base ZigbeePacket to clone with .replace()."""
+    return t.ZigbeePacket(
+        src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234),
+        src_ep=1,
+        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+        dst_ep=1,
+        tsn=123,
+        profile_id=0x0104,
+        cluster_id=0x0006,
+        data=t.SerializableBytes(b"test"),
+        lqi=255,
+        rssi=-30,
+    )
 
 
 @pytest.mark.parametrize(
@@ -48,58 +46,53 @@ async def test_packet_callback_register_cancel(app, filter_address):
         (t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x5678), False),
     ],
 )
-async def test_packet_callback_address_filter(app, src_address, should_trigger):
+async def test_packet_callback_address_filter(app, base_packet, src_address, should_trigger):
     """Source address match."""
     filt = t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234)
     cb = MagicMock()
     app.register_packet_callback(filt, cb)
-    pkt = make_packet(src_address=src_address)
+    pkt = base_packet.replace(src=src_address)
     app.notify_packet_callbacks(pkt)
     if should_trigger:
-        cb.assert_called_once_with(pkt)
+        assert cb.mock_calls == [call(pkt)]
     else:
-        cb.assert_not_called()
+        assert cb.mock_calls == []
 
 
-async def test_packet_callback_addr_mode_mismatch(app):
+async def test_packet_callback_addr_mode_mismatch(app, base_packet):
     """Address mode mismatch."""
     ieee = make_ieee()
     filt = t.AddrModeAddress(addr_mode=t.AddrMode.IEEE, address=ieee)
     cb = MagicMock()
     app.register_packet_callback(filt, cb)
-    pkt = make_packet(
-        src_address=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x1234)
-    )
-    app.notify_packet_callbacks(pkt)
-    cb.assert_not_called()
+    app.notify_packet_callbacks(base_packet)
+    assert cb.mock_calls == []
 
 
-async def test_packet_callback_multiple_same_filter(app):
+async def test_packet_callback_multiple_same_filter(app, base_packet):
     """Multiple callbacks, cancel one."""
     addr = t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x9ABC)
     cb1 = MagicMock()
     cb2 = MagicMock()
     cancel1 = app.register_packet_callback(addr, cb1)
     app.register_packet_callback(addr, cb2)
-    pkt1 = make_packet(src_address=addr)
+    pkt1 = base_packet.replace(src=addr, tsn=200)
     app.notify_packet_callbacks(pkt1)
-    cb1.assert_called_once_with(pkt1)
-    cb2.assert_called_once_with(pkt1)
+    assert cb1.mock_calls == [call(pkt1)]
+    assert cb2.mock_calls == [call(pkt1)]
     cancel1()
-    pkt2 = make_packet(src_address=addr, tsn=124)
+    pkt2 = base_packet.replace(src=addr, tsn=201)
     app.notify_packet_callbacks(pkt2)
-    cb1.assert_called_once()
-    assert cb2.call_count == 2
-    cb2.assert_called_with(pkt2)
+    assert cb1.mock_calls == [call(pkt1)] 
+    assert cb2.mock_calls == [call(pkt1), call(pkt2)] 
 
 
-async def test_packet_callback_exception_global(app, caplog):
+async def test_packet_callback_exception_global(app, base_packet, caplog):
     """Exception isolation."""
     failing = MagicMock(side_effect=ValueError("boom"))
     ok = MagicMock()
     app.register_packet_callback(None, failing)
     app.register_packet_callback(None, ok)
-    pkt = make_packet()
-    app.notify_packet_callbacks(pkt)
-    ok.assert_called_once_with(pkt)
+    app.notify_packet_callbacks(base_packet)
+    assert ok.mock_calls == [call(base_packet)]
     assert any("packet callback" in r.message.lower() for r in caplog.records)

--- a/tests/test_packet_callbacks.py
+++ b/tests/test_packet_callbacks.py
@@ -92,11 +92,25 @@ async def test_packet_callback_multiple_same_filter(app, base_packet):
 
 
 async def test_packet_callback_exception_global(app, base_packet, caplog):
-    """Exception isolation."""
+    """Exception isolation for global callbacks."""
     failing = MagicMock(side_effect=ValueError("boom"))
     ok = MagicMock()
     app.register_packet_callback(None, failing)
     app.register_packet_callback(None, ok)
     app.notify_packet_callbacks(base_packet)
     assert ok.mock_calls == [call(base_packet)]
-    assert any("packet callback" in r.message.lower() for r in caplog.records)
+    assert any("global packet callback" in r.message.lower() for r in caplog.records)
+
+
+async def test_packet_callback_exception_address(app, base_packet, caplog):
+    """Exception isolation for address-specific callbacks."""
+    addr = base_packet.src
+    failing = MagicMock(side_effect=ValueError("boom"))
+    ok = MagicMock()
+    app.register_packet_callback(addr, failing)
+    app.register_packet_callback(addr, ok)
+    app.notify_packet_callbacks(base_packet)
+    assert ok.mock_calls == [call(base_packet)]
+    assert any(
+        "packet callback for address" in r.message.lower() for r in caplog.records
+    )

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1227,14 +1227,14 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def notify_packet_callbacks(self, packet: t.ZigbeePacket) -> None:
         """Notify registered packet callbacks about a received Zigbee packet."""
-        
+
         # Notify global callbacks (registered with None filter)
         for callback in self._packet_callbacks.get(None, []):
             try:
                 callback(packet)
             except Exception:
                 LOGGER.exception("Error in global packet callback: %s", callback)
-        
+
         # Notify address-specific callbacks
         for callback in self._packet_callbacks.get(packet.src, []):
             try:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -92,6 +92,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             collections.deque[zigpy.listeners.BaseRequestListener],
         ] = collections.defaultdict(lambda: collections.deque([]))
 
+        # Add callback storage
+        self._packet_callbacks: collections.defaultdict[
+            t.AddrModeAddress | None,
+            list[typing.Callable[[t.ZigbeePacket], Any]]
+        ] = collections.defaultdict(list)
+
         # Context variable for request priority context manager
         self._packet_priority_var = contextvars.ContextVar(
             "request_priority", default=t.PacketPriority.NORMAL
@@ -1059,7 +1065,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def packet_received(self, packet: t.ZigbeePacket) -> None:
         """Notify zigpy of a received Zigbee packet."""
-
+        
         LOGGER.debug("Received a packet: %r", packet)
         assert packet.src is not None
         assert packet.dst is not None
@@ -1196,6 +1202,37 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             return self.get_device(ieee=address.address)
         else:
             raise ValueError(f"Invalid address: {address!r}")
+
+    def register_packet_callback(
+        self,
+        filter: t.AddrModeAddress | None,
+        callback: typing.Callable[[t.ZigbeePacket], Any],
+        # Question: Can every device (including unknown, provide a full AddrModeAddress filter? And is AddrModeAddress always unique?)
+        ) -> typing.Callable[[], None]:
+
+        """Register a callback that is called when a Zigbee packet is received.
+
+        Args:
+            callback: Function to call when a packet is received.
+            filter: Optional address filter to apply to the received packets.
+                    If provided, only packets matching this address will trigger the callback.
+
+        Returns:
+            A callable that can be used to unregister the callback.
+        """
+
+        # Register the callback
+        self._packet_callbacks[filter].append(callback)
+        
+        def cancel_callback() -> None:
+            """Remove the callback."""
+            if callback in self._packet_callbacks[filter]:
+                self._packet_callbacks[filter].remove(callback)
+
+        return cancel_callback
+    
+    # notify packet callbacks when a packet is received, this would happen in packet_received before any device lookup
+
 
     def register_callback_listener(
         self,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -94,8 +94,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         # Add callback storage
         self._packet_callbacks: collections.defaultdict[
-            t.AddrModeAddress | None,
-            list[typing.Callable[[t.ZigbeePacket], None]]
+            t.AddrModeAddress | None, list[typing.Callable[[t.ZigbeePacket], None]]
         ] = collections.defaultdict(list)
 
         # Context variable for request priority context manager
@@ -1208,11 +1207,13 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Register a callback that is called when a Zigbee packet is received.
 
         Args:
+        ----
             filter: Optional address filter. If None, callback receives all packets.
             If provided, only packets from this source address trigger the callback.
             callback: Function to call when a matching packet is received.
 
         Returns:
+        -------
             A callable that can be used to unregister the callback.
 
         """

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1066,6 +1066,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     def packet_received(self, packet: t.ZigbeePacket) -> None:
         """Notify zigpy of a received Zigbee packet."""
         
+        # self.notify_packet_received(packet)
+        
         LOGGER.debug("Received a packet: %r", packet)
         assert packet.src is not None
         assert packet.dst is not None
@@ -1208,6 +1210,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         filter: t.AddrModeAddress | None,
         callback: typing.Callable[[t.ZigbeePacket], Any],
         # Question: Can every device (including unknown, provide a full AddrModeAddress filter? And is AddrModeAddress always unique?)
+        # In what form do packets arrive? What does bellows send us?
+        # When we do a scan in interpan mode, what packets are received from unknown devices? What do unknown devices emit?
+        # What info do they have about the device? Has bellows created a ZigbeePacket?
         ) -> typing.Callable[[], None]:
 
         """Register a callback that is called when a Zigbee packet is received.
@@ -1219,20 +1224,40 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         Returns:
             A callable that can be used to unregister the callback.
-        """
+            """
 
         # Register the callback
         self._packet_callbacks[filter].append(callback)
-        
+
         def cancel_callback() -> None:
             """Remove the callback."""
             if callback in self._packet_callbacks[filter]:
                 self._packet_callbacks[filter].remove(callback)
 
         return cancel_callback
-    
-    # notify packet callbacks when a packet is received, this would happen in packet_received before any device lookup
 
+    # notify packet callbacks when a packet is received, this would happen in packet_received() before any device lookup
+    # When a packet is received, we check if there is a callback waiting to be executed on it
+    def notify_packet_callbacks(self, packet: t.ZigbeePacket) -> None:
+        """Notify registered packet callbacks about a received Zigbee packet."""
+        # Notify global callbacks (registered with None filter)
+                
+        for callback in self._packet_callbacks.get(None, []):
+            try:
+                callback(packet)
+            except Exception:
+                LOGGER.exception("Error in packet callback: %s", callback)
+        
+        # Notify address-specific callbacks
+        for callback in self._packet_callbacks.get(packet.src, []):
+            try:
+                callback(packet)
+            except Exception:
+                LOGGER.exception(
+                    "Error in packet callback for address %s: %s",
+                    packet.src,
+                    callback,
+                )
 
     def register_callback_listener(
         self,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1065,9 +1065,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def packet_received(self, packet: t.ZigbeePacket) -> None:
         """Notify zigpy of a received Zigbee packet."""
-        
-        # self.notify_packet_received(packet)
-        
+
         LOGGER.debug("Received a packet: %r", packet)
         assert packet.src is not None
         assert packet.dst is not None
@@ -1208,25 +1206,19 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     def register_packet_callback(
         self,
         filter: t.AddrModeAddress | None,
-        callback: typing.Callable[[t.ZigbeePacket], Any],
-        # Question: Can every device (including unknown, provide a full AddrModeAddress filter? And is AddrModeAddress always unique?)
-        # In what form do packets arrive? What does bellows send us?
-        # When we do a scan in interpan mode, what packets are received from unknown devices? What do unknown devices emit?
-        # What info do they have about the device? Has bellows created a ZigbeePacket?
-        ) -> typing.Callable[[], None]:
-
+        callback: typing.Callable[[t.ZigbeePacket], None],
+    ) -> typing.Callable[[], None]:
         """Register a callback that is called when a Zigbee packet is received.
 
         Args:
-            callback: Function to call when a packet is received.
-            filter: Optional address filter to apply to the received packets.
-                    If provided, only packets matching this address will trigger the callback.
+            filter: Optional address filter. If None, callback receives all packets.
+            If provided, only packets from this source address trigger the callback.
+            callback: Function to call when a matching packet is received.
 
         Returns:
             A callable that can be used to unregister the callback.
-            """
 
-        # Register the callback
+        """
         self._packet_callbacks[filter].append(callback)
 
         def cancel_callback() -> None:
@@ -1236,17 +1228,15 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         return cancel_callback
 
-    # notify packet callbacks when a packet is received, this would happen in packet_received() before any device lookup
-    # When a packet is received, we check if there is a callback waiting to be executed on it
     def notify_packet_callbacks(self, packet: t.ZigbeePacket) -> None:
         """Notify registered packet callbacks about a received Zigbee packet."""
+        
         # Notify global callbacks (registered with None filter)
-                
         for callback in self._packet_callbacks.get(None, []):
             try:
                 callback(packet)
             except Exception:
-                LOGGER.exception("Error in packet callback: %s", callback)
+                LOGGER.exception("Error in global packet callback: %s", callback)
         
         # Notify address-specific callbacks
         for callback in self._packet_callbacks.get(packet.src, []):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -95,7 +95,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # Add callback storage
         self._packet_callbacks: collections.defaultdict[
             t.AddrModeAddress | None,
-            list[typing.Callable[[t.ZigbeePacket], Any]]
+            list[typing.Callable[[t.ZigbeePacket], None]]
         ] = collections.defaultdict(list)
 
         # Context variable for request priority context manager
@@ -1220,7 +1220,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         def cancel_callback() -> None:
             """Remove the callback."""
-            if callback in self._packet_callbacks[filter]:
+            with contextlib.suppress(ValueError):
                 self._packet_callbacks[filter].remove(callback)
 
         return cancel_callback
@@ -1229,14 +1229,14 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Notify registered packet callbacks about a received Zigbee packet."""
 
         # Notify global callbacks (registered with None filter)
-        for callback in self._packet_callbacks.get(None, []):
+        for callback in self._packet_callbacks[None]:
             try:
                 callback(packet)
             except Exception:
                 LOGGER.exception("Error in global packet callback: %s", callback)
 
         # Notify address-specific callbacks
-        for callback in self._packet_callbacks.get(packet.src, []):
+        for callback in self._packet_callbacks[packet.src]:
             try:
                 callback(packet)
             except Exception:


### PR DESCRIPTION
This PR implements a generic packet reception API as referenced in issue #1468. It allows for registration of callbacks for raw ZigbeePacket objects to enable future features like TouchLink support via inter-PAN communication.

- Add `register_packet_callback()` method for raw packet callbacks
  - Supports address-specific filtering via `AddrModeAddress` and global callbacks when filter=None
  - Returns cancellation function for cleanup
- Add `notify_packet_callbacks()` to dispatch packets to registered callbacks
- Add `_packet_callbacks` storage using defaultdict

**Usage**:
```python
# Global packet callback
cancel_global = app.register_packet_callback(None, my_global_handler)

# Address-specific callback  
cancel_specific = app.register_packet_callback(
    AddrModeAddress(addr_mode=AddrMode.IEEE, address=some_ieee),
    my_address_handler
)

# Clean up
cancel_global()
cancel_specific()
```

Callback functions are called synchronously - async support could be added later as use cases develop. API is WIP and could be extended for more filters (cluster/profile ID etc).

Next, we will implement standalone parsing utilities for packet processing independent of device and cluster objects, enabling TouchLink cluster command processing using this packet callback interface.
