### PR TITLE
Load devices by default when performing a backup

### DIFF
--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -139,7 +139,7 @@ class BackupManager(ListenableMixin):
             node_info=self.app.state.node_info,
         )
 
-    async def create_backup(self, *, load_devices: bool = False) -> NetworkBackup:
+    async def create_backup(self, *, load_devices: bool = True) -> NetworkBackup:
         await self.app.load_network_info(load_devices=load_devices)
 
         backup = self.from_network_state()


### PR DESCRIPTION
Backup/restore for EZSP requires an up-to-date child table for the network to work properly with older Aqara devices. For this reason, we should always perform a complete backup/restore.

This is a minor change but has two side effects:

1. EZSP and ZNP adapters will take a little longer to back up.
2. There will be more serial traffic on startup.
