### PR TITLE
Green Power Clusters and supporting Schemas

### DIFF
--- a/zigpy/zcl/clusters/__init__.py
+++ b/zigpy/zcl/clusters/__init__.py
@@ -7,6 +7,7 @@ from . import (
     closures,
     general,
     general_const as general_const,  # noqa: PLC0414
+    greenpower,
     homeautomation,
     hvac,
     lighting,
@@ -24,6 +25,7 @@ CLUSTERS_BY_NAME: dict[str, Cluster] = {}
 for cls in (
     closures,
     general,
+    greenpower,
     homeautomation,
     hvac,
     lighting,

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -15,6 +15,9 @@ from zigpy.zcl.foundation import (
     ZCLCommandDef,
 )
 
+# Backwards compatibility for when ZGP was still included in this file
+from .greenpower import GreenPowerProxy  # noqa: F401
+
 ZIGBEE_EPOCH = datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
 
 
@@ -2403,11 +2406,6 @@ class PollControl(Cluster):
 
     class ClientCommandDefs(BaseCommandDefs):
         checkin: Final = ZCLCommandDef(id=0x0000, schema={})
-
-
-class GreenPowerProxy(Cluster):
-    cluster_id: Final[t.uint16_t] = 0x0021
-    ep_attribute: Final = "green_power"
 
 
 class KeepAlive(Cluster):

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -16,18 +16,19 @@ from zigpy.zcl.foundation import (
 import zigpy.zgp.types as zgptypes
 
 
+class CommissioningNotificationOptions(t.Struct):
+    application_id: zgptypes.ApplicationID
+    rx_after_tx: t.uint1_t
+    security_level: zgptypes.SecurityLevel
+    security_key_type: zgptypes.SecurityKeyType
+    security_failed: t.uint1_t
+    bidirectional_cap: t.uint1_t
+    proxy_info_present: t.uint1_t
+    _reserved: t.uint6_t
+
+
 # Figure 27
 class CommissioningNotificationSchema(foundation.CommandSchema):
-    class CommissioningNotificationOptions(t.Struct):
-        application_id: zgptypes.ApplicationID
-        rx_after_tx: t.uint1_t
-        security_level: zgptypes.SecurityLevel
-        security_key_type: zgptypes.SecurityKeyType
-        security_failed: t.uint1_t
-        bidirectional_cap: t.uint1_t
-        proxy_info_present: t.uint1_t
-        _reserved: t.uint6_t
-
     options: CommissioningNotificationOptions
     gpd_id: zgptypes.DeviceID
     frame_counter: t.uint32_t
@@ -42,12 +43,13 @@ class CommissioningNotificationSchema(foundation.CommandSchema):
     mic: t.uint32_t = StructField(requires=lambda s: s.security_failed, optional=True)
 
 
+class ResponseOptions(t.Struct):
+    application_id: zgptypes.ApplicationID
+    _reserved: t.uint5_t
+
+
 # Figure 45
 class ResponseSchema(foundation.CommandSchema):
-    class ResponseOptions(t.Struct):
-        application_id: zgptypes.ApplicationID
-        _reserved: t.uint5_t
-
     options: ResponseOptions
     temp_master_short_addr: t.uint16_t
     temp_master_tx_channel: t.uint8_t
@@ -56,36 +58,38 @@ class ResponseSchema(foundation.CommandSchema):
     gpd_command_payload: t.LVBytes
 
 
+# Figure 26
+class PairingSearchOptions(t.Struct):
+    application_id: zgptypes.ApplicationID
+    request_unicast_sink: t.uint1_t
+    request_derived_groupcast_sink: t.uint1_t
+    request_commissioned_groupcast_sink: t.uint1_t
+    request_frame_counter: t.uint1_t
+    request_security_key: t.uint1_t
+    _reserved: t.uint8_t
+
+
 # Figure 25
 class PairingSearchSchema(foundation.CommandSchema):
-    # Figure 26
-    class PairingSearchOptions(t.Struct):
-        application_id: zgptypes.ApplicationID
-        request_unicast_sink: t.uint1_t
-        request_derived_groupcast_sink: t.uint1_t
-        request_commissioned_groupcast_sink: t.uint1_t
-        request_frame_counter: t.uint1_t
-        request_security_key: t.uint1_t
-        _reserved: t.uint8_t
-
     options: PairingSearchOptions
     gpd_id: zgptypes.DeviceID
 
 
+# Figure 24
+class NotificationOptions(t.Struct):
+    application_id: zgptypes.ApplicationID
+    also_unicast: t.uint1_t
+    also_derived_group: t.uint1_t
+    also_commissioned_group: t.uint1_t
+    security_level: zgptypes.SecurityLevel
+    security_key_type: zgptypes.SecurityKeyType
+    appoint_temp_master: t.uint1_t
+    tx_queue_full: t.uint1_t
+    _reserved: t.uint3_t
+
+
 # Figure 23
 class NotificationSchema(foundation.CommandSchema):
-    # Figure 24
-    class NotificationOptions(t.Struct):
-        application_id: zgptypes.ApplicationID
-        also_unicast: t.uint1_t
-        also_derived_group: t.uint1_t
-        also_commissioned_group: t.uint1_t
-        security_level: zgptypes.SecurityLevel
-        security_key_type: zgptypes.SecurityKeyType
-        appoint_temp_master: t.uint1_t
-        tx_queue_full: t.uint1_t
-        _reserved: t.uint3_t
-
     options: NotificationOptions
     gpd_id: zgptypes.DeviceID
     frame_counter: t.uint32_t
@@ -99,24 +103,25 @@ class NotificationSchema(foundation.CommandSchema):
     )
 
 
+# Figure 40, 41
+class PairingOptions(t.Struct):
+    application_id: zgptypes.ApplicationID
+    add_sink: t.uint1_t
+    remove_gpd: t.uint1_t
+    communication_mode: zgptypes.CommunicationMode
+    gpd_fixed: t.uint1_t
+    gpd_mac_seq_num_cap: t.uint1_t
+    security_level: zgptypes.SecurityLevel
+    security_key_type: zgptypes.SecurityKeyType
+    security_frame_counter_present: t.uint1_t
+    security_key_present: t.uint1_t
+    assigned_alias_present: t.uint1_t
+    forwarding_radius_present: t.uint1_t
+    _reserved: t.uint6_t
+
+
 # Figure 38, 39
 class PairingSchema(foundation.CommandSchema):
-    # Figure 40, 41
-    class PairingOptions(t.Struct):
-        application_id: zgptypes.ApplicationID
-        add_sink: t.uint1_t
-        remove_gpd: t.uint1_t
-        communication_mode: zgptypes.CommunicationMode
-        gpd_fixed: t.uint1_t
-        gpd_mac_seq_num_cap: t.uint1_t
-        security_level: zgptypes.SecurityLevel
-        security_key_type: zgptypes.SecurityKeyType
-        security_frame_counter_present: t.uint1_t
-        security_key_present: t.uint1_t
-        assigned_alias_present: t.uint1_t
-        forwarding_radius_present: t.uint1_t
-        _reserved: t.uint6_t
-
     options: PairingOptions
     gpd_id: zgptypes.DeviceID
     # Table 37
@@ -170,28 +175,30 @@ class PairingSchema(foundation.CommandSchema):
     )
 
 
-class NotificationResponseSchema(foundation.CommandSchema):
-    # Figure 37
-    class NotificationResponseOptions(t.Struct):
-        application_id: zgptypes.ApplicationID
-        first_to_forward: t.uint1_t
-        no_pairing: t.uint1_t
-        _reserved: t.uint3_t
+# Figure 37
+class NotificationResponseOptions(t.Struct):
+    application_id: zgptypes.ApplicationID
+    first_to_forward: t.uint1_t
+    no_pairing: t.uint1_t
+    _reserved: t.uint3_t
 
+
+class NotificationResponseSchema(foundation.CommandSchema):
     options: NotificationResponseOptions
     gpd_id: zgptypes.DeviceID
     frame_counter: t.uint32_t
 
 
-class ProxyCommissioningModeSchema(foundation.CommandSchema):
-    # Figure 43
-    class ProxyCommissioningModeOptions(t.Struct):
-        enter: t.uint1_t
-        exit_mode: zgptypes.ProxyCommissioningModeExitMode
-        channel_present: t.uint1_t
-        unicast: t.uint1_t
-        _reserved: t.uint2_t
+# Figure 43
+class ProxyCommissioningModeOptions(t.Struct):
+    enter: t.uint1_t
+    exit_mode: zgptypes.ProxyCommissioningModeExitMode
+    channel_present: t.uint1_t
+    unicast: t.uint1_t
+    _reserved: t.uint2_t
 
+
+class ProxyCommissioningModeSchema(foundation.CommandSchema):
     options: ProxyCommissioningModeOptions
     window: t.uint16_t = StructField(optional=True)
 

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -96,11 +96,9 @@ class NotificationSchema(foundation.CommandSchema):
     command_id: t.uint8_t
     payload: t.LVBytes
     short_addr: t.uint16_t = StructField(
-        requires=lambda s: s.options.appoint_temp_master, optional=True
+        requires=lambda s: s.options.appoint_temp_master
     )
-    distance: t.uint8_t = StructField(
-        requires=lambda s: s.options.appoint_temp_master, optional=True
-    )
+    distance: t.uint8_t = StructField(requires=lambda s: s.options.appoint_temp_master)
 
 
 # Figure 40, 41
@@ -131,8 +129,7 @@ class PairingSchema(foundation.CommandSchema):
         in (
             zgptypes.CommunicationMode.Unicast,
             zgptypes.CommunicationMode.UnicastLightweight,
-        ),
-        optional=True,
+        )
     )
     sink_nwk_addr: t.NWK = StructField(
         requires=lambda s: not s.options.remove_gpd
@@ -140,8 +137,7 @@ class PairingSchema(foundation.CommandSchema):
         in (
             zgptypes.CommunicationMode.Unicast,
             zgptypes.CommunicationMode.UnicastLightweight,
-        ),
-        optional=True,
+        )
     )
     sink_group: t.Group = StructField(
         requires=lambda s: not s.options.remove_gpd
@@ -149,29 +145,22 @@ class PairingSchema(foundation.CommandSchema):
         in (
             zgptypes.CommunicationMode.GroupcastForwardToDGroup,
             zgptypes.CommunicationMode.GroupcastForwardToCommGroup,
-        ),
-        optional=True,
+        )
     )
 
