### PR TITLE
Fix mypy `type-arg` and `return-value` ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,6 @@ show_error_context = true
 error_summary = true
 disable_error_code = [
     # Only a few notifications left:
-    "return-value",
     "valid-type",
     "misc",
     "attr-defined",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,8 +252,6 @@ show_error_context = true
 error_summary = true
 disable_error_code = [
     # Only a few notifications left:
-    "type-arg",
-    # Only a few notifications left:
     "return-value",
     "valid-type",
     "misc",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -64,8 +64,8 @@ def test_fractional_ints_corner():
     with pytest.raises(TypeError):
         n.serialize()
 
-    assert t.uint1_t(0).bits() == [0]
-    assert t.uint1_t(1).bits() == [1]
+    assert t.uint1_t(0).bits() == t.Bits([0])
+    assert t.uint1_t(1).bits() == t.Bits([1])
 
     assert t.uint1_t.from_bits([1, 1]) == (1, [1])
     assert t.uint1_t.from_bits([0, 1]) == (1, [0])
@@ -92,9 +92,9 @@ def test_fractional_ints_larger():
     with pytest.raises(TypeError):
         n.serialize()
 
-    assert t.uint7_t(0).bits() == [0, 0, 0, 0, 0, 0, 0]
-    assert t.uint7_t(1).bits() == [0, 0, 0, 0, 0, 0, 1]
-    assert t.uint7_t(0b1011111).bits() == [1, 0, 1, 1, 1, 1, 1]
+    assert t.uint7_t(0).bits() == t.Bits([0, 0, 0, 0, 0, 0, 0])
+    assert t.uint7_t(1).bits() == t.Bits([0, 0, 0, 0, 0, 0, 1])
+    assert t.uint7_t(0b1011111).bits() == t.Bits([1, 0, 1, 1, 1, 1, 1])
 
     assert t.uint7_t.from_bits([1, 0, 1, 1, 1, 1, 0, 1, 1, 1]) == (0b1110111, [1, 0, 1])
 
@@ -126,10 +126,10 @@ def test_ints_signed():
     with pytest.raises(TypeError):
         n.serialize()
 
-    assert int7s(0).bits() == [0, 0, 0, 0, 0, 0, 0]
-    assert int7s(1).bits() == [0, 0, 0, 0, 0, 0, 1]
-    assert int7s(-1).bits() == [1, 1, 1, 1, 1, 1, 1]
-    assert int7s(2**6 - 1).bits() == [0, 1, 1, 1, 1, 1, 1]
+    assert int7s(0).bits() == t.Bits([0, 0, 0, 0, 0, 0, 0])
+    assert int7s(1).bits() == t.Bits([0, 0, 0, 0, 0, 0, 1])
+    assert int7s(-1).bits() == t.Bits([1, 1, 1, 1, 1, 1, 1])
+    assert int7s(2**6 - 1).bits() == t.Bits([0, 1, 1, 1, 1, 1, 1])
 
     assert int7s.from_bits([1, 0, 1, 0, 1, 1, 0, 1, 1, 1]) == (0b0110111, [1, 0, 1])
 
@@ -139,8 +139,8 @@ def test_ints_signed():
     t.int8s.deserialize(b"\xff")
 
     n = t.int8s(-126)
-    bits = [1, 0] + t.Bits.deserialize(n.serialize())[0]
-    assert t.int8s.from_bits(bits) == (n, [1, 0])
+    bits = t.Bits([1, 0]) + t.Bits.deserialize(n.serialize())[0]
+    assert t.int8s.from_bits(bits) == (n, t.Bits([1, 0]))
 
 
 def test_bigendian_ints():
@@ -156,9 +156,9 @@ def test_bigendian_ints():
 
 
 def test_bits():
-    assert t.Bits() == []
+    assert t.Bits() == t.Bits([])
     assert t.Bits([1] + [0] * 15).serialize() == b"\x80\x00"
-    assert t.Bits.deserialize(b"\x80\x00") == ([1] + [0] * 15, b"")
+    assert t.Bits.deserialize(b"\x80\x00") == (t.Bits([1] + [0] * 15), b"")
 
     bits = t.Bits([0] * 7)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -158,6 +158,7 @@ def test_bigendian_ints():
 
 def test_bits():
     assert t.Bits() == t.Bits([])
+    assert t.Bits([1]) != [1]
     assert t.Bits([1] + [0] * 15).serialize() == b"\x80\x00"
     assert t.Bits.deserialize(b"\x80\x00") == (t.Bits([1] + [0] * 15), b"")
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -457,7 +457,7 @@ def test_fixedlist():
 
 def test_lvlist_types():
     # Brackets create singleton types
-    anon_lst1 = t.LVList[t.uint16_t]
+    anon_lst1 = t.LVList[t.uint16_t, t.uint8_t]
     anon_lst2 = t.LVList[t.uint16_t, t.uint8_t]
 
     assert anon_lst1._length_type is t.uint8_t
@@ -489,11 +489,20 @@ def test_lvlist_types():
     )
 
     # Similar-looking classes are not compatible
-    class NewListType(list, metaclass=t.KwargTypeMeta):
-        _item_type = None
-        _length_type = t.uint8_t
+    class NewListType[T: type[t.Serializable], V: type[t.uint_t]](
+        list, metaclass=t.KwargTypeMeta
+    ):
+        _item_type: T | None
+        _length_type: V | None
 
-        _getitem_kwargs = {"item_type": None, "length_type": t.uint8_t}
+        _getitem_kwargs = {"item_type": None, "length_type": None}
+
+        def __init_subclass__(cls, item_type: T, length_type: V) -> None:
+            if item_type is not None:
+                cls._item_type = item_type
+
+            if length_type is not None:
+                cls._length_type = length_type
 
     class NewList(NewListType, item_type=t.uint16_t, length_type=t.uint8_t):
         pass

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -499,7 +499,9 @@ def test_lvlist_types():
 
         _getitem_kwargs = {"item_type": None, "length_type": None}
 
-        def __init_subclass__(cls, item_type: type[_T], length_type: type[_V]) -> None:
+        def __init_subclass__(
+            cls, item_type: type[_T] | None = None, length_type: type[_V] | None = None
+        ) -> None:
             if item_type is not None:
                 cls._item_type = item_type
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,7 @@
 import itertools
 import math
 import struct
+from typing import Generic, TypeVar
 
 import pytest
 
@@ -489,15 +490,16 @@ def test_lvlist_types():
     )
 
     # Similar-looking classes are not compatible
