### PR TITLE
fix: avoid waiting on checkin response response

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1521,6 +1521,7 @@ async def test_poll_control_checkin_callback(
                     start_fast_polling=expected_fast_poll,
                     fast_poll_timeout=int(device.DEFAULT_FAST_POLL_TIMEOUT * 4),
                     tsn=0x12,
+                    expect_reply=False,
                 )
             ]
         else:
@@ -1529,6 +1530,7 @@ async def test_poll_control_checkin_callback(
                     start_fast_polling=expected_fast_poll,
                     fast_poll_timeout=0,
                     tsn=0x12,
+                    expect_reply=False,
                 )
             ]
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -354,12 +354,14 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     start_fast_polling=True,
                     fast_poll_timeout=int(DEFAULT_FAST_POLL_TIMEOUT * 4),
                     tsn=zcl_hdr.tsn,
+                    expect_reply=False,
                 )
             else:
                 await poll_control.checkin_response(
                     start_fast_polling=False,
                     fast_poll_timeout=0,
                     tsn=zcl_hdr.tsn,
+                    expect_reply=False,
                 )
 
     async def begin_fast_polling(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -388,7 +388,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
             schema=schema,
             manufacturer=manufacturer,
             tsn=tsn,
-            disable_default_response=self.is_client,
+            disable_default_response=not expect_reply,
             direction=(
                 foundation.Direction.Server_to_Client
                 if self.is_client


### PR DESCRIPTION
Avoid waiting on the Default_Response for a checkin_response request. There is no use for the reply data.

Ensure we set disable_default_response on the frames whenever we are not expecting a reply. It does not matter if this is a client or server request, what matters is if we are going to be waiting for a reply.

This avoid these type of errors:

```
Loggare: homeassistant
Källa: /usr/src/homeassistant/homeassistant/runner.py:238
Inträffade först: 10 november 2025 kl. 07:47:15 (95 förekomster)
Senast loggade: 28 november 2025 kl. 21:11:41

Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/zigpy/device.py", line 593, in request
    return await future
           ^^^^^^^^^^^^
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/zigpy/device.py", line 359, in poll_control_checkin_callback
    await poll_control.checkin_response(
    ...<3 lines>...
    )
  File "/usr/local/lib/python3.13/site-packages/zigpy/zcl/__init__.py", line 405, in request
    return await self._endpoint.request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/zigpy/endpoint.py", line 233, in request
    return await self.device.request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<11 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/zigpy/device.py", line 592, in request
    async with asyncio_timeout(timeout):
               ~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/local/lib/python3.13/asyncio/timeouts.py", line 116, in __aexit__
    raise TimeoutError from exc_val
TimeoutError
```

Note. We should likely also catch these errors and add device iee context so we can see what fails.