-    device_id: t.uint8_t = StructField(
-        requires=lambda s: s.options.add_sink, optional=True
-    )
+    device_id: t.uint8_t = StructField(requires=lambda s: s.options.add_sink)
     frame_counter: t.uint32_t = StructField(
         requires=lambda s: s.options.add_sink
-        and s.options.security_frame_counter_present,
-        optional=True,
+        and s.options.security_frame_counter_present
     )
     key: t.KeyData = StructField(
-        requires=lambda s: s.options.add_sink and s.options.security_key_present,
-        optional=True,
+        requires=lambda s: s.options.add_sink and s.options.security_key_present
     )
     alias: t.uint16_t = StructField(
-        requires=lambda s: s.options.add_sink and s.options.assigned_alias_present,
-        optional=True,
+        requires=lambda s: s.options.add_sink and s.options.assigned_alias_present
     )
     forwarding_radius: t.uint8_t = StructField(
-        requires=lambda s: s.options.add_sink and s.options.forwarding_radius_present,
-        optional=True,
+        requires=lambda s: s.options.add_sink and s.options.forwarding_radius_present
     )
 
 

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -220,76 +220,66 @@ class GreenPowerProxy(Cluster):
         max_sink_table_entries: Final = ZCLAttributeDef(
             id=0x0000,
             type=t.uint8_t,
-            access=foundation.ZCLAttributeAccess.Read,
+            access="r",
             mandatory=True,
         )
         sink_table: Final = ZCLAttributeDef(
             id=0x0001,
             type=t.LongOctetString,
-            access=foundation.ZCLAttributeAccess.Read,
+            access="r",
             mandatory=True,
         )
         communication_mode: Final = ZCLAttributeDef(
             id=0x0002,
             type=zgptypes.CommunicationMode,
-            access=(
-                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
-            ),
+            access="rw",
             mandatory=True,
         )
         commissioning_exit_mode: Final = ZCLAttributeDef(
             id=0x0003,
             type=zgptypes.ProxyCommissioningModeExitMode,
-            access=(
-                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
-            ),
+            access="rw",
             mandatory=True,
         )
         commissioning_window: Final = ZCLAttributeDef(
             id=0x0004,
             type=t.uint16_t,
-            access=(
-                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
-            ),
+            access="rw",
         )
         security_level: Final = ZCLAttributeDef(
             id=0x0005,
             type=zgptypes.SecurityLevel,
-            access=(
-                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
-            ),
+            access="rw",
             mandatory=True,
         )
         functionality: Final = ZCLAttributeDef(
             id=0x0006,
             type=t.bitmap24,
-            access=(
-                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
-            ),
+            access="rw",
             mandatory=True,
         )
         active_functionality: Final = ZCLAttributeDef(
             id=0x0007,
             type=t.bitmap24,
-            access=foundation.ZCLAttributeAccess.Read,
+            access="r",
             mandatory=True,
         )
         gpp_max_table_entries: Final = ZCLAttributeDef(
-            id=0x0010, type=t.uint8_t, access=foundation.ZCLAttributeAccess.Read
+            id=0x0010, type=t.uint8_t, access="r"
         )
         gpp_proxy_table: Final = ZCLAttributeDef(
-            id=0x0011, type=t.LongOctetString, access=foundation.ZCLAttributeAccess.Read
+            id=0x0011, type=t.LongOctetString, access="r"
         )
         gpp_functionality: Final = ZCLAttributeDef(
-            id=0x0016, type=t.bitmap24, access=foundation.ZCLAttributeAccess.Read
+            id=0x0016, type=t.bitmap24, access="r"
         )
         gpp_active_functionality: Final = ZCLAttributeDef(
-            id=0x0017, type=t.bitmap24, access=foundation.ZCLAttributeAccess.Read
+            id=0x0017, type=t.bitmap24, access="r"
         )
         link_key: Final = ZCLAttributeDef(
             id=0x0022,
             type=t.KeyData,
-            access=foundation.ZCLAttributeAccess.Read,
+            access="r",
             mandatory=True,
         )
 

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -18,7 +18,17 @@ import zigpy.zgp.types as zgptypes
 
 # Figure 27
 class CommissioningNotificationSchema(foundation.CommandSchema):