-    class NewListType[T: type[t.Serializable], V: type[t.uint_t]](
-        list, metaclass=t.KwargTypeMeta
-    ):
-        _item_type: T | None
-        _length_type: V | None
+    _T = TypeVar("_T", bound=t.Serializable)
+    _V = TypeVar("_V", bound=t.uint_t)
+
+    class NewListType(list, Generic[_T, _V], metaclass=t.KwargTypeMeta):
+        _item_type: type[_T] | None
+        _length_type: type[_V] | None
 
         _getitem_kwargs = {"item_type": None, "length_type": None}
 
-        def __init_subclass__(cls, item_type: T, length_type: V) -> None:
+        def __init_subclass__(cls, item_type: type[_T], length_type: type[_V]) -> None:
             if item_type is not None:
                 cls._item_type = item_type
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import math
 import struct
 from typing import Generic, TypeVar
@@ -641,6 +642,14 @@ def test_keydata():
     assert list(key) == list(data)
     assert key.serialize() == data
     assert t.KeyData(key) == key
+
+
+def test_deprecated_enum_factory(caplog) -> None:
+    with caplog.at_level(logging.ERROR):
+        assert t.enum_factory(t.uint8_t) is t.enum8
+
+    with caplog.at_level(logging.ERROR):
+        assert t.enum_factory(t.uint16_t) is t.enum16
 
 
 def test_enum_uint():

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1587,7 +1587,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         )
         await self.permit_ncp(time_s)
 
-    def get_sequence(self) -> t.uint8_t:
+    def get_sequence(self) -> int:
         self._send_sequence = (self._send_sequence + 1) % 256
         return self._send_sequence
 

--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -14,22 +14,24 @@ import logging
 import math
 import types
 import typing
-from typing import Any, Self
+from typing import Any, Generic, Self, TypeVar
 import warnings
 
 _LOGGER = logging.getLogger(__name__)
 
+_T = TypeVar("_T", bound=contextlib.AbstractAsyncContextManager)
 
-class WrappedContextManager[T: contextlib.AbstractAsyncContextManager]:
+
+class WrappedContextManager(Generic[_T]):
     def __init__(
         self,
-        context_manager: T,
+        context_manager: _T,
         on_enter: typing.Callable[[], Coroutine[Any, Any, Any]],
     ) -> None:
         self.on_enter = on_enter
         self.context_manager = context_manager
 
-    async def __aenter__(self) -> T:
+    async def __aenter__(self) -> _T:
         await self.on_enter()
         return self.context_manager
 

--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import bisect
 import collections
+from collections.abc import Coroutine
 import contextlib
 from fractions import Fraction
 import functools
@@ -13,21 +14,22 @@ import logging
 import math
 import types
 import typing
+from typing import Any, Self
 import warnings
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class WrappedContextManager:
+class WrappedContextManager[T: contextlib.AbstractAsyncContextManager]:
     def __init__(
         self,
-        context_manager: contextlib.AbstractAsyncContextManager,
-        on_enter: typing.Callable[[], typing.Awaitable[None]],
+        context_manager: T,
+        on_enter: typing.Callable[[], Coroutine[Any, Any, Any]],
     ) -> None:
         self.on_enter = on_enter
         self.context_manager = context_manager
 
-    async def __aenter__(self) -> None:
+    async def __aenter__(self) -> T:
         await self.on_enter()
         return self.context_manager
 
@@ -48,9 +50,9 @@ class PriorityDynamicBoundedSemaphore:
         self._max_value: int = value
         self._comparison_counter: int = 0
         self._waiters: list[tuple[int, int, asyncio.Future]] = []
-        self._loop: asyncio.BaseEventLoop | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
 
-    def _get_loop(self) -> asyncio.BaseEventLoop:
+    def _get_loop(self) -> asyncio.AbstractEventLoop:
         loop = asyncio.get_running_loop()
 
         if self._loop is None:
@@ -170,7 +172,7 @@ class PriorityDynamicBoundedSemaphore:
         self._value += 1
         self._wake_up_next()
 
