### PR TITLE
Use `serialx` in place of `pyserial` and `pyserial-asyncio-fast` when available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "cryptography",
     "voluptuous",
     "jsonschema",
+    "serialx",
     'pyserial-asyncio-fast',
     "typing_extensions",
     "frozendict",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "cryptography",
     "voluptuous",
     "jsonschema",
-    "serialx",
     'pyserial-asyncio-fast',
     "typing_extensions",
     "frozendict",

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -8,8 +8,13 @@ import typing
 from typing import Literal
 import urllib.parse
 
-import serial as pyserial
-import serial_asyncio_fast as pyserial_asyncio
+try:
+    # serialx is API-compatible with pyserial
+    import serialx as pyserial
+    import serialx as pyserial_asyncio
+except ImportError:
+    import serial as pyserial
+    import serial_asyncio_fast as pyserial_asyncio
 
 from zigpy.typing import UNDEFINED, UndefinedType
 


### PR DESCRIPTION
I'm pleased to announce the v0.1.0 release of [serialx](https://github.com/puddly/serialx), an asyncio-first serial port library:

- Makes zigpy-cli compatible with Windows
- Fixes serial port flushing deadlocks blocking shutdown
- 33% less runtime overhead than pyserial-asyncio-fast (75% less than pyserial-asyncio)

We've had continuous issues with pyserial in Home Assistant that have required layers upon layers of workarounds, hacks, and asyncio compatibility shims. Given our target platform is POSIX, macOS for development, and a little bit of Windows, it isn't much effort to directly support those two and a half platforms.

For opt-in beta testing, I would like zigpy to preferentially use it if available. This will propagate to zigpy-cli, universal-silabs-flasher, and all the other packages in Core.