-    options: t.bitmap16
+    class CommissioningNotificationOptions(t.IntStruct, t.uint16_t):
+        application_id: zgptypes.ApplicationID
+        rx_after_tx: t.uint1_t
+        security_level: zgptypes.SecurityLevel
+        security_key_type: zgptypes.SecurityKeyType
+        security_failed: t.uint1_t
+        bidirectional_cap: t.uint1_t
+        proxy_info_present: t.uint1_t
+        _reserved: t.uint6_t
+
+    options: CommissioningNotificationOptions
     gpd_id: zgptypes.DeviceID
     frame_counter: t.uint32_t
     command_id: t.uint8_t
@@ -31,140 +41,83 @@ class CommissioningNotificationSchema(foundation.CommandSchema):
     )
     mic: t.uint32_t = StructField(requires=lambda s: s.security_failed, optional=True)
 
-    @property
-    def application_id(self) -> zgptypes.ApplicationID:
-        return zgptypes.ApplicationID(self.options & 0b111)
 
-    @property
-    def rx_after_tx(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 3) & 0x01)
-
-    @property
-    def security_level(self) -> zgptypes.SecurityLevel:
-        return zgptypes.SecurityLevel((self.options >> 4) & 0b11)
-
-    @property
-    def security_key_type(self) -> zgptypes.SecurityKeyType:
-        return zgptypes.SecurityKeyType((self.options >> 6) & 0b111)
-
-    @property
-    def security_failed(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 9) & 0x01)
-
-    @property
-    def bidirectional_cap(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 10) & 0x01)
-
-    @property
-    def proxy_info_present(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 11) & 0x01)
-
-
-# ZGP spec Figure 45
+# Figure 45
 class ResponseSchema(foundation.CommandSchema):
-    options: t.bitmap8
+    class ResponseOptions(t.IntStruct, t.uint8_t):
+        application_id: zgptypes.ApplicationID
+        _reserved: t.uint5_t
+
+    options: ResponseOptions
     temp_master_short_addr: t.uint16_t
     temp_master_tx_channel: t.uint8_t
     gpd_id: zgptypes.DeviceID
     gpd_command_id: t.uint8_t
     gpd_command_payload: t.LVBytes
 
-    @property
-    def application_id(self) -> zgptypes.ApplicationID:
-        return zgptypes.ApplicationID(self.options & 0b111)
 
-    @application_id.setter
-    def application_id(self, value: zgptypes.ApplicationID):
-        self.options = (self.options & ~(0b111)) | value
-
-
-# ZGP spec Figure 26
+# Figure 25
 class PairingSearchSchema(foundation.CommandSchema):
-    options: t.bitmap16
+    # Figure 26
+    class PairingSearchOptions(t.IntStruct, t.uint16_t):
+        application_id: zgptypes.ApplicationID
+        request_unicast_sink: t.uint1_t
+        request_derived_groupcast_sink: t.uint1_t
+        request_commissioned_groupcast_sink: t.uint1_t
+        request_frame_counter: t.uint1_t
+        request_security_key: t.uint1_t
+        _reserved: t.uint8_t
+
+    options: PairingSearchOptions
     gpd_id: zgptypes.DeviceID
 
-    @property
-    def application_id(self) -> zgptypes.ApplicationID:
-        return zgptypes.ApplicationID(self.options & 0b111)
 
-    @property
-    def request_unicast_sink(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 3) & 0x01)
-
-    @property
-    def request_derived_groupcast_sink(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 4) & 0x01)
-
-    @property
-    def request_commissioned_groupcast_sink(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 5) & 0x01)
-
-    @property
-    def request_frame_counter(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 6) & 0x01)
-
-    @property
-    def request_security_key(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 7) & 0x01)
-
-
+# Figure 23
 class NotificationSchema(foundation.CommandSchema):
