### PR TITLE
fix: catch exceptions for checkin_response

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1797,3 +1797,58 @@ async def test_shutdown_device_remove_fails(app, ieee, caplog):
 
     assert "Failed to remove device" in caplog.text
     assert "Boom!" in caplog.text
+
+
+async def test_callback_wrapping(
+    app: zigpy.application.ControllerApplication, ieee, caplog
+) -> None:
+    # The default is True
+    dev = app.add_device(ieee, 0x1234)
+
+    def _callback():
+        raise ValueError("Boom!")
+
+    callback = app.wrap_callback(dev, _callback)
+    with caplog.at_level(logging.WARNING):
+        callback()
+
+    assert caplog.record_tuples == [
+        (
+            "zigpy.application",
+            logging.WARNING,
+            (
+                "Device <Device model=None manuf=None nwk=0x1234 "
+                "ieee=07:06:05:04:03:02:01:00 is_initialized=False> "
+                "callback failed - ValueError('Boom!')"
+            ),
+        ),
+    ]
+
+
+async def test_callback_wrapping_async(
+    app: zigpy.application.ControllerApplication, ieee, caplog
+) -> None:
+    # The default is True
+    dev = app.add_device(ieee, 0x1234)
+
+    async def _callback():
+        raise ValueError("Boom!")
+
+    callback = app.wrap_callback(dev, _callback)
+    with caplog.at_level(logging.WARNING):
+        callback()
+        tasks = app._tasks.copy()
+        for task in tasks:
+            await task
+
+    assert caplog.record_tuples == [
+        (
+            "zigpy.application",
+            logging.WARNING,
+            (
+                "Device <Device model=None manuf=None nwk=0x1234 "
+                "ieee=07:06:05:04:03:02:01:00 is_initialized=False> "
+                "callback failed - ValueError('Boom!')"
+            ),
+        ),
+    ]

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -116,21 +116,6 @@ async def test_callback_listener():
     ]
 
 
-async def test_callback_listener_error(caplog):
-    listener = listeners.CallbackListener(
-        matchers=[
-            on(),
-        ],
-        callback=mock.Mock(side_effect=RuntimeError("Uh oh")),
-    )
-
-    with caplog.at_level(logging.WARNING):
-        assert listener.resolve(make_hdr(on()), on())
-
-    assert "Caught an exception while executing callback" in caplog.text
-    assert "RuntimeError: Uh oh" in caplog.text
-
-
 async def test_listener_callback_matches():
     listener = listeners.CallbackListener(
         matchers=[lambda hdr, command: True],

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -9,6 +9,7 @@ import contextlib
 import contextvars
 from datetime import UTC, datetime
 import errno
+import inspect
 import logging
 import os
 import random
@@ -48,6 +49,7 @@ TRANSIENT_CONNECTION_ERRORS = {
 
 ENERGY_SCAN_WARN_THRESHOLD = 0.75 * 255
 _R = TypeVar("_R")
+_C = TypeVar("_C", bound=typing.Callable)
 
 CHANNEL_CHANGE_BROADCAST_DELAY_S = 1.0
 CHANNEL_CHANGE_SETTINGS_RELOAD_DELAY_S = 1.0
@@ -94,6 +96,35 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._packet_priority_var = contextvars.ContextVar(
             "request_priority", default=t.PacketPriority.NORMAL
         )
+
+    def wrap_callback(
+        self, src: zigpy.device.Device | zigpy.listeners.ANY_DEVICE, callback: _C
+    ) -> _C:
+        """Wrap a callback to log exceptions and run as task if needed."""
+        if inspect.iscoroutinefunction(callback):
+
+            async def _async_callback(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    return await callback(*args, **kwargs)
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning(
+                        "Device %r callback failed - %r", src, exc, exc_info=True
+                    )
+
+            def _callback(*args: Any, **kwargs: Any) -> Any:
+                self.create_task(_async_callback(*args, **kwargs))
+
+        else:
+
+            def _callback(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    return callback(*args, **kwargs)
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning(
+                        "Device %r callback failed - %r", src, exc, exc_info=True
+                    )
+
+        return _callback
 
     def create_task(
         self, target: Coroutine[Any, Any, _R], name: str | None = None
@@ -1348,7 +1379,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     ) -> typing.Callable[[], None]:
         listener = zigpy.listeners.CallbackListener(
             matchers=tuple(filters),
-            callback=callback,
+            callback=self.wrap_callback(src, callback),
         )
 
         self._req_listeners[src].append(listener)

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -99,7 +99,6 @@ class CallbackListener(BaseRequestListener):
     callback: typing.Callable[
         [foundation.ZCLHeader | zdo_t.ZDOHeader, foundation.CommandSchema], typing.Any
     ]
-    _tasks: set[asyncio.Task] = dataclasses.field(default_factory=set)
 
     def _resolve(
         self,

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-import inspect
 import logging
 import typing
 
@@ -107,19 +106,7 @@ class CallbackListener(BaseRequestListener):
         hdr: foundation.ZCLHeader | zdo_t.ZDOHeader,
         command: foundation.CommandSchema,
     ) -> bool:
-        try:
-            potential_awaitable = self.callback(hdr, command)
-            if inspect.isawaitable(potential_awaitable):
-                task: asyncio.Task = asyncio.get_running_loop().create_task(
-                    potential_awaitable, name="CallbackListener"
-                )
-                self._tasks.add(task)
-                task.add_done_callback(self._tasks.remove)
-        except Exception:  # noqa: BLE001
-            LOGGER.warning(
-                "Caught an exception while executing callback", exc_info=True
-            )
-
+        self.callback(hdr, command)
         # Callbacks are always resolved
         return True
 


### PR DESCRIPTION
Add callback wrapper to application controller
that catches exceptions heading for event loop
and logs these with device context

Remove the now unneeded handling of this
in CallbackListener.