### PR TITLE
Defer image download until install for trusted OTA providers

### DIFF
--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -1,6 +1,7 @@
 import itertools
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import aiohttp
 import pytest
 
 from tests.conftest import (
@@ -776,3 +777,19 @@ async def test_ota_manager_deferred_download():
 
     # The update itself returns NO_IMAGE_AVAILABLE because the device rejected it
     assert result == foundation.Status.NO_IMAGE_AVAILABLE
+
+
+async def test_ota_manager_deferred_download_failure():
+    """Test that a fetch failure during deferred download propagates correctly."""
+
+    deferred_image = zigpy.ota.OtaImageWithMetadata(
+        metadata=FW_IMAGE.metadata.replace(trusted=True),
+        firmware=None,
+    )
+
+    mock_fetch = AsyncMock(side_effect=aiohttp.ClientError("Download failed"))
+    with (
+        patch.object(OtaImageWithMetadata, "fetch", mock_fetch),
+        pytest.raises(aiohttp.ClientError, match="Download failed"),
+    ):
+        await update_firmware(MagicMock(), deferred_image)

--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -715,3 +715,64 @@ async def test_ota_manager_image_page_failure():
     result = await update_firmware(dev, FW_IMAGE, progress_callback)
 
     assert result != foundation.Status.SUCCESS
+
+
+async def test_ota_manager_deferred_download():
+    """Test that firmware is fetched at install time for trusted providers."""
+
+    app = make_app({})
+    dev = add_initialized_device(
+        app, nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77")
+    )
+    cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
+
+    with mock_attribute_reads(
+        cluster, {"current_file_version": FW_IMAGE.firmware.header.file_version - 10}
+    ):
+        await dev.initialize()
+
+    # Create an image without firmware (simulating deferred download)
+    deferred_image = zigpy.ota.OtaImageWithMetadata(
+        metadata=FW_IMAGE.metadata.replace(trusted=True),
+        firmware=None,
+    )
+
+    # Stop the general cluster handler from interfering
+    dev.ota_in_progress = True
+
+    async def send_packet(packet: t.ZigbeePacket):
+        if packet.cluster_id != Ota.cluster_id:
+            return
+
+        hdr, cmd = cluster.deserialize(packet.data.serialize())
+        assert FW_IMAGE.firmware is not None
+
+        if isinstance(cmd, Ota.ImageNotifyCommand):
+            # Device rejects the update to end the test quickly
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "query_next_image",
+                    field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    # Claim current version is higher than file version
+                    current_file_version=FW_IMAGE.firmware.header.file_version + 10,
+                    hardware_version=1,
+                )
+            )
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+
+    # Mock fetch() to return the complete image
+    mock_fetch = AsyncMock(return_value=FW_IMAGE)
+    with patch.object(OtaImageWithMetadata, "fetch", mock_fetch):
+        # Run firmware update with the deferred image
+        result = await update_firmware(dev, deferred_image)
+
+        # fetch() should have been called exactly once
+        mock_fetch.assert_awaited_once_with()
+
+    # The update itself returns NO_IMAGE_AVAILABLE because the device rejected it
+    assert result == foundation.Status.NO_IMAGE_AVAILABLE

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import pathlib
 import typing
 from unittest.mock import patch
 
 import aiohttp
 import attrs
+import pytest
 
 from tests.ota.test_ota_providers import SelfContainedOtaImageMetadata, make_device
 from zigpy import config
@@ -15,6 +17,47 @@ import zigpy.ota
 from zigpy.ota.image import FieldControl
 from zigpy.ota.providers import BaseOtaImageMetadata, BaseOtaProvider
 from zigpy.zcl.clusters.general import Ota
+
+
+@pytest.fixture
+def query_cmd():
+    """Common query command for OTA tests."""
+    return Ota.ServerCommandDefs.query_next_image.schema(
+        field_control=FieldControl.HARDWARE_VERSIONS_PRESENT,
+        manufacturer_code=0x1234,
+        image_type=0xABCD,
+        current_file_version=1,
+        hardware_version=1,
+    )
+
+
+@pytest.fixture
+def ota_hdr(query_cmd):
+    """Common OTA image header for tests (can be customized with .replace())."""
+    return zigpy.ota.image.OTAImageHeader(
+        upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
+        file_version=query_cmd.current_file_version + 1,
+        image_type=query_cmd.image_type,
+        manufacturer_id=query_cmd.manufacturer_code,
+        header_version=256,
+        header_length=56,
+        field_control=0,
+        stack_version=2,
+        header_string="This is a test header!",
+        image_size=56 + 2 + 4 + 8,
+    )
+
+
+@pytest.fixture
+def ota_subelements():
+    """Common OTA subelements for tests."""
+    return [zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")]
+
+
+@pytest.fixture
+def ota_image(ota_hdr, ota_subelements):
+    """Common OTA image for tests."""
+    return zigpy.ota.image.OTAImage(header=ota_hdr, subelements=ota_subelements)
 
 
 class SelfContainedProvider(BaseOtaProvider):
@@ -404,3 +447,117 @@ async def test_ota_matching_hardware_version_changes_after_download() -> None:
             firmware=zigpy.ota.image.OTAImage.deserialize(index[0].test_data)[0],
         ),
     )
