### PR TITLE
Better enum typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ exclude = ["tests", "tests.*"]
 
 [tool.setuptools.package-data]
 "*" = ["appdb_schemas/schema_v*.sql"]
+zigpy = ["py.typed"]
 
 [project.optional-dependencies]
 testing = [

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -492,51 +492,51 @@ class _EnumMixin:
             return object.__format__(repr(self), format_spec)
 
 
-class enum1(_EnumMixin, uint1_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum1(_EnumMixin, uint1_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum2(_EnumMixin, uint2_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum2(_EnumMixin, uint2_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum3(_EnumMixin, uint3_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum3(_EnumMixin, uint3_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum4(_EnumMixin, uint4_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum4(_EnumMixin, uint4_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum5(_EnumMixin, uint5_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum5(_EnumMixin, uint5_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum6(_EnumMixin, uint6_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum6(_EnumMixin, uint6_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum7(_EnumMixin, uint7_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum7(_EnumMixin, uint7_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum8(_EnumMixin, uint8_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum8(_EnumMixin, uint8_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum16(_EnumMixin, uint16_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum16(_EnumMixin, uint16_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum32(_EnumMixin, uint32_t, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum32(_EnumMixin, uint32_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum16_be(_EnumMixin, uint16_t_be, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum16_be(_EnumMixin, uint16_t_be, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum32_be(_EnumMixin, uint32_t_be, enum.IntEnum, metaclass=_IntEnumMeta):
+class enum32_be(_EnumMixin, uint32_t_be, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -157,7 +157,7 @@ class FixedIntType(int):
         return Bits([(self >> n) & 0b1 for n in range(self._bits - 1, -1, -1)])
 
     @classmethod
-    def from_bits(cls, bits: Bits) -> tuple[FixedIntType, Bits]:
+    def from_bits(cls, bits: Bits) -> tuple[Self, Bits]:
         if len(bits) < cls._bits:
             raise ValueError(f"Not enough bits to decode {cls}: {bits}")
 
@@ -179,7 +179,7 @@ class FixedIntType(int):
         return self.to_bytes(self._bits // 8, self._byteorder, signed=self._signed)
 
     @classmethod
-    def deserialize(cls, data: bytes) -> tuple[FixedIntType, bytes]:
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
         if cls._bits % 8 != 0:
             raise TypeError(f"Integer type with {cls._bits} bits is not byte aligned")
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -91,7 +91,7 @@ class FixedIntType(int):
         if cls._signed is None or cls._bits is None:
             raise TypeError(f"{cls} is abstract and cannot be created")
 
-        n = super().__new__(cls, *args, **kwargs)
+        n = int.__new__(cls, *args, **kwargs)
 
         # We use `n + 0` to convert `n` into an integer without calling `int()`
         if not cls.min_value <= n + 0 <= cls.max_value:
@@ -428,80 +428,115 @@ class _IntEnumMeta(AlwaysCreateEnumType):
                 value = self[value].value
         return super().__call__(value, names, *args, **kwargs)
 
+    @classmethod
+    def _find_data_type_(mcls, class_name, bases):  # noqa: N804
+        # a datatype has a __new__ method, or a __dataclass_fields__ attribute
+        data_types = set()
+        base_chain = set()
+        for chain in bases:
+            candidate = None
+            for base in chain.__mro__:
+                base_chain.add(base)
+                if base is object:
+                    continue
+                elif isinstance(base, enum.EnumType):
+                    if base._member_type_ is not object:
+                        data_types.add(base._member_type_)
+                        break
+                elif (
+                    "__new__" in base.__dict__
+                    or "__dataclass_fields__" in base.__dict__
+                ):
+                    data_types.add(candidate or base)
+                    break
+                else:
+                    candidate = candidate or base
 
-def enum_factory(int_type: CALLABLE_T, undefined: str = "undefined") -> CALLABLE_T:
-    """Enum factory."""
+        # Ignore chains of data types: uint8_t is a subclass of int
+        data_types = {
+            base
+            for base in data_types
+            if not any(
+                issubclass(other, base) for other in data_types if other is not base
+            )
+        }
 
-    class _NewEnum(int_type, enum.Enum, metaclass=_IntEnumMeta):
-        @classmethod
-        def _missing_(cls, value):
-            new = cls._member_type_.__new__(cls, value)
-
-            if cls._bits % 8 == 0:
-                name = f"{undefined}_{new._hex_repr().lower()}"
-            else:
-                name = f"{undefined}_{new._bin_repr()}"
-
-            new._name_ = name.format(value)
-            new._value_ = value
-            return new
-
-        def __format__(self, format_spec: str) -> str:
-            if format_spec:
-                # Allow formatting the integer enum value
-                return self._member_type_.__format__(self, format_spec)
-            else:
-                # Otherwise, format it as its string representation
-                return object.__format__(repr(self), format_spec)
-
-    return _NewEnum
+        if len(data_types) > 1:
+            raise TypeError("too many data types for %r: %r" % (class_name, data_types))  # noqa: UP031
+        elif data_types:
+            return data_types.pop()
+        else:
+            return None
 
 
-class enum1(enum_factory(uint1_t)):  # noqa: N801
+class _EnumMixin:
+    @classmethod
+    def _missing_(cls, value):
+        new = cls._member_type_.__new__(cls, value)
+
+        if cls._bits % 8 == 0:
+            name = f"undefined_{new._hex_repr().lower()}"
+        else:
+            name = f"undefined_{new._bin_repr()}"
+
+        new._name_ = name.format(value)
+        new._value_ = value
+        return new
+
+    def __format__(self, format_spec: str) -> str:
+        if format_spec:
+            # Allow formatting the integer enum value
+            return self._member_type_.__format__(self, format_spec)
+        else:
+            # Otherwise, format it as its string representation
+            return object.__format__(repr(self), format_spec)
+
+
+class enum1(_EnumMixin, uint1_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum2(enum_factory(uint2_t)):  # noqa: N801
+class enum2(_EnumMixin, uint2_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum3(enum_factory(uint3_t)):  # noqa: N801
+class enum3(_EnumMixin, uint3_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum4(enum_factory(uint4_t)):  # noqa: N801
+class enum4(_EnumMixin, uint4_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum5(enum_factory(uint5_t)):  # noqa: N801
+class enum5(_EnumMixin, uint5_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum6(enum_factory(uint6_t)):  # noqa: N801
+class enum6(_EnumMixin, uint6_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum7(enum_factory(uint7_t)):  # noqa: N801
+class enum7(_EnumMixin, uint7_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum8(enum_factory(uint8_t)):  # noqa: N801
+class enum8(_EnumMixin, uint8_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum16(enum_factory(uint16_t)):  # noqa: N801
+class enum16(_EnumMixin, uint16_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum32(enum_factory(uint32_t)):  # noqa: N801
+class enum32(_EnumMixin, uint32_t, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum16_be(enum_factory(uint16_t_be)):  # noqa: N801
+class enum16_be(_EnumMixin, uint16_t_be, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 
-class enum32_be(enum_factory(uint32_t_be)):  # noqa: N801
+class enum32_be(_EnumMixin, uint32_t_be, enum.IntEnum, metaclass=_IntEnumMeta):
     pass
 
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -315,7 +315,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
                 )
                 return hdr, data
 
-            command = foundation.GENERAL_COMMANDS[hdr.command_id]
+            command_id = foundation.GeneralCommand(hdr.command_id)
+            command = foundation.GENERAL_COMMANDS[command_id]
 
         response, data = command.schema.deserialize(data)
 
@@ -958,7 +959,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
     def general_command(
         self,
-        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        command_id: foundation.GeneralCommand,
         *args,
         manufacturer: int | t.uint16_t | None = None,
         expect_reply: bool = True,

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any, Final
+from typing import Any, Final, Self
 
 import zigpy.types as t
 from zigpy.typing import AddressingMode
@@ -36,7 +36,7 @@ class PowerSource(t.enum8):
         self.battery_backup = False
 
     @classmethod
-    def deserialize(cls, data: bytes) -> tuple[bytes, bytes]:
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
         val, data = t.uint8_t.deserialize(data)
         r = cls(val & 0x7F)
         r.battery_backup = bool(val & 0x80)

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -613,7 +613,7 @@ class DataType(DataTypeInfo, enum.Enum):
 
     @classmethod
     @functools.cache
-    def _python_type_index(cls: type[Self]) -> dict[type, Self]:  # noqa: N805
+    def _python_type_index(cls: type[Self]) -> dict[type, Self]:
         return {d.python_type: d for d in cls}
 
     @classmethod
@@ -630,7 +630,7 @@ class DataType(DataTypeInfo, enum.Enum):
 
     @classmethod
     @functools.cache
-    def _data_type_index(cls: type[Self]) -> dict[type, Self]:  # noqa: N805
+    def _data_type_index(cls: type[Self]) -> dict[DataTypeId, Self]:
         return {d.type_id: d for d in cls}
 
     @classmethod

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -452,11 +452,7 @@ IEEE = ("IEEEAddr", t.EUI64)
 STATUS = ("Status", Status)
 
 
-class _CommandID(t.uint16_t, repr="hex"):
-    pass
-
-
-class ZDOCmd(t.enum_factory(_CommandID)):
+class ZDOCmd(t.enum16):
     # Device and Service Discovery Server Requests
     NWK_addr_req = 0x0000
     IEEE_addr_req = 0x0001


### PR DESCRIPTION
Since we support more recent Python versions now, we can ditch some of the typing hacks that make type checkers very unhappy. This PR fixes a bug affecting type checking in an unrelated repo.

Our internal `enum_factory` function can be removed. This is unfortunate used in a single place in quirks but this is a mistake, since the subclass should be `t.enum8`.

A side effect of typing this more correctly is that it is no longer `Any` so a few type issues with enums have shown up elsewhere, which have now been fixed.