### PR TITLE
Add route table to network backup

### DIFF
--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -31,6 +31,7 @@ def backup_factory():
                 nwk_manager_id=t.NWK(0x0000),
                 channel=t.uint8_t(15),
                 channel_mask=t.Channels.from_channel_list([15, 20, 25]),
+                tx_power=8,
                 security_level=t.uint8_t(5),
                 network_key=app_state.Key(
                     key=t.KeyData.convert(
@@ -82,6 +83,10 @@ def backup_factory():
                     t.EUI64.convert("10:55:FE:67:24:EA:96:D3"): t.NWK(0xBFB9),
                     t.EUI64.convert("9A:0E:10:50:00:1B:1A:5F"): t.NWK(0x1AF6),
                     t.EUI64.convert("AA:BB:CC:DD:11:22:33:44"): t.NWK(0x0ABC),
+                },
+                route_table={
+                    t.NWK(0x16B5): t.NWK(0xBFB9),
+                    t.NWK(0x1AF6): t.NWK(0x0ABC),
                 },
                 stack_specific={
                     "zstack": {"tclk_seed": "71e31105bb92a2d15747a0d0a042dbfd"}
@@ -238,6 +243,8 @@ def test_z2m_backup_parsing(z2m_backup_json, backup):
     backup.node_info.model = None
     backup.node_info.version = None
     backup.network_info.tc_link_key.tx_counter = 0
+    backup.network_info.tx_power = None
+    backup.network_info.route_table = {}
 
     for key in backup.network_info.key_table:
         key.seq = 0

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -31,7 +31,6 @@ def backup_factory():
                 nwk_manager_id=t.NWK(0x0000),
                 channel=t.uint8_t(15),
                 channel_mask=t.Channels.from_channel_list([15, 20, 25]),
-                tx_power=8,
                 security_level=t.uint8_t(5),
                 network_key=app_state.Key(
                     key=t.KeyData.convert(
@@ -243,7 +242,6 @@ def test_z2m_backup_parsing(z2m_backup_json, backup):
     backup.node_info.model = None
     backup.node_info.version = None
     backup.network_info.tc_link_key.tx_counter = 0
-    backup.network_info.tx_power = None
     backup.network_info.route_table = {}
 
     for key in backup.network_info.key_table:

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import zigpy.application
 
 LOGGER = logging.getLogger(__name__)
-BACKUP_FORMAT_VERSION = 1
+BACKUP_FORMAT_VERSION = 2
 
 
 @dataclasses.dataclass
@@ -99,6 +99,14 @@ class NetworkBackup(t.BaseDataclassMixin):
                 obj["node_info"]["manufacturer"] = None
                 obj["node_info"]["version"] = None
                 version = 1
+
+            # Version 2 introduced the `route_table` and `tx_power` fields
+            if version == 1:
+                obj = copy.deepcopy(obj)
+
+                obj["network_info"]["route_table"] = {}
+                obj["network_info"]["tx_power"] = None
+                version = 2
 
             assert version == BACKUP_FORMAT_VERSION
 
@@ -296,6 +304,11 @@ def _network_backup_to_open_coordinator_backup(backup: NetworkBackup) -> dict[st
                     key.partner_ieee.serialize()[::-1].hex(): key.seq
                     for key in network_info.key_table
                 },
+                "route_table": {
+                    str(t.NWK(dst))[2:]: str(t.NWK(next_hop))[2:]
+                    for dst, next_hop in network_info.route_table.items()
+                },
+                "tx_power": network_info.tx_power,
                 **network_info.metadata,
             },
         },
@@ -346,7 +359,15 @@ def _open_coordinator_backup_to_network_backup(obj: dict[str, Any]) -> NetworkBa
     network_info.metadata = {
         k: v
         for k, v in internal.items()
-        if k not in ("node", "network", "link_key_seqs", "creation_time")
+        if k
+        not in (
+            "node",
+            "network",
+            "link_key_seqs",
+            "creation_time",
+            "route_table",
+            "tx_power",
+        )
     }
     network_info.pan_id, _ = t.NWK.deserialize(bytes.fromhex(obj["pan_id"])[::-1])
     network_info.extended_pan_id, _ = t.EUI64.deserialize(
@@ -432,6 +453,11 @@ def _open_coordinator_backup_to_network_backup(obj: dict[str, Any]) -> NetworkBa
 
         # XXX: Devices that are not children, have no NWK address, and have no link key
         #      are effectively ignored, since there is no place to write them
+
+    for dst, next_hop in obj["metadata"]["internal"].get("route_table", {}).items():
+        network_info.route_table[t.NWK.convert(dst)] = t.NWK.convert(next_hop)
+
+    network_info.tx_power = obj["metadata"]["internal"].get("tx_power")
 
     if "date" in internal:
         # Z2M format

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -105,7 +105,6 @@ class NetworkBackup(t.BaseDataclassMixin):
                 obj = copy.deepcopy(obj)
 
                 obj["network_info"]["route_table"] = {}
-                obj["network_info"]["tx_power"] = None
                 version = 2
 
             assert version == BACKUP_FORMAT_VERSION
@@ -308,7 +307,6 @@ def _network_backup_to_open_coordinator_backup(backup: NetworkBackup) -> dict[st
                     str(t.NWK(dst))[2:]: str(t.NWK(next_hop))[2:]
                     for dst, next_hop in network_info.route_table.items()
                 },
-                "tx_power": network_info.tx_power,
                 **network_info.metadata,
             },
         },
@@ -366,7 +364,6 @@ def _open_coordinator_backup_to_network_backup(obj: dict[str, Any]) -> NetworkBa
             "link_key_seqs",
             "creation_time",
             "route_table",
-            "tx_power",
         )
     }
     network_info.pan_id, _ = t.NWK.deserialize(bytes.fromhex(obj["pan_id"])[::-1])
