### PR TITLE
Fix `ZCLCommandButtonMetadata.kwargs` to `factory=frozendict`

### DIFF
--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -412,7 +412,7 @@ class ZCLCommandButtonMetadata(EntityMetadata):
 
     command_name: str = attrs.field()
     args: tuple = attrs.field(default=tuple)
-    kwargs: frozendict[str, Any] = attrs.field(default=frozendict, converter=frozendict)
+    kwargs: frozendict[str, Any] = attrs.field(factory=frozendict, converter=frozendict)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)


### PR DESCRIPTION
Before this change, `default=frozendict` would set the `frozendict` class itself for `kwargs`.
However, as we'll only use `ZCLCommandButtonMetadata` when `command_button` is called, which defaults to `frozendict()` for `kwargs`, the issue didn't manifest itself.

Still, we should fix this, either by doing `default=frozendict()` or  `factory=frozendict`. As this default will never be really used and we already use `factory` for `constant_attributes`, I also went with that.
With `default=frozendict()`, we'd have the same instance for all `ZCLCommandButtonMetadata`. With `factory`, a new one for each. To us, this doesn't really matter, but see the other points I made 😄 