### PR TITLE
Use attribute zcl_type when configuring reporting.

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -683,6 +683,7 @@ async def test_configure_reporting_manuf():
         (0, "device_enabled", 0x10),
         (0, "alarm_mask", 0x18),
         (0x0202, "fan_mode", 0x30),
+        (0x0702, "summation_formatting", 0x18),
     ],
 )
 async def test_configure_reporting_types(cluster_id, attr, data_type, cluster_by_id):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -738,7 +738,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         cfg = foundation.AttributeReportingConfig()
         cfg.direction = direction
         cfg.attrid = attr_def.id
-        cfg.datatype = foundation.DataType.from_python_type(attr_def.type).type_id
+        cfg.datatype = (
+            attr_def.zcl_type
+            if attr_def.zcl_type is not None
+            else foundation.DataType.from_python_type(attr_def.type).type_id
+        )
         cfg.min_interval = min_interval
         cfg.max_interval = max_interval
         cfg.reportable_change = reportable_change

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -7,7 +7,7 @@ from zigpy.zcl import Cluster
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
-    DataType,
+    DataTypeId,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
@@ -354,7 +354,7 @@ class Metering(Cluster):
         # • DFTSummation
         # • Block Information attributes
         summation_formatting: Final = ZCLAttributeDef(
-            id=0x0303, zcl_type=DataType.map8, type=NumberFormatting, access="r"
+            id=0x0303, zcl_type=DataTypeId.map8, type=NumberFormatting, access="r"
         )
 
         # This attribute shall be used against the following attributes:
@@ -362,7 +362,7 @@ class Metering(Cluster):
         # • CurrentMaxDemandReceived
         # • InstantaneousDemand
         demand_formatting: Final = ZCLAttributeDef(
-            id=0x0304, zcl_type=DataType.map8, type=NumberFormatting, access="r"
+            id=0x0304, zcl_type=DataTypeId.map8, type=NumberFormatting, access="r"
         )
 
         # This attribute shall be used against the following attributes:
@@ -386,7 +386,7 @@ class Metering(Cluster):
         # • PreviousMonthNConsumptionDelivered
         # • PreviousMonthNConsumptionReceived
         historical_consumption_formatting: Final = ZCLAttributeDef(
-            id=0x0305, zcl_type=DataType.map8, type=NumberFormatting, access="r"
+            id=0x0305, zcl_type=DataTypeId.map8, type=NumberFormatting, access="r"
         )
         metering_device_type: Final = ZCLAttributeDef(
             id=0x0306,
@@ -395,7 +395,7 @@ class Metering(Cluster):
             # as indicated in the attribute description. For backwards compatibility
             # reasons, the data type has not been changed, though the data itself should
             # be treated like an enum
-            zcl_type=DataType.map8,
+            zcl_type=DataTypeId.map8,
             access="r",
         )
         site_id: Final = ZCLAttributeDef(
@@ -408,10 +408,10 @@ class Metering(Cluster):
             id=0x0309, type=MeteringUnitofMeasure, access="r"
         )
         energy_carrier_summation_formatting: Final = ZCLAttributeDef(
-            id=0x030A, zcl_type=DataType.map8, type=NumberFormatting, access="r"
+            id=0x030A, zcl_type=DataTypeId.map8, type=NumberFormatting, access="r"
         )
         energy_carrier_demand_formatting: Final = ZCLAttributeDef(
-            id=0x030B, zcl_type=DataType.map8, type=NumberFormatting, access="r"
+            id=0x030B, zcl_type=DataTypeId.map8, type=NumberFormatting, access="r"
         )
         temperature_unit_of_measure: Final = ZCLAttributeDef(
             id=0x030C, type=MeteringUnitofMeasure, access="r"
@@ -422,7 +422,7 @@ class Metering(Cluster):
         # • OutletTemperature
         # • ControlTemperature
         temperature_formatting: Final = ZCLAttributeDef(
-            id=0x030D, zcl_type=DataType.map8, type=NumberFormatting, access="r"
+            id=0x030D, zcl_type=DataTypeId.map8, type=NumberFormatting, access="r"
         )
         module_serial_number: Final = ZCLAttributeDef(
             id=0x030E, type=t.LimitedLVBytes(24), access="r"
@@ -443,7 +443,7 @@ class Metering(Cluster):
         # This attribute shall be used against the following attribute:
         # • AlternativeInstantaneousDemand
         alternative_demand_formatting: Final = ZCLAttributeDef(
-            id=0x0313, zcl_type=DataType.map8, type=NumberFormatting, access="r"
+            id=0x0313, zcl_type=DataTypeId.map8, type=NumberFormatting, access="r"
         )
         # This attribute shall be used against the following attributes:
         # • CurrentDayAlternativeConsumptionDelivered
@@ -462,7 +462,7 @@ class Metering(Cluster):
         # • PreviousMonthNAlternativeConsumptionDelivered
         # • PreviousMonthNAlternativeConsumptionReceived
         alternative_consumption_formatting: Final = ZCLAttributeDef(
-            id=0x0314, zcl_type=DataType.map8, type=NumberFormatting, access="r"
+            id=0x0314, zcl_type=DataTypeId.map8, type=NumberFormatting, access="r"
         )
         instantaneous_demand: Final = ZCLAttributeDef(
             id=0x0400, type=t.int24s, access="r"


### PR DESCRIPTION
Fixes https://github.com/zigpy/zigpy/issues/1645

When configuring an attribute with different ZCLAttributeDef.type and ZCLAttributeDef.zcl_type, reporting configuration would use zcl_type.

Fixes also existing Metering cluster attributes zcl_type value types (from DataType to DataTypeId).