### PR TITLE
Allow specifying `config` for exposed features

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1548,13 +1548,13 @@ async def test_quirks_v2_exposes_feature(device_mock: Device) -> None:
     entry = (
         QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .exposes_feature("some_feature")
-        .exposes_feature("another_feature")
+        .exposes_feature("another_feature", config={"option": True})
         .add_to_registry()
     )
 
     assert entry.exposes_features == (
         ExposesFeatureMetadata(feature="some_feature"),
-        ExposesFeatureMetadata(feature="another_feature"),
+        ExposesFeatureMetadata(feature="another_feature", config={"option": True}),
     )
 
 

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -438,6 +438,7 @@ class ExposesFeatureMetadata:
     """Metadata for an exposed feature to match against in ZHA."""
 
     feature: str = attrs.field()
+    config: frozendict[str, Any] = attrs.field(factory=frozendict, converter=frozendict)
 
 
 class DeviceAlertLevel(Enum):
@@ -1228,9 +1229,13 @@ class QuirkBuilder:
         )
         return self
 
-    def exposes_feature(self, feature: str) -> Self:
+    def exposes_feature(
+        self, feature: str, config: dict[str, Any] | None = None
+    ) -> Self:
         """Adds an exposed feature."""
-        self.exposes_features.append(ExposesFeatureMetadata(feature=feature))
+        self.exposes_features.append(
+            ExposesFeatureMetadata(feature=feature, config=config or {})
+        )
         return self
 
     def device_alert(self, *, level: DeviceAlertLevel, message: str) -> Self:


### PR DESCRIPTION
This PR would also allow optionally specifying config options for exposed features on v2 quirks.

Follow-up to:
- https://github.com/zigpy/zigpy/pull/1711

I'm not sure if this is something we want/need to merge in the current state though. Otherwise, it's so simple, that we might as well(?) 😄 