### PR TITLE
Catch more `aiohttp` errors when downloading OTA test files

### DIFF
--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -41,7 +41,7 @@ def download_external_files():
         if not path.is_file():
             try:
                 data = asyncio.run(download(obj["url"]))
-            except (TimeoutError, aiohttp.ClientResponseError) as e:
+            except (TimeoutError, aiohttp.ClientError) as e:
                 _LOGGER.error("Failed to download %s: %s", obj["url"], e)
                 continue
             else:


### PR DESCRIPTION
## Proposed change

This changes `download_external_files` in OTA tests to catch all aiohttp `ClientError`s, not just `ClientResponseError`.
This fixes the following issue during test execution where `ClientConnectorDNSError` was not caught:
```python
 aiohttp.client_exceptions.ClientConnectorDNSError: Cannot connect to host us-fm.cloud.sengled.com:443 ssl:False [Name or service not known]
```

## Additional information

Noticed whilst working on:
- https://github.com/zigpy/zigpy/pull/1731
- https://github.com/zigpy/zigpy/actions/runs/20357640138/job/58496282772?pr=1731