### PR TITLE
Remove mypy `valid-type` ignore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,4 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [attrs]
+        exclude: ^tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,11 +252,11 @@ show_error_context = true
 error_summary = true
 disable_error_code = [
     # Only a few notifications left:
-    "valid-type",
-    "misc",
-    "attr-defined",
-    "assignment",
-    "arg-type"
+    #"valid-type",  # 78 errors
+    "misc",  # 462 errors
+    "attr-defined",  # 238 errors
+    "assignment",  # 313 errors
+    "arg-type"  # 2709 errors
 ]
 # Only report on selected files
 follow_imports = "silent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,7 @@ non_interactive = true
 show_error_codes = true
 show_error_context = true
 error_summary = true
+exclude = ["^tests/"]
 disable_error_code = [
     # Only a few notifications left:
     "misc",  # 314 errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,10 +252,10 @@ show_error_context = true
 error_summary = true
 disable_error_code = [
     # Only a few notifications left:
-    "misc",  # 462 errors
-    "attr-defined",  # 238 errors
-    "assignment",  # 313 errors
-    "arg-type"  # 2709 errors
+    "misc",  # 314 errors
+    "attr-defined",  # 137 errors
+    "assignment",  # 304 errors
+    "arg-type"  # 2714 errors
 ]
 # Only report on selected files
 follow_imports = "silent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,6 @@ show_error_context = true
 error_summary = true
 disable_error_code = [
     # Only a few notifications left:
-    #"valid-type",  # 78 errors
     "misc",  # 462 errors
     "attr-defined",  # 238 errors
     "assignment",  # 313 errors

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -154,9 +154,7 @@ def test_handle_announce(zdo_f):
     dev._application.devices.pop(dev.ieee)
     hdr = MagicMock()
     hdr.command_id = zdo_types.ZDOCmd.Device_annce
-    zdo_f.handle_message(
-        5, 0x0013, hdr, [dev.nwk, dev.ieee, 0], dst_addressing=sentinel.dst_addr
-    )
+    zdo_f.handle_message(5, 0x0013, hdr, [dev.nwk, dev.ieee, 0])
 
     assert listener.device_announce.call_count == 1
     assert listener.device_announce.call_args[0][0] is dev

--- a/tests/test_zdo.py
+++ b/tests/test_zdo.py
@@ -161,7 +161,7 @@ def test_handle_announce(zdo_f):
 
     assert listener.zdo_device_annce.call_count == 1
     assert listener.zdo_device_annce.call_args[0][0] is dev
-    assert listener.zdo_device_annce.call_args[0][1] is sentinel.dst_addr
+    assert listener.zdo_device_annce.call_args[0][1] is None
     assert listener.zdo_device_annce.call_args[0][2] is hdr
     assert listener.zdo_device_annce.call_args[0][3] == [dev.nwk, dev.ieee, 0]
 

--- a/tests/test_zigbee_util.py
+++ b/tests/test_zigbee_util.py
@@ -425,17 +425,6 @@ def test_picking_optimal_channel(plot):
     assert util.pick_optimal_channel(channel_energy) == expected_channel
 
 
-def test_singleton():
-    singleton = util.Singleton("NAME")
-
-    assert str(singleton) == repr(singleton) == "<Singleton 'NAME'>"
-    assert singleton == singleton  # noqa: PLR0124
-
-    obj = {}
-    obj[singleton] = 5
-    assert obj[singleton] == 5
-
-
 @pytest.mark.parametrize(
     ("input_relays", "expected_relays"),
     [

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 import types
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
@@ -23,9 +23,12 @@ import zigpy.state
 import zigpy.types as t
 import zigpy.typing
 import zigpy.util
-from zigpy.zcl import ClusterType
+from zigpy.zcl import Cluster, ClusterType
 from zigpy.zcl.clusters.general import Basic
 from zigpy.zdo import types as zdo_t
+
+if TYPE_CHECKING:
+    from zigpy.application import ControllerApplication
 
 LOGGER = logging.getLogger(__name__)
 
@@ -106,7 +109,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def __init__(
         self,
         connection: aiosqlite.Connection,
-        application: zigpy.typing.ControllerApplicationType,
+        application: ControllerApplication,
     ) -> None:
         _register_sqlite_adapters()
 
@@ -146,7 +149,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
     @classmethod
     async def new(
-        cls, database_file: str, app: zigpy.typing.ControllerApplicationType
+        cls, database_file: str, app: ControllerApplication
     ) -> PersistingListener:
         """Create an instance of persisting listener."""
         sqlite_conn = await aiosqlite_connect(
@@ -275,7 +278,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
     def attribute_updated(
         self,
-        cluster: zigpy.typing.ClusterType,
+        cluster: Cluster,
         attrid: int,
         value: Any,
         timestamp: datetime,
@@ -291,7 +294,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             timestamp,
         )
 
-    def attribute_cleared(self, cluster: zigpy.typing.ClusterType, attrid: int) -> None:
+    def attribute_cleared(self, cluster: Cluster, attrid: int) -> None:
         self.enqueue(
             "_clear_attribute",
             cluster.endpoint.device.ieee,
@@ -301,9 +304,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             attrid,
         )
 
-    def unsupported_attribute_added(
-        self, cluster: zigpy.typing.ClusterType, attrid: int
-    ) -> None:
+    def unsupported_attribute_added(self, cluster: Cluster, attrid: int) -> None:
         self.enqueue(
             "_unsupported_attribute_added",
             cluster.endpoint.device.ieee,
@@ -327,9 +328,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self.execute(q, (ieee, endpoint_id, cluster_type, cluster_id, attrid))
         await self._db.commit()
 
-    def unsupported_attribute_removed(
-        self, cluster: zigpy.typing.ClusterType, attrid: int
-    ) -> None:
+    def unsupported_attribute_removed(self, cluster: Cluster, attrid: int) -> None:
         self.enqueue(
             "_unsupported_attribute_removed",
             cluster.endpoint.device.ieee,
@@ -493,6 +492,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._db.executemany(q, rows)
 
     async def _save_node_descriptor(self, device: Device) -> None:
+        if device.node_desc is None:
+            return
+
         q = f"""INSERT INTO node_descriptors{DB_V}
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT (ieee)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -13,7 +13,7 @@ import aiosqlite
 
 import zigpy.appdb_schemas
 import zigpy.backups
-import zigpy.device
+from zigpy.device import Device, Status as DeviceStatus
 import zigpy.endpoint
 import zigpy.exceptions
 import zigpy.group
@@ -227,22 +227,20 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         for statement in sql.split(";"):
             await self.execute(statement)
 
-    def device_joined(self, device: zigpy.typing.DeviceType) -> None:
+    def device_joined(self, device: Device) -> None:
         self.enqueue("_update_device_nwk", device.ieee, device.nwk)
 
     async def _update_device_nwk(self, ieee: t.EUI64, nwk: t.NWK) -> None:
         await self.execute(f"UPDATE devices{DB_V} SET nwk=? WHERE ieee=?", (nwk, ieee))
         await self._db.commit()
 
-    def device_initialized(self, device: zigpy.typing.DeviceType) -> None:
+    def device_initialized(self, device: Device) -> None:
         pass
 
-    def device_left(self, device: zigpy.typing.DeviceType) -> None:
+    def device_left(self, device: Device) -> None:
         pass
 
-    def device_last_seen_updated(
-        self, device: zigpy.typing.DeviceType, last_seen: datetime
-    ) -> None:
+    def device_last_seen_updated(self, device: Device, last_seen: datetime) -> None:
         """Device last_seen time is updated."""
         self.enqueue("_save_device_last_seen", device.ieee, last_seen)
 
@@ -260,9 +258,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         )
         await self._db.commit()
 
-    def device_relays_updated(
-        self, device: zigpy.typing.DeviceType, relays: t.Relays | None
-    ) -> None:
+    def device_relays_updated(self, device: Device, relays: t.Relays | None) -> None:
         """Device relay list is updated."""
         self.enqueue("_save_device_relays", device.ieee, relays)
 
@@ -439,17 +435,17 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self.execute(q, (group.group_id,))
         await self._db.commit()
 
-    def device_removed(self, device: zigpy.typing.DeviceType) -> None:
+    def device_removed(self, device: Device) -> None:
         self.enqueue("_remove_device", device)
 
-    async def _remove_device(self, device: zigpy.typing.DeviceType) -> None:
+    async def _remove_device(self, device: Device) -> None:
         await self.execute(f"DELETE FROM devices{DB_V} WHERE ieee = ?", (device.ieee,))
         await self._db.commit()
 
-    def raw_device_initialized(self, device: zigpy.typing.DeviceType) -> None:
+    def raw_device_initialized(self, device: Device) -> None:
         self.enqueue("_save_device", device)
 
-    async def _save_device(self, device: zigpy.typing.DeviceType) -> None:
+    async def _save_device(self, device: Device) -> None:
         q = f"""INSERT INTO devices{DB_V} (ieee, nwk, status, last_seen)
                     VALUES (?, ?, ?, ?)
                     ON CONFLICT (ieee)
@@ -481,7 +477,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             await self._save_unsupported_attributes(ep)
         await self._db.commit()
 
-    async def _save_endpoints(self, device: zigpy.typing.DeviceType) -> None:
+    async def _save_endpoints(self, device: Device) -> None:
         rows = [
             (
                 device.ieee,
@@ -502,7 +498,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         await self._db.executemany(q, rows)
 
-    async def _save_node_descriptor(self, device: zigpy.typing.DeviceType) -> None:
+    async def _save_node_descriptor(self, device: Device) -> None:
         q = f"""INSERT INTO node_descriptors{DB_V}
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT (ieee)
@@ -772,7 +768,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         async with self.execute(f"SELECT * FROM devices{DB_V}") as cursor:
             async for ieee, nwk, status, last_seen in cursor:
                 dev = self._application.add_device(ieee, nwk)
-                dev.status = zigpy.device.Status(status)
+                dev.status = DeviceStatus(status)
 
                 if last_seen > 0:
                     dev.last_seen = last_seen

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -14,7 +14,7 @@ import aiosqlite
 import zigpy.appdb_schemas
 import zigpy.backups
 from zigpy.device import Device, Status as DeviceStatus
-import zigpy.endpoint
+from zigpy.endpoint import Endpoint, Status as EndpointStatus
 import zigpy.exceptions
 import zigpy.group
 import zigpy.profiles
@@ -396,29 +396,23 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self.execute(q, (group.group_id, group.name))
         await self._db.commit()
 
-    def group_member_added(
-        self, group: zigpy.group.Group, ep: zigpy.typing.EndpointType
-    ) -> None:
+    def group_member_added(self, group: zigpy.group.Group, ep: Endpoint) -> None:
         """Called when a group member is added."""
         self.enqueue("_group_member_added", group, ep)
 
-    async def _group_member_added(
-        self, group: zigpy.group.Group, ep: zigpy.typing.EndpointType
-    ) -> None:
+    async def _group_member_added(self, group: zigpy.group.Group, ep: Endpoint) -> None:
         q = f"""INSERT INTO group_members{DB_V} VALUES (?, ?, ?)
                     ON CONFLICT
                     DO NOTHING"""
         await self.execute(q, (group.group_id, *ep.unique_id))
         await self._db.commit()
 
-    def group_member_removed(
-        self, group: zigpy.group.Group, ep: zigpy.typing.EndpointType
-    ) -> None:
+    def group_member_removed(self, group: zigpy.group.Group, ep: Endpoint) -> None:
         """Called when a group member is removed."""
         self.enqueue("_group_member_removed", group, ep)
 
     async def _group_member_removed(
-        self, group: zigpy.group.Group, ep: zigpy.typing.EndpointType
+        self, group: zigpy.group.Group, ep: Endpoint
     ) -> None:
         q = f"""DELETE FROM group_members{DB_V} WHERE group_id=?
                                                 AND ieee=?
@@ -519,7 +513,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         await self.execute(q, (device.ieee, *device.node_desc.as_tuple()))
 
-    async def _save_clusters(self, endpoint: zigpy.typing.EndpointType) -> None:
+    async def _save_clusters(self, endpoint: Endpoint) -> None:
         clusters = [
             (
                 endpoint.device.ieee,
@@ -534,7 +528,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     DO NOTHING"""
         await self._db.executemany(q, clusters)
 
-    async def _save_attribute_cache(self, ep: zigpy.typing.EndpointType) -> None:
+    async def _save_attribute_cache(self, ep: Endpoint) -> None:
         clusters = [
             (
                 ep.device.ieee,
@@ -553,7 +547,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     DO UPDATE SET value=excluded.value, last_updated=excluded.last_updated"""
         await self._db.executemany(q, clusters)
 
-    async def _save_unsupported_attributes(self, ep: zigpy.typing.EndpointType) -> None:
+    async def _save_unsupported_attributes(self, ep: Endpoint) -> None:
         clusters = [
             (
                 ep.device.ieee,
@@ -786,7 +780,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 dev = self._application.get_device(ieee)
                 ep = dev.add_endpoint(epid)
                 ep.profile_id = profile_id
-                ep.status = zigpy.endpoint.Status(status)
+                ep.status = EndpointStatus(status)
 
                 if profile_id == zigpy.profiles.zha.PROFILE_ID:
                     ep.device_type = zigpy.profiles.zha.DeviceType(device_type)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -21,7 +21,6 @@ import zigpy.profiles
 import zigpy.quirks
 import zigpy.state
 import zigpy.types as t
-import zigpy.typing
 import zigpy.util
 from zigpy.zcl import Cluster, ClusterType
 from zigpy.zcl.clusters.general import Basic

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1279,17 +1279,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         src_ep: int,
         dst_ep: int,
         message: bytes,
-        *,
-        dst_addressing: zigpy.typing.AddressingMode | None = None,
     ):
         """Deprecated compatibility function. Use `packet_received` instead."""
 
         warnings.warn(
             "`handle_message` is deprecated, use `packet_received`", DeprecationWarning
         )
-
-        if dst_addressing is None:
-            dst_addressing = t.AddrMode.NWK
 
         self.packet_received(
             t.ZigbeePacket(
@@ -1299,11 +1294,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 dst_ep=dst_ep,
                 data=t.SerializableBytes(message),
                 src=t.AddrModeAddress(
-                    addr_mode=dst_addressing,
-                    address={
-                        t.AddrMode.NWK: sender.nwk,
-                        t.AddrMode.IEEE: sender.ieee,
-                    }[dst_addressing],
+                    addr_mode=t.AddrMode.NWK,
+                    address=sender.nwk,
                 ),
                 dst=t.AddrModeAddress(
                     addr_mode=t.AddrMode.NWK,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -83,7 +83,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.topology: zigpy.topology.Topology = zigpy.topology.Topology(self)
 
         self._req_listeners: collections.defaultdict[
-            zigpy.device.Device | zigpy.listeners.Singleton,
+            zigpy.device.Device | zigpy.listeners.AnyDeviceType,
             collections.deque[zigpy.listeners.BaseRequestListener],
         ] = collections.defaultdict(lambda: collections.deque([]))
 
@@ -99,7 +99,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def wrap_callback(
         self,
-        src: zigpy.device.Device | zigpy.listeners.ANY_DEVICE,
+        src: zigpy.device.Device | zigpy.listeners.AnyDeviceType,
         callback: typing.Callable[_P, Any],
     ) -> typing.Callable[_P, None]:
         """Wrap a callback to log exceptions and run as task if needed."""
@@ -1366,7 +1366,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def register_callback_listener(
         self,
-        src: zigpy.device.Device | zigpy.listeners.ANY_DEVICE,
+        src: zigpy.device.Device | zigpy.listeners.AnyDeviceType,
         filters: list[zigpy.listeners.MatcherType],
         callback: typing.Callable[
             [
@@ -1393,7 +1393,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     @contextlib.contextmanager
     def callback_for_response(
         self,
-        src: zigpy.device.Device | zigpy.listeners.ANY_DEVICE,
+        src: zigpy.device.Device | zigpy.listeners.AnyDeviceType,
         filters: list[zigpy.listeners.MatcherType],
         callback: typing.Callable[
             [
@@ -1416,7 +1416,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     @contextlib.contextmanager
     def wait_for_response(
         self,
-        src: zigpy.device.Device | zigpy.listeners.ANY_DEVICE,
+        src: zigpy.device.Device | zigpy.listeners.AnyDeviceType,
         filters: list[zigpy.listeners.MatcherType],
     ) -> typing.Any:
         """Context manager to wait for a Zigbee response."""

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -34,7 +34,6 @@ import zigpy.quirks
 import zigpy.state
 import zigpy.topology
 import zigpy.types as t
-import zigpy.typing
 import zigpy.util
 import zigpy.zcl
 import zigpy.zdo

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from asyncio import timeout as asyncio_timeout
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 import contextlib
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -893,7 +893,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     async def update_firmware(
         self,
         image: OtaImageWithMetadata,
-        progress_callback: callable | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
         force: bool = False,
     ) -> foundation.Status | None:
         """Update device firmware."""

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -893,7 +893,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     async def update_firmware(
         self,
         image: OtaImageWithMetadata,
-        progress_callback: Callable[[int, int], None] | None = None,
+        progress_callback: Callable[[int, int, float], None] | None = None,
         force: bool = False,
     ) -> foundation.Status | None:
         """Update device firmware."""

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -36,7 +36,6 @@ import zigpy.listeners
 from zigpy.ota.manager import update_firmware
 from zigpy.profiles import zha, zll
 import zigpy.types as t
-from zigpy.typing import AddressingMode
 import zigpy.util
 from zigpy.zcl import Cluster, ClusterType, foundation
 from zigpy.zcl.clusters.general import Ota, PollControl
@@ -616,17 +615,12 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         src_ep: int,
         dst_ep: int,
         message: bytes,
-        *,
-        dst_addressing: AddressingMode | None = None,
     ):
         """Deprecated compatibility function. Use `packet_received` instead."""
 
         warnings.warn(
             "`handle_message` is deprecated, use `packet_received`", DeprecationWarning
         )
-
-        if dst_addressing is None:
-            dst_addressing = t.AddrMode.NWK
 
         self.packet_received(
             t.ZigbeePacket(
@@ -636,11 +630,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 dst_ep=dst_ep,
                 data=t.SerializableBytes(message),
                 dst=t.AddrModeAddress(
-                    addr_mode=dst_addressing,
-                    address={
-                        t.AddrMode.NWK: self.nwk,
-                        t.AddrMode.IEEE: self.ieee,
-                    }[dst_addressing],
+                    addr_mode=t.AddrMode.NWK,
+                    address=self.nwk,
                 ),
             )
         )

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -2,17 +2,19 @@ from __future__ import annotations
 
 import enum
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from zigpy.const import APS_REPLY_TIMEOUT
 import zigpy.exceptions
 import zigpy.profiles
 import zigpy.types as t
-from zigpy.typing import DeviceType
 import zigpy.util
 import zigpy.zcl
 from zigpy.zcl.foundation import GENERAL_COMMANDS, GeneralCommand, Status as ZCLStatus
 from zigpy.zdo.types import Status as ZDOStatus
+
+if TYPE_CHECKING:
+    from zigpy.device import Device
 
 LOGGER = logging.getLogger(__name__)
 
@@ -31,8 +33,8 @@ class Status(enum.IntEnum):
 class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     """An endpoint on a device on the network"""
 
-    def __init__(self, device: DeviceType, endpoint_id: int) -> None:
-        self._device: DeviceType = device
+    def __init__(self, device: Device, endpoint_id: int) -> None:
+        self._device: Device = device
         self._endpoint_id: int = endpoint_id
         self._listeners: dict = {}
 
@@ -72,9 +74,9 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.device_type = sd.device_type
 
             if self.profile_id == zigpy.profiles.zha.PROFILE_ID:
-                self.device_type = zigpy.profiles.zha.DeviceType(self.device_type)
+                self.device_type = zigpy.profiles.zha.Device(self.device_type)
             elif self.profile_id == zigpy.profiles.zll.PROFILE_ID:
-                self.device_type = zigpy.profiles.zll.DeviceType(self.device_type)
+                self.device_type = zigpy.profiles.zll.Device(self.device_type)
 
             for cluster in sd.input_clusters:
                 self.add_input_cluster(cluster)
@@ -284,7 +286,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         LOGGER.log(lvl, msg, *args, **kwargs)
 
     @property
-    def device(self) -> DeviceType:
+    def device(self) -> Device:
         return self._device
 
     @property

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -74,9 +74,9 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.device_type = sd.device_type
 
             if self.profile_id == zigpy.profiles.zha.PROFILE_ID:
-                self.device_type = zigpy.profiles.zha.Device(self.device_type)
+                self.device_type = zigpy.profiles.zha.DeviceType(self.device_type)
             elif self.profile_id == zigpy.profiles.zll.PROFILE_ID:
-                self.device_type = zigpy.profiles.zll.Device(self.device_type)
+                self.device_type = zigpy.profiles.zll.DeviceType(self.device_type)
 
             for cluster in sd.input_clusters:
                 self.add_input_cluster(cluster)

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -294,7 +294,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return self._endpoint_id
 
     @property
-    def manufacturer(self) -> str:
+    def manufacturer(self) -> str | None:
         if self._manufacturer is not None:
             return self._manufacturer
         return self.device.manufacturer
@@ -317,7 +317,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return self._member_of
 
     @property
-    def model(self) -> str:
+    def model(self) -> str | None:
         if self._model is not None:
             return self._model
         return self.device.model

--- a/zigpy/group.py
+++ b/zigpy/group.py
@@ -179,7 +179,7 @@ class GroupCluster(zigpy.zcl.Cluster):
     """Virtual cluster for group requests."""
 
     @classmethod
-    def from_id(
+    def from_id(  # type: ignore[override]
         cls, group_endpoint: GroupEndpoint, cluster_id: int, is_server=True
     ) -> zigpy.zcl.Cluster:
         """Instantiate from ZCL cluster by cluster id."""

--- a/zigpy/listeners.py
+++ b/zigpy/listeners.py
@@ -2,17 +2,23 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import enum
 import logging
 import typing
 
-from zigpy.util import Singleton
 from zigpy.zcl import foundation
 import zigpy.zdo.types as zdo_t
 
 LOGGER = logging.getLogger(__name__)
 
 
-ANY_DEVICE = Singleton("ANY_DEVICE")
+class AnyDeviceType(enum.Enum):
+    """Singleton type for "any device"."""
+
+    _singleton = 0
+
+
+ANY_DEVICE = AnyDeviceType._singleton  # noqa: SLF001
 
 
 @dataclasses.dataclass(frozen=True)

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -35,13 +35,11 @@ import zigpy.profiles.zha
 import zigpy.types as t
 import zigpy.util
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Ota
+from zigpy.zcl.clusters.general import Ota, QueryNextImageCommand
 
 if typing.TYPE_CHECKING:
     import zigpy.application
     import zigpy.device
-
-    query_next_image = Ota.ServerCommandDefs.query_next_image.schema
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -147,7 +145,7 @@ class OtaImageWithMetadata(t.BaseDataclassMixin):
     def check_compatibility(
         self,
         device: zigpy.device.Device,
-        query_cmd: query_next_image,
+        query_cmd: QueryNextImageCommand,
     ) -> bool:
         """Check if an OTA image and its metadata is compatible with a device."""
         if (
@@ -383,7 +381,7 @@ class OTA:
     async def get_ota_images(
         self,
         device: zigpy.device.Device,
-        query_cmd: query_next_image,
+        query_cmd: QueryNextImageCommand,
     ) -> OtaImagesResult:
         """Get OTA images compatible with the device."""
         # Only consider providers that are compatible with the device

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import contextlib
 from typing import TYPE_CHECKING
 
@@ -306,7 +307,7 @@ class OTAManager:
 async def update_firmware(
     device: Device,
     image: OtaImageWithMetadata,
-    progress_callback: callable | None = None,
+    progress_callback: Callable[[int, int, float], None] | None = None,
     force: bool = False,
 ) -> foundation.Status:
     """Update the firmware on a Zigbee device."""

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING
 import zigpy.datastructures
 import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
-from zigpy.zcl.clusters.general import Ota
+from zigpy.zcl.clusters.general import (
+    ImageBlockCommand,
+    ImagePageCommand,
+    Ota,
+    QueryNextImageCommand,
+)
 
 if TYPE_CHECKING:
     from typing import Self
@@ -108,7 +113,7 @@ class OTAManager:
             self._upgrade_end_future.set_result(status)
 
     async def _image_query_req(
-        self, hdr: foundation.ZCLHeader, command: Ota.QueryNextImageCommand
+        self, hdr: foundation.ZCLHeader, command: QueryNextImageCommand
     ) -> None:
         """Handle image query request."""
 
@@ -151,7 +156,7 @@ class OTAManager:
         self._finish(foundation.Status.MALFORMED_COMMAND)
 
     async def _image_block_req(
-        self, hdr: foundation.ZCLHeader, command: Ota.ImageBlockCommand
+        self, hdr: foundation.ZCLHeader, command: ImageBlockCommand
     ) -> None:
         """Handle image block request."""
         if command.manufacturer_code == 4129:
@@ -196,7 +201,7 @@ class OTAManager:
             self.device.debug("OTA image_block handler exception", exc_info=ex)
 
     async def _image_page_req(
-        self, hdr: foundation.ZCLHeader, command: Ota.ImagePageCommand
+        self, hdr: foundation.ZCLHeader, command: ImagePageCommand
     ) -> None:
         """Handle image page request."""
         offset = command.file_offset

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -11,10 +11,10 @@ from typing import TYPE_CHECKING
 
 from zigpy.const import SIG_MANUFACTURER, SIG_MODEL, SIG_MODELS_INFO
 import zigpy.quirks
-from zigpy.typing import CustomDeviceType, DeviceType
 from zigpy.util import deprecated
 
 if TYPE_CHECKING:
+    from zigpy.device import Device
     from zigpy.quirks import CustomDevice
     from zigpy.quirks.v2 import QuirksV2RegistryEntry
 
@@ -26,9 +26,9 @@ class DeviceRegistry:
 
     def __init__(self, *args, **kwargs) -> None:
         """Initialize the registry."""
-        self._registry_v1: dict[str | None, dict[str | None, deque[CustomDevice]]] = (
-            defaultdict(lambda: defaultdict(deque))
-        )
+        self._registry_v1: dict[
+            str | None, dict[str | None, deque[type[CustomDevice]]]
+        ] = defaultdict(lambda: defaultdict(deque))
 
         self._registry_v2: dict[tuple[str, str], deque[QuirksV2RegistryEntry]] = (
             defaultdict(deque)
@@ -64,7 +64,7 @@ class DeviceRegistry:
                 _LOGGER.debug("Removing stale custom v2 quirk: %s", entry)
                 registry.remove(entry)
 
-    def add_to_registry(self, custom_device: CustomDeviceType) -> None:
+    def add_to_registry(self, custom_device: type[CustomDevice]) -> None:
         """Add a device to the registry"""
         models_info = custom_device.signature.get(SIG_MODELS_INFO)
         if models_info:
@@ -83,7 +83,7 @@ class DeviceRegistry:
         """Add an entry to the registry."""
         self._registry_v2[(manufacturer, model)].appendleft(entry)
 
-    def remove(self, custom_device: CustomDeviceType) -> None:
+    def remove(self, custom_device: type[CustomDevice]) -> None:
         """Remove a device from the registry"""
 
         if hasattr(custom_device, "quirk_metadata"):
@@ -100,7 +100,7 @@ class DeviceRegistry:
             model = custom_device.signature.get(SIG_MODEL)
             self.registry_v1[manufacturer][model].remove(custom_device)
 
-    def get_device(self, device: DeviceType) -> CustomDeviceType | DeviceType:
+    def get_device(self, device: Device) -> CustomDevice | Device:
         """Get a CustomDevice object, if one is available"""
         if isinstance(device, zigpy.quirks.BaseCustomDevice):
             return device
@@ -142,12 +142,14 @@ class DeviceRegistry:
 
     @property
     @deprecated("The `registry` property is deprecated, use `registry_v1` instead.")
-    def registry(self) -> dict[str | None, dict[str | None, deque[CustomDevice]]]:
+    def registry(self) -> dict[str | None, dict[str | None, deque[type[CustomDevice]]]]:
         """Return the v1 registry."""
         return self._registry_v1
 
     @property
-    def registry_v1(self) -> dict[str | None, dict[str | None, deque[CustomDevice]]]:
+    def registry_v1(
+        self,
+    ) -> dict[str | None, dict[str | None, deque[type[CustomDevice]]]]:
         """Return the v1 registry."""
         return self._registry_v1
 
@@ -156,7 +158,7 @@ class DeviceRegistry:
         """Return the v2 registry."""
         return self._registry_v2
 
-    def __contains__(self, device: CustomDeviceType) -> bool:
+    def __contains__(self, device: CustomDevice) -> bool:
         """Check if a device is in the registry."""
 
         if hasattr(device, "quirk_metadata"):

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -7,7 +7,7 @@ import inspect
 import itertools
 import logging
 import pathlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from zigpy.const import SIG_MANUFACTURER, SIG_MODEL, SIG_MODELS_INFO
 import zigpy.quirks
@@ -16,7 +16,7 @@ from zigpy.util import deprecated
 if TYPE_CHECKING:
     from zigpy.device import Device
     from zigpy.quirks import CustomDevice
-    from zigpy.quirks.v2 import QuirksV2RegistryEntry
+    from zigpy.quirks.v2 import CustomDeviceV2, QuirksV2RegistryEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,9 +30,9 @@ class DeviceRegistry:
             str | None, dict[str | None, deque[type[CustomDevice]]]
         ] = defaultdict(lambda: defaultdict(deque))
 
-        self._registry_v2: dict[tuple[str, str], deque[QuirksV2RegistryEntry]] = (
-            defaultdict(deque)
-        )
+        self._registry_v2: dict[
+            tuple[str | None, str | None], deque[QuirksV2RegistryEntry]
+        ] = defaultdict(deque)
 
     def purge_custom_quirks(self, custom_quirks_root: pathlib.Path) -> None:
         # If zhaquirks aren't being used, we can't tell if a quirk is custom or not
@@ -83,12 +83,13 @@ class DeviceRegistry:
         """Add an entry to the registry."""
         self._registry_v2[(manufacturer, model)].appendleft(entry)
 
-    def remove(self, custom_device: type[CustomDevice]) -> None:
+    def remove(self, custom_device: type[CustomDevice] | CustomDeviceV2) -> None:
         """Remove a device from the registry"""
 
         if hasattr(custom_device, "quirk_metadata"):
-            key = (custom_device.manufacturer, custom_device.model)
-            self._registry_v2[key].remove(custom_device.quirk_metadata)
+            device = cast("CustomDeviceV2", custom_device)
+            key = (device.manufacturer, device.model)
+            self._registry_v2[key].remove(device.quirk_metadata)
             return
 
         models_info = custom_device.signature.get(SIG_MODELS_INFO)
@@ -154,16 +155,23 @@ class DeviceRegistry:
         return self._registry_v1
 
     @property
-    def registry_v2(self) -> dict[tuple[str, str], deque[QuirksV2RegistryEntry]]:
+    def registry_v2(
+        self,
+    ) -> dict[tuple[str | None, str | None], deque[QuirksV2RegistryEntry]]:
         """Return the v2 registry."""
         return self._registry_v2
 
-    def __contains__(self, device: CustomDevice) -> bool:
+    def __contains__(self, device: type[CustomDevice] | CustomDeviceV2) -> bool:
         """Check if a device is in the registry."""
 
         if hasattr(device, "quirk_metadata"):
-            manufacturer, model = device.manufacturer, device.model
-            return device.quirk_metadata in self._registry_v2[(manufacturer, model)]
+            v2_device = cast("CustomDeviceV2", device)
+            manufacturer, model = v2_device.manufacturer, v2_device.model
+
+            if manufacturer is None or model is None:
+                return False
+
+            return v2_device.quirk_metadata in self._registry_v2[(manufacturer, model)]
 
         manufacturer, model = device.signature.get(
             SIG_MODELS_INFO,

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -167,10 +167,6 @@ class DeviceRegistry:
         if hasattr(device, "quirk_metadata"):
             v2_device = cast("CustomDeviceV2", device)
             manufacturer, model = v2_device.manufacturer, v2_device.model
-
-            if manufacturer is None or model is None:
-                return False
-
             return v2_device.quirk_metadata in self._registry_v2[(manufacturer, model)]
 
         manufacturer, model = device.signature.get(

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -5,7 +5,7 @@ import enum
 import inspect
 import logging
 import struct
-from typing import Generic, Literal, Protocol, Self, TypeVar
+from typing import TYPE_CHECKING, Generic, Literal, Protocol, Self, TypeVar
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -553,7 +553,35 @@ def enum_factory(base_type: type[FixedIntType]) -> type[enum.Enum]:
     return enum_mapping[base_type]
 
 
+if TYPE_CHECKING:
+    # mypy needs help understanding that the bitwise operations return int subclasses
+    class _BitmapMixin:
+        def __or__(self, other: object) -> Self:
+            return super().__or__(other)
+
+        def __ror__(self, other: object) -> Self:
+            return super().__ror__(other)
+
+        def __and__(self, other: object) -> Self:
+            return super().__and__(other)
+
+        def __rand__(self, other: object) -> Self:
+            return super().__rand__(other)
+
+        def __xor__(self, other: object) -> Self:
+            return super().__xor__(other)
+
+        def __rxor__(self, other: object) -> Self:
+            return super().__rxor__(other)
+
+        def __invert__(self) -> Self:
+            return super().__invert__()
+else:
+    _BitmapMixin = object
+
+
 class bitmap2(
+    _BitmapMixin,
     uint2_t,
     enum.ReprEnum,
     enum.Flag,
@@ -564,6 +592,7 @@ class bitmap2(
 
 
 class bitmap3(
+    _BitmapMixin,
     uint3_t,
     enum.ReprEnum,
     enum.Flag,
@@ -574,6 +603,7 @@ class bitmap3(
 
 
 class bitmap4(
+    _BitmapMixin,
     uint4_t,
     enum.ReprEnum,
     enum.Flag,
@@ -584,6 +614,7 @@ class bitmap4(
 
 
 class bitmap5(
+    _BitmapMixin,
     uint5_t,
     enum.ReprEnum,
     enum.Flag,
@@ -594,6 +625,7 @@ class bitmap5(
 
 
 class bitmap6(
+    _BitmapMixin,
     uint6_t,
     enum.ReprEnum,
     enum.Flag,
@@ -604,6 +636,7 @@ class bitmap6(
 
 
 class bitmap7(
+    _BitmapMixin,
     uint7_t,
     enum.ReprEnum,
     enum.Flag,
@@ -614,6 +647,7 @@ class bitmap7(
 
 
 class bitmap8(
+    _BitmapMixin,
     uint8_t,
     enum.ReprEnum,
     enum.Flag,
@@ -624,6 +658,7 @@ class bitmap8(
 
 
 class bitmap16(
+    _BitmapMixin,
     uint16_t,
     enum.ReprEnum,
     enum.Flag,
@@ -634,6 +669,7 @@ class bitmap16(
 
 
 class bitmap24(
+    _BitmapMixin,
     uint24_t,
     enum.ReprEnum,
     enum.Flag,
@@ -644,6 +680,7 @@ class bitmap24(
 
 
 class bitmap32(
+    _BitmapMixin,
     uint32_t,
     enum.ReprEnum,
     enum.Flag,
@@ -654,6 +691,7 @@ class bitmap32(
 
 
 class bitmap40(
+    _BitmapMixin,
     uint40_t,
     enum.ReprEnum,
     enum.Flag,
@@ -664,6 +702,7 @@ class bitmap40(
 
 
 class bitmap48(
+    _BitmapMixin,
     uint48_t,
     enum.ReprEnum,
     enum.Flag,
@@ -674,6 +713,7 @@ class bitmap48(
 
 
 class bitmap56(
+    _BitmapMixin,
     uint56_t,
     enum.ReprEnum,
     enum.Flag,
@@ -684,6 +724,7 @@ class bitmap56(
 
 
 class bitmap64(
+    _BitmapMixin,
     uint64_t,
     enum.ReprEnum,
     enum.Flag,
@@ -694,6 +735,7 @@ class bitmap64(
 
 
 class bitmap16_be(
+    _BitmapMixin,
     uint16_t_be,
     enum.ReprEnum,
     enum.Flag,
@@ -704,6 +746,7 @@ class bitmap16_be(
 
 
 class bitmap24_be(
+    _BitmapMixin,
     uint24_t_be,
     enum.ReprEnum,
     enum.Flag,
@@ -714,6 +757,7 @@ class bitmap24_be(
 
 
 class bitmap32_be(
+    _BitmapMixin,
     uint32_t_be,
     enum.ReprEnum,
     enum.Flag,
@@ -724,6 +768,7 @@ class bitmap32_be(
 
 
 class bitmap40_be(
+    _BitmapMixin,
     uint40_t_be,
     enum.ReprEnum,
     enum.Flag,
@@ -734,6 +779,7 @@ class bitmap40_be(
 
 
 class bitmap48_be(
+    _BitmapMixin,
     uint48_t_be,
     enum.ReprEnum,
     enum.Flag,
@@ -744,6 +790,7 @@ class bitmap48_be(
 
 
 class bitmap56_be(
+    _BitmapMixin,
     uint56_t_be,
     enum.ReprEnum,
     enum.Flag,
@@ -754,6 +801,7 @@ class bitmap56_be(
 
 
 class bitmap64_be(
+    _BitmapMixin,
     uint64_t_be,
     enum.ReprEnum,
     enum.Flag,

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -577,7 +577,9 @@ if TYPE_CHECKING:
         def __invert__(self) -> Self:
             return super().__invert__()
 else:
-    _BitmapMixin = object
+    # Empty class at runtime to avoid MRO conflicts
+    class _BitmapMixin:
+        pass
 
 
 class bitmap2(
@@ -949,7 +951,7 @@ class KwargTypeMeta(type):
     # So things like `LVList[NWK, t.uint8_t]` are singletons
     _anonymous_classes: dict[tuple[type, tuple[type, ...]], type] = {}
 
-    def __getitem__(cls, key):
+    def __getitem__(cls, key: type | int | tuple[type | int, ...]) -> type[Self]:
         # Make sure Foo[a] is the same as Foo[a,]
         if not isinstance(key, tuple):
             key = (key,)
@@ -974,7 +976,7 @@ class KwargTypeMeta(type):
         if (cls, expanded_key) in cls._anonymous_classes:
             return cls._anonymous_classes[cls, expanded_key]
 
-        class AnonSubclass(cls, **bound.arguments):
+        class AnonSubclass(cls, **bound.arguments):  # type: ignore[valid-type]
             pass
 
         AnonSubclass.__name__ = AnonSubclass.__qualname__ = f"Anonymous{cls.__name__}"

--- a/zigpy/typing.py
+++ b/zigpy/typing.py
@@ -16,7 +16,6 @@ CustomEndpointType = "CustomEndpoint"
 DeviceType = "Device"
 EndpointType = "Endpoint"
 ZDOType = "ZDO"
-AddressingMode = "AddressingMode"
 
 
 class UndefinedType(enum.Enum):
@@ -45,9 +44,3 @@ if TYPE_CHECKING:
     DeviceType = zigpy.device.Device
     EndpointType = zigpy.endpoint.Endpoint
     ZDOType = zigpy.zdo.ZDO
-
-    AddressingMode = (
-        zigpy.types.Addressing.Group
-        | zigpy.types.Addressing.IEEE
-        | zigpy.types.Addressing.NWK
-    )

--- a/zigpy/typing.py
+++ b/zigpy/typing.py
@@ -3,19 +3,8 @@
 from __future__ import annotations
 
 import enum
-from typing import TYPE_CHECKING, Any
 
-ConfigType = dict[str, Any]
-
-# pylint: disable=invalid-name
-ClusterType = "Cluster"
-ControllerApplicationType = "ControllerApplication"
-CustomClusterType = "CustomCluster"
-CustomDeviceType = "CustomDevice"
-CustomEndpointType = "CustomEndpoint"
-DeviceType = "Device"
-EndpointType = "Endpoint"
-ZDOType = "ZDO"
+import zigpy.types as t
 
 
 class UndefinedType(enum.Enum):
@@ -27,20 +16,4 @@ class UndefinedType(enum.Enum):
 UNDEFINED = UndefinedType._singleton  # noqa: SLF001
 
 
-if TYPE_CHECKING:
-    import zigpy.application
-    import zigpy.device
-    import zigpy.endpoint
-    import zigpy.quirks
-    import zigpy.types
-    import zigpy.zcl
-    import zigpy.zdo
-
-    ClusterType = zigpy.zcl.Cluster
-    ControllerApplicationType = zigpy.application.ControllerApplication
-    CustomClusterType = zigpy.quirks.CustomCluster
-    CustomDeviceType = zigpy.quirks.BaseCustomDevice
-    CustomEndpointType = zigpy.quirks.CustomEndpoint
-    DeviceType = zigpy.device.Device
-    EndpointType = zigpy.endpoint.Endpoint
-    ZDOType = zigpy.zdo.ZDO
+AddressingMode = t.AddrMode

--- a/zigpy/util.py
+++ b/zigpy/util.py
@@ -415,19 +415,6 @@ def pick_optimal_channel(
     return optimal_channel
 
 
-class Singleton:
-    """Singleton class."""
-
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-    def __repr__(self) -> str:
-        return f"<Singleton {self.name!r}>"
-
-    def __hash__(self) -> int:
-        return hash(self.name)
-
-
 def filter_relays(relays: list[int]) -> list[int]:
     """Filter out invalid relays."""
     filtered_relays = []

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -490,6 +490,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         self,
         hdr: foundation.ZCLHeader,
         args: list[Any],
+        *,
+        # This parameter is unused and kept only for backwards compatibility
+        dst_addressing: t.AddrMode | None = None,
     ):
         self.debug(
             "No explicit handler for cluster command 0x%02x: %s",
@@ -507,6 +510,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         self,
         hdr: foundation.ZCLHeader,
         args: list,
+        *,
+        # This parameter is unused and kept only for backwards compatibility
+        dst_addressing: t.AddrMode | None = None,
     ) -> None:
         if hdr.command_id == foundation.GeneralCommand.Read_Attributes:
             records = []

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -14,7 +14,6 @@ import warnings
 from zigpy import util
 from zigpy.const import APS_REPLY_TIMEOUT
 import zigpy.types as t
-from zigpy.typing import EndpointType
 from zigpy.zcl import foundation
 from zigpy.zcl.foundation import BaseAttributeDefs, BaseCommandDefs, CommandSchema
 
@@ -237,8 +236,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         if cls.cluster_id_range is not None:
             cls._registry_range[cls.cluster_id_range] = cls
 
-    def __init__(self, endpoint: EndpointType, is_server: bool = True) -> None:
-        self._endpoint: EndpointType = endpoint
+    def __init__(self, endpoint: Endpoint, is_server: bool = True) -> None:
+        self._endpoint: Endpoint = endpoint
         self._attr_cache: dict[int, Any] = {}
         self._attr_last_updated: dict[int, datetime] = {}
         self.unsupported_attributes: set[int | str] = set()
@@ -268,7 +267,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
 
     @classmethod
     def from_id(
-        cls, endpoint: EndpointType, cluster_id: int, is_server: bool = True
+        cls, endpoint: Endpoint, cluster_id: int, is_server: bool = True
     ) -> Cluster:
         cluster_id = t.ClusterId(cluster_id)
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -14,7 +14,7 @@ import warnings
 from zigpy import util
 from zigpy.const import APS_REPLY_TIMEOUT
 import zigpy.types as t
-from zigpy.typing import AddressingMode, EndpointType
+from zigpy.typing import EndpointType
 from zigpy.zcl import foundation
 from zigpy.zcl.foundation import BaseAttributeDefs, BaseCommandDefs, CommandSchema
 
@@ -476,25 +476,21 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         self,
         hdr: foundation.ZCLHeader,
         args: list[Any],
-        *,
-        dst_addressing: AddressingMode | None = None,
     ) -> None:
         self.debug(
             "Received command 0x%02X (TSN %d): %s", hdr.command_id, hdr.tsn, args
         )
         if hdr.frame_control.is_cluster:
-            self.handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+            self.handle_cluster_request(hdr, args)
             self.listener_event("cluster_command", hdr.tsn, hdr.command_id, args)
             return
         self.listener_event("general_command", hdr, args)
-        self.handle_cluster_general_request(hdr, args, dst_addressing=dst_addressing)
+        self.handle_cluster_general_request(hdr, args)
 
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
         args: list[Any],
-        *,
-        dst_addressing: AddressingMode | None = None,
     ):
         self.debug(
             "No explicit handler for cluster command 0x%02x: %s",
@@ -512,8 +508,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin):
         self,
         hdr: foundation.ZCLHeader,
         args: list,
-        *,
-        dst_addressing: AddressingMode | None = None,
     ) -> None:
         if hdr.command_id == foundation.GeneralCommand.Read_Attributes:
             records = []

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -211,13 +211,6 @@ class Basic(Cluster):
     and enabling a device.
     """
 
-    PowerSource: Final = PowerSource
-    PhysicalEnvironment: Final = PhysicalEnvironment
-    AlarmMask: Final = AlarmMask
-    DisableLocalConfig: Final = DisableLocalConfig
-    GenericDeviceClass: Final = GenericDeviceClass
-    GenericLightingDeviceType: Final = GenericLightingDeviceType
-
     cluster_id: Final[t.uint16_t] = 0x0000
     ep_attribute: Final = "basic"
 
@@ -287,6 +280,14 @@ class Basic(Cluster):
 
     def handle_read_attribute_power_source(self) -> PowerSource:
         return PowerSource.DC_Source
+
+    # For backwards compatibility
+    PowerSource: Final = PowerSource
+    PhysicalEnvironment: Final = PhysicalEnvironment
+    AlarmMask: Final = AlarmMask
+    DisableLocalConfig: Final = DisableLocalConfig
+    GenericDeviceClass: Final = GenericDeviceClass
+    GenericLightingDeviceType: Final = GenericLightingDeviceType
 
 
 class MainsAlarmMask(t.bitmap8):
@@ -1105,8 +1106,6 @@ class Time(Cluster):
     to a real-time clock.
     """
 
-    TimeStatus: Final = TimeStatus
-
     cluster_id: Final[t.uint16_t] = 0x000A
     ep_attribute: Final = "time"
 
@@ -1155,6 +1154,9 @@ class Time(Cluster):
         assert tz_offset is not None
 
         return t.LocalTime((now + tz_offset - ZIGBEE_EPOCH).total_seconds())
+
+    # For backwards compatibility
+    TimeStatus: Final = TimeStatus
 
 
 class LocationMethod(t.enum8):

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from typing import Any, Final, Self
 
 import zigpy.types as t
-from zigpy.typing import AddressingMode
 from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
@@ -2119,13 +2118,7 @@ class Ota(Cluster):
             },
         )
 
-    def handle_cluster_request(
-        self,
-        hdr: foundation.ZCLHeader,
-        args: list[Any],
-        *,
-        dst_addressing: AddressingMode | None = None,
-    ):
+    def handle_cluster_request(self, hdr: foundation.ZCLHeader, args: list[Any]):
         # We don't want the cluster to do anything here because it would interfere with
         # the OTA manager
         device = self.endpoint.device

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2120,7 +2120,14 @@ class Ota(Cluster):
             },
         )
 
-    def handle_cluster_request(self, hdr: foundation.ZCLHeader, args: list[Any]):
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        # This parameter is unused and kept only for backwards compatibility
+        dst_addressing: t.AddrMode | None = None,
+    ):
         # We don't want the cluster to do anything here because it would interfere with
         # the OTA manager
         device = self.endpoint.device

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -51,7 +51,7 @@ class AnalogInputRegular(Cluster):
     class AttributeDefs(BaseAttributeDefs):
         cov_increment: Final = ZCLAttributeDef(id=0x0016, type=t.Single)
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
-        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
+        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         update_interval: Final = ZCLAttributeDef(id=0x0076, type=t.uint8_t)
@@ -90,7 +90,7 @@ class AnalogOutputRegular(Cluster):
     class AttributeDefs(BaseAttributeDefs):
         cov_increment: Final = ZCLAttributeDef(id=0x0016, type=t.Single)
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
-        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
+        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         update_interval: Final = ZCLAttributeDef(id=0x0076, type=t.uint8_t)
@@ -122,7 +122,7 @@ class AnalogValueRegular(Cluster):
 
     class AttributeDefs(BaseAttributeDefs):
         cov_increment: Final = ZCLAttributeDef(id=0x0016, type=t.Single)
-        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
+        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
@@ -154,7 +154,7 @@ class BinaryInputRegular(Cluster):
         change_of_state_time: Final = ZCLAttributeDef(id=0x0010, type=DateTime)
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         elapsed_active_time: Final = ZCLAttributeDef(id=0x0021, type=t.uint32_t)
-        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
+        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         time_of_at_reset: Final = ZCLAttributeDef(id=0x0072, type=DateTime)
@@ -188,7 +188,7 @@ class BinaryOutputRegular(Cluster):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         elapsed_active_time: Final = ZCLAttributeDef(id=0x0021, type=t.uint32_t)
         feed_back_value: Final = ZCLAttributeDef(id=0x0028, type=t.enum8)
-        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
+        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         time_of_at_reset: Final = ZCLAttributeDef(id=0x0072, type=DateTime)
@@ -219,7 +219,7 @@ class BinaryValueRegular(Cluster):
         change_of_state_count: Final = ZCLAttributeDef(id=0x000F, type=t.uint32_t)
         change_of_state_time: Final = ZCLAttributeDef(id=0x0010, type=DateTime)
         elapsed_active_time: Final = ZCLAttributeDef(id=0x0021, type=t.uint32_t)
-        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
+        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         time_of_at_reset: Final = ZCLAttributeDef(id=0x0072, type=DateTime)
@@ -249,7 +249,7 @@ class MultistateInputRegular(Cluster):
 
     class AttributeDefs(BaseAttributeDefs):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
-        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
+        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
@@ -279,7 +279,7 @@ class MultistateOutputRegular(Cluster):
     class AttributeDefs(BaseAttributeDefs):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         feed_back_value: Final = ZCLAttributeDef(id=0x0028, type=t.enum8)
-        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
+        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
@@ -305,7 +305,7 @@ class MultistateValueRegular(Cluster):
     ep_attribute: Final = "bacnet_regular_multistate_value"
 
     class AttributeDefs(BaseAttributeDefs):
-        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.FixedList[4, t.uint8_t])
+        object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -445,6 +445,8 @@ class WarningType(_SquawkOrWarningCommand):
 
     # For backwards compatibility
     Strobe: Final = Strobe
+    WarningMode: Final = WarningMode
+    SirenLevel: Final = SirenLevel
 
 
 class SquawkLevel(t.enum8):
@@ -486,6 +488,7 @@ class Squawk(_SquawkOrWarningCommand):
 
     # For backwards compatibility
     Strobe: Final = Strobe
+    SquawkLevel: Final = SquawkLevel
 
 
 class IasWd(Cluster):

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -76,11 +76,6 @@ class IasZone(Cluster):
     reports and supervision of the IAS network.
     """
 
-    ZoneState: Final = ZoneState
-    ZoneType: Final = ZoneType
-    ZoneStatus: Final = ZoneStatus
-    EnrollResponse: Final = EnrollResponse
-
     cluster_id: Final[t.uint16_t] = 0x0500
     name: Final = "IAS Zone"
     ep_attribute: Final = "ias_zone"
@@ -142,6 +137,12 @@ class IasZone(Cluster):
             id=0x01,
             schema={"zone_type": ZoneType, "manufacturer_code": t.uint16_t},
         )
+
+    # For backwards compatibility
+    ZoneState: Final = ZoneState
+    ZoneType: Final = ZoneType
+    ZoneStatus: Final = ZoneStatus
+    EnrollResponse: Final = EnrollResponse
 
 
 class AlarmStatus(t.enum8):
@@ -222,7 +223,7 @@ class ZoneStatusRsp(t.Struct):
     """Zone status response."""
 
     zone_id: t.uint8_t
-    zone_status: IasZone.ZoneStatus
+    zone_status: ZoneStatus
 
 
 class IasAce(Cluster):
@@ -398,27 +399,27 @@ class StrobeLevel(t.enum8):
     Very_high_level_strobe = 0x03
 
 
+class SirenLevel(t.enum8):
+    Low_level_sound = 0x00
+    Medium_level_sound = 0x01
+    High_level_sound = 0x02
+    Very_high_level_sound = 0x03
+
+
+class WarningMode(t.enum8):
+    Stop = 0x00
+    Burglar = 0x01
+    Fire = 0x02
+    Emergency = 0x03
+    Police_Panic = 0x04
+    Fire_Panic = 0x05
+    Emergency_Panic = 0x06
+
+
 class WarningType(_SquawkOrWarningCommand):
-    Strobe = Strobe
-
-    class SirenLevel(t.enum8):
-        Low_level_sound = 0x00
-        Medium_level_sound = 0x01
-        High_level_sound = 0x02
-        Very_high_level_sound = 0x03
-
-    class WarningMode(t.enum8):
-        Stop = 0x00
-        Burglar = 0x01
-        Fire = 0x02
-        Emergency = 0x03
-        Police_Panic = 0x04
-        Fire_Panic = 0x05
-        Emergency_Panic = 0x06
-
     @property
     def mode(self) -> WarningMode:
-        return self.WarningMode((self.value >> 4) & 0x0F)
+        return WarningMode((self.value >> 4) & 0x0F)
 
     @mode.setter
     def mode(self, mode: WarningMode) -> None:
@@ -426,7 +427,7 @@ class WarningType(_SquawkOrWarningCommand):
 
     @property
     def strobe(self) -> Strobe:
-        return self.Strobe((self.value >> 2) & 0x01)
+        return Strobe((self.value >> 2) & 0x01)
 
     @strobe.setter
     def strobe(self, strobe: Strobe) -> None:
@@ -436,29 +437,32 @@ class WarningType(_SquawkOrWarningCommand):
 
     @property
     def level(self) -> SirenLevel:
-        return self.SirenLevel(self.value & 0x03)
+        return SirenLevel(self.value & 0x03)
 
     @level.setter
     def level(self, level: SirenLevel) -> None:
         self.value = (self.value & 0xFC) | (level & 0x03)
 
+    # For backwards compatibility
+    Strobe: Final = Strobe
+
+
+class SquawkLevel(t.enum8):
+    Low_level_sound = 0x00
+    Medium_level_sound = 0x01
+    High_level_sound = 0x02
+    Very_high_level_sound = 0x03
+
+
+class SquawkMode(t.enum8):
+    Armed = 0x00
+    Disarmed = 0x01
+
 
 class Squawk(_SquawkOrWarningCommand):
-    Strobe = Strobe
-
-    class SquawkLevel(t.enum8):
-        Low_level_sound = 0x00
-        Medium_level_sound = 0x01
-        High_level_sound = 0x02
-        Very_high_level_sound = 0x03
-
-    class SquawkMode(t.enum8):
-        Armed = 0x00
-        Disarmed = 0x01
-
     @property
     def mode(self) -> SquawkMode:
-        return self.SquawkMode((self.value >> 4) & 0x0F)
+        return SquawkMode((self.value >> 4) & 0x0F)
 
     @mode.setter
     def mode(self, mode: SquawkMode) -> None:
@@ -466,7 +470,7 @@ class Squawk(_SquawkOrWarningCommand):
 
     @property
     def strobe(self) -> Strobe:
-        return self.Strobe((self.value >> 3) & 0x01)
+        return Strobe((self.value >> 3) & 0x01)
 
     @strobe.setter
     def strobe(self, strobe: Strobe) -> None:
@@ -474,11 +478,14 @@ class Squawk(_SquawkOrWarningCommand):
 
     @property
     def level(self) -> SquawkLevel:
-        return self.SquawkLevel(self.value & 0x03)
+        return SquawkLevel(self.value & 0x03)
 
     @level.setter
     def level(self, level: SquawkLevel) -> None:
         self.value = (self.value & 0xFC) | (level & 0x03)
+
+    # For backwards compatibility
+    Strobe: Final = Strobe
 
 
 class IasWd(Cluster):

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -489,6 +489,7 @@ class Squawk(_SquawkOrWarningCommand):
     # For backwards compatibility
     Strobe: Final = Strobe
     SquawkLevel: Final = SquawkLevel
+    SquawkMode: Final = SquawkMode
 
 
 class IasWd(Cluster):

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -6,7 +6,7 @@ import functools
 import keyword
 import logging
 import typing
-from typing import Self
+from typing import Literal, Self
 
 import zigpy.types as t
 
@@ -1027,7 +1027,7 @@ class FrameControl(t.IntStruct, t.uint8_t):
 
 
 class ZCLHeader(t.Struct):
-    NO_MANUFACTURER_ID = -1  # type: typing.Literal
+    NO_MANUFACTURER_ID: Literal[-1] = -1
 
     frame_control: FrameControl
     manufacturer: t.uint16_t = t.StructField(
@@ -1249,7 +1249,7 @@ ZCLAttributeAccess._names = {
 @dataclasses.dataclass(frozen=True)
 class ZCLAttributeDef(t.BaseDataclassMixin):
     id: t.uint16_t = None
-    type: type = None
+    type: typing.Any = None
     zcl_type: DataTypeId = None
     access: ZCLAttributeAccess = (
         ZCLAttributeAccess.Read | ZCLAttributeAccess.Write | ZCLAttributeAccess.Report

--- a/zigpy/zdo/__init__.py
+++ b/zigpy/zdo/__init__.py
@@ -7,7 +7,6 @@ import logging
 from zigpy.const import APS_REPLY_TIMEOUT
 import zigpy.profiles
 import zigpy.types as t
-from zigpy.typing import AddressingMode
 import zigpy.util
 
 from . import types
@@ -113,21 +112,19 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         cluster: int,
         hdr: types.ZDOHeader,
         args: list,
-        *,
-        dst_addressing: AddressingMode | None = None,
     ) -> None:
         self.debug("ZDO request %s: %s", hdr.command_id, args)
 
         handler = getattr(self, f"handle_{hdr.command_id.name.lower()}", None)
         if handler is not None:
-            handler(hdr, *args, dst_addressing=dst_addressing)
+            handler(hdr, *args)
         else:
             self.debug("No handler for ZDO request:%s(%s)", hdr.command_id, args)
 
         self.listener_event(
             f"zdo_{hdr.command_id.name.lower()}",
             self._device,
-            dst_addressing,
+            None,  # was `dst_addressing` but this was never set
             hdr,
             args,
         )
@@ -138,7 +135,6 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         ieee: t.EUI64,
         request_type: int,
         start_index: int | None = None,
-        dst_addressing: AddressingMode | None = None,
     ):
         """Handle ZDO NWK Address request."""
 
@@ -163,7 +159,6 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         nwk: t.NWK,
         request_type: int,
         start_index: int | None = None,
-        dst_addressing: AddressingMode | None = None,
     ):
         """Handle ZDO IEEE Address request."""
 
@@ -193,7 +188,6 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         nwk: t.NWK,
         ieee: t.EUI64,
         capability: int,
-        dst_addressing: AddressingMode | None = None,
     ):
         """Handle ZDO device announcement request."""
         self.listener_event("device_announce", self._device)
@@ -203,7 +197,6 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         hdr: types.ZDOHeader,
         permit_duration: int,
         tc_significance: int,
-        dst_addressing: AddressingMode | None = None,
     ):
         """Handle ZDO permit joining request."""
 
@@ -216,7 +209,6 @@ class ZDO(zigpy.util.CatchingTaskMixin, zigpy.util.ListenableMixin):
         profile: int,
         in_clusters: list,
         out_cluster: list,
-        dst_addressing: AddressingMode | None = None,
     ):
         """Handle ZDO Match_desc_req request."""
 

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from typing import Final
+from typing import Any, Final
 
 import zigpy.types as t
 
@@ -539,7 +539,7 @@ class ZDOCmd(t.enum16):
     Mgmt_NWK_Update_rsp = 0x8038
 
 
-CLUSTERS = {
+CLUSTERS: dict[ZDOCmd, tuple[tuple[str, Any], ...]] = {
     # Device and Service Discovery Server Requests
     ZDOCmd.NWK_addr_req: (
         IEEE,
@@ -567,7 +567,7 @@ CLUSTERS = {
     ZDOCmd.Device_annce: (NWK, IEEE, ("Capability", t.uint8_t)),
     ZDOCmd.User_Desc_set: (
         NWKI,
-        ("UserDescriptor", t.FixedList[16, t.uint8_t]),
+        ("UserDescriptor", t.CharacterString),
     ),  # Really a string
     ZDOCmd.System_Server_Discovery_req: (("ServerMask", t.uint16_t),),
     ZDOCmd.Discovery_store_req: (
@@ -684,8 +684,7 @@ CLUSTERS = {
     ZDOCmd.User_Desc_rsp: (
         STATUS,
         NWKI,
-        ("Length", t.uint8_t),
-        ("UserDescriptor", t.Optional(t.FixedList[16, t.uint8_t])),
+        ("UserDescriptor", t.CharacterString),
     ),
     ZDOCmd.Discovery_Cache_rsp: (STATUS,),
     ZDOCmd.User_Desc_conf: (STATUS, NWKI),

--- a/zigpy/zdo/types.py
+++ b/zigpy/zdo/types.py
@@ -1,38 +1,41 @@
 from __future__ import annotations
 
 import typing
+from typing import Final
 
 import zigpy.types as t
 
 
-class _PowerDescriptorEnums:
-    class CurrentPowerMode(t.enum4):
-        RxOnSyncedWithNodeDesc = 0b0000
-        RxOnPeriodically = 0b0001
-        RxOnWhenStimulated = 0b0010
+class CurrentPowerMode(t.enum4):
+    RxOnSyncedWithNodeDesc = 0b0000
+    RxOnPeriodically = 0b0001
+    RxOnWhenStimulated = 0b0010
 
-    class PowerSources(t.bitmap4):
-        MainsPower = 0b0001
-        RechargeableBattery = 0b0010
-        DisposableBattery = 0b0100
-        Reserved = 0b1000
 
-    class PowerSourceLevel(t.enum4):
-        Critical = 0b0000
-        Percent33 = 0b0100
-        Percent66 = 0b1000
-        Percent100 = 0b1100
+class PowerSources(t.bitmap4):
+    MainsPower = 0b0001
+    RechargeableBattery = 0b0010
+    DisposableBattery = 0b0100
+    Reserved = 0b1000
+
+
+class PowerSourceLevel(t.enum4):
+    Critical = 0b0000
+    Percent33 = 0b0100
+    Percent66 = 0b1000
+    Percent100 = 0b1100
 
 
 class PowerDescriptor(t.Struct):
-    CurrentPowerMode = _PowerDescriptorEnums.CurrentPowerMode
-    PowerSources = _PowerDescriptorEnums.PowerSources
-    PowerSourceLevel = _PowerDescriptorEnums.PowerSourceLevel
+    current_power_mode: CurrentPowerMode
+    available_power_sources: PowerSources
+    current_power_source: PowerSources
+    current_power_source_level: PowerSourceLevel
 
-    current_power_mode: _PowerDescriptorEnums.CurrentPowerMode
-    available_power_sources: _PowerDescriptorEnums.PowerSources
-    current_power_source: _PowerDescriptorEnums.PowerSources
-    current_power_source_level: _PowerDescriptorEnums.PowerSourceLevel
+    # Kept for backwards compatibility
+    CurrentPowerMode: Final = CurrentPowerMode
+    PowerSources: Final = PowerSources
+    PowerSourceLevel: Final = PowerSourceLevel
 
 
 class SimpleDescriptor(t.Struct):
@@ -62,49 +65,46 @@ class LogicalType(t.enum3):
     EndDevice = 0b010
 
 
-class _NodeDescriptorEnums:
-    class MACCapabilityFlags(t.bitmap8):
-        NONE = 0
+class MACCapabilityFlags(t.bitmap8):
+    NONE = 0
 
-        AlternatePanCoordinator = 0b00000001
-        FullFunctionDevice = 0b00000010
-        MainsPowered = 0b00000100
-        RxOnWhenIdle = 0b00001000
-        SecurityCapable = 0b01000000
-        AllocateAddress = 0b10000000
+    AlternatePanCoordinator = 0b00000001
+    FullFunctionDevice = 0b00000010
+    MainsPowered = 0b00000100
+    RxOnWhenIdle = 0b00001000
+    SecurityCapable = 0b01000000
+    AllocateAddress = 0b10000000
 
-    class FrequencyBand(t.bitmap5):
-        Freq868MHz = 0b00001
-        Freq902MHz = 0b00100
-        Freq2400MHz = 0b01000
 
-    class DescriptorCapability(t.bitmap8):
-        NONE = 0
+class FrequencyBand(t.bitmap5):
+    Freq868MHz = 0b00001
+    Freq902MHz = 0b00100
+    Freq2400MHz = 0b01000
 
-        ExtendedActiveEndpointListAvailable = 0b00000001
-        ExtendedSimpleDescriptorListAvailable = 0b00000010
+
+class DescriptorCapability(t.bitmap8):
+    NONE = 0
+
+    ExtendedActiveEndpointListAvailable = 0b00000001
+    ExtendedSimpleDescriptorListAvailable = 0b00000010
 
 
 class NodeDescriptor(t.Struct):
-    FrequencyBand = _NodeDescriptorEnums.FrequencyBand
-    MACCapabilityFlags = _NodeDescriptorEnums.MACCapabilityFlags
-    DescriptorCapability = _NodeDescriptorEnums.DescriptorCapability
-
     logical_type: LogicalType
     complex_descriptor_available: t.uint1_t
     user_descriptor_available: t.uint1_t
     reserved: t.uint3_t
 
     aps_flags: t.uint3_t
-    frequency_band: _NodeDescriptorEnums.FrequencyBand
+    frequency_band: FrequencyBand
 
-    mac_capability_flags: _NodeDescriptorEnums.MACCapabilityFlags
+    mac_capability_flags: MACCapabilityFlags
     manufacturer_code: t.uint16_t
     maximum_buffer_size: t.uint8_t
     maximum_incoming_transfer_size: t.uint16_t
     server_mask: t.uint16_t
     maximum_outgoing_transfer_size: t.uint16_t
-    descriptor_capability_field: _NodeDescriptorEnums.DescriptorCapability
+    descriptor_capability_field: DescriptorCapability
 
     def __new__(cls, *args, **kwargs):
         # Old style constructor
@@ -233,6 +233,11 @@ class NodeDescriptor(t.Struct):
 
         return bool(self.mac_capability_flags & self.MACCapabilityFlags.AllocateAddress)
 
+    # Kept for backwards compatibility
+    FrequencyBand: Final = FrequencyBand
+    MACCapabilityFlags: Final = MACCapabilityFlags
+    DescriptorCapability: Final = DescriptorCapability
+
 
 class MultiAddress(t.Struct):
     """Used for binds, represents an IEEE+endpoint or NWK address"""
@@ -258,38 +263,35 @@ class MultiAddress(t.Struct):
         return super().serialize()
 
 
-class _NeighborEnums:
-    class DeviceType(t.enum2):
-        Coordinator = 0x0
-        Router = 0x1
-        EndDevice = 0x2
-        Unknown = 0x3
+class DeviceType(t.enum2):
+    Coordinator = 0x0
+    Router = 0x1
+    EndDevice = 0x2
+    Unknown = 0x3
 
-    class RxOnWhenIdle(t.enum2):
-        Off = 0x0
-        On = 0x1
-        Unknown = 0x2
 
-    class Relationship(t.enum3):
-        Parent = 0x0
-        Child = 0x1
-        Sibling = 0x2
-        NoneOfTheAbove = 0x3
-        PreviousChild = 0x4
+class RxOnWhenIdle(t.enum2):
+    Off = 0x0
+    On = 0x1
+    Unknown = 0x2
 
-    class PermitJoins(t.enum2):
-        NotAccepting = 0x0
-        Accepting = 0x1
-        Unknown = 0x2
+
+class Relationship(t.enum3):
+    Parent = 0x0
+    Child = 0x1
+    Sibling = 0x2
+    NoneOfTheAbove = 0x3
+    PreviousChild = 0x4
+
+
+class PermitJoins(t.enum2):
+    NotAccepting = 0x0
+    Accepting = 0x1
+    Unknown = 0x2
 
 
 class Neighbor(t.Struct):
     """Neighbor Descriptor"""
-
-    PermitJoins = _NeighborEnums.PermitJoins
-    DeviceType = _NeighborEnums.DeviceType
-    RxOnWhenIdle = _NeighborEnums.RxOnWhenIdle
-    Relationship = _NeighborEnums.Relationship
 
     # Backwards-compatible alternate spelling
     RelationShip = Relationship
@@ -298,12 +300,12 @@ class Neighbor(t.Struct):
     ieee: t.EUI64
     nwk: t.NWK
 
-    device_type: _NeighborEnums.DeviceType
-    rx_on_when_idle: _NeighborEnums.RxOnWhenIdle
-    relationship: _NeighborEnums.Relationship
+    device_type: DeviceType
+    rx_on_when_idle: RxOnWhenIdle
+    relationship: Relationship
     reserved1: t.uint1_t
 
-    permit_joining: _NeighborEnums.PermitJoins
+    permit_joining: PermitJoins
     reserved2: t.uint6_t
 
     depth: t.uint8_t
@@ -320,6 +322,12 @@ class Neighbor(t.Struct):
             "relationship": tmp_neighbor.relationship,
             "reserved1": tmp_neighbor.reserved1,
         }
+
+    # Kept for backwards compatibility
+    PermitJoins: Final = PermitJoins
+    DeviceType: Final = DeviceType
+    RxOnWhenIdle: Final = RxOnWhenIdle
+    Relationship: Final = Relationship
 
 
 class Neighbors(t.Struct):


### PR DESCRIPTION
- `zigpy.typing` is now a tiny stub module, it can be removed in the future. All types are now correctly referenced via `if TYPE_CHECKING` guards, if necessary.
- `AddressingMode` is not something we actually use internally but a few quirks override methods and pass it through. It's kept around for existing quirks and can also be removed in the future.

The remaining changes are all zigpy-internal.