### PR TITLE
Add Telink OTA parsing support and propagate telinkEncryption flag

### DIFF
--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Self
 
 import attr
+from typing_extensions import Self
 
 import zigpy.types as t
 
@@ -250,6 +250,51 @@ class HueSBLOTAImage(BaseOTAImage):
 
         return cls(header=header, data=firmware), data[header.image_size :]
 
+@attr.s
+class TelinkSubElement:
+    tag_id = attr.ib()
+    tag_length = attr.ib()
+    tag_info = attr.ib()
+    data = attr.ib()
+
+    def serialize(self) -> bytes:
+        res = self.tag_id.serialize()
+        res += t.uint32_t(self.tag_length).serialize()
+        res += t.uint16_t(self.tag_info).serialize()
+        res += self.data
+        return res
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple["TelinkSubElement", bytes]:
+        tag_id, data = ElementTagId.deserialize(data)
+        tag_length, data = t.uint32_t.deserialize(data)
+        tag_info, data = t.uint16_t.deserialize(data)
+        if len(data) < tag_length:
+            raise ValueError("Not enough data for Telink element")
+        data_bytes, data = data[:tag_length], data[tag_length:]
+        return cls(tag_id=tag_id, tag_length=tag_length, tag_info=tag_info, data=data_bytes), data
+
+@attr.s
+class TelinkOTAImage(BaseOTAImage):
+    header = attr.ib()
+    subelements = attr.ib(factory=list)
+
+    def serialize(self) -> bytes:
+        res = self.header.serialize()
+        for sub in self.subelements:
+            res += sub.serialize()
+        return res
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple["TelinkOTAImage", bytes]:
+        header, data = OTAImageHeader.deserialize(data)
+        elements_len = header.image_size - header.header_length
+        subelements = []
+        element_data, data = data[:elements_len], data[elements_len:]
+        while element_data:
+            element, element_data = TelinkSubElement.deserialize(element_data)
+            subelements.append(element)
+        return cls(header=header, subelements=subelements), data
 
 def parse_ota_image(data: bytes) -> tuple[BaseOTAImage, bytes]:
     """Attempts to extract any known OTA image type from data. Does not validate firmware."""

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -21,7 +21,7 @@ import voluptuous as vol
 
 import zigpy.config
 from zigpy.ota import json_schemas
-from zigpy.ota.image import BaseOTAImage, parse_ota_image
+from zigpy.ota.image import BaseOTAImage, TelinkOTAImage, parse_ota_image
 import zigpy.types as t
 import zigpy.util
 
@@ -90,6 +90,8 @@ class BaseOtaImageMetadata(t.BaseDataclassMixin):
     max_current_file_version: int | None = None
     specificity: int | None = None
 
+    telink_encryption: bool | None = None
+
     source: str = "Unknown"
 
     async def _fetch(self) -> bytes:
@@ -116,7 +118,12 @@ class BaseOtaImageMetadata(t.BaseDataclassMixin):
     async def fetch(self) -> BaseOTAImage:
         data = await self._fetch()
         await self._validate(data)
-
+        if self.telink_encryption:
+            try:
+                image, _ = TelinkOTAImage.deserialize(data)
+                return image
+            except Exception:
+                pass
         image, _ = parse_ota_image(data)
         return image
 
@@ -598,6 +605,7 @@ class BaseZ2MProvider(BaseOtaProvider):
                 "min_hardware_version": fw.get("hardwareVersionMin"),
                 "max_hardware_version": fw.get("hardwareVersionMax"),
                 "changelog": fw.get("releaseNotes"),  # Changelog is short
+                "telink_encryption": fw.get("telinkEncryption"),
                 "source": "",  # Set in a subclass
             }
 


### PR DESCRIPTION
### Goal
add first-class handling for Telink-encrypted Zigbee OTA images so they can be fetched, parsed, and validated without failing the generic Zigbee OTA parser.
### Key changes
- Added telink_encryption flag to OTA metadata and propagate it from the Z2M index (field telinkEncryption).
- In metadata fetch(), when telink_encryption is set, attempt Telink-specific parsing (TelinkOTAImage) before falling back to the generic parse_ota_image.
- Introduced Telink container parsing in image.py: Telink subelements carry tag_id, tag_length, tag_info, and data, differing from the standard subelement shape (which only has tag_id+ length-prefixed data). Telink images now deserialize to TelinkOTAImage.
### Behavior
- For Z2M-provided firmware entries that set telinkEncryption, the downloaded blob is parsed with the Telink layout; if successful, the Telink image is returned. If parsing fails, we fall back to the standard parser.
- Checksum/size validation still runs before parsing. This assumes the index’s checksum/size corresponds to the encrypted blob; if upstream moves to decrypted values, the validation order will need revisiting.
### Rationale
Telink OTA files use a distinct container format; the generic Zigbee OTA parser cannot interpret the extra tag_info/length fields, leading to failures. Dedicated parsing enables these images to be consumed like other vendors’ firmware.

### Additionally
We encountered the same issue in Z2M and applied a similar fix there. 
Z2M PR:  https://github.com/Koenkk/zigbee-herdsman-converters/pull/9984#issuecomment-3288777252