-    options: t.bitmap16
+    # Figure 24
+    class NotificationOptions(t.IntStruct, t.uint16_t):
+        application_id: zgptypes.ApplicationID
+        also_unicast: t.uint1_t
+        also_derived_group: t.uint1_t
+        also_commissioned_group: t.uint1_t
+        security_level: zgptypes.SecurityLevel
+        security_key_type: zgptypes.SecurityKeyType
+        appoint_temp_master: t.uint1_t
+        tx_queue_full: t.uint1_t
+        _reserved: t.uint3_t
+
+    options: NotificationOptions
     gpd_id: zgptypes.DeviceID
     frame_counter: t.uint32_t
     command_id: t.uint8_t
     payload: t.LVBytes
     short_addr: t.uint16_t = StructField(
-        requires=lambda s: s.proxy_info_present, optional=True
+        requires=lambda s: s.options.appoint_temp_master, optional=True
     )
     distance: t.uint8_t = StructField(
-        requires=lambda s: s.proxy_info_present, optional=True
+        requires=lambda s: s.options.appoint_temp_master, optional=True
     )
 
-    @property
-    def application_id(self) -> zgptypes.ApplicationID:
-        return zgptypes.ApplicationID(self.options & 0b111)
 
-    @property
-    def also_unicast(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 3) & 0x01)
-
-    @property
-    def also_derived_group(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 4) & 0x01)
-
-    @property
-    def also_commissioned_group(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 5) & 0x01)
-
-    @property
-    def security_level(self) -> zgptypes.SecurityLevel:
-        return zgptypes.SecurityLevel((self.options >> 6) & 0b11)
-
-    @property
-    def security_key_type(self) -> zgptypes.SecurityKeyType:
-        return zgptypes.SecurityKeyType((self.options >> 8) & 0b111)
-
-    # XXX: these come from Wireshark, not the spec!
-    @property
-    def rx_after_tx(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 11) & 0x01)
-
-    @property
-    def gpp_tx_queue_full(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 12) & 0x01)
-
-    @property
-    def bidirectional_cap(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 13) & 0x01)
-
-    @property
-    def proxy_info_present(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 14) & 0x01)
-
-
+# Figure 38, 39
 class PairingSchema(foundation.CommandSchema):
-    options: t.bitmap24
+    # Figure 40, 41
+    class PairingOptions(t.IntStruct, t.uint24_t):
+        application_id: zgptypes.ApplicationID
+        add_sink: t.uint1_t
+        remove_gpd: t.uint1_t
+        communication_mode: zgptypes.CommunicationMode
+        gpd_fixed: t.uint1_t
+        gpd_mac_seq_num_cap: t.uint1_t
+        security_level: zgptypes.SecurityLevel
+        security_key_type: zgptypes.SecurityKeyType
+        security_frame_counter_present: t.uint1_t
+        security_key_present: t.uint1_t
+        assigned_alias_present: t.uint1_t
+        forwarding_radius_present: t.uint1_t
+        _reserved: t.uint6_t
+
+    options: PairingOptions
     gpd_id: zgptypes.DeviceID
     sink_ieee: t.EUI64 = StructField(optional=True)
     sink_nwk_addr: t.NWK = StructField(optional=True)
@@ -174,102 +127,6 @@ class PairingSchema(foundation.CommandSchema):
     key: t.KeyData = StructField(optional=True)
     alias: t.uint16_t = StructField(optional=True)
     forwarding_radius: t.uint8_t = StructField(optional=True)
-
-    @property
-    def application_id(self) -> zgptypes.ApplicationID:
-        return zgptypes.ApplicationID(self.options & 0b111)
-
-    @application_id.setter
-    def application_id(self, value: zgptypes.ApplicationID):
-        self.options = (self.options & ~(0b111)) | value
-
-    @property
-    def add_sink(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 3) & 0x01)
-
-    @add_sink.setter
-    def add_sink(self, value: t.uint1_t):
-        self.options = (self.options & ~(1 << 3)) | (value << 3)
-
-    @property
-    def remove_gpd(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 4) & 0x01)
-
-    @remove_gpd.setter
-    def remove_gpd(self, value: t.uint1_t):
-        self.options = (self.options & ~(1 << 4)) | (value << 4)
-
-    @property
-    def communication_mode(self) -> zgptypes.CommunicationMode:
-        return zgptypes.CommunicationMode((self.options >> 5) & 0b11)
-
-    @communication_mode.setter
-    def communication_mode(self, value: zgptypes.CommunicationMode):
-        self.options = (self.options & ~(0b11 << 5)) | (value << 5)
-
-    @property
-    def gpd_fixed(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 7) & 0x01)
-
-    @gpd_fixed.setter
-    def gpd_fixed(self, value: t.uint1_t):
-        self.options = (self.options & ~(1 << 7)) | (value << 7)
-
-    @property
-    def gpd_mac_seq_num_cap(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 8) & 0x01)
-
-    @gpd_mac_seq_num_cap.setter
-    def gpd_mac_seq_num_cap(self, value: t.uint1_t):
-        self.options = (self.options & ~(1 << 8)) | (value << 8)
-
-    @property
-    def security_level(self) -> zgptypes.SecurityLevel:
-        return zgptypes.SecurityLevel((self.options >> 9) & 0b11)
-
-    @security_level.setter
-    def security_level(self, value: zgptypes.SecurityLevel):
-        self.options = (self.options & ~(0b11 << 9)) | (value << 9)
-
-    @property
-    def security_key_type(self) -> zgptypes.SecurityKeyType:
-        return zgptypes.SecurityKeyType((self.options >> 11) & 0b111)
-
-    @security_key_type.setter
-    def security_key_type(self, value: zgptypes.SecurityKeyType):
-        self.options = (self.options & ~(0b111 << 11)) | (value << 11)
-
-    @property
-    def security_frame_counter_present(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 14) & 0x01)
-
-    @security_frame_counter_present.setter
-    def security_frame_counter_present(self, value: t.uint1_t):
-        self.options = (self.options & ~(1 << 14)) | (value << 14)
-
-    @property
-    def security_key_present(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 15) & 0x01)
-
-    @security_key_present.setter
-    def security_key_present(self, value: t.uint1_t):
-        self.options = (self.options & ~(1 << 15)) | (value << 15)
-
-    @property
-    def assigned_alias_present(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 16) & 0x01)
-
-    @assigned_alias_present.setter
-    def assigned_alias_present(self, value: t.uint1_t):
-        self.options = (self.options & ~(1 << 16)) | (value << 16)
-
-    @property
-    def forwarding_radius_present(self) -> t.uint1_t:
-        return t.uint1_t((self.options >> 17) & 0x01)
-
-    @forwarding_radius_present.setter
-    def forwarding_radius_present(self, value: t.uint1_t):
-        self.options = (self.options & ~(1 << 17)) | (value << 17)
 
 
 class GreenPowerProxy(Cluster):

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -18,7 +18,7 @@ import zigpy.zgp.types as zgptypes
 
 # Figure 27
 class CommissioningNotificationSchema(foundation.CommandSchema):
