### PR TITLE
Mention ThirdReality (3reality) OTA provider in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The **[ZHA integration component for Home Assistant](https://www.home-assistant.
 
 zigpy have ability to download and perform Zigbee OTAU (Over-The-Air Updates) of Zigbee devices firmware. The Zigbee OTA update firmware image files should conform to standard Zigbee OTA format and OTA provider source URLs need to be published for public availability. Updates from a local OTA update directory also is also supported and can be used as an option for offline firmware updates if user provide correct Zigbee OTA formatted firmware files themselves.
 
-Support for automatic download from existing online OTA providers in zigpy OTA provider code is currently only available for IKEA, Inovelli, LEDVANCE/OSRAM, and SONOFF/ITEAD devices. Support for additional OTA providers for other manufacturers devices could be added to zigpy in the future, if device manufacturers publish their firmware images publicly and developers contribute the needed download code for them.
+Support for automatic download from existing online OTA providers in zigpy OTA provider code is currently only available for IKEA, Inovelli, LEDVANCE/OSRAM, SONOFF/ITEAD, and ThirdReality (3reality) devices. Support for additional OTA providers for other manufacturers devices could be added to zigpy in the future, if device manufacturers publish their firmware images publicly and developers contribute the needed download code for them.
 
 ## How to install and test, report bugs, or contribute to this project
 


### PR DESCRIPTION
Add mentioning of ThirdReality (3reality) OTA provider in zigpy readme file:

* https://github.com/zigpy/zigpy/pull/1096

Ping @hwzolin FYI.

PS: Third Reality OTA support is already mentioned in the ZHA integration documentation:

* https://www.home-assistant.io/integrations/zha