@@ -456,8 +453,6 @@ def _open_coordinator_backup_to_network_backup(obj: dict[str, Any]) -> NetworkBa
 
     for dst, next_hop in obj["metadata"]["internal"].get("route_table", {}).items():
         network_info.route_table[t.NWK.convert(dst)] = t.NWK.convert(next_hop)
-
-    network_info.tx_power = obj["metadata"]["internal"].get("tx_power")
 
     if "date" in internal:
         # Z2M format

--- a/zigpy/state.py
+++ b/zigpy/state.py
@@ -113,6 +113,8 @@ class NetworkInfo(t.BaseDataclassMixin):
     )
     key_table: list[Key] = dataclasses.field(default_factory=list)
     children: list[t.EUI64] = dataclasses.field(default_factory=list)
+    route_table: dict[t.NWK, t.NWK] = dataclasses.field(default_factory=dict)
+    tx_power: int | None = None
 
     # If exposed by the stack, NWK addresses of other connected devices on the network
     nwk_addresses: dict[t.EUI64, t.NWK] = dataclasses.field(default_factory=dict)
@@ -140,6 +142,11 @@ class NetworkInfo(t.BaseDataclassMixin):
             "tc_link_key": self.tc_link_key.as_dict(),
             "key_table": [key.as_dict() for key in self.key_table],
             "children": sorted(str(ieee) for ieee in self.children),
+            "route_table": {
+                str(t.NWK(dst))[2:]: str(t.NWK(next_hop))[2:]
+                for dst, next_hop in self.route_table.items()
+            },
+            "tx_power": self.tx_power,
             "nwk_addresses": {
                 str(ieee): str(t.NWK(nwk))[2:]
                 for ieee, nwk in sorted(self.nwk_addresses.items())
@@ -166,6 +173,11 @@ class NetworkInfo(t.BaseDataclassMixin):
                 key=lambda k: k.partner_ieee,
             ),
             children=[t.EUI64.convert(ieee) for ieee in obj["children"]],
+            route_table={
+                t.NWK.convert(dst): t.NWK.convert(next_hop)
+                for dst, next_hop in obj["route_table"].items()
+            },
+            tx_power=obj["tx_power"],
             nwk_addresses={
                 t.EUI64.convert(ieee): t.NWK.convert(nwk)
                 for ieee, nwk in obj["nwk_addresses"].items()

--- a/zigpy/state.py
+++ b/zigpy/state.py
@@ -114,7 +114,6 @@ class NetworkInfo(t.BaseDataclassMixin):
     key_table: list[Key] = dataclasses.field(default_factory=list)
     children: list[t.EUI64] = dataclasses.field(default_factory=list)
     route_table: dict[t.NWK, t.NWK] = dataclasses.field(default_factory=dict)
-    tx_power: int | None = None
 
     # If exposed by the stack, NWK addresses of other connected devices on the network
     nwk_addresses: dict[t.EUI64, t.NWK] = dataclasses.field(default_factory=dict)
@@ -146,7 +145,6 @@ class NetworkInfo(t.BaseDataclassMixin):
                 str(t.NWK(dst))[2:]: str(t.NWK(next_hop))[2:]
                 for dst, next_hop in self.route_table.items()
             },
-            "tx_power": self.tx_power,
             "nwk_addresses": {
                 str(ieee): str(t.NWK(nwk))[2:]
                 for ieee, nwk in sorted(self.nwk_addresses.items())
@@ -177,7 +175,6 @@ class NetworkInfo(t.BaseDataclassMixin):
                 t.NWK.convert(dst): t.NWK.convert(next_hop)
                 for dst, next_hop in obj["route_table"].items()
             },
-            tx_power=obj["tx_power"],
             nwk_addresses={
                 t.EUI64.convert(ieee): t.NWK.convert(nwk)
                 for ieee, nwk in obj["nwk_addresses"].items()


### PR DESCRIPTION
In preparation for https://github.com/NabuCasa/silabs-firmware-builder/pull/118, I'm extending the network info JSON with a next-hop route table. While the EmberZNet structures reference route status, route age, cost, and so on, we do not actually need any of this information to restore the route table: we just need the destination node and the next-hop node.