### PR TITLE
Move install code parsing out of ZHA and into zigpy

### DIFF
--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -602,6 +602,20 @@ async def test_async_iterate_in_chunks() -> None:
                 bytes.fromhex("2E5D2E5F401B82F1A45621A50B551F726101")
             ),
         ),
+        # Bosch (install code)
+        (
+            "RB01SG0D8310182648007000000000000000000094DEB8FFFE41F6D6DLKA87710C3E5C332E5327EE532C3C310E5DFE0",
+            EUI64.convert("94:DE:B8:FF:FE:41:F6:D6"),
+            util.convert_install_code(
+                bytes.fromhex("A87710C3E5C332E5327EE532C3C310E5DFE0")
+            ),
+        ),
+        # Bosch (link key)
+        (
+            "RB01SG0D836591B3CC0010000000000000000000000D6F0017E0870CDLK999F98A7DFBCA6DD3955823AD9089631",
+            EUI64.convert("00:0D:6F:00:17:E0:87:0C"),
+            KeyData.convert("999F98A7DFBCA6DD3955823AD9089631"),
+        ),
     ],
 )
 def test_qr_code_parsing(code: str, ieee: EUI64, link_key: KeyData) -> None:

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -623,3 +623,9 @@ def test_qr_code_parsing(code: str, ieee: EUI64, link_key: KeyData) -> None:
     parsed_ieee, parsed_link_key = util.parse_install_code_qr(code)
     assert parsed_ieee == ieee
     assert parsed_link_key == link_key
+
+
+def test_qr_code_parsing_failure() -> None:
+    """Test install code QR parsing failure."""
+    with pytest.raises(ValueError, match="Unknown QR code format: "):
+        util.parse_install_code_qr("some invalid QR code")

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -8,7 +8,7 @@ import typing
 import pytest
 
 from zigpy import util
-from zigpy.types.named import KeyData
+from zigpy.types.named import EUI64, KeyData
 
 from .async_mock import AsyncMock, MagicMock, call, patch, sentinel
 
@@ -232,12 +232,11 @@ def test_convert_install_code(message, expected_key):
 
 
 def test_fail_convert_install_code():
-    key = util.convert_install_code(bytes([]))
-    assert key is None
+    with pytest.raises(ValueError, match="Invalid install code length"):
+        util.convert_install_code(b"")
 
-    message = bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xFF, 0xFF])
-    key = util.convert_install_code(message)
-    assert key is None
+    with pytest.raises(ValueError, match="Invalid install code CRC"):
+        util.convert_install_code(b"\x11\x22\x33\x44\x55\x66\x77\x88\xff\xff")
 
 
 async def test_async_listener():
