### PR TITLE
Improve type annotations in OTA modules

### DIFF
--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -372,10 +372,8 @@ class OTA:
             return await provider.load_index()
 
     @zigpy.util.combine_concurrent_calls
-    async def _fetch_image(
-        self, image: OtaImageWithMetadata
-    ) -> list[OtaImageWithMetadata]:
-        """Load the index of a provider."""
+    async def _fetch_image(self, image: OtaImageWithMetadata) -> OtaImageWithMetadata:
+        """Fetch an OTA image."""
 
         async with asyncio_timeout(OTA_FETCH_TIMEOUT):
             return await image.fetch()

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -469,10 +469,11 @@ class OTA:
                 upgrades[img.metadata] = img
 
         # As a final pass, identify images with identical versions and specificity but
-        # differing contents
-        upgrade_collisions: defaultdict[defaultdict[list]] = defaultdict(
-            lambda: defaultdict(list)
-        )
+        # differing contents.
+        # Structure: {(version, specificity): {serialized_firmware: [images]}}
+        upgrade_collisions: defaultdict[
+            tuple[int, int], defaultdict[bytes, list[OtaImageWithMetadata]]
+        ] = defaultdict(lambda: defaultdict(list))
 
         for img in upgrades.values():
             assert img.firmware is not None

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -31,6 +31,7 @@ from zigpy.config import (
 )
 from zigpy.ota.image import BaseOTAImage
 import zigpy.ota.providers
+import zigpy.profiles.zha
 import zigpy.types as t
 import zigpy.util
 from zigpy.zcl import foundation

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -534,15 +534,8 @@ class OTA:
         # eventually check in, just not every time.
         if jitter is None:
             num_devices = len(self._application.devices)
-            jitter = int(
-                100
-                * min(
-                    max(
-                        0.0, MAX_DEVICES_CHECKING_IN_PER_BROADCAST / max(1, num_devices)
-                    ),
-                    1,
-                )
-            )
+            ratio = MAX_DEVICES_CHECKING_IN_PER_BROADCAST / max(1, num_devices)
+            jitter = int(100 * min(max(0.0, ratio), 1.0))
 
         hdr, request = Ota._create_request(
             self=None,

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -366,7 +366,7 @@ class OTA:
     @zigpy.util.combine_concurrent_calls
     async def _load_provider_index(
         self, provider: zigpy.ota.providers.BaseOtaProvider
-    ) -> list[zigpy.ota.providers.BaseOtaImageMetadata]:
+    ) -> list[zigpy.ota.providers.BaseOtaImageMetadata] | None:
         """Load the index of a provider."""
         async with asyncio_timeout(OTA_FETCH_TIMEOUT):
             return await provider.load_index()

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -49,8 +49,8 @@ MAX_DEVICES_CHECKING_IN_PER_BROADCAST = 15
 
 @dataclasses.dataclass(frozen=True)
 class OtaImagesResult(t.BaseDataclassMixin):
-    upgrades: tuple[zigpy.ota.providers.BaseOtaImageMetadata]
-    downgrades: tuple[zigpy.ota.providers.BaseOtaImageMetadata]
+    upgrades: tuple[OtaImageWithMetadata, ...]
+    downgrades: tuple[OtaImageWithMetadata, ...]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -39,6 +39,7 @@ from zigpy.zcl.clusters.general import Ota
 
 if typing.TYPE_CHECKING:
     import zigpy.application
+    import zigpy.device
 
     query_next_image = Ota.ServerCommandDefs.query_next_image.schema
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -534,8 +534,14 @@ class OTA:
         # eventually check in, just not every time.
         if jitter is None:
             num_devices = len(self._application.devices)
-            jitter = 100 * min(
-                max(0, MAX_DEVICES_CHECKING_IN_PER_BROADCAST / max(1, num_devices)), 1
+            jitter = int(
+                100
+                * min(
+                    max(
+                        0.0, MAX_DEVICES_CHECKING_IN_PER_BROADCAST / max(1, num_devices)
+                    ),
+                    1,
+                )
             )
 
         hdr, request = Ota._create_request(

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -108,7 +108,7 @@ class OTAImageHeader(t.Struct):
     )
 
     @property
-    def security_credential_version_present(self) -> bool:
+    def security_credential_version_present(self) -> bool | None:
         if self.field_control is None:
             return None
         return bool(
@@ -116,13 +116,13 @@ class OTAImageHeader(t.Struct):
         )
 
     @property
-    def device_specific_file(self) -> bool:
+    def device_specific_file(self) -> bool | None:
         if self.field_control is None:
             return None
         return bool(self.field_control & FieldControl.DEVICE_SPECIFIC_FILE_PRESENT)
 
     @property
-    def hardware_versions_present(self) -> bool:
+    def hardware_versions_present(self) -> bool | None:
         if self.field_control is None:
             return None
         return bool(self.field_control & FieldControl.HARDWARE_VERSIONS_PRESENT)

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -77,8 +77,8 @@ class BaseOtaImageMetadata(t.BaseDataclassMixin):
     checksum: str | None = None
     file_size: int | None = None
 
-    manufacturer_names: tuple[str] = ()
-    model_names: tuple[str] = ()
+    manufacturer_names: tuple[str, ...] = ()
+    model_names: tuple[str, ...] = ()
 
     changelog: str | None = None
     release_notes: str | None = None

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -25,6 +25,9 @@ from zigpy.ota.image import BaseOTAImage, parse_ota_image
 import zigpy.types as t
 import zigpy.util
 
+if typing.TYPE_CHECKING:
+    import zigpy.device
+
 LOGGER = logging.getLogger(__name__)
 
 # `openssl s_client -connect fw.ota.homesmart.ikea.com:443 -showcerts`

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -188,7 +188,7 @@ class SignedIkeaRemoteOtaImageMetadata(IkeaRemoteOtaImageMetadata):
 
 class BaseOtaProvider:
     NAME: str
-    MANUFACTURER_IDS: tuple[int] = ()
+    MANUFACTURER_IDS: tuple[int, ...] = ()
     DEFAULT_URL: str | None = None
     VOL_SCHEMA: vol.Schema
     JSON_SCHEMA: dict | None = None


### PR DESCRIPTION
## Proposed changes
- Fixes some typing related issues in various OTA modules.
- `jitter` is now also converted from a `float` to an `int`. I guess zigpy must have done an implicit conversion later?
- Adds a missing import needed for `zigpy.profiles.zha.PROFILE_ID` (only imported implicitly before by something else).