-    class CommissioningNotificationOptions(t.IntStruct, t.uint16_t):
+    class CommissioningNotificationOptions(t.Struct):
         application_id: zgptypes.ApplicationID
         rx_after_tx: t.uint1_t
         security_level: zgptypes.SecurityLevel
@@ -44,7 +44,7 @@ class CommissioningNotificationSchema(foundation.CommandSchema):
 
 # Figure 45
 class ResponseSchema(foundation.CommandSchema):
-    class ResponseOptions(t.IntStruct, t.uint8_t):
+    class ResponseOptions(t.Struct):
         application_id: zgptypes.ApplicationID
         _reserved: t.uint5_t
 
@@ -59,7 +59,7 @@ class ResponseSchema(foundation.CommandSchema):
 # Figure 25
 class PairingSearchSchema(foundation.CommandSchema):
     # Figure 26
-    class PairingSearchOptions(t.IntStruct, t.uint16_t):
+    class PairingSearchOptions(t.Struct):
         application_id: zgptypes.ApplicationID
         request_unicast_sink: t.uint1_t
         request_derived_groupcast_sink: t.uint1_t
@@ -75,7 +75,7 @@ class PairingSearchSchema(foundation.CommandSchema):
 # Figure 23
 class NotificationSchema(foundation.CommandSchema):
     # Figure 24
-    class NotificationOptions(t.IntStruct, t.uint16_t):
+    class NotificationOptions(t.Struct):
         application_id: zgptypes.ApplicationID
         also_unicast: t.uint1_t
         also_derived_group: t.uint1_t
@@ -102,7 +102,7 @@ class NotificationSchema(foundation.CommandSchema):
 # Figure 38, 39
 class PairingSchema(foundation.CommandSchema):
     # Figure 40, 41
-    class PairingOptions(t.IntStruct, t.uint24_t):
+    class PairingOptions(t.Struct):
         application_id: zgptypes.ApplicationID
         add_sink: t.uint1_t
         remove_gpd: t.uint1_t
@@ -119,14 +119,81 @@ class PairingSchema(foundation.CommandSchema):
 
     options: PairingOptions
     gpd_id: zgptypes.DeviceID
-    sink_ieee: t.EUI64 = StructField(optional=True)
-    sink_nwk_addr: t.NWK = StructField(optional=True)
-    sink_group: t.Group = StructField(optional=True)
-    device_id: t.uint8_t = StructField(optional=True)
-    frame_counter: t.uint32_t = StructField(optional=True)
-    key: t.KeyData = StructField(optional=True)
-    alias: t.uint16_t = StructField(optional=True)
-    forwarding_radius: t.uint8_t = StructField(optional=True)
+    # Table 37
+    sink_ieee: t.EUI64 = StructField(
+        requires=lambda s: not s.options.remove_gpd
+        and s.options.communication_mode
+        in (
+            zgptypes.CommunicationMode.Unicast,
+            zgptypes.CommunicationMode.UnicastLightweight,
+        ),
+        optional=True,
+    )
+    sink_nwk_addr: t.NWK = StructField(
+        requires=lambda s: not s.options.remove_gpd
+        and s.options.communication_mode
+        in (
+            zgptypes.CommunicationMode.Unicast,
+            zgptypes.CommunicationMode.UnicastLightweight,
+        ),
+        optional=True,
+    )
+    sink_group: t.Group = StructField(
+        requires=lambda s: not s.options.remove_gpd
+        and s.options.communication_mode
+        in (
+            zgptypes.CommunicationMode.GroupcastForwardToDGroup,
+            zgptypes.CommunicationMode.GroupcastForwardToCommGroup,
+        ),
+        optional=True,
+    )
+
+    device_id: t.uint8_t = StructField(
+        requires=lambda s: s.options.add_sink, optional=True
+    )
+    frame_counter: t.uint32_t = StructField(
+        requires=lambda s: s.options.add_sink
+        and s.options.security_frame_counter_present,
+        optional=True,
+    )
+    key: t.KeyData = StructField(
+        requires=lambda s: s.options.add_sink and s.options.security_key_present,
+        optional=True,
+    )
+    alias: t.uint16_t = StructField(
+        requires=lambda s: s.options.add_sink and s.options.assigned_alias_present,
+        optional=True,
+    )
+    forwarding_radius: t.uint8_t = StructField(
+        requires=lambda s: s.options.add_sink and s.options.forwarding_radius_present,
+        optional=True,
+    )
+
+
+class NotificationResponseSchema(foundation.CommandSchema):
+    # Figure 37
+    class NotificationResponseOptions(t.Struct):
+        application_id: zgptypes.ApplicationID
+        first_to_forward: t.uint1_t
+        no_pairing: t.uint1_t
+        _reserved: t.uint3_t
+
+    options: NotificationResponseOptions
+    gpd_id: zgptypes.DeviceID
+    frame_counter: t.uint32_t
+
+
+class ProxyCommissioningModeSchema(foundation.CommandSchema):
+    # Figure 43
+    class ProxyCommissioningModeOptions(t.Struct):
+        enter: t.uint1_t
+        exit_mode: zgptypes.ProxyCommissioningModeExitMode
+        channel_present: t.uint1_t
+        unicast: t.uint1_t
+        _reserved: t.uint2_t
+
+    options: ProxyCommissioningModeOptions
+    window: t.uint16_t = StructField(optional=True)
 
 
 class GreenPowerProxy(Cluster):
@@ -136,11 +203,11 @@ class GreenPowerProxy(Cluster):
 
     NotificationSchema: Final = NotificationSchema
     PairingSearchSchema: Final = PairingSearchSchema
