### PR TITLE
Allow loading backups with unsupported versions

### DIFF
--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 import json
+import logging
 
 import pytest
 
@@ -270,6 +271,22 @@ def test_from_dict_automatic(z2m_backup_json):
 def test_from_dict_failure():
     with pytest.raises(ValueError):
         zigpy.backups.NetworkBackup.from_dict({"some": "json"})
+
+
+def test_from_dict_future_version(backup: zigpy.backups.NetworkBackup, caplog) -> None:
+    """Test that loading a backup with a future version logs a warning."""
+    with caplog.at_level(logging.WARNING):
+        backup = zigpy.backups.NetworkBackup.from_dict(
+            {**backup.as_dict(), "version": 99}
+        )
+
+    assert "Network backup has version 99 but current backup format" in caplog.text
+    assert "Downgrading is not recommended" in caplog.text
+
+    assert backup is not None
+
+    # Verify version was downgraded to current BACKUP_FORMAT_VERSION
+    assert backup.version == zigpy.backups.BACKUP_FORMAT_VERSION
 
 
 def test_backup_compatibility(backup_factory):

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -91,6 +91,14 @@ class NetworkBackup(t.BaseDataclassMixin):
         elif "network_info" in obj:
             version = obj.get("version", 0)
 
+            if version > BACKUP_FORMAT_VERSION:
+                LOGGER.warning(
+                    "Network backup has version %d but current backup format"
+                    " version is %d. Downgrading is not recommended.",
+                    version,
+                    BACKUP_FORMAT_VERSION,
+                )
+
             # Version 1 introduced the `model`, `manufacturer`, and `version` fields
             if version == 0:
                 obj = copy.deepcopy(obj)
@@ -107,8 +115,6 @@ class NetworkBackup(t.BaseDataclassMixin):
                 obj["network_info"]["route_table"] = {}
                 obj["network_info"]["tx_power"] = None
                 version = 2
-
-            assert version == BACKUP_FORMAT_VERSION
 
             return cls(
                 version=BACKUP_FORMAT_VERSION,


### PR DESCRIPTION
Downgrading ZHA after we do a major change to the backup schema causes zigpy to fail to load. This won't help us this release but will from this point forward.

Alternatively, we could keep the backup format version at 1 and perform the migration in-place, bumping it next release?