### PR TITLE
Load attribute cache fully before trying to match quirks

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -23,9 +23,11 @@ from zigpy.device import Device, Status
 import zigpy.endpoint
 import zigpy.ota
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.registry import DeviceRegistry
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 import zigpy.zcl
-from zigpy.zcl.clusters.general import Basic
+from zigpy.zcl.clusters.general import Basic, Ota
 from zigpy.zcl.foundation import Status as ZCLStatus
 from zigpy.zdo import types as zdo_t
 
@@ -1175,3 +1177,73 @@ async def test_appdb_attribute_clear(tmp_path):
     dev3 = app3.get_device(ieee=dev.ieee)
     assert Basic.AttributeDefs.zcl_version.id not in dev3.endpoints[1].basic._attr_cache
     await app3.shutdown()
+
+
+async def test_appdb_complex_quirk_matching(tmp_path) -> None:
+    """Test quirks are given full attribute state for matching."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+
+    # Create a simple device
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+    dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+
+    basic = ep.add_input_cluster(Basic.cluster_id)
+    basic.update_attribute(Basic.AttributeDefs.model.id, "Some Model")
+    basic.update_attribute(Basic.AttributeDefs.manufacturer.id, "Some Manufacturer")
+
+    ota = ep.add_output_cluster(Ota.cluster_id)
+    ota.update_attribute(Ota.AttributeDefs.current_file_version.id, 0x12345678)
+
+    app.device_initialized(dev)
+    await app.shutdown()
+
+    # Ensure quirks have the correct information to match properly
+    registry = DeviceRegistry()
+
+    # Doesn't match
+    _quirk1 = (
+        QuirkBuilder("Some Manufacturer", "Some Model", registry=registry)
+        .firmware_version_filter(
+            min_version=0x12345678 - 1,
+            max_version=0x12345678,
+            allow_missing=False,
+        )
+        .add_to_registry()
+    )
+
+    # Matches
+    quirk2 = (
+        QuirkBuilder("Some Manufacturer", "Some Model", registry=registry)
+        .firmware_version_filter(
+            min_version=0x12345678,
+            max_version=0x12345678 + 1,
+            allow_missing=False,
+        )
+        .add_to_registry()
+    )
+
+    # Doesn't match
+    _quirk3 = (
+        QuirkBuilder("Some Manufacturer", "Some Model", registry=registry)
+        .firmware_version_filter(
+            min_version=0x12345678 + 1,
+            max_version=0x12345678 + 2,
+            allow_missing=False,
+        )
+        .add_to_registry()
+    )
+
+    with patch("zigpy.quirks.get_device", side_effect=registry.get_device):
+        app2 = await make_app_with_db(db)
+
+    # Only the second quirk should match
+    dev2 = app2.get_device(t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+    assert dev2.quirk_metadata == quirk2
+
+    await app2.shutdown()

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -676,7 +676,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             device = zigpy.quirks.get_device(device)
             self._application.devices[device.ieee] = device
 
-        # Load them again once more, to make sure virtual clusters get re-populated
+        # Load them once more, to make sure virtual clusters get re-populated
         await self._load_attributes()
         await self._load_unsupported_attributes()
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -668,24 +668,18 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._load_endpoints()
         await self._load_clusters()
 
-        # Quirks require the manufacturer and model name to be populated
-        await self._load_attributes(
-            f"""
-                cluster_type={ClusterType.Server}
-            AND cluster_id={Basic.cluster_id}
-            AND (
-                   attr_id={Basic.AttributeDefs.manufacturer.id}
-                OR attr_id={Basic.AttributeDefs.model.id}
-            )
-            """
-        )
+        # Load as many attributes as we can in the first pass
+        await self._load_attributes()
+        await self._load_unsupported_attributes()
 
         for device in self._application.devices.values():
             device = zigpy.quirks.get_device(device)
             self._application.devices[device.ieee] = device
 
+        # Load them again once more, to make sure virtual clusters get re-populated
         await self._load_attributes()
         await self._load_unsupported_attributes()
+
         await self._load_groups()
         await self._load_group_members()
         await self._load_relays()
@@ -694,13 +688,8 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._load_network_backups()
         await self._register_device_listeners()
 
-    async def _load_attributes(self, filter: str | None = None) -> None:
-        if filter:
-            query = f"SELECT * FROM attributes_cache{DB_V} WHERE {filter}"
-        else:
-            query = f"SELECT * FROM attributes_cache{DB_V}"
-
-        async with self.execute(query) as cursor:
+    async def _load_attributes(self) -> None:
+        async with self.execute(f"SELECT * FROM attributes_cache{DB_V}") as cursor:
             async for (
                 ieee,
                 endpoint_id,


### PR DESCRIPTION
The quirks v2 firmware version filters do not currently function because quirks aren't given enough attribute context when loading. This PR attempts to fix this by loading all attributes (not just model/manufacturer), then matching quirks, and finally reloading the attribute cache again to populate newly-added clusters.

Should resolve https://github.com/zigpy/zha-device-handlers/pull/4592#issuecomment-3700225502