### PR TITLE
Do not log warning when passing bytes to listener object

### DIFF
--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -157,7 +157,7 @@ async def test_listener_callback_invalid_matcher(caplog):
         callback=mock.Mock(),
     )
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         assert not listener.resolve(make_hdr(off()), off())
 
     assert listener.callback.mock_calls == []
@@ -170,7 +170,7 @@ async def test_listener_callback_invalid_call(caplog):
         callback=mock.Mock(),
     )
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         assert not listener.resolve(make_hdr(on()), b"data")
 
     assert listener.callback.mock_calls == []

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -832,16 +832,15 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             return
 
         # Pass the request off to a listener, if one is registered
-        if not isinstance(cmd, bytes):
-            for listener in itertools.chain(
-                self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
-                self._application._req_listeners[self],
+        for listener in itertools.chain(
+            self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
+            self._application._req_listeners[self],
+        ):
+            # Resolve only until the first future listener
+            if listener.resolve(hdr, cmd) and isinstance(
+                listener, zigpy.listeners.FutureListener
             ):
-                # Resolve only until the first future listener
-                if listener.resolve(hdr, cmd) and isinstance(
-                    listener, zigpy.listeners.FutureListener
-                ):
-                    break
+                break
 
         # Finally, pass it off to the cluster message handler. This will be removed.
         if zcl_cluster is not None:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -832,15 +832,16 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             return
 
         # Pass the request off to a listener, if one is registered
-        for listener in itertools.chain(
-            self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
-            self._application._req_listeners[self],
-        ):
-            # Resolve only until the first future listener
-            if listener.resolve(hdr, cmd) and isinstance(
-                listener, zigpy.listeners.FutureListener
+        if not isinstance(cmd, bytes):
+            for listener in itertools.chain(
+                self._application._req_listeners[zigpy.listeners.ANY_DEVICE],
+                self._application._req_listeners[self],
             ):
-                break
+                # Resolve only until the first future listener
+                if listener.resolve(hdr, cmd) and isinstance(
+                    listener, zigpy.listeners.FutureListener
+                ):
+                    break
 
         # Finally, pass it off to the cluster message handler. This will be removed.
         if zcl_cluster is not None:

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -41,7 +41,7 @@ class BaseRequestListener:
             elif callable(matcher):
                 match = matcher(hdr, command)
             else:
-                LOGGER.warning(
+                LOGGER.debug(
                     "Matcher %r and command %r %r are incompatible",
                     matcher,
                     hdr,


### PR DESCRIPTION
Fixes #1655.

For devices that send unknown ZCL commands, zigpy currently passes through the raw bytes instead of parsing the command into a structure. This is behavior that will be removed at some point.