@@ -550,3 +549,63 @@ async def test_async_iterate_in_chunks() -> None:
 
     chunks = [c async for c in util.async_iterate_in_chunks(iterator(10), chunk_size=3)]
     assert chunks == [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
+
+
+@pytest.mark.parametrize(
+    ("code", "ieee", "link_key"),
+    [
+        # Atlantic Galapagos electric heater (core#155014)
+        (
+            "Z:22B78EFEFF16A720$I:B1817AFD64D8BB3A8F275C2117327AEC684B",
+            EUI64.convert("20:A7:16:FF:FE:8E:B7:22"),  # reversed!
+            util.convert_install_code(
+                bytes.fromhex("B1817AFD64D8BB3A8F275C2117327AEC684B")
+            ),
+        ),
+        # Inovelli, others
+        (
+            "Z:943469FFFE05CE55$I:FC5ECD1E8DFD3E0603E3689F8D0226BBF80B",
+            EUI64.convert("94:34:69:FF:FE:05:CE:55"),
+            util.convert_install_code(
+                bytes.fromhex("FC5ECD1E8DFD3E0603E3689F8D0226BBF80B")
+            ),
+        ),
+        # Muller-Light, Schneider, others
+        (
+            "000D6FFFFE63CCA0|58A4DD6123F38ECF22B17FDA0D95A43DED19",
+            EUI64.convert("00:0D:6F:FF:FE:63:CC:A0"),
+            util.convert_install_code(
+                bytes.fromhex("58A4DD6123F38ECF22B17FDA0D95A43DED19")
+            ),
+        ),
+        # Aqara
+        (
+            "G$M:69775$S:680S00003915$D:0000000017B2335C%Z$A:54EF44100006E7DF$I:3313A005E177A647FC7925620AB207C4BEF5",
+            EUI64.convert("54:EF:44:10:00:06:E7:DF"),
+            util.convert_install_code(
+                bytes.fromhex("3313A005E177A647FC7925620AB207C4BEF5")
+            ),
+        ),
+        # Somfy?
+        (
+            "Z:4CC206FFFE805E7A$I:560BCC1FF50E704B9BA93A5CA817C35E799F$D:202%B:4CC206805E7A$P:613727%M:1220$F:0024",
+            EUI64.convert("4C:C2:06:FF:FE:80:5E:7A"),
+            util.convert_install_code(
+                bytes.fromhex("560BCC1FF50E704B9BA93A5CA817C35E799F")
+            ),
+        ),
+        # Hue
+        (
+            "HUE:Z:2E5D2E5F401B82F1A45621A50B551F726101 M:001788010CE5C843 D:H2504 A:2266",
+            EUI64.convert("00:17:88:01:0C:E5:C8:43"),
+            util.convert_install_code(
+                bytes.fromhex("2E5D2E5F401B82F1A45621A50B551F726101")
+            ),
+        ),
+    ],
+)
+def test_qr_code_parsing(code: str, ieee: EUI64, link_key: KeyData) -> None:
+    """Test install code QR parsing."""
+    parsed_ieee, parsed_link_key = util.parse_install_code_qr(code)
+    assert parsed_ieee == ieee
+    assert parsed_link_key == link_key

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -517,4 +517,4 @@ def parse_install_code_qr(qr_code: str) -> tuple[t.EUI64, t.KeyData]:
 
         return ieee, link_key
 
-    raise ValueError(f"QR code {qr_code!r} does not follow any known pattern")
+    raise ValueError(f"Unknown QR code format: {qr_code!r}")

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -15,7 +15,6 @@ from crccheck.crc import CrcX25
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.ciphers.modes import ECB
-import voluptuous as vol
 
 from zigpy.exceptions import ZigbeeException
 import zigpy.types as t
@@ -25,34 +24,17 @@ LOGGER = logging.getLogger(__name__)
 _T = typing.TypeVar("_T")
 
 
-QR_CODES = (
+QR_CODE_FORMATS = (
     # Consciot
-    r"^([\da-fA-F]{16})\|([\da-fA-F]{36})$",
-    # Enbrighten
-    r"""
-        ^Z:
-        ([0-9a-fA-F]{16})  # IEEE address
-        \$I:
-        ([0-9a-fA-F]{36})  # install code
-        $
-    """,
+    r"^(?P<ieee>[0-9a-fA-F]{16})\|(?P<code>[0-9a-fA-F]{36})$",
+    # Enbrighten (and many others, can be suffixed with extra data)
+    r"^Z:(?P<ieee>[0-9a-fA-F]{16})\$I:(?P<code>[0-9a-fA-F]{36})",
     # Aqara
-    r"""
-        \$A:
-        ([0-9a-fA-F]{16})  # IEEE address
-        \$I:
-        ([0-9a-fA-F]{36})  # install code
-        $
-    """,
-    # Bosch
-    r"""
-        ^RB01SG
-        [0-9a-fA-F]{34}
-        ([0-9a-fA-F]{16}) # IEEE address
-        DLK
-        ([0-9a-fA-F]{36}|[0-9a-fA-F]{32}) # install code / link key
-        $
-    """,
+    r"\$A:(?P<ieee>[0-9a-fA-F]{16})\$I:(?P<code>[0-9a-fA-F]{36})$",
+    # Bosch (can contain either an install code or the link key directly)
+    r"^RB01SG[0-9a-fA-F]{34}(?P<ieee>[0-9a-fA-F]{16})DLK(?:(?P<code>[0-9a-fA-F]{36})|(?P<link_key>[0-9a-fA-F]{32}))$",
+    # Hue (contains a lot of other stuff at the end)
+    r"^HUE:Z:(?P<code>[0-9a-fA-F]{36}) M:(?P<ieee>[0-9a-fA-F]{16})",
 )
 
 
@@ -506,40 +488,28 @@ async def async_iterate_in_chunks(
         yield chunk
 
 
-def qr_to_raw_install_code(qr_code: str) -> tuple[t.EUI64, t.KeyData]:
-    """Try to parse the QR code.
+def parse_install_code_qr(qr_code: str) -> tuple[t.EUI64, t.KeyData]:
+    """Try to parse the QR code into a tuple of EUI64 and install code."""
 
-    if successful, return a tuple of a EUI64 address and install code.
-    """
-
-    for code_pattern in QR_CODES:
-        match = re.search(code_pattern, qr_code, re.VERBOSE)
+    for code_pattern in QR_CODE_FORMATS:
+        match = re.search(code_pattern, qr_code)
         if match is None:
             continue
 
-        ieee_hex = bytes.fromhex(match[1])
-        ieee = t.EUI64(ieee_hex[::-1])
+        ieee = t.EUI64.convert(match.group("ieee"))
 
-        # Bosch supplies (A) device specific link key (DSLK) or (A) install code + crc
-        if "RB01SG" in code_pattern and len(match[2]) == 32:
-            link_key_hex = bytes.fromhex(match[2])
-            link_key = t.KeyData(link_key_hex)
-            return ieee, link_key
-        install_code = match[2]
-        # install_code sanity check
-        link_key = convert_install_code(install_code)
+        # Some manufacturers flip the endianness of their IEEE addresses in QR codes. We
+        # can try to detect this and flip it back.
+        if str(ieee).lower().endswith("16:a7:20"):
+            ieee = t.EUI64(reversed(ieee))
+
+        code = match.group("code")
+
+        if code is not None:
+            link_key = convert_install_code(bytes.fromhex(code))
+        else:
+            link_key = match.group("link_key")
+
         return ieee, link_key
 
-    raise vol.Invalid(f"couldn't convert qr code: {qr_code}")
-
-
-def qr_code_to_install_code(qr_code: str) -> tuple[t.EUI64, t.KeyData]:
-    """Convert a QR code to install code and IEEE address, rewriting if necessary."""
-    ieee, link_key = qr_to_raw_install_code(qr_code)
-
-    # Some manufacturers flip the endianness of their IEEE addresses in QR codes. We can
-    # try to detect this and flip it back.
-    if str(ieee).endswith("20:a7:16"):
-        ieee = t.EUI64(reversed(ieee))
-
-    return ieee, link_key
+    raise ValueError(f"QR code {qr_code!r} does not follow any known pattern")

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -31,8 +31,10 @@ QR_CODE_FORMATS = (
     r"^Z:(?P<ieee>[0-9a-fA-F]{16})\$I:(?P<code>[0-9a-fA-F]{36})",
     # Aqara
     r"\$A:(?P<ieee>[0-9a-fA-F]{16})\$I:(?P<code>[0-9a-fA-F]{36})$",
-    # Bosch (can contain either an install code or the link key directly)
-    r"^RB01SG[0-9a-fA-F]{34}(?P<ieee>[0-9a-fA-F]{16})DLK(?:(?P<code>[0-9a-fA-F]{36})|(?P<link_key>[0-9a-fA-F]{32}))$",
+    # Bosch (install code)
+    r"^RB01SG[0-9a-fA-F]{34}(?P<ieee>[0-9a-fA-F]{16})DLK(?P<code>[0-9a-fA-F]{36})$",
+    # Bosch (link key directly)
+    r"^RB01SG[0-9a-fA-F]{34}(?P<ieee>[0-9a-fA-F]{16})DLK(?P<link_key>[0-9a-fA-F]{32})$",
     # Hue (contains a lot of other stuff at the end)
     r"^HUE:Z:(?P<code>[0-9a-fA-F]{36}) M:(?P<ieee>[0-9a-fA-F]{16})",
 )
@@ -503,12 +505,15 @@ def parse_install_code_qr(qr_code: str) -> tuple[t.EUI64, t.KeyData]:
         if str(ieee).lower().endswith("16:a7:20"):
             ieee = t.EUI64(reversed(ieee))
 
-        code = match.group("code")
+        try:
+            code = match.group("code")
+        except IndexError:
+            code = None
 
         if code is not None:
             link_key = convert_install_code(bytes.fromhex(code))
         else:
-            link_key = match.group("link_key")
+            link_key = t.KeyData.convert(match.group("link_key"))
 
         return ieee, link_key
 

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -6,6 +6,7 @@ import functools
 import inspect
 import itertools
 import logging
+import re
 import traceback
 import typing
 import warnings
@@ -14,6 +15,7 @@ from crccheck.crc import CrcX25
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.ciphers.modes import ECB
+import voluptuous as vol
 
 from zigpy.exceptions import ZigbeeException
 import zigpy.types as t
@@ -21,6 +23,37 @@ import zigpy.types as t
 LOGGER = logging.getLogger(__name__)
 
 _T = typing.TypeVar("_T")
+
+
+QR_CODES = (
+    # Consciot
+    r"^([\da-fA-F]{16})\|([\da-fA-F]{36})$",
+    # Enbrighten
+    r"""
+        ^Z:
+        ([0-9a-fA-F]{16})  # IEEE address
+        \$I:
+        ([0-9a-fA-F]{36})  # install code
+        $
+    """,
+    # Aqara
+    r"""
+        \$A:
+        ([0-9a-fA-F]{16})  # IEEE address
+        \$I:
+        ([0-9a-fA-F]{36})  # install code
+        $
+    """,
+    # Bosch
+    r"""
+        ^RB01SG
+        [0-9a-fA-F]{34}
+        ([0-9a-fA-F]{16}) # IEEE address
+        DLK
+        ([0-9a-fA-F]{36}|[0-9a-fA-F]{32}) # install code / link key
+        $
+    """,
+)
 
 
 class ListenableMixin:
@@ -238,13 +271,15 @@ def aes_mmo_hash(data: bytes) -> t.KeyData:
 
 def convert_install_code(code: bytes) -> t.KeyData:
     if len(code) not in (8, 10, 14, 18):
-        return None
+        raise ValueError(
+            f"Invalid install code length: {code.hex()} must be 8, 10, 14, or 18 bytes"
+        )
 
     real_crc = bytes(code[-2:])
     crc = CrcX25()
     crc.process(code[:-2])
     if real_crc != crc.finalbytes(byteorder="little"):
-        return None
+        raise ValueError(f"Invalid install code CRC: {code.hex()}")
 
     return aes_mmo_hash(code)
 
@@ -469,3 +504,42 @@ async def async_iterate_in_chunks(
             break
 
         yield chunk
+
+
+def qr_to_raw_install_code(qr_code: str) -> tuple[t.EUI64, t.KeyData]:
+    """Try to parse the QR code.
+
+    if successful, return a tuple of a EUI64 address and install code.
+    """
+
+    for code_pattern in QR_CODES:
+        match = re.search(code_pattern, qr_code, re.VERBOSE)
+        if match is None:
+            continue
+
+        ieee_hex = bytes.fromhex(match[1])
+        ieee = t.EUI64(ieee_hex[::-1])
+
+        # Bosch supplies (A) device specific link key (DSLK) or (A) install code + crc
+        if "RB01SG" in code_pattern and len(match[2]) == 32:
+            link_key_hex = bytes.fromhex(match[2])
+            link_key = t.KeyData(link_key_hex)
+            return ieee, link_key
+        install_code = match[2]
+        # install_code sanity check
+        link_key = convert_install_code(install_code)
+        return ieee, link_key
+
+    raise vol.Invalid(f"couldn't convert qr code: {qr_code}")
+
+
+def qr_code_to_install_code(qr_code: str) -> tuple[t.EUI64, t.KeyData]:
+    """Convert a QR code to install code and IEEE address, rewriting if necessary."""
+    ieee, link_key = qr_to_raw_install_code(qr_code)
+
+    # Some manufacturers flip the endianness of their IEEE addresses in QR codes. We can
+    # try to detect this and flip it back.
+    if str(ieee).endswith("20:a7:16"):
+        ieee = t.EUI64(reversed(ieee))
+
+    return ieee, link_key


### PR DESCRIPTION
ZHA currently contains logic for parsing QR codes but this really should belong in zigpy. This PR cleans up the parsing logic, adds unit tests for a bunch of QR codes from real devices, and adds support for the backwards IEEE address from https://github.com/home-assistant/core/issues/155014.