### PR TITLE
Avoid `frozendict.deepfreeze`

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1014,12 +1014,12 @@ async def test_quirks_v2_matches_v1(app_mock):
     triggers = {
         (SHORT_PRESS, TURN_ON): {
             COMMAND: COMMAND_TOGGLE,
-            CLUSTER_ID: 6,
+            CLUSTER_ID: OnOff.cluster_id,
             ENDPOINT_ID: 1,
         },
         (LONG_PRESS, TURN_ON): {
             COMMAND: COMMAND_RELEASE,
-            CLUSTER_ID: 5,
+            CLUSTER_ID: Scenes.cluster_id,
             ENDPOINT_ID: 1,
             PARAMS: {"param1": 0},
         },
@@ -1153,6 +1153,12 @@ async def test_quirks_v2_matches_v1(app_mock):
         )
 
     assert quirked.device_automation_triggers == quirked_v2.device_automation_triggers
+    assert (
+        quirked.device_automation_triggers[("remote_button_long_press", "turn_on")][
+            "cluster_id"
+        ]
+        == 0x0005
+    )
 
 
 async def test_quirks_v2_add_to_registry_v2_logs_error(caplog):

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -167,7 +167,7 @@ class AddsMetadata:
     endpoint_id: int = attrs.field(default=1)
     cluster_type: ClusterType = attrs.field(default=ClusterType.Server)
     constant_attributes: frozendict[ZCLAttributeDef, Any] = attrs.field(
-        factory=frozendict
+        factory=frozendict, converter=frozendict
     )
 
     def __call__(self, device: CustomDeviceV2) -> None:

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -13,7 +13,7 @@ from types import FrameType
 from typing import TYPE_CHECKING, Any, Callable
 
 import attrs
-from frozendict import deepfreeze, frozendict
+from frozendict import frozendict
 
 from zigpy.const import (
     SIG_ENDPOINTS,
@@ -167,7 +167,7 @@ class AddsMetadata:
     endpoint_id: int = attrs.field(default=1)
     cluster_type: ClusterType = attrs.field(default=ClusterType.Server)
     constant_attributes: frozendict[ZCLAttributeDef, Any] = attrs.field(
-        factory=frozendict, converter=deepfreeze
+        factory=frozendict
     )
 
     def __call__(self, device: CustomDeviceV2) -> None:
@@ -530,7 +530,10 @@ class QuirksV2RegistryEntry:
     ] = attrs.field(factory=tuple)
     device_automation_triggers_metadata: frozendict[
         tuple[str, str], frozendict[str, str]
-    ] = attrs.field(factory=frozendict, converter=deepfreeze)
+    ] = attrs.field(
+        factory=frozendict,
+        converter=lambda d: frozendict({k: frozendict(v) for k, v in d.items()}),
+    )
 
     def matches_device(self, device: Device) -> bool:
         """Determine if this quirk should be applied to the passed in device."""


### PR DESCRIPTION
Seen here: https://github.com/zigpy/zha-device-handlers/pull/4251

This function makes a pretty bizarre assumption:

```python
In [1]: from frozendict import deepfreeze

In [2]: deepfreeze?
Signature: deepfreeze(o, custom_converters=None, custom_inverse_converters=None)
Docstring:
Converts the object and all the objects nested in it in its
immutable counterparts.

The conversion map is in getFreezeConversionMap().

You can register a new conversion using `register()` You can also
pass a map of custom converters with `custom_converters` and a map
of custom inverse converters with `custom_inverse_converters`,
without using `register()`.

By default, if the type is not registered and has a `__dict__`
attribute, it's converted to the `frozendict` of that `__dict__`.                <------------------

This function assumes that hashable == immutable (that is not
always true).

This function uses recursion, with all the limits of recursions in
Python.

Where is a good old tail call when you need it?
```

This fails for basically every primitive type subclass:

```python
In [3]: class MyInt(int):
   ...:     pass
   ...:

In [4]: deepfreeze(MyInt())
Out[4]: frozendict.frozendict({})
```