### PR TITLE
Ignore aiosqlite 0.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.11"
 dependencies = [
     "attrs",
     "aiohttp",
-    "aiosqlite>=0.20.0",
+    "aiosqlite>=0.20.0,<0.22.0",
     "crccheck",
     "cryptography",
     "voluptuous",


### PR DESCRIPTION
0.22.0 changes the background thread behavior but does not fix the underlying race condition where `await db.close()` doesn't actually wait for the thread to join.