### PR TITLE
Allow for the default response bit to be explicitly controlled

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1522,6 +1522,7 @@ async def test_poll_control_checkin_callback(
                     fast_poll_timeout=int(device.DEFAULT_FAST_POLL_TIMEOUT * 4),
                     tsn=0x12,
                     expect_reply=False,
+                    disable_default_response=True,
                 )
             ]
         else:
@@ -1531,6 +1532,7 @@ async def test_poll_control_checkin_callback(
                     fast_poll_timeout=0,
                     tsn=0x12,
                     expect_reply=False,
+                    disable_default_response=True,
                 )
             ]
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -355,6 +355,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     fast_poll_timeout=int(DEFAULT_FAST_POLL_TIMEOUT * 4),
                     tsn=zcl_hdr.tsn,
                     expect_reply=False,
+                    disable_default_response=True,
                 )
             else:
                 await poll_control.checkin_response(
@@ -362,6 +363,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     fast_poll_timeout=0,
                     tsn=zcl_hdr.tsn,
                     expect_reply=False,
+                    disable_default_response=True,
                 )
 
     async def begin_fast_polling(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -377,18 +377,22 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         expect_reply: bool = True,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
+        disable_default_response: bool | None = None,
         priority: int | None = None,
         tsn: int | t.uint8_t | None = None,
         timeout=APS_REPLY_TIMEOUT,
         **kwargs,
     ):
+        if disable_default_response is None:
+            disable_default_response = self.is_client
+
         hdr, request = self._create_request(
             general=general,
             command_id=command_id,
             schema=schema,
             manufacturer=manufacturer,
             tsn=tsn,
-            disable_default_response=not expect_reply,
+            disable_default_response=disable_default_response,
             direction=(
                 foundation.Direction.Server_to_Client
                 if self.is_client
@@ -426,16 +430,20 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         expect_reply: bool = False,
         use_ieee: bool = False,
         ask_for_ack: bool | None = None,
+        disable_default_response: bool | None = None,
         priority: int | None = None,
         **kwargs,
     ) -> None:
+        if disable_default_response is None:
+            disable_default_response = True
+
         hdr, request = self._create_request(
             general=general,
             command_id=command_id,
             schema=schema,
             manufacturer=manufacturer,
             tsn=tsn,
-            disable_default_response=True,
+            disable_default_response=disable_default_response,
             direction=(
                 foundation.Direction.Server_to_Client
                 if self.is_client


### PR DESCRIPTION
https://github.com/zigpy/zigpy/pull/1714 affected quirks unit tests. As an alternative implementation, I think it would be better to explicitly pass an override for the `disable_default_response` bit. This allows the exact behavior to be controlled by the caller as opposed to using indirect methods (e.g. `not self.is_client` or `expect_reply`).