### PR TITLE
Enforce more kwargs in v2 quirks

### DIFF
--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -666,6 +666,7 @@ class QuirkBuilder:
 
     def firmware_version_filter(
         self,
+        *,
         min_version: int | None = None,
         max_version: int | None = None,
         allow_missing: bool = True,
@@ -716,6 +717,7 @@ class QuirkBuilder:
         self,
         cluster: int | type[Cluster | CustomCluster],
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
         constant_attributes: dict[ZCLAttributeDef, Any] | None = None,
     ) -> QuirkBuilder:
@@ -744,6 +746,7 @@ class QuirkBuilder:
         self,
         cluster_id: int,
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
     ) -> QuirkBuilder:
         """Add a RemovesMetadata entry and returns self.
@@ -763,6 +766,7 @@ class QuirkBuilder:
         replacement_cluster_class: type[Cluster | CustomCluster],
         cluster_id: int | None = None,
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
     ) -> QuirkBuilder:
         """Add a ReplacesMetadata entry and returns self.
@@ -795,6 +799,7 @@ class QuirkBuilder:
     def replace_cluster_occurrences(
         self,
         replacement_cluster_class: type[Cluster | CustomCluster],
+        *,
         replace_server_instances: bool = True,
         replace_client_instances: bool = True,
     ) -> QuirkBuilder:
@@ -862,6 +867,7 @@ class QuirkBuilder:
         enum_class: type[Enum],
         cluster_id: int,
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
         entity_platform: EntityPlatform = EntityPlatform.SELECT,
         entity_type: EntityType = EntityType.CONFIG,
@@ -902,6 +908,7 @@ class QuirkBuilder:
         attribute_name: str,
         cluster_id: int,
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
         divisor: int = 1,
         multiplier: int = 1,
@@ -954,6 +961,7 @@ class QuirkBuilder:
         attribute_name: str,
         cluster_id: int,
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
         force_inverted: bool = False,
         invert_attribute_name: str | None = None,
@@ -1001,6 +1009,7 @@ class QuirkBuilder:
         attribute_name: str,
         cluster_id: int,
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
         min_value: float | None = None,
         max_value: float | None = None,
@@ -1053,6 +1062,7 @@ class QuirkBuilder:
         attribute_name: str,
         cluster_id: int,
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
         entity_type: EntityType = EntityType.DIAGNOSTIC,
         device_class: BinarySensorDeviceClass | None = None,
@@ -1096,6 +1106,7 @@ class QuirkBuilder:
         attribute_value: int,
         cluster_id: int,
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,
@@ -1136,6 +1147,7 @@ class QuirkBuilder:
         command_args: tuple | None = None,
         command_kwargs: dict[str, Any] | None = None,
         cluster_type: ClusterType = ClusterType.Server,
+        *,
         endpoint_id: int = 1,
         entity_type: EntityType = EntityType.CONFIG,
         initially_disabled: bool = False,


### PR DESCRIPTION
This enforces v2 quirks to use more kwargs for certain quirks v2 methods.

For the added entities, there are some arguments I wouldn't want to enforce as kwargs (for now), like `attribute_name`, `cluster_id`, and `cluster_type`. We can revisit this in the future, but they're always the first two (or three) parameters provided in v2 quirks, and it's generally very clear what we provide there. But I'm open to other opinions.