+
+
+class TrustedSelfContainedProvider(SelfContainedProvider):
+    """A trusted provider that defers image downloads."""
+
+    TRUSTED = True
+
+
+async def test_ota_trusted_provider_deferred_download(query_cmd, ota_image) -> None:
+    """Trusted providers should not download images proactively."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+    test_data = ota_image.serialize()
+
+    index = [
+        SelfContainedOtaImageMetadata(
+            file_version=query_cmd.current_file_version + 1,
+            manufacturer_id=query_cmd.manufacturer_code,
+            checksum="sha3-256:" + hashlib.sha3_256(test_data).hexdigest(),
+            file_size=len(test_data),
+            test_data=test_data,
+        ),
+    ]
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.register_provider(TrustedSelfContainedProvider(index))
+
+    images = await ota.get_ota_images(device, query_cmd)
+
+    # Image should be returned but firmware should NOT be downloaded
+    assert len(images.upgrades) == 1
+    assert images.upgrades[0].firmware is None
+    assert images.upgrades[0].metadata.trusted is True
+
+
+async def test_ota_untrusted_provider_proactive_download(query_cmd, ota_image) -> None:
+    """Untrusted providers should download images proactively."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    index = [
+        SelfContainedOtaImageMetadata(
+            file_version=query_cmd.current_file_version + 1,
+            manufacturer_id=query_cmd.manufacturer_code,
+            test_data=ota_image.serialize(),
+        ),
+    ]
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.register_provider(SelfContainedProvider(index))  # Untrusted (default)
+
+    images = await ota.get_ota_images(device, query_cmd)
+
+    # Image should be returned WITH firmware downloaded
+    assert len(images.upgrades) == 1
+    assert images.upgrades[0].firmware is not None
+    assert images.upgrades[0].metadata.trusted is False
+
+
+async def test_ota_trusted_provider_specificity_boost(query_cmd, ota_image) -> None:
+    """Trusted provider images should have higher specificity."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+    test_data = ota_image.serialize()
+
+    # Same image from trusted and untrusted providers
+    trusted_meta = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 1,
+        manufacturer_id=query_cmd.manufacturer_code,
+        checksum="sha3-256:" + hashlib.sha3_256(test_data).hexdigest(),
+        file_size=len(test_data),
+        test_data=test_data,
+    )
+
+    untrusted_meta = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 1,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=test_data,
+    )
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    # Register untrusted first, then trusted to ensure ordering is due to specificity
+    ota.register_provider(SelfContainedProvider([untrusted_meta]))
+    ota.register_provider(TrustedSelfContainedProvider([trusted_meta]))
+
+    images = await ota.get_ota_images(device, query_cmd)
+
+    # Both images should be present, but trusted one should be first (higher specificity)
+    assert len(images.upgrades) == 2
+    assert images.upgrades[0].metadata.trusted is True
+    assert images.upgrades[1].metadata.trusted is False
+
+
+async def test_ota_trusted_provider_missing_sha3_256_checksum(
+    query_cmd, caplog
+) -> None:
+    """Trusted images without SHA3-256 checksum should be removed with warning."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    # Trusted image with sha256 checksum instead of sha3-256
+    index = [
+        SelfContainedOtaImageMetadata(
+            file_version=query_cmd.current_file_version + 1,
+            manufacturer_id=query_cmd.manufacturer_code,
+            checksum="sha256:abc123",  # Wrong algorithm
+            test_data=b"",  # Won't be fetched anyway
+        ),
+    ]
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.register_provider(TrustedSelfContainedProvider(index))
+
+    images = await ota.get_ota_images(device, query_cmd)
+
+    # Image should be removed due to missing SHA3-256 checksum
+    assert len(images.upgrades) == 0
+    assert "does not have SHA3-256 checksum" in caplog.text

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -444,18 +444,18 @@ async def test_ota_trusted_provider_specificity_boost(query_cmd, ota_image) -> N
     assert images.upgrades[1].metadata.trusted is False
 
 
