### PR TITLE
Use base zigpy dataclass mixin for all `attrs` objects

### DIFF
--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -6,7 +6,7 @@ import hashlib
 import logging
 from typing import Self
 
-import attr
+import attrs
 
 import zigpy.types as t
 
@@ -217,16 +217,16 @@ class OTAImage(t.Struct, BaseOTAImage):
         return res
 
 
-@attr.s
-class HueSBLOTAImage(BaseOTAImage):
+@attrs.define(kw_only=True)
+class HueSBLOTAImage(BaseOTAImage, t.BaseDataclassMixin):
     """Unique OTA image format for certain Hue devices. Starts with a valid header but does
     not contain any valid subelements beyond that point.
     """
 
     SUBELEMENTS_MAGIC = b"\x2a\x00\x01"
 
-    header = attr.ib(default=None)
-    data = attr.ib(default=None)
+    header: OTAImageHeader = None
+    data: bytes = None
 
     def serialize(self) -> bytes:
         return self.header.serialize() + self.data
@@ -254,13 +254,13 @@ class HueSBLOTAImage(BaseOTAImage):
         return cls(header=header, data=firmware), data[header.image_size :]
 
 
-@attr.s(repr=False)
+@attrs.define(kw_only=True, repr=False)
 class TelinkEncryptedSubElement:
     TELINK_ENCRYPTED_TAG_ID = ElementTagId(0xF000)
 
-    tag_id: ElementTagId = attr.ib(default=None, converter=ElementTagId)
-    tag_info: t.uint16_t = attr.ib(default=None)
-    data: bytes = attr.ib(default=None)
+    tag_id: ElementTagId = attrs.field(default=None, converter=ElementTagId)
+    tag_info: t.uint16_t = None
+    data: bytes = None
 
     def __repr__(self) -> str:
         return (
@@ -302,12 +302,12 @@ class TelinkEncryptedSubElement:
         return result
 
 
-@attr.s
-class TelinkOTAImage(BaseOTAImage):
+@attrs.define(kw_only=True)
+class TelinkOTAImage(BaseOTAImage, t.BaseDataclassMixin):
     """Telink OTA image. Includes a proprietary "tag info" after the tag length."""
 
-    header: OTAImageHeader = attr.ib(default=None)
-    subelements: t.List[SubElement | TelinkEncryptedSubElement] = attr.ib(default=None)
+    header: OTAImageHeader = None
+    subelements: t.List[SubElement | TelinkEncryptedSubElement] = None
 
     @classmethod
     def deserialize(cls, data: bytes) -> tuple[Self, bytes]:

--- a/zigpy/ota/image.py
+++ b/zigpy/ota/image.py
@@ -255,7 +255,7 @@ class HueSBLOTAImage(BaseOTAImage, t.BaseDataclassMixin):
 
 
 @attrs.define(kw_only=True, repr=False)
-class TelinkEncryptedSubElement:
+class TelinkEncryptedSubElement(t.BaseDataclassMixin):
     TELINK_ENCRYPTED_TAG_ID = ElementTagId(0xF000)
 
     tag_id: ElementTagId = attrs.field(default=None, converter=ElementTagId)


### PR DESCRIPTION
Fixes https://github.com/zigpy/zigpy/issues/1742.

We have `BaseDataclassMixin` already, which implements `.replace()` on both dataclasses and attrs objects.  The OTA image module was never upgraded to use it.