-    def __call__(self, priority: int = 0) -> WrappedContextManager:
+    def __call__(self, priority: int = 0) -> WrappedContextManager[Self]:
         """Allows specifying the priority by calling the context manager.
 
         This allows both `async with sem:` and `async with sem(priority=5):`.
@@ -268,7 +270,7 @@ class Debouncer:
         self._dedup_counter: int = 0
 
     @functools.cached_property
-    def _loop(self) -> asyncio.BaseEventLoop:
+    def _loop(self) -> asyncio.AbstractEventLoop:
         return asyncio.get_running_loop()
 
     def clean(self, now: float | None = None) -> None:
@@ -383,7 +385,7 @@ class RequestLimiter:
         self._wake_waiters()
 
     @property
-    def max_value(self) -> None:
+    def max_value(self) -> int:
         """Deprecated alias for `max_concurrency`."""
         warnings.warn(
             "`max_value` is deprecated, use `max_concurrency` instead",

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -595,7 +595,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     f"Duplicate request key: {rsp_key}"
                 )
 
-            future: asyncio.Future[list[typing.Any, ...] | foundation.CommandSchema] = (
+            future: asyncio.Future[list[typing.Any] | foundation.CommandSchema] = (
                 asyncio.Future()
             )
             self._requests[rsp_key] = future

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -198,7 +198,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
             yield
 
-    def get_sequence(self) -> t.uint8_t:
+    def get_sequence(self) -> int:
         self._send_sequence = (self._send_sequence + 1) % 256
         return self._send_sequence
 
@@ -748,8 +748,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         endpoint = self.endpoints[packet.src_ep]
 
         if packet.src_ep == zdo.ZDO_ENDPOINT:
+            assert isinstance(endpoint, zigpy.zdo.ZDO)
             return endpoint, None
         else:
+            assert isinstance(endpoint, zigpy.endpoint.Endpoint)
             try:
                 zcl_cluster = self._find_zcl_cluster(hdr, packet)
             except KeyError:
@@ -902,7 +904,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         image: OtaImageWithMetadata,
         progress_callback: callable | None = None,
         force: bool = False,
-    ) -> foundation.Status:
+    ) -> foundation.Status | None:
         """Update device firmware."""
         if self.ota_in_progress:
             self.debug("OTA already in progress")

--- a/zigpy/group.py
+++ b/zigpy/group.py
@@ -36,7 +36,7 @@ class Group(ListenableMixin, dict):
         if groups is not None:
             self.add_listener(groups)
 
-    def get_sequence(self) -> t.uint8_t:
+    def get_sequence(self) -> int:
         self._send_sequence = (self._send_sequence + 1) % 256
         return self._send_sequence
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -1018,9 +1018,9 @@ class List(list, Generic[_T], metaclass=KwargTypeMeta):
 
 class LVList(list, Generic[_T, _V], metaclass=KwargTypeMeta):
     _item_type: type[_T] | None
-    _length_type: type[_V] | None
+    _length_type: type[_V] = uint8_t
 
-    _getitem_kwargs = {"item_type": None, "length_type": None}
+    _getitem_kwargs = {"item_type": None, "length_type": uint8_t}
 
     def __init_subclass__(
         cls, item_type: type[_T] | None = None, length_type: type[_V] | None = None

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -919,11 +919,7 @@ class LongOctetString(LVBytes):
 
 class KwargTypeMeta(type):
     # So things like `LVList[NWK, t.uint8_t]` are singletons
-    _anonymous_classes = {}  # type:ignore[var-annotated]
-
-    # def __new__(cls, name, bases, namespaces, **kwargs):
-    #    cls_kwarg_attrs = namespaces.get("_getitem_kwargs", {})
-    #    return type.__new__(cls, name, bases, namespaces, **kwargs)
+    _anonymous_classes: dict[tuple[type, tuple[type, ...]], type] = {}
 
     def __getitem__(cls, key):
         # Make sure Foo[a] is the same as Foo[a,]

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 import enum
 import inspect
 import struct
@@ -15,9 +16,36 @@ class Serializable(Protocol):
     def deserialize(cls, data: bytes) -> tuple[Self, bytes]: ...
 
 
-class Bits(list):
+class Bits:
+    def __init__(self, bits: list[int] | None = None) -> None:
+        self._bits: list[int] = bits or []
+
+    def __len__(self) -> int:
+        return len(self._bits)
+
+    def __getitem__(self, index: slice) -> Self:
+        return type(self)(self._bits[index])
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self._bits)
+
+    def extend(self, bits: list[int]) -> None:
+        self._bits.extend(bits)
+
+    def __repr__(self) -> str:
+        return f"Bits({self._bits})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return self._bits == other._bits
+
+    def __add__(self, other: Self) -> Self:
+        return type(self)(self._bits + other._bits)
+
     @classmethod
-    def from_bitfields(cls, fields):
+    def from_bitfields(cls, fields: list[FixedIntType]) -> Self:
         instance = cls()
 
         # Little endian, so [11, 1000, 00] will be packed as 00_1000_11
@@ -35,7 +63,7 @@ class Bits(list):
         for index in range(0, len(self), 8):
             byte = 0x00
 
-            for bit in self[index : index + 8]:
+            for bit in self._bits[index : index + 8]:
                 byte <<= 1
                 byte |= bit
 
@@ -44,7 +72,7 @@ class Bits(list):
         return bytes(serialized_bytes)
 
     @classmethod
-    def deserialize(cls, data) -> tuple[Bits, bytes]:
+    def deserialize(cls, data) -> tuple[Self, bytes]:
         bits: list[int] = []
 
         for byte in data:
@@ -379,7 +407,7 @@ class AlwaysCreateEnumType(enum.EnumMeta):
         # by-value search for a matching enum member
         # see if it's in the reverse mapping (for hashable values)
         try:
-            return self._value2member_map_[value]
+            return self._value2member_map_[value]  # type: ignore[return-value]
         except KeyError:
             # Not found, no need to do long O(n) search
             pass
@@ -387,7 +415,7 @@ class AlwaysCreateEnumType(enum.EnumMeta):
             # not there, now do long search -- O(n) behavior
             for member in self._member_map_.values():
                 if member._value_ == value:
-                    return member
+                    return member  # type: ignore[return-value]
         # still not found -- try _missing_ hook
         try:
             exc = None
@@ -402,7 +430,7 @@ class AlwaysCreateEnumType(enum.EnumMeta):
                 and self._boundary_ is enum.EJECT
                 and isinstance(result, int)
             ):
-                return result
+                return result  # type: ignore[return-value]
             else:
                 ve_exc = ValueError(f"{value!r} is not a valid {self.__qualname__}")
                 if result is None and exc is None:

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -4,7 +4,7 @@ from collections.abc import Iterator
 import enum
 import inspect
 import struct
-from typing import Literal, Protocol, Self
+from typing import Generic, Literal, Protocol, Self, TypeVar
 
 
 class Serializable(Protocol):
@@ -992,11 +992,15 @@ class KwargTypeMeta(type):
         return super().__instancecheck__(subclass)
 
 
-class List[T: Serializable](list, metaclass=KwargTypeMeta):
-    _item_type: type[T] | None
+_T = TypeVar("_T", bound="Serializable")
+_V = TypeVar("_V", bound="uint_t")
+
+
+class List(list, Generic[_T], metaclass=KwargTypeMeta):
+    _item_type: type[_T] | None
     _getitem_kwargs = {"item_type": None}
 
-    def __init_subclass__(cls, item_type: type[T] | None = None) -> None:
+    def __init_subclass__(cls, item_type: type[_T] | None = None) -> None:
         if item_type is not None:
             cls._item_type = item_type
 
@@ -1016,14 +1020,14 @@ class List[T: Serializable](list, metaclass=KwargTypeMeta):
         return lst, data
 
 
-class LVList[T: Serializable, V: uint_t](list, metaclass=KwargTypeMeta):
-    _item_type: type[T] | None
-    _length_type: type[V] | None
+class LVList(list, Generic[_T, _V], metaclass=KwargTypeMeta):
+    _item_type: type[_T] | None
+    _length_type: type[_V] | None
 
     _getitem_kwargs = {"item_type": None, "length_type": None}
 
     def __init_subclass__(
-        cls, item_type: type[T] | None = None, length_type: type[V] | None = None
+        cls, item_type: type[_T] | None = None, length_type: type[_V] | None = None
     ) -> None:
         if item_type is not None:
             cls._item_type = item_type
@@ -1054,14 +1058,14 @@ class LVList[T: Serializable, V: uint_t](list, metaclass=KwargTypeMeta):
         return r, data
 
 
-class FixedList[T: Serializable, L: int](list, metaclass=KwargTypeMeta):
-    _item_type: type[T] | None
-    _length: L | None
+class FixedList(list, Generic[_T], metaclass=KwargTypeMeta):
+    _item_type: type[_T] | None
+    _length: int | None
 
     _getitem_kwargs = {"item_type": None, "length": None}
 
     def __init_subclass__(
-        cls, item_type: type[T] | None = None, length: L | None = None
+        cls, item_type: type[_T] | None = None, length: int | None = None
     ) -> None:
         if item_type is not None:
             cls._item_type = item_type

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from collections.abc import Iterator
 import enum
 import inspect
+import logging
 import struct
 from typing import Generic, Literal, Protocol, Self, TypeVar
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Serializable(Protocol):
@@ -525,6 +528,29 @@ class enum16_be(_EnumMixin, uint16_t_be, enum.Enum, metaclass=_IntEnumMeta):
 
 class enum32_be(_EnumMixin, uint32_t_be, enum.Enum, metaclass=_IntEnumMeta):
     pass
+
+
+def enum_factory(base_type: type[FixedIntType]) -> type[enum.Enum]:
+    _LOGGER.error(
+        "enum_factory is internal to zigpy and deprecated. Use the enum types directly."
+    )
+
+    enum_mapping: dict[type[FixedIntType], type[enum.Enum]] = {
+        uint1_t: enum1,
+        uint2_t: enum2,
+        uint3_t: enum3,
+        uint4_t: enum4,
+        uint5_t: enum5,
+        uint6_t: enum6,
+        uint7_t: enum7,
+        uint8_t: enum8,
+        uint16_t: enum16,
+        uint32_t: enum32,
+        uint16_t_be: enum16_be,
+        uint32_t_be: enum32_be,
+    }
+
+    return enum_mapping[base_type]
 
 
 class bitmap2(

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -390,76 +390,30 @@ class uint64_t_be(uint_t_be, bits=64):
     pass
 
 
-class AlwaysCreateEnumType(enum.EnumMeta):
-    """Enum metaclass that skips the functional creation API."""
+class _AlwaysCreateEnumMeta(enum.EnumMeta):
+    """An EnumMeta that always creates a new enum member for unknown values."""
 
-    def __call__(self, value, names=None, *values) -> type[enum.Enum]:  # type: ignore[override]  # noqa: N804
-        """Custom implementation of Enum.__new__.
+    def __call__(cls, value, *args, **kwargs) -> type[enum.Enum]:  # type: ignore[override]
+        # Until zigpy stops using constructs like `t.enum8(0xFF)`, we need this check
+        if not cls._member_map_:
+            return cls._missing_(value)
 