+@pytest.mark.parametrize("checksum", [None, "sha256:abc123"])
 async def test_ota_trusted_provider_missing_sha3_256_checksum(
-    query_cmd, caplog
+    query_cmd, checksum, caplog
 ) -> None:
     """Trusted images without SHA3-256 checksum should be removed with warning."""
     device = make_device(model="device model", manufacturer_id=0x1234)
 
-    # Trusted image with sha256 checksum instead of sha3-256
     index = [
         SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             manufacturer_id=query_cmd.manufacturer_code,
-            checksum="sha256:abc123",  # Wrong algorithm
+            checksum=checksum,
             test_data=b"",  # Won't be fetched anyway
         ),
     ]

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -468,3 +468,34 @@ async def test_ota_trusted_provider_missing_sha3_256_checksum(
     # Image should be removed due to missing SHA3-256 checksum
     assert len(images.upgrades) == 0
     assert "does not have SHA3-256 checksum" in caplog.text
+
+
+@attrs.define(frozen=True, kw_only=True)
+class NoFirmwareOtaImageMetadata(SelfContainedOtaImageMetadata):
+    """Metadata class that returns None from fetch(), simulating missing firmware."""
+
+    test_data: bytes = b""
+
+    async def fetch(self) -> None:
+        return None
+
+
+async def test_ota_untrusted_image_without_firmware(query_cmd, caplog) -> None:
+    """Untrusted images without firmware should be removed with warning (edge case)."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    index = [
+        NoFirmwareOtaImageMetadata(
+            file_version=query_cmd.current_file_version + 1,
+            manufacturer_id=query_cmd.manufacturer_code,
+        ),
+    ]
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.register_provider(SelfContainedProvider(index))
+
+    images = await ota.get_ota_images(device, query_cmd)
+
+    # Image should be removed due to missing firmware (defensive check)
+    assert len(images.upgrades) == 0
+    assert "has no firmware downloaded" in caplog.text

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -95,23 +95,8 @@ class BrokenOtaImageMetadata(BaseOtaImageMetadata):
         raise RuntimeError("Some problem")
 
 
-async def test_ota_matching_priority(query_cmd) -> None:
+async def test_ota_matching_priority(query_cmd, ota_hdr, ota_subelements) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
-
-    ota_hdr = zigpy.ota.image.OTAImageHeader(
-        upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
-        file_version=query_cmd.current_file_version + 1,
-        image_type=query_cmd.image_type,
-        manufacturer_id=query_cmd.manufacturer_code,
-        header_version=256,
-        header_length=56,
-        field_control=0,
-        stack_version=2,
-        header_string="This is a test header!",
-        image_size=56 + 2 + 4 + 8,
-    )
-
-    ota_subelements = [zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")]
 
     index = [
         # Manufacturer ID
@@ -193,21 +178,11 @@ async def test_ota_matching_priority(query_cmd) -> None:
     assert images2 == images1
 
 
-async def test_ota_matching_ambiguous_error(query_cmd) -> None:
+async def test_ota_matching_ambiguous_error(query_cmd, ota_hdr) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
 
-    ota_hdr = zigpy.ota.image.OTAImageHeader(
-        upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
-        file_version=query_cmd.current_file_version + 1,
-        image_type=query_cmd.image_type,
-        manufacturer_id=query_cmd.manufacturer_code,
-        header_version=256,
-        header_length=56,
-        field_control=0,
-        stack_version=2,
-        header_string="This is a test header!",
-        image_size=56 + 2 + 4 + 10,
-    )
+    # Adjust header size for different firmware content
+    ota_hdr = ota_hdr.replace(image_size=56 + 2 + 4 + 10)
 
     index = [
         SelfContainedOtaImageMetadata(
@@ -240,21 +215,13 @@ async def test_ota_matching_ambiguous_error(query_cmd) -> None:
     assert not images.upgrades
 
 
-async def test_ota_matching_ambiguous_specificity_tie_breaker(query_cmd) -> None:
+async def test_ota_matching_ambiguous_specificity_tie_breaker(
+    query_cmd, ota_hdr
+) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
 
-    ota_hdr = zigpy.ota.image.OTAImageHeader(
-        upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
-        file_version=query_cmd.current_file_version + 1,
-        image_type=query_cmd.image_type,
-        manufacturer_id=query_cmd.manufacturer_code,
-        header_version=256,
-        header_length=56,
-        field_control=0,
-        stack_version=2,
-        header_string="This is a test header!",
-        image_size=56 + 2 + 4 + 10,
-    )
+    # Adjust header size for different firmware content
+    ota_hdr = ota_hdr.replace(image_size=56 + 2 + 4 + 10)
 
     index = [
         SelfContainedOtaImageMetadata(
@@ -294,26 +261,18 @@ async def test_ota_matching_ambiguous_specificity_tie_breaker(query_cmd) -> None
     )
 
 
-async def test_ota_concurrent_fetching(query_cmd) -> None:
+async def test_ota_concurrent_fetching(query_cmd, ota_hdr) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
+
+    # Adjust header size for different firmware content
+    ota_hdr = ota_hdr.replace(image_size=56 + 2 + 4 + 10)
 
     index = [
         SelfContainedOtaImageMetadata(
             file_version=query_cmd.current_file_version + 1,
             manufacturer_id=query_cmd.manufacturer_code,
             test_data=zigpy.ota.image.OTAImage(
-                header=zigpy.ota.image.OTAImageHeader(
-                    upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
-                    file_version=query_cmd.current_file_version + 1,
-                    image_type=query_cmd.image_type,
-                    manufacturer_id=query_cmd.manufacturer_code,
-                    header_version=256,
-                    header_length=56,
-                    field_control=0,
-                    stack_version=2,
-                    header_string="This is a test header!",
-                    image_size=56 + 2 + 4 + 10,
-                ),
+                header=ota_hdr,
                 subelements=[
                     zigpy.ota.image.SubElement(tag_id=0x0000, data=b"Firmware 1")
                 ],
@@ -339,36 +298,25 @@ async def test_ota_concurrent_fetching(query_cmd) -> None:
     assert images1 == images2
 
 
-async def test_ota_matching_hardware_version_changes_after_download(query_cmd) -> None:
+async def test_ota_matching_hardware_version_changes_after_download(
+    query_cmd, ota_hdr
+) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
 
-    ota_hdr_01 = zigpy.ota.image.OTAImageHeader(
-        upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
-        file_version=query_cmd.current_file_version + 1,
-        image_type=query_cmd.image_type,
-        manufacturer_id=query_cmd.manufacturer_code,
-        header_version=256,
+    # Create headers with hardware version constraints
+    ota_hdr_01 = ota_hdr.replace(
         header_length=60,
         field_control=FieldControl.HARDWARE_VERSIONS_PRESENT,
         minimum_hardware_version=0,
         maximum_hardware_version=1,
-        stack_version=2,
-        header_string="This is a test header!",
         image_size=56 + 2 + 4 + 4 + 10,
     )
 
-    ota_hdr_27 = zigpy.ota.image.OTAImageHeader(
-        upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
-        file_version=query_cmd.current_file_version + 1,
-        image_type=query_cmd.image_type,
-        manufacturer_id=query_cmd.manufacturer_code,
-        header_version=256,
+    ota_hdr_27 = ota_hdr.replace(
         header_length=60,
         field_control=FieldControl.HARDWARE_VERSIONS_PRESENT,
         minimum_hardware_version=2,
         maximum_hardware_version=7,
-        stack_version=2,
-        header_string="This is a test header!",
         image_size=56 + 2 + 4 + 4 + 10,
     )
 

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import pathlib
 import typing
 from unittest.mock import patch
 
@@ -96,16 +95,8 @@ class BrokenOtaImageMetadata(BaseOtaImageMetadata):
         raise RuntimeError("Some problem")
 
 
-async def test_ota_matching_priority(tmp_path: pathlib.Path) -> None:
+async def test_ota_matching_priority(query_cmd) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
-
-    query_cmd = Ota.ServerCommandDefs.query_next_image.schema(
-        field_control=FieldControl.HARDWARE_VERSIONS_PRESENT,
-        manufacturer_code=0x1234,
-        image_type=0xABCD,
-        current_file_version=1,
-        hardware_version=1,
-    )
 
     ota_hdr = zigpy.ota.image.OTAImageHeader(
         upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
@@ -202,16 +193,8 @@ async def test_ota_matching_priority(tmp_path: pathlib.Path) -> None:
     assert images2 == images1
 
 
-async def test_ota_matching_ambiguous_error() -> None:
+async def test_ota_matching_ambiguous_error(query_cmd) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
-
-    query_cmd = Ota.ServerCommandDefs.query_next_image.schema(
-        field_control=FieldControl.HARDWARE_VERSIONS_PRESENT,
-        manufacturer_code=0x1234,
-        image_type=0xABCD,
-        current_file_version=1,
-        hardware_version=1,
-    )
 
     ota_hdr = zigpy.ota.image.OTAImageHeader(
         upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
@@ -257,16 +240,8 @@ async def test_ota_matching_ambiguous_error() -> None:
     assert not images.upgrades
 
 
-async def test_ota_matching_ambiguous_specificity_tie_breaker() -> None:
+async def test_ota_matching_ambiguous_specificity_tie_breaker(query_cmd) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
-
-    query_cmd = Ota.ServerCommandDefs.query_next_image.schema(
-        field_control=FieldControl.HARDWARE_VERSIONS_PRESENT,
-        manufacturer_code=0x1234,
-        image_type=0xABCD,
-        current_file_version=1,
-        hardware_version=1,
-    )
 
     ota_hdr = zigpy.ota.image.OTAImageHeader(
         upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
@@ -319,16 +294,8 @@ async def test_ota_matching_ambiguous_specificity_tie_breaker() -> None:
     )
 
 
-async def test_ota_concurrent_fetching() -> None:
+async def test_ota_concurrent_fetching(query_cmd) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
-
-    query_cmd = Ota.ServerCommandDefs.query_next_image.schema(
-        field_control=FieldControl.HARDWARE_VERSIONS_PRESENT,
-        manufacturer_code=0x1234,
-        image_type=0xABCD,
-        current_file_version=1,
-        hardware_version=1,
-    )
 
     index = [
         SelfContainedOtaImageMetadata(
@@ -372,16 +339,8 @@ async def test_ota_concurrent_fetching() -> None:
     assert images1 == images2
 
 
-async def test_ota_matching_hardware_version_changes_after_download() -> None:
+async def test_ota_matching_hardware_version_changes_after_download(query_cmd) -> None:
     device = make_device(model="device model", manufacturer_id=0x1234)
-
-    query_cmd = Ota.ServerCommandDefs.query_next_image.schema(
-        field_control=FieldControl.HARDWARE_VERSIONS_PRESENT,
-        manufacturer_code=0x1234,
-        image_type=0xABCD,
-        current_file_version=1,
-        hardware_version=1,
-    )
 
     ota_hdr_01 = zigpy.ota.image.OTAImageHeader(
         upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -468,34 +468,3 @@ async def test_ota_trusted_provider_missing_sha3_256_checksum(
     # Image should be removed due to missing SHA3-256 checksum
     assert len(images.upgrades) == 0
     assert "does not have SHA3-256 checksum" in caplog.text
-
-
-@attrs.define(frozen=True, kw_only=True)
-class NoFirmwareOtaImageMetadata(SelfContainedOtaImageMetadata):
-    """Metadata class that returns None from fetch(), simulating missing firmware."""
-
-    test_data: bytes = b""
-
-    async def fetch(self) -> None:
-        return None
-
-
-async def test_ota_untrusted_image_without_firmware(query_cmd, caplog) -> None:
-    """Untrusted images without firmware should be removed with warning (edge case)."""
-    device = make_device(model="device model", manufacturer_id=0x1234)
-
-    index = [
-        NoFirmwareOtaImageMetadata(
-            file_version=query_cmd.current_file_version + 1,
-            manufacturer_id=query_cmd.manufacturer_code,
-        ),
-    ]
-
-    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
-    ota.register_provider(SelfContainedProvider(index))
-
-    images = await ota.get_ota_images(device, query_cmd)
-
-    # Image should be removed due to missing firmware (defensive check)
-    assert len(images.upgrades) == 0
-    assert "has no firmware downloaded" in caplog.text

--- a/tests/ota/test_ota_metadata.py
+++ b/tests/ota/test_ota_metadata.py
@@ -191,3 +191,26 @@ async def test_metadata_fetch(image_with_metadata: OtaImageWithMetadata) -> None
     # New image is identical
     new_img = await image_without_firmware.fetch()
     assert new_img == image_with_metadata
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_trusted", "specificity_boost"),
+    [
+        ({}, False, 0),
+        ({"trusted": False}, False, 0),
+        ({"trusted": True}, True, 10000),
+    ],
+)
+def test_metadata_trusted_specificity(
+    image_with_metadata: OtaImageWithMetadata,
+    kwargs: dict,
+    expected_trusted: bool,
+    specificity_boost: int,
+) -> None:
+    """Test trusted field and its effect on specificity."""
+    img = image_with_metadata.replace(
+        metadata=image_with_metadata.metadata.replace(**kwargs)
+    )
+
+    assert img.metadata.trusted is expected_trusted
+    assert img.specificity == image_with_metadata.specificity + specificity_boost

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -452,19 +452,21 @@ async def test_handle_unknown_cluster(dev, caplog) -> None:
 
 async def test_update_device_firmware_no_ota_cluster(dev):
     """Test that device firmware updates fails: no ota cluster."""
+    mock_image = MagicMock()
+
     with pytest.raises(ValueError, match="Cluster 0x0019 not found"):
-        await dev.update_firmware(sentinel.firmware_image, sentinel.progress_callback)
+        await dev.update_firmware(mock_image, sentinel.progress_callback)
 
     dev.add_endpoint(1)
     dev.endpoints[1].output_clusters = MagicMock(side_effect=KeyError)
     with pytest.raises(ValueError, match="Cluster 0x0019 not found"):
-        await dev.update_firmware(sentinel.firmware_image, sentinel.progress_callback)
+        await dev.update_firmware(mock_image, sentinel.progress_callback)
 
 
 async def test_update_device_firmware_already_in_progress(dev, caplog):
     """Test that device firmware updates no ops when update is in progress."""
     dev.ota_in_progress = True
-    await dev.update_firmware(sentinel.firmware_image, sentinel.progress_callback)
+    await dev.update_firmware(MagicMock(), sentinel.progress_callback)
     assert "OTA already in progress" in caplog.text
 
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -491,13 +491,9 @@ class OTA:
 
         # Calculate content hashes for collision detection
         for img in upgrades.values():
-            # Ignore untrusted image without firmware, should not occur
-            if img.firmware is None and not img.metadata.trusted:
-                _LOGGER.warning(
-                    "Untrusted image %s has no firmware downloaded, ignoring", img
-                )
-                images_to_remove.append(img.metadata)
-                continue
+            # Untrusted images are always downloaded above and ones that failed
+            # to download were already removed; this should never happen.
+            assert img.firmware is not None or img.metadata.trusted
 
             # Ignore trusted image without SHA3-256 checksum
             if img.firmware is None and (

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -480,16 +480,41 @@ class OTA:
             else:
                 upgrades[img.metadata] = img
 
-        # As a final pass, identify images with identical versions and specificity but
-        # differing contents.
+        await self._remove_colliding_images(upgrades)
+
+        return OtaImagesResult(
+            upgrades=tuple(
+                sorted(
+                    upgrades.values(),
+                    key=lambda img: (img.version, img.specificity),
+                    reverse=True,
+                )
+            ),
+            downgrades=tuple(
+                sorted(
+                    downgrades.values(),
+                    key=lambda img: (img.version, img.specificity),
+                    reverse=True,
+                )
+            ),
+        )
+
+    async def _remove_colliding_images(
+        self,
+        upgrades: dict[zigpy.ota.providers.BaseOtaImageMetadata, OtaImageWithMetadata],
+    ) -> None:
+        """Remove images with identical versions and specificity but differing contents.
+
+        Also removes trusted images that lack a SHA3-256 checksum, since their content
+        cannot be verified for collision detection.
+        """
         # Structure: {(version, specificity): {content_hash: [images]}}
-        upgrade_collisions: defaultdict[
+        collisions: defaultdict[
             tuple[int, int], defaultdict[str, list[OtaImageWithMetadata]]
         ] = defaultdict(lambda: defaultdict(list))
 
         images_to_remove: list[zigpy.ota.providers.BaseOtaImageMetadata] = []
 
-        # Calculate content hashes for collision detection
         for img in upgrades.values():
             # Untrusted images are always downloaded above and ones that failed
             # to download were already removed; this should never happen.
@@ -517,12 +542,12 @@ class OTA:
                 assert img.metadata.checksum is not None  # Checked above
                 content_hash = img.metadata.checksum
 
-            upgrade_collisions[img.version, img.specificity][content_hash].append(img)
+            collisions[img.version, img.specificity][content_hash].append(img)
 
         for meta in images_to_remove:
             upgrades.pop(meta)
 
-        for (version, specificity), buckets in upgrade_collisions.items():
+        for (version, specificity), buckets in collisions.items():
             # If there are multiple unique hashes, we have a collision
             if len(buckets) < 2:
                 continue
@@ -544,23 +569,6 @@ class OTA:
 
             for img in bad_images:
                 upgrades.pop(img.metadata)
-
-        return OtaImagesResult(
-            upgrades=tuple(
-                sorted(
-                    upgrades.values(),
-                    key=lambda img: (img.version, img.specificity),
-                    reverse=True,
-                )
-            ),
-            downgrades=tuple(
-                sorted(
-                    downgrades.values(),
-                    key=lambda img: (img.version, img.specificity),
-                    reverse=True,
-                )
-            ),
-        )
 
     async def broadcast_notify(
         self,

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -7,6 +7,7 @@ from asyncio import timeout as asyncio_timeout
 from collections import defaultdict
 import contextlib
 import dataclasses
+import hashlib
 import logging
 import typing
 
@@ -442,9 +443,13 @@ class OTA:
             img.metadata: img for img in candidates if img.metadata not in upgrades
         }
 
-        # Only download upgrade images, downgrades are used just to indicate the latest
-        # version
-        undownloaded_images = [img for img in upgrades.values() if img.firmware is None]
+        # Only download upgrade images from untrusted providers; trusted providers have
+        # complete metadata so we can defer the download until install time
+        undownloaded_images = [
+            img
+            for img in upgrades.values()
+            if img.firmware is None and not img.metadata.trusted
+        ]
 
         # Fetch all the candidates that are missing from the cache
         results = await asyncio.gather(
@@ -477,18 +482,50 @@ class OTA:
 
         # As a final pass, identify images with identical versions and specificity but
         # differing contents.
-        # Structure: {(version, specificity): {serialized_firmware: [images]}}
+        # Structure: {(version, specificity): {content_hash: [images]}}
         upgrade_collisions: defaultdict[
-            tuple[int, int], defaultdict[bytes, list[OtaImageWithMetadata]]
+            tuple[int, int], defaultdict[str, list[OtaImageWithMetadata]]
         ] = defaultdict(lambda: defaultdict(list))
 
+        images_to_remove: list[zigpy.ota.providers.BaseOtaImageMetadata] = []
+
+        # Calculate content hashes for collision detection
         for img in upgrades.values():
-            assert img.firmware is not None
-            upgrade_collisions[img.version, img.specificity][
-                img.firmware.serialize()
-            ].append(img)
+            # Ignore untrusted image without firmware, should not occur
+            if img.firmware is None and not img.metadata.trusted:
+                _LOGGER.warning(
+                    "Untrusted image %s has no firmware downloaded, ignoring", img
+                )
+                images_to_remove.append(img.metadata)
+                continue
+
+            # Ignore trusted image without SHA3-256 checksum
+            if img.firmware is None and (
+                img.metadata.checksum is None
+                or not img.metadata.checksum.startswith("sha3-256:")
+            ):
+                _LOGGER.warning(
+                    "Trusted image %s does not have SHA3-256 checksum, ignoring", img
+                )
+                images_to_remove.append(img.metadata)
+                continue
+
+            # Calculate content hash from firmware if available, otherwise use metadata
+            if img.firmware is not None:
+                content_hash = (
+                    "sha3-256:" + hashlib.sha3_256(img.firmware.serialize()).hexdigest()
+                )
+            else:
+                assert img.metadata.checksum is not None  # Checked above
+                content_hash = img.metadata.checksum
+
+            upgrade_collisions[img.version, img.specificity][content_hash].append(img)
+
+        for meta in images_to_remove:
+            upgrades.pop(meta)
 
         for (version, specificity), buckets in upgrade_collisions.items():
+            # If there are multiple unique hashes, we have a collision
             if len(buckets) < 2:
                 continue
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -410,6 +410,9 @@ class OTA:
             # caller will cache these images
             for meta in index:
                 if meta not in self._image_cache:
+                    # Mark metadata as trusted if it comes from a trusted provider
+                    if provider.TRUSTED and not meta.trusted:
+                        meta = meta.replace(trusted=True)
                     self._image_cache[meta] = OtaImageWithMetadata(
                         metadata=meta, firmware=None
                     )

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -508,9 +508,11 @@ class OTA:
 
             # Calculate content hash from firmware if available, otherwise use metadata
             if img.firmware is not None:
-                content_hash = (
-                    "sha3-256:" + hashlib.sha3_256(img.firmware.serialize()).hexdigest()
+                hasher = hashlib.sha3_256()
+                await asyncio.get_running_loop().run_in_executor(
+                    None, hasher.update, img.firmware.serialize()
                 )
+                content_hash = "sha3-256:" + hasher.hexdigest()
             else:
                 assert img.metadata.checksum is not None  # Checked above
                 content_hash = img.metadata.checksum

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -140,6 +140,10 @@ class OtaImageWithMetadata(t.BaseDataclassMixin):
         if self.metadata.specificity is not None:
             total += self.metadata.specificity
 
+        # Prefer images from trusted providers (e.g. zigpy-ota has richer metadata)
+        if self.metadata.trusted:
+            total += 10000
+
         return total
 
     def check_compatibility(

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from asyncio import timeout as asyncio_timeout
 from collections.abc import Callable
 import contextlib
 from typing import TYPE_CHECKING
@@ -314,7 +315,7 @@ async def update_firmware(
     """Update the firmware on a Zigbee device."""
     # Fetch firmware if not already downloaded (deferred download for trusted providers)
     if image.firmware is None:
-        async with asyncio.timeout(OTA_FETCH_TIMEOUT):
+        async with asyncio_timeout(OTA_FETCH_TIMEOUT):
             image = await image.fetch()
 
     if force:

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -8,6 +8,7 @@ import contextlib
 from typing import TYPE_CHECKING
 
 import zigpy.datastructures
+from zigpy.ota import OTA_FETCH_TIMEOUT
 import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import (
@@ -313,7 +314,8 @@ async def update_firmware(
     """Update the firmware on a Zigbee device."""
     # Fetch firmware if not already downloaded (deferred download for trusted providers)
     if image.firmware is None:
-        image = await image.fetch()
+        async with asyncio.timeout(OTA_FETCH_TIMEOUT):
+            image = await image.fetch()
 
     if force:
         # Force it to send the image even if it's the same version

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -311,6 +311,10 @@ async def update_firmware(
     force: bool = False,
 ) -> foundation.Status:
     """Update the firmware on a Zigbee device."""
+    # Fetch firmware if not already downloaded (deferred download for trusted providers)
+    if image.firmware is None:
+        image = await image.fetch()
+
     if force:
         # Force it to send the image even if it's the same version
         image = image.replace(

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -683,6 +683,7 @@ class ZigpyOtaProvider(BaseZigpyProvider):
 
     NAME = "zigpy_ota"
     VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_ZIGPY_OTA
+    TRUSTED = True
 
     DEFAULT_CHANNEL = "stable"
     SUPPORTED_CHANNELS = {"stable", "beta", "dev"}

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -94,6 +94,7 @@ class BaseOtaImageMetadata(t.BaseDataclassMixin):
     specificity: int | None = None
 
     source: str = "Unknown"
+    trusted: bool = False
 
     async def _fetch(self) -> bytes:
         raise NotImplementedError

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -196,6 +196,7 @@ class BaseOtaProvider:
     VOL_SCHEMA: vol.Schema
     JSON_SCHEMA: dict | None = None
     INDEX_EXPIRATION_TIME = datetime.timedelta(hours=24)
+    TRUSTED: bool = False
 
     def __init__(
         self,


### PR DESCRIPTION
## Proposed changes

- This PR introduces OTA providers that can be "trusted".
- The zigpy-ota provider is trusted.
- The specificity for all images fetched from trusted OTA providers is boosted.
  - Previously, the default enabled OTA provider registration order was critical for the zigpy-ota provider, so that its metadata (like release notes) got used, instead of ones from others (that would likely miss release notes), for identical images hosted by multiple providers.
- For trusted OTA providers, the behavior changes from downloading all possible (newer) images on any "device image request" to defer the download until the image is actually needed when the user tries to install firmware.
  - This is possible because trusted OTA providers are expected to have an SHA3-256 hash and all image metadata in the index (like min/max hardware versions from the OTA file).
   - If a trusted provider doesn't provide a checksum at all or one not prefixed with "sha3-256", a warning gets logged and the image is not considered for upgrading.
- Existing tests in `test_ota_matching` are also adjusted to use the new `query_cmd` and `ota_hdr` fixtures (keep this?)
- `get_ota_images` was also getting a bit long, so I've extracted the collision detection from it into a separate `_remove_colliding_images` method with https://github.com/zigpy/zigpy/pull/1749/changes/e8fd4a3a99a4d20ce9216303184d30fa50707f7f. I can revert that if we don't want it.


## Additional information / Advantages

- This should avoid unnecessary downloads when devices check in for the first time after rebooting Home Assistant, especially when users refuse to upgrade, for whatever reason.
  - When we makes changes for zigpy to properly persist OTA manufacturer id + image type (+ fw version) between restarts, so updates can be fetched directly at startup, instead of when the device first checks in, this will be more important, so we don't (re-)download not yet installed updates on startup.
- This is more important if there are intermediate upgrades that are not installed anyway (only used for release notes), but still downloaded with the current behavior.
- This should also make sure the zigpy-ota provider gets priority when the same images are also present in other providers.

### TODO
- Check if we should `check_compatibility` when actually downloading the image?
  - We shouldn't need to do for trusted providers technically and the checksum is validated already.
    Zigpy-ota uses parts of zigpy to parse and include all additional metadata in the index. I think zigpy shouldn't need to care about something breaking there, since it's "trusted". (It should also never happen for zigpy-ota)
   - EDIT: We also force the device to send another OTA query command where we `check_compatibility` with the real image. See this comment for more details: https://github.com/zigpy/zigpy/pull/1749#discussion_r2950035059. This is not an issue. `image.fetch()` also validates the checksum we got from the metadata.
- Check if this can (or needs to) be cleaned up?
- Manual testing

### Comments

- ~~I'm not sure if this is something we actually need, but it might be nice. **This is very much open to discussion.**~~ Because of the reasons listed above, I think this is going to be very useful and something we should implement.
- Going through the commits step by step might be better than going through the whole diff.