### PR TITLE
Add exposed features to v2 quirks

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -28,6 +28,7 @@ from zigpy.quirks.v2 import (
     EntityMetadata,
     EntityPlatform,
     EntityType,
+    ExposesFeatureMetadata,
     FirmwareVersionFilterMetadata,
     NumberMetadata,
     PreventDefaultEntityCreationMetadata,
@@ -1537,6 +1538,23 @@ async def test_quirks_v2_change_entity_metadata(device_mock: Device) -> None:
             new_entity_registry_enabled_default=None,
             new_fallback_name="Custom Fallback Name",
         ),
+    )
+
+
+async def test_quirks_v2_exposes_feature(device_mock: Device) -> None:
+    """Test exposes feature functionality."""
+    registry = DeviceRegistry()
+
+    entry = (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .exposes_feature("some_feature")
+        .exposes_feature("another_feature")
+        .add_to_registry()
+    )
+
+    assert entry.exposes_features == (
+        ExposesFeatureMetadata(feature="some_feature"),
+        ExposesFeatureMetadata(feature="another_feature"),
     )
 
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -433,6 +433,13 @@ class FriendlyNameMetadata:
     manufacturer: str = attrs.field()
 
 
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class ExposesFeatureMetadata:
+    """Metadata for an exposed feature to match against in ZHA."""
+
+    feature: str = attrs.field()
+
+
 class DeviceAlertLevel(Enum):
     """Device alert level."""
 
@@ -513,6 +520,7 @@ class QuirksV2RegistryEntry:
         factory=tuple
     )
     friendly_name: FriendlyNameMetadata | None = attrs.field(default=None)
+    exposes_features: tuple[ExposesFeatureMetadata] = attrs.field(factory=tuple)
     device_alerts: tuple[DeviceAlertMetadata] = attrs.field(factory=tuple)
     disabled_default_entities: tuple[PreventDefaultEntityCreationMetadata] = (
         attrs.field(factory=tuple)
@@ -608,6 +616,7 @@ class QuirkBuilder:
         self.registry: DeviceRegistry = registry
         self.manufacturer_model_metadata: list[ManufacturerModelMetadata] = []
         self.friendly_name_metadata: FriendlyNameMetadata | None = None
+        self.exposes_features: list[ExposesFeatureMetadata] = []
         self.device_alerts: list[DeviceAlertMetadata] = []
         self.disabled_default_entities: list[PreventDefaultEntityCreationMetadata] = []
         self.changed_entity_metadata: list[ChangedEntityMetadata] = []
@@ -1219,6 +1228,11 @@ class QuirkBuilder:
         )
         return self
 
+    def exposes_feature(self, *, feature: str) -> Self:
+        """Adds an exposed feature."""
+        self.exposes_features.append(ExposesFeatureMetadata(feature=feature))
+        return self
+
     def device_alert(self, *, level: DeviceAlertLevel, message: str) -> Self:
         """Adds a device alert."""
         self.device_alerts.append(DeviceAlertMetadata(level=level, message=message))
@@ -1301,6 +1315,7 @@ class QuirkBuilder:
         quirk: QuirksV2RegistryEntry = QuirksV2RegistryEntry(
             manufacturer_model_metadata=tuple(self.manufacturer_model_metadata),
             friendly_name=self.friendly_name_metadata,
+            exposes_features=tuple(self.exposes_features),
             device_alerts=tuple(self.device_alerts),
             disabled_default_entities=tuple(self.disabled_default_entities),
             changed_entity_metadata=tuple(self.changed_entity_metadata),

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -1228,7 +1228,7 @@ class QuirkBuilder:
         )
         return self
 
-    def exposes_feature(self, *, feature: str) -> Self:
+    def exposes_feature(self, feature: str) -> Self:
         """Adds an exposed feature."""
         self.exposes_features.append(ExposesFeatureMetadata(feature=feature))
         return self


### PR DESCRIPTION
After https://github.com/zigpy/zha/pull/575, there'll be another PR to also parse these quirks v2 exposed features in ZHA, so it might be nice to already get this into zigpy.