### PR TITLE
Add more `enum` sizes and a `Bytes` type

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -853,3 +853,13 @@ def test_serializable_bytes():
 
     with pytest.raises(ValueError):
         t.SerializableBytes([1, 2, 3])
+
+
+def test_bytes() -> None:
+    data = b"example data"
+
+    obj, rest = t.Bytes.deserialize(data)
+    assert obj == t.Bytes(data)
+    assert obj == data
+    assert rest == b""
+    assert obj.serialize() == data

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -518,7 +518,19 @@ class enum16(_EnumMixin, uint16_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
+class enum24(_EnumMixin, uint24_t, enum.Enum, metaclass=_IntEnumMeta):
+    pass
+
+
 class enum32(_EnumMixin, uint32_t, enum.Enum, metaclass=_IntEnumMeta):
+    pass
+
+
+class enum40(_EnumMixin, uint40_t, enum.Enum, metaclass=_IntEnumMeta):
+    pass
+
+
+class enum64(_EnumMixin, uint64_t, enum.Enum, metaclass=_IntEnumMeta):
     pass
 
 
@@ -545,7 +557,10 @@ def enum_factory(base_type: type[FixedIntType]) -> type[enum.Enum]:
         uint7_t: enum7,
         uint8_t: enum8,
         uint16_t: enum16,
+        uint24_t: enum24,
         uint32_t: enum32,
+        uint40_t: enum40,
+        uint64_t: enum64,
         uint16_t_be: enum16_be,
         uint32_t_be: enum32_be,
     }

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -14,6 +14,15 @@ if typing.TYPE_CHECKING:
     from typing import Self
 
 
+class Bytes(bytes):
+    def serialize(self) -> Bytes:
+        return self
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
+        return cls(data), b""
+
+
 class BaseDataclassMixin:
     def replace(self, **kwargs: typing.Any) -> Self:
         if dataclasses.is_dataclass(self):

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -15,6 +15,8 @@ if typing.TYPE_CHECKING:
 
 
 class Bytes(bytes):
+    """A serializable type to consume all remaining bytes."""
+
     def serialize(self) -> Bytes:
         return self
 


### PR DESCRIPTION
zigpy-znp uses a few larger enum variants and `Bytes` is used by a few different libraries already. We should implement them in zigpy directly.