### PR TITLE
Log a warning if device removal callbacks during shutdown throw

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1704,3 +1704,15 @@ async def test_can_write_network_settings(app) -> None:
     assert await app.can_write_network_settings(
         network_info=app.state.network_info, node_info=app.state.node_info
     )
+
+
+async def test_shutdown_device_remove_fails(app, ieee, caplog):
+    """Test shutdown continues if a device fails to be removed."""
+    dev = app.add_device(ieee, 0x1234)
+
+    with patch.object(dev, "on_remove", side_effect=Exception("Boom!")):
+        with caplog.at_level(logging.WARNING):
+            await app.shutdown()
+
+    assert "Failed to remove device" in caplog.text
+    assert "Boom!" in caplog.text

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -449,7 +449,14 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.topology.stop_periodic_scans()
 
         for device in self.devices.values():
-            device.on_remove()
+            try:
+                device.on_remove()
+            except Exception:  # noqa: BLE001
+                LOGGER.warning(
+                    "Failed to remove device %s during shutdown",
+                    device,
+                    exc_info=True,
+                )
 
         try:
             await self.disconnect()


### PR DESCRIPTION
See https://github.com/zigpy/zha/pull/542

Every exception thrown during shutdown is a bug and we should not have any. This prevents ZHA shutdown from failing.