-    NotificationResponseOptions: Final = zgptypes.NotificationResponseOptions
     PairingSchema: Final = PairingSchema
-    ProxyCommissioningModeOptions: Final = zgptypes.ProxyCommissioningModeOptions
     ResponseSchema: Final = ResponseSchema
     CommissioningNotificationSchema: Final = CommissioningNotificationSchema
+    NotificationResponseSchema: Final = NotificationResponseSchema
+    ProxyCommissioningModeSchema: Final = ProxyCommissioningModeSchema
 
     class AttributeDefs(BaseAttributeDefs):
         max_sink_table_entries: Final = ZCLAttributeDef(
@@ -238,11 +305,7 @@ class GreenPowerProxy(Cluster):
     class ClientCommandDefs(BaseCommandDefs):
         notification_response: Final = ZCLCommandDef(
             id=0x00,
-            schema={
-                "options": zgptypes.NotificationResponseOptions,
-                "gpd_id": zgptypes.DeviceID,
-                "frame_counter": t.uint32_t,
-            },
+            schema=NotificationResponseSchema,
         )
 
         pairing: Final = ZCLCommandDef(
@@ -252,10 +315,7 @@ class GreenPowerProxy(Cluster):
 
         proxy_commissioning_mode: Final = ZCLCommandDef(
             id=0x02,
-            schema={
-                "options": zgptypes.ProxyCommissioningModeOptions,
-                "window?": t.uint16_t,
-            },
+            schema=ProxyCommissioningModeSchema,
         )
 
         response: Final = ZCLCommandDef(

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -1,0 +1,407 @@
+"""Zigbee Green Power Domain"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import zigpy.types as t
+from zigpy.types.struct import StructField
+from zigpy.zcl import Cluster, foundation
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    BaseCommandDefs,
+    ZCLAttributeDef,
+    ZCLCommandDef,
+)
+import zigpy.zgp.types as zgptypes
+
+
+# Figure 27
+class CommissioningNotificationSchema(foundation.CommandSchema):
+    options: t.bitmap16
+    gpd_id: zgptypes.DeviceID
+    frame_counter: t.uint32_t
+    command_id: t.uint8_t
+    payload: t.LVBytes
+    gpp_short_addr: t.uint16_t = StructField(
+        requires=lambda s: s.proxy_info_present, optional=True
+    )
+    distance: t.uint8_t = StructField(
+        requires=lambda s: s.proxy_info_present, optional=True
+    )
+    mic: t.uint32_t = StructField(requires=lambda s: s.security_failed, optional=True)
+
+    @property
+    def application_id(self) -> zgptypes.ApplicationID:
+        return zgptypes.ApplicationID(self.options & 0b111)
+
+    @property
+    def rx_after_tx(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 3) & 0x01)
+
+    @property
+    def security_level(self) -> zgptypes.SecurityLevel:
+        return zgptypes.SecurityLevel((self.options >> 4) & 0b11)
+
+    @property
+    def security_key_type(self) -> zgptypes.SecurityKeyType:
+        return zgptypes.SecurityKeyType((self.options >> 6) & 0b111)
+
+    @property
+    def security_failed(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 9) & 0x01)
+
+    @property
+    def bidirectional_cap(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 10) & 0x01)
+
+    @property
+    def proxy_info_present(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 11) & 0x01)
+
+
+# ZGP spec Figure 45
+class ResponseSchema(foundation.CommandSchema):
+    options: t.bitmap8
+    temp_master_short_addr: t.uint16_t
+    temp_master_tx_channel: t.uint8_t
+    gpd_id: zgptypes.DeviceID
+    gpd_command_id: t.uint8_t
+    gpd_command_payload: t.LVBytes
+
+    @property
+    def application_id(self) -> zgptypes.ApplicationID:
+        return zgptypes.ApplicationID(self.options & 0b111)
+
+    @application_id.setter
+    def application_id(self, value: zgptypes.ApplicationID):
+        self.options = (self.options & ~(0b111)) | value
+
+
+# ZGP spec Figure 26
+class PairingSearchSchema(foundation.CommandSchema):
+    options: t.bitmap16
+    gpd_id: zgptypes.DeviceID
+
+    @property
+    def application_id(self) -> zgptypes.ApplicationID:
+        return zgptypes.ApplicationID(self.options & 0b111)
+
+    @property
+    def request_unicast_sink(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 3) & 0x01)
+
+    @property
+    def request_derived_groupcast_sink(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 4) & 0x01)
+
+    @property
+    def request_commissioned_groupcast_sink(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 5) & 0x01)
+
+    @property
+    def request_frame_counter(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 6) & 0x01)
+
+    @property
+    def request_security_key(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 7) & 0x01)
+
+
+class NotificationSchema(foundation.CommandSchema):
+    options: t.bitmap16
+    gpd_id: zgptypes.DeviceID
+    frame_counter: t.uint32_t
+    command_id: t.uint8_t
+    payload: t.LVBytes
+    short_addr: t.uint16_t = StructField(
+        requires=lambda s: s.proxy_info_present, optional=True
+    )
+    distance: t.uint8_t = StructField(
+        requires=lambda s: s.proxy_info_present, optional=True
+    )
+
+    @property
+    def application_id(self) -> zgptypes.ApplicationID:
+        return zgptypes.ApplicationID(self.options & 0b111)
+
+    @property
+    def also_unicast(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 3) & 0x01)
+
+    @property
+    def also_derived_group(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 4) & 0x01)
+
+    @property
+    def also_commissioned_group(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 5) & 0x01)
+
+    @property
+    def security_level(self) -> zgptypes.SecurityLevel:
+        return zgptypes.SecurityLevel((self.options >> 6) & 0b11)
+
+    @property
+    def security_key_type(self) -> zgptypes.SecurityKeyType:
+        return zgptypes.SecurityKeyType((self.options >> 8) & 0b111)
+
+    # XXX: these come from Wireshark, not the spec!
+    @property
+    def rx_after_tx(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 11) & 0x01)
+
+    @property
+    def gpp_tx_queue_full(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 12) & 0x01)
+
+    @property
+    def bidirectional_cap(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 13) & 0x01)
+
+    @property
+    def proxy_info_present(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 14) & 0x01)
+
+
+class PairingSchema(foundation.CommandSchema):
+    options: t.bitmap24
+    gpd_id: zgptypes.DeviceID
+    sink_ieee: t.EUI64 = StructField(optional=True)
+    sink_nwk_addr: t.NWK = StructField(optional=True)
+    sink_group: t.Group = StructField(optional=True)
+    device_id: t.uint8_t = StructField(optional=True)
+    frame_counter: t.uint32_t = StructField(optional=True)
+    key: t.KeyData = StructField(optional=True)
+    alias: t.uint16_t = StructField(optional=True)
+    forwarding_radius: t.uint8_t = StructField(optional=True)
+
+    @property
+    def application_id(self) -> zgptypes.ApplicationID:
+        return zgptypes.ApplicationID(self.options & 0b111)
+
+    @application_id.setter
+    def application_id(self, value: zgptypes.ApplicationID):
+        self.options = (self.options & ~(0b111)) | value
+
+    @property
+    def add_sink(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 3) & 0x01)
+
+    @add_sink.setter
+    def add_sink(self, value: t.uint1_t):
+        self.options = (self.options & ~(1 << 3)) | (value << 3)
+
+    @property
+    def remove_gpd(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 4) & 0x01)
+
+    @remove_gpd.setter
+    def remove_gpd(self, value: t.uint1_t):
+        self.options = (self.options & ~(1 << 4)) | (value << 4)
+
+    @property
+    def communication_mode(self) -> zgptypes.CommunicationMode:
+        return zgptypes.CommunicationMode((self.options >> 5) & 0b11)
+
+    @communication_mode.setter
+    def communication_mode(self, value: zgptypes.CommunicationMode):
+        self.options = (self.options & ~(0b11 << 5)) | (value << 5)
+
+    @property
+    def gpd_fixed(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 7) & 0x01)
+
+    @gpd_fixed.setter
+    def gpd_fixed(self, value: t.uint1_t):
+        self.options = (self.options & ~(1 << 7)) | (value << 7)
+
+    @property
+    def gpd_mac_seq_num_cap(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 8) & 0x01)
+
+    @gpd_mac_seq_num_cap.setter
+    def gpd_mac_seq_num_cap(self, value: t.uint1_t):
+        self.options = (self.options & ~(1 << 8)) | (value << 8)
+
+    @property
+    def security_level(self) -> zgptypes.SecurityLevel:
+        return zgptypes.SecurityLevel((self.options >> 9) & 0b11)
+
+    @security_level.setter
+    def security_level(self, value: zgptypes.SecurityLevel):
+        self.options = (self.options & ~(0b11 << 9)) | (value << 9)
+
+    @property
+    def security_key_type(self) -> zgptypes.SecurityKeyType:
+        return zgptypes.SecurityKeyType((self.options >> 11) & 0b111)
+
+    @security_key_type.setter
+    def security_key_type(self, value: zgptypes.SecurityKeyType):
+        self.options = (self.options & ~(0b111 << 11)) | (value << 11)
+
+    @property
+    def security_frame_counter_present(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 14) & 0x01)
+
+    @security_frame_counter_present.setter
+    def security_frame_counter_present(self, value: t.uint1_t):
+        self.options = (self.options & ~(1 << 14)) | (value << 14)
+
+    @property
+    def security_key_present(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 15) & 0x01)
+
+    @security_key_present.setter
+    def security_key_present(self, value: t.uint1_t):
+        self.options = (self.options & ~(1 << 15)) | (value << 15)
+
+    @property
+    def assigned_alias_present(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 16) & 0x01)
+
+    @assigned_alias_present.setter
+    def assigned_alias_present(self, value: t.uint1_t):
+        self.options = (self.options & ~(1 << 16)) | (value << 16)
+
+    @property
+    def forwarding_radius_present(self) -> t.uint1_t:
+        return t.uint1_t((self.options >> 17) & 0x01)
+
+    @forwarding_radius_present.setter
+    def forwarding_radius_present(self, value: t.uint1_t):
+        self.options = (self.options & ~(1 << 17)) | (value << 17)
+
+
+class GreenPowerProxy(Cluster):
+    cluster_id: Final[t.uint16_t] = 0x0021
+    name: Final = "Green Power"
+    ep_attribute: Final = "green_power"
+
+    NotificationSchema: Final = NotificationSchema
+    PairingSearchSchema: Final = PairingSearchSchema
+    NotificationResponseOptions: Final = zgptypes.NotificationResponseOptions
+    PairingSchema: Final = PairingSchema
+    ProxyCommissioningModeOptions: Final = zgptypes.ProxyCommissioningModeOptions
+    ResponseSchema: Final = ResponseSchema
+    CommissioningNotificationSchema: Final = CommissioningNotificationSchema
+
+    class AttributeDefs(BaseAttributeDefs):
+        max_sink_table_entries: Final = ZCLAttributeDef(
+            id=0x0000,
+            type=t.uint8_t,
+            access=foundation.ZCLAttributeAccess.Read,
+            mandatory=True,
+        )
+        sink_table: Final = ZCLAttributeDef(
+            id=0x0001,
+            type=t.LongOctetString,
+            access=foundation.ZCLAttributeAccess.Read,
+            mandatory=True,
+        )
+        communication_mode: Final = ZCLAttributeDef(
+            id=0x0002,
+            type=zgptypes.CommunicationMode,
+            access=(
+                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
+            ),
+            mandatory=True,
+        )
+        commissioning_exit_mode: Final = ZCLAttributeDef(
+            id=0x0003,
+            type=zgptypes.ProxyCommissioningModeExitMode,
+            access=(
+                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
+            ),
+            mandatory=True,
+        )
+        commissioning_window: Final = ZCLAttributeDef(
+            id=0x0004,
+            type=t.uint16_t,
+            access=(
+                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
+            ),
+        )
+        security_level: Final = ZCLAttributeDef(
+            id=0x0005,
+            type=zgptypes.SecurityLevel,
+            access=(
+                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
+            ),
+            mandatory=True,
+        )
+        functionality: Final = ZCLAttributeDef(
+            id=0x0006,
+            type=t.bitmap24,
+            access=(
+                foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write
+            ),
+            mandatory=True,
+        )
+        active_functionality: Final = ZCLAttributeDef(
+            id=0x0007,
+            type=t.bitmap24,
+            access=foundation.ZCLAttributeAccess.Read,
+            mandatory=True,
+        )
+        gpp_max_table_entries: Final = ZCLAttributeDef(
+            id=0x0010, type=t.uint8_t, access=foundation.ZCLAttributeAccess.Read
+        )
+        gpp_proxy_table: Final = ZCLAttributeDef(
+            id=0x0011, type=t.LongOctetString, access=foundation.ZCLAttributeAccess.Read
+        )
+        gpp_functionality: Final = ZCLAttributeDef(
+            id=0x0016, type=t.bitmap24, access=foundation.ZCLAttributeAccess.Read
+        )
+        gpp_active_functionality: Final = ZCLAttributeDef(
+            id=0x0017, type=t.bitmap24, access=foundation.ZCLAttributeAccess.Read
+        )
+        link_key: Final = ZCLAttributeDef(
+            id=0x0022,
+            type=t.KeyData,
+            access=foundation.ZCLAttributeAccess.Read,
+            mandatory=True,
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        notification: Final = ZCLCommandDef(
+            id=0x00,
+            schema=NotificationSchema,
+        )
+
+        pairing_search: Final = ZCLCommandDef(
+            id=0x01,
+            schema=PairingSearchSchema,
+        )
+
+        commissioning_notification: Final = ZCLCommandDef(
+            id=0x04,
+            schema=CommissioningNotificationSchema,
+        )
+
+    class ClientCommandDefs(BaseCommandDefs):
+        notification_response: Final = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "options": zgptypes.NotificationResponseOptions,
+                "gpd_id": zgptypes.DeviceID,
+                "frame_counter": t.uint32_t,
+            },
+        )
+
+        pairing: Final = ZCLCommandDef(
+            id=0x01,
+            schema=PairingSchema,
+        )
+
+        proxy_commissioning_mode: Final = ZCLCommandDef(
+            id=0x02,
+            schema={
+                "options": zgptypes.ProxyCommissioningModeOptions,
+                "window?": t.uint16_t,
+            },
+        )
+
+        response: Final = ZCLCommandDef(
+            id=0x06,
+            schema=ResponseSchema,
+        )

--- a/zigpy/zgp/__init__.py
+++ b/zigpy/zgp/__init__.py
@@ -1,0 +1,1 @@
+from .types import *  # noqa: F403, F401

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import typing
-
 from zigpy.types import basic
-
-if typing.TYPE_CHECKING:
-    pass
 
 
 class DeviceID(basic.uint32_t, repr="hex"):

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing
 
-import zigpy.types as t
 from zigpy.types import basic
 
 if typing.TYPE_CHECKING:
@@ -63,20 +62,3 @@ class CommunicationMode(basic.enum2):
 class CommunicationDirection(basic.enum1):
     GPDtoGPP = 0
     GPPtoGPD = 1
-
-
-# ZGP spec Figure 37
-class NotificationResponseOptions(t.Struct):
-    application_id: ApplicationID
-    first_to_forward: basic.uint1_t
-    no_pairing: basic.uint1_t
-    reserved: basic.uint3_t
-
-
-# ZGP spec Figure 43
-class ProxyCommissioningModeOptions(t.Struct):
-    enter: t.uint1_t
-    exit_mode: ProxyCommissioningModeExitMode
-    channel_present: t.uint1_t
-    unicast: t.uint1_t
-    reserved: t.uint2_t

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import typing
+
+import zigpy.types as t
+from zigpy.types import basic
+
+if typing.TYPE_CHECKING:
+    pass
+
+
+class DeviceID(basic.uint32_t, repr="hex"):
+    pass
+
+
+class FrameType(basic.enum2):
+    DataFrame = 0x00
+    MaintenanceFrame = 0x01
+
+
+class ApplicationID(basic.enum3):
+    SrcID = 0b000
+    IEEE = 0b010
+    LPED = 0b001
+
+
+# Table 13
+class SecurityLevel(basic.enum2):
+    NoSecurity = 0b00
+    ShortFrameCounterAndMIC = 0b01
+    FullFrameCounterAndMIC = 0b10
+    Encrypted = 0b11
+
+
+# Table 14
+class SecurityKeyType(basic.enum3):
+    NoKey = 0b000
+    NWKKey = 0b001
+    GPDGroupKey = 0b010
+    NWKKeyDerivedGPD = 0b011
+    IndividualKey = 0b100
+    DerivedIndividual = 0b111
+
+
+# ZGP spec Figure 22
+class ProxyCommissioningModeExitMode(basic.enum3):
+    NotDefined = 0b000
+    OnExpire = 0b001
+    OnFirstPairing = 0b010
+    OnExplicitExit = 0b100
+    OnExpireOrFirstPairing = 0b011
+    OnExpireOrExplicitExit = 0b101
+
+
+# Table 29
+class CommunicationMode(basic.enum2):
+    Unicast = 0b00
+    GroupcastForwardToDGroup = 0b01
+    GroupcastForwardToCommGroup = 0b10
+    UnicastLightweight = 0b11
+
+
+class CommunicationDirection(basic.enum1):
+    GPDtoGPP = 0
+    GPPtoGPD = 1
+
+
+# ZGP spec Figure 37
+class NotificationResponseOptions(t.Struct):
+    application_id: ApplicationID
+    first_to_forward: basic.uint1_t
+    no_pairing: basic.uint1_t
+    reserved: basic.uint3_t
+
+
+# ZGP spec Figure 43
+class ProxyCommissioningModeOptions(t.Struct):
+    enter: t.uint1_t
+    exit_mode: ProxyCommissioningModeExitMode
+    channel_present: t.uint1_t
+    unicast: t.uint1_t
+    reserved: t.uint2_t


### PR DESCRIPTION
Adds green power clusters to the ZCL, including a mess of supporting CommandSchemas and Schemas.

Organizational changes from original PR:

- Remove `GP` prefix, preferring instead using module-level scoping
- Split `Struct` types into `types.py`, leave `CommandSchema` types in `greenpower.py`

Questions:

- For unit tests, should I be parsing known-good ZGP frames for commands? Or since these are just structs basically, are we good for unit tests on this one?

Thanks everyone for your patience, and of course @puddly for your help!