-        From https://github.com/python/cpython/blob/v3.11.5/Lib/enum.py#L1091-L1140
-        """
-        # all enum instances are actually created during class construction
-        # without calling this method; this method is called by the metaclass'
-        # __call__ (i.e. Color(3) ), and by pickle
-        if type(value) is self:
-            # For lookups like Color(Color.RED)
-            return value
-        # by-value search for a matching enum member
-        # see if it's in the reverse mapping (for hashable values)
-        try:
-            return self._value2member_map_[value]  # type: ignore[return-value]
-        except KeyError:
-            # Not found, no need to do long O(n) search
-            pass
-        except TypeError:
-            # not there, now do long search -- O(n) behavior
-            for member in self._member_map_.values():
-                if member._value_ == value:
-                    return member  # type: ignore[return-value]
-        # still not found -- try _missing_ hook
-        try:
-            exc = None
-            result = self._missing_(value)
-        except Exception as e:  # noqa: BLE001
-            exc = e
-            result = None
-        try:
-            if isinstance(result, self) or (
-                enum.Flag is not None
-                and issubclass(self, enum.Flag)
-                and self._boundary_ is enum.EJECT
-                and isinstance(result, int)
-            ):
-                return result  # type: ignore[return-value]
-            else:
-                ve_exc = ValueError(f"{value!r} is not a valid {self.__qualname__}")
-                if result is None and exc is None:
-                    raise ve_exc
-                elif exc is None:
-                    exc = TypeError(
-                        f"error in {self.__name__}._missing_: returned {result!r} instead of None or a valid member"
-                    )
-                if not isinstance(exc, ValueError):
-                    exc.__context__ = ve_exc
-                raise exc
-        finally:
-            # ensure all variables that could hold an exception are destroyed
-            exc = None
-            ve_exc = None
+        return super().__call__(value, *args, **kwargs)
 
 
-class _IntEnumMeta(AlwaysCreateEnumType):
-    def __call__(self, value, names=None, *args, **kwargs):  # noqa: N804
+class _IntEnumMeta(_AlwaysCreateEnumMeta):
+    def __call__(cls, value, *args, **kwargs) -> type[enum.Enum]:  # type: ignore[override]
         if isinstance(value, str):
             if value.startswith("0x"):
                 value = int(value, base=16)
             elif value.isnumeric():
                 value = int(value)
-            elif value.startswith(self.__name__ + "."):
-                value = self[value[len(self.__name__) + 1 :]].value
+            elif value.startswith(cls.__name__ + "."):
+                value = cls[value[len(cls.__name__) + 1 :]].value
             else:
-                value = self[value].value
-        return super().__call__(value, names, *args, **kwargs)
+                value = cls[value].value
+
+        return super().__call__(value, *args, **kwargs)
 
     @classmethod
     def _find_data_type_(mcls, class_name, bases):  # noqa: N804
@@ -578,7 +532,7 @@ class bitmap2(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -588,7 +542,7 @@ class bitmap3(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -598,7 +552,7 @@ class bitmap4(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -608,7 +562,7 @@ class bitmap5(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -618,7 +572,7 @@ class bitmap6(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -628,7 +582,7 @@ class bitmap7(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -638,7 +592,7 @@ class bitmap8(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -648,7 +602,7 @@ class bitmap16(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -658,7 +612,7 @@ class bitmap24(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -668,7 +622,7 @@ class bitmap32(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -678,7 +632,7 @@ class bitmap40(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -688,7 +642,7 @@ class bitmap48(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -698,7 +652,7 @@ class bitmap56(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -708,7 +662,7 @@ class bitmap64(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -718,7 +672,7 @@ class bitmap16_be(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -728,7 +682,7 @@ class bitmap24_be(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -738,7 +692,7 @@ class bitmap32_be(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -748,7 +702,7 @@ class bitmap40_be(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -758,7 +712,7 @@ class bitmap48_be(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -768,7 +722,7 @@ class bitmap56_be(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 
@@ -778,7 +732,7 @@ class bitmap64_be(
     enum.ReprEnum,
     enum.Flag,
     boundary=enum.KEEP,
-    metaclass=AlwaysCreateEnumType,
+    metaclass=_AlwaysCreateEnumMeta,
 ):
     pass
 

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import enum
 import inspect
 import struct
-from typing import Literal, Self
+from typing import Literal, Protocol, Self
+
+
+class Serializable(Protocol):
+    def __init__(self, *args, **kwargs) -> None: ...
+
+    def serialize(self) -> bytes: ...
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]: ...
 
 
 class Bits(list):
@@ -884,22 +893,9 @@ class KwargTypeMeta(type):
     # So things like `LVList[NWK, t.uint8_t]` are singletons
     _anonymous_classes = {}  # type:ignore[var-annotated]
 
-    def __new__(cls, name, bases, namespaces, **kwargs):
-        cls_kwarg_attrs = namespaces.get("_getitem_kwargs", {})
-
-        def __init_subclass__(cls, **kwargs):
-            filtered_kwargs = kwargs.copy()
-
-            for key in kwargs:
-                if key in cls_kwarg_attrs:
-                    setattr(cls, f"_{key}", filtered_kwargs.pop(key))
-
-            super().__init_subclass__(**filtered_kwargs)
-
-        if "__init_subclass__" not in namespaces:
-            namespaces["__init_subclass__"] = __init_subclass__
-
-        return type.__new__(cls, name, bases, namespaces, **kwargs)
+    # def __new__(cls, name, bases, namespaces, **kwargs):
+    #    cls_kwarg_attrs = namespaces.get("_getitem_kwargs", {})
+    #    return type.__new__(cls, name, bases, namespaces, **kwargs)
 
     def __getitem__(cls, key):
         # Make sure Foo[a] is the same as Foo[a,]
@@ -968,9 +964,13 @@ class KwargTypeMeta(type):
         return super().__instancecheck__(subclass)
 
 
-class List(list, metaclass=KwargTypeMeta):
-    _item_type = None
+class List[T: Serializable](list, metaclass=KwargTypeMeta):
+    _item_type: type[T] | None
     _getitem_kwargs = {"item_type": None}
+
+    def __init_subclass__(cls, item_type: type[T] | None = None) -> None:
+        if item_type is not None:
+            cls._item_type = item_type
 
     def serialize(self) -> bytes:
         assert self._item_type is not None
@@ -979,8 +979,8 @@ class List(list, metaclass=KwargTypeMeta):
     @classmethod
     def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
         assert cls._item_type is not None
-
         lst = cls()
+
         while data:
             item, data = cls._item_type.deserialize(data)
             lst.append(item)
@@ -988,34 +988,58 @@ class List(list, metaclass=KwargTypeMeta):
         return lst, data
 
 
-class LVList(list, metaclass=KwargTypeMeta):
-    _item_type = None
-    _length_type = uint8_t
+class LVList[T: Serializable, V: uint_t](list, metaclass=KwargTypeMeta):
+    _item_type: type[T] | None
+    _length_type: type[V] | None
 
-    _getitem_kwargs = {"item_type": None, "length_type": uint8_t}
+    _getitem_kwargs = {"item_type": None, "length_type": None}
+
+    def __init_subclass__(
+        cls, item_type: type[T] | None = None, length_type: type[V] | None = None
+    ) -> None:
+        if item_type is not None:
+            cls._item_type = item_type
+
+        if length_type is not None:
+            cls._length_type = length_type
 
     def serialize(self) -> bytes:
+        assert self._length_type is not None
         assert self._item_type is not None
+
         return self._length_type(len(self)).serialize() + b"".join(
             [self._item_type(i).serialize() for i in self]
         )
 
     @classmethod
     def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
+        assert cls._length_type is not None
         assert cls._item_type is not None
+
         length, data = cls._length_type.deserialize(data)
         r = cls()
+
         for _i in range(length):
             item, data = cls._item_type.deserialize(data)
             r.append(item)
+
         return r, data
 
 
-class FixedList(list, metaclass=KwargTypeMeta):
-    _item_type = None
-    _length = None
+class FixedList[T: Serializable, L: int](list, metaclass=KwargTypeMeta):
+    _item_type: type[T] | None
+    _length: L | None
 
     _getitem_kwargs = {"item_type": None, "length": None}
+
+    def __init_subclass__(
+        cls, item_type: type[T] | None = None, length: L | None = None
+    ) -> None:
+        if item_type is not None:
+            cls._item_type = item_type
+
+        if length is not None:
+            cls._length = length
 
     def serialize(self) -> bytes:
         assert self._length is not None

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -955,7 +955,7 @@ class KwargTypeMeta(type):
         for key in cls._getitem_kwargs:
             key = f"_{key}"
 
-            if getattr(cls, key) != getattr(subclass, key):
+            if getattr(cls, key, None) != getattr(subclass, key, None):
                 return False
 
         return True

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import typing
-from typing import Self
+from typing import TYPE_CHECKING, Self, cast
 
 import zigpy.types as t
 
@@ -30,8 +30,8 @@ class EmptyObject:
 
 @dataclasses.dataclass(frozen=True)
 class StructField:
-    name: str = None
-    type: type = None
+    name: str | None = None
+    type: type | None = None
 
     requires: typing.Callable[[Struct], bool] | None = dataclasses.field(
         default=None, repr=False
@@ -42,7 +42,7 @@ class StructField:
         default=repr, repr=False
     )
 
-    def replace(self, **kwargs) -> StructField:
+    def replace(self, **kwargs) -> Self:
         return dataclasses.replace(self, **kwargs)
 
     def _convert_type(self, value):
@@ -56,6 +56,17 @@ class StructField:
                 f"Failed to convert {self.name}={value!r} from type"
                 f" {type(value)} to {self.type}"
             ) from e
+
+
+if TYPE_CHECKING:
+
+    class ResolvedStructField(StructField):
+        """`StructField` instance with name and type resolved."""
+
+        name: str
+        type: type
+else:
+    ResolvedStructField = StructField
 
 
 class Struct:
@@ -121,7 +132,7 @@ class Struct:
         return instance
 
     @classmethod
-    def _get_fields(cls) -> list[StructField]:
+    def _get_fields(cls) -> list[ResolvedStructField]:
         fields = ListSubclass()
 
         # We need both to throw type errors in case a field is not annotated
@@ -160,12 +171,14 @@ class Struct:
             elif field.type is None:
                 raise TypeError(f"Field {name!r} has no type")
 
-            fields.append(field)
+            fields.append(cast(ResolvedStructField, field))
             setattr(fields, field.name, field)
 
         return fields
 
-    def assigned_fields(self, *, strict=False) -> list[tuple[StructField, typing.Any]]:
+    def assigned_fields(
+        self, *, strict=False
+    ) -> list[tuple[ResolvedStructField, typing.Any]]:
         assigned_fields = ListSubclass()
 
         for field in self.fields:
@@ -270,7 +283,7 @@ class Struct:
 
     @staticmethod
     def _deserialize_internal(
-        fields: list[StructField], data: bytes
+        fields: list[ResolvedStructField], data: bytes
     ) -> tuple[dict[str, typing.Any], bytes]:
         bit_length = 0
         bitfields = []

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -30,7 +30,7 @@ class EmptyObject:
 
 @dataclasses.dataclass(frozen=True)
 class StructField:
-    name: str | None = None
+    name: str = None
     type: type = None
 
     requires: typing.Callable[[Struct], bool] | None = dataclasses.field(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -16,7 +16,7 @@ from zigpy.const import APS_REPLY_TIMEOUT
 import zigpy.types as t
 from zigpy.typing import AddressingMode, EndpointType
 from zigpy.zcl import foundation
-from zigpy.zcl.foundation import BaseAttributeDefs, BaseCommandDefs
+from zigpy.zcl.foundation import BaseAttributeDefs, BaseCommandDefs, CommandSchema
 
 if TYPE_CHECKING:
     from zigpy.appdb import PersistingListener
@@ -287,7 +287,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         cluster.cluster_id = cluster_id
         return cluster
 
-    def deserialize(self, data: bytes) -> tuple[foundation.ZCLHeader, ...]:
+    def deserialize(
+        self, data: bytes
+    ) -> tuple[foundation.ZCLHeader, CommandSchema | bytes]:
         self.debug("Received ZCL frame: %r", data.hex(" "))
 
         hdr, data = foundation.ZCLHeader.deserialize(data)
@@ -332,7 +334,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         *,
         general: bool,
         command_id: foundation.GeneralCommand | int,
-        schema: type[t.Struct],
+        schema: type[CommandSchema],
         manufacturer: int | None = None,
         tsn: int | None = None,
         disable_default_response: bool,
@@ -340,8 +342,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         # Schema args and kwargs
         args: tuple[Any, ...],
         kwargs: Any,
-    ) -> tuple[foundation.ZCLHeader, bytes]:
-        request = schema(*args, **kwargs)  # type:ignore[operator]
+    ) -> tuple[foundation.ZCLHeader, CommandSchema]:
+        request = schema(*args, **kwargs)
         request.serialize()  # Throw an error before generating a new TSN
 
         if tsn is None:

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -627,7 +627,7 @@ class Groups(Cluster):
         view: Final = ZCLCommandDef(id=0x01, schema={"group_id": t.Group})
         get_membership: Final = ZCLCommandDef(
             id=0x02,
-            schema={"groups": t.LVList[t.Group]},
+            schema={"groups": t.LVList[t.Group, t.uint8_t]},
         )
         remove: Final = ZCLCommandDef(id=0x03, schema={"group_id": t.Group})
         remove_all: Final = ZCLCommandDef(id=0x04, schema={})
@@ -651,7 +651,7 @@ class Groups(Cluster):
         )
         get_membership_response: Final = ZCLCommandDef(
             id=0x02,
-            schema={"capacity": t.uint8_t, "groups": t.LVList[t.Group]},
+            schema={"capacity": t.uint8_t, "groups": t.LVList[t.Group, t.uint8_t]},
         )
         remove_response: Final = ZCLCommandDef(
             id=0x03,
@@ -795,7 +795,7 @@ class Scenes(Cluster):
                 "status": foundation.Status,
                 "capacity": t.uint8_t,
                 "group_id": t.Group,
-                "scenes?": t.LVList[t.uint8_t],
+                "scenes?": t.LVList[t.uint8_t, t.uint8_t],
             },
         )
         enhanced_add_response: Final = ZCLCommandDef(
@@ -1324,7 +1324,7 @@ class RSSILocation(Cluster):
             id=0x06,
             schema={
                 "measuring_device": t.EUI64,
-                "neighbors": t.LVList[NeighborInfo],
+                "neighbors": t.LVList[NeighborInfo, t.uint8_t],
             },
         )
         request_own_location: Final = ZCLCommandDef(
@@ -2241,14 +2241,14 @@ class PowerProfile(Cluster):
             id=0x04,
             schema={
                 "power_profile_id": t.uint8_t,
-                "scheduled_phases": t.LVList[ScheduleRecord],
+                "scheduled_phases": t.LVList[ScheduleRecord, t.uint8_t],
             },
         )
         energy_phases_schedule_response: Final = ZCLCommandDef(
             id=0x05,
             schema={
                 "power_profile_id": t.uint8_t,
-                "scheduled_phases": t.LVList[ScheduleRecord],
+                "scheduled_phases": t.LVList[ScheduleRecord, t.uint8_t],
             },
         )
         power_profile_schedule_constraints_request: Final = ZCLCommandDef(
@@ -2275,7 +2275,7 @@ class PowerProfile(Cluster):
             schema={
                 "total_profile_num": t.uint8_t,
                 "power_profile_id": t.uint8_t,
-                "transfer_phases": t.LVList[PowerProfilePhase],
+                "transfer_phases": t.LVList[PowerProfilePhase, t.uint8_t],
             },
         )
         power_profile_response: Final = ZCLCommandDef(
@@ -2283,12 +2283,12 @@ class PowerProfile(Cluster):
             schema={
                 "total_profile_num": t.uint8_t,
                 "power_profile_id": t.uint8_t,
-                "transfer_phases": t.LVList[PowerProfilePhase],
+                "transfer_phases": t.LVList[PowerProfilePhase, t.uint8_t],
             },
         )
         power_profile_state_response: Final = ZCLCommandDef(
             id=0x02,
-            schema={"power_profiles": t.LVList[PowerProfileType]},
+            schema={"power_profiles": t.LVList[PowerProfileType, t.uint8_t]},
         )
         get_power_profile_price: Final = ZCLCommandDef(
             id=0x03,
@@ -2296,7 +2296,7 @@ class PowerProfile(Cluster):
         )
         power_profile_state_notification: Final = ZCLCommandDef(
             id=0x04,
-            schema={"power_profiles": t.LVList[PowerProfileType]},
+            schema={"power_profiles": t.LVList[PowerProfileType, t.uint8_t]},
         )
         get_overall_schedule_price: Final = ZCLCommandDef(id=0x05, schema={})
         energy_phases_schedule_request: Final = ZCLCommandDef(

--- a/zigpy/zcl/clusters/lightlink.py
+++ b/zigpy/zcl/clusters/lightlink.py
@@ -218,7 +218,7 @@ class LightLink(Cluster):
                 "inter_pan_transaction_id": t.uint32_t,
                 "num_sub_devices": t.uint8_t,
                 "start_index": t.uint8_t,
-                "device_info_records": t.LVList[DeviceInfoRecord],
+                "device_info_records": t.LVList[DeviceInfoRecord, t.uint8_t],
             },
         )
         network_start_rsp: Final = ZCLCommandDef(
@@ -263,7 +263,7 @@ class LightLink(Cluster):
             schema={
                 "total": t.uint8_t,
                 "start_index": t.uint8_t,
-                "group_info_records": t.LVList[GroupInfoRecord],
+                "group_info_records": t.LVList[GroupInfoRecord, t.uint8_t],
             },
         )
         get_endpoint_list_rsp: Final = ZCLCommandDef(
@@ -271,6 +271,6 @@ class LightLink(Cluster):
             schema={
                 "total": t.uint8_t,
                 "start_index": t.uint8_t,
-                "endpoint_info_records": t.LVList[EndpointInfoRecord],
+                "endpoint_info_records": t.LVList[EndpointInfoRecord, t.uint8_t],
             },
         )

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -258,7 +258,7 @@ class IasAce(Cluster):
         bypass: Final = ZCLCommandDef(
             id=0x01,
             schema={
-                "zones_ids": t.LVList[t.uint8_t],
+                "zones_ids": t.LVList[t.uint8_t, t.uint8_t],
                 "arm_disarm_code": t.CharacterString,
             },
         )
@@ -347,17 +347,17 @@ class IasAce(Cluster):
         )
         set_bypassed_zone_list: Final = ZCLCommandDef(
             id=0x06,
-            schema={"zone_ids": t.LVList[t.uint8_t]},
+            schema={"zone_ids": t.LVList[t.uint8_t, t.uint8_t]},
         )
         bypass_response: Final = ZCLCommandDef(
             id=0x07,
-            schema={"bypass_results": t.LVList[BypassResponse]},
+            schema={"bypass_results": t.LVList[BypassResponse, t.uint8_t]},
         )
         get_zone_status_response: Final = ZCLCommandDef(
             id=0x08,
             schema={
                 "zone_status_complete": t.Bool,
-                "zone_statuses": t.LVList[ZoneStatusRsp],
+                "zone_statuses": t.LVList[ZoneStatusRsp, t.uint8_t],
             },
         )
 

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1053,7 +1053,7 @@ class ZCLHeader(t.Struct):
         return super().__new__(cls, frame_control, manufacturer, tsn, command_id)
 
     @property
-    def direction(self) -> bool:
+    def direction(self) -> Direction:
         """Return direction of Frame Control."""
         return self.frame_control.direction
 

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -40,8 +40,8 @@ class SimpleDescriptor(t.Struct):
     profile: t.uint16_t
     device_type: t.uint16_t
     device_version: t.uint8_t
-    input_clusters: t.LVList[t.uint16_t]
-    output_clusters: t.LVList[t.uint16_t]
+    input_clusters: t.LVList[t.uint16_t, t.uint8_t]
+    output_clusters: t.LVList[t.uint16_t, t.uint8_t]
 
 
 class SizePrefixedSimpleDescriptor(SimpleDescriptor):
@@ -327,7 +327,7 @@ class Neighbors(t.Struct):
 
     Entries: t.uint8_t
     StartIndex: t.uint8_t
-    NeighborTableList: t.LVList[Neighbor]
+    NeighborTableList: t.LVList[Neighbor, t.uint8_t]
 
 
 class RouteStatus(t.enum3):
@@ -366,7 +366,7 @@ class Route(t.Struct):
 class Routes(t.Struct):
     Entries: t.uint8_t
     StartIndex: t.uint8_t
-    RoutingTableList: t.LVList[Route]
+    RoutingTableList: t.LVList[Route, t.uint8_t]
 
 
 CHANNEL_CHANGE_REQ = 0xFE
@@ -550,8 +550,8 @@ CLUSTERS = {
     ZDOCmd.Match_Desc_req: (
         NWKI,
         ("ProfileID", t.uint16_t),
-        ("InClusterList", t.LVList[t.uint16_t]),
-        ("OutClusterList", t.LVList[t.uint16_t]),
+        ("InClusterList", t.LVList[t.uint16_t, t.uint8_t]),
+        ("OutClusterList", t.LVList[t.uint16_t, t.uint8_t]),
     ),
     # ZDO.Complex_Desc_req: (NWKI, ),
     ZDOCmd.User_Desc_req: (NWKI,),
@@ -568,10 +568,14 @@ CLUSTERS = {
         ("NodeDescSize", t.uint8_t),
         ("PowerDescSize", t.uint8_t),
         ("ActiveEPSize", t.uint8_t),
-        ("SimpleDescSizeList", t.LVList[t.uint8_t]),
+        ("SimpleDescSizeList", t.LVList[t.uint8_t, t.uint8_t]),
     ),
     ZDOCmd.Node_Desc_store_req: (NWK, IEEE, ("NodeDescriptor", NodeDescriptor)),
-    ZDOCmd.Active_EP_store_req: (NWK, IEEE, ("ActiveEPList", t.LVList[t.uint8_t])),
+    ZDOCmd.Active_EP_store_req: (
+        NWK,
+        IEEE,
+        ("ActiveEPList", t.LVList[t.uint8_t, t.uint8_t]),
+    ),
     ZDOCmd.Simple_Desc_store_req: (
         NWK,
         IEEE,
@@ -585,15 +589,15 @@ CLUSTERS = {
         ("StartIndex", t.uint8_t),
     ),
     ZDOCmd.Extended_Active_EP_req: (NWKI, ("StartIndex", t.uint8_t)),
-    ZDOCmd.Parent_annce: (("Children", t.LVList[t.EUI64]),),
+    ZDOCmd.Parent_annce: (("Children", t.LVList[t.EUI64, t.uint8_t]),),
     #  Bind Management Server Services Responses
     ZDOCmd.End_Device_Bind_req: (
         ("BindingTarget", t.uint16_t),
         ("SrcAddress", t.EUI64),
         ("SrcEndpoint", t.uint8_t),
         ("ProfileID", t.uint8_t),
-        ("InClusterList", t.LVList[t.uint8_t]),
-        ("OutClusterList", t.LVList[t.uint8_t]),
+        ("InClusterList", t.LVList[t.uint8_t, t.uint8_t]),
+        ("OutClusterList", t.LVList[t.uint8_t, t.uint8_t]),
     ),
     ZDOCmd.Bind_req: (
         ("SrcAddress", t.EUI64),
@@ -653,8 +657,16 @@ CLUSTERS = {
         NWKI,
         ("SimpleDescriptor", t.Optional(SizePrefixedSimpleDescriptor)),
     ),
-    ZDOCmd.Active_EP_rsp: (STATUS, NWKI, ("ActiveEPList", t.LVList[t.uint8_t])),
-    ZDOCmd.Match_Desc_rsp: (STATUS, NWKI, ("MatchList", t.LVList[t.uint8_t])),
+    ZDOCmd.Active_EP_rsp: (
+        STATUS,
+        NWKI,
+        ("ActiveEPList", t.LVList[t.uint8_t, t.uint8_t]),
+    ),
+    ZDOCmd.Match_Desc_rsp: (
+        STATUS,
+        NWKI,
+        ("MatchList", t.LVList[t.uint8_t, t.uint8_t]),
+    ),
     # ZDO.Complex_Desc_rsp: (
     #     STATUS,
     #     NWKI,
@@ -693,7 +705,7 @@ CLUSTERS = {
         ("StartIndex", t.uint8_t),
         ("ActiveEPList", t.List[t.uint8_t]),
     ),
-    ZDOCmd.Parent_annce_rsp: (STATUS, ("Children", t.LVList[t.EUI64])),
+    ZDOCmd.Parent_annce_rsp: (STATUS, ("Children", t.LVList[t.EUI64, t.uint8_t])),
     #  Bind Management Server Services Responses
     ZDOCmd.End_Device_Bind_rsp: (STATUS,),
     ZDOCmd.Bind_rsp: (STATUS,),
@@ -706,7 +718,7 @@ CLUSTERS = {
         STATUS,
         ("BindingTableEntries", t.uint8_t),
         ("StartIndex", t.uint8_t),
-        ("BindingTableList", t.LVList[Binding]),
+        ("BindingTableList", t.LVList[Binding, t.uint8_t]),
     ),
     # ... TODO optional stuff ...
     ZDOCmd.Mgmt_Leave_rsp: (STATUS,),
@@ -716,7 +728,7 @@ CLUSTERS = {
         ("ScannedChannels", t.Channels),
         ("TotalTransmissions", t.uint16_t),
         ("TransmissionFailures", t.uint16_t),
-        ("EnergyValues", t.LVList[t.uint8_t]),
+        ("EnergyValues", t.LVList[t.uint8_t, t.uint8_t]),
     ),
     # ... TODO optional stuff ...
 }


### PR DESCRIPTION
- The `Bits` type (used only internally) has been rewritten to not be a `list` subclass, for typing (slicing causes issues).
- I originally rewrote `LVList` to require both type arguments due to typing issues but this is seemingly no longer required. I've left the tweaks in, since we can drop the default at any point now (it's again something used in exactly one quirk)

Not strictly required but https://github.com/zigpy/zha-device-handlers/pull/4649 fixes a few issues found while making this change.