### PR TITLE
Populate `Device.original_signature` before loading quirks

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -25,7 +25,16 @@ from zigpy import profiles
 import zigpy.appdb
 import zigpy.application
 import zigpy.config as conf
-from zigpy.const import SIG_ENDPOINTS, SIG_MANUFACTURER, SIG_MODEL
+from zigpy.const import (
+    SIG_ENDPOINTS,
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    SIG_MANUFACTURER,
+    SIG_MODEL,
+    SIG_NODE_DESC,
+)
 from zigpy.device import Device, Status
 import zigpy.endpoint
 import zigpy.ota
@@ -35,8 +44,8 @@ from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 import zigpy.zcl
-from zigpy.zcl import UnsupportedAttribute
-from zigpy.zcl.clusters.general import Basic, Ota
+from zigpy.zcl import ClusterType, UnsupportedAttribute
+from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota
 from zigpy.zcl.foundation import Status as ZCLStatus, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
 
@@ -1562,3 +1571,89 @@ async def test_attribute_cache_null_manufacturer_code_uniqueness(tmp_path):
         )
         row = await cursor.fetchone()
         assert row[0] == "Model 2"
+
+
+@patch("zigpy.quirks.DEVICE_REGISTRY", new=DeviceRegistry())
+async def test_device_signature_ignores_quirks(tmp_path) -> None:
+    """Test that `device.original_signature` is populated before quirks modify the device."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+    dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+
+    ep.add_output_cluster(OnOff.cluster_id)
+
+    basic = ep.add_input_cluster(Basic.cluster_id)
+    basic.update_attribute(Basic.AttributeDefs.model, "some model")
+    basic.update_attribute(Basic.AttributeDefs.manufacturer, "some manufacturer")
+
+    dev.model = "some model"
+    dev.manufacturer = "some manufacturer"
+
+    app.device_initialized(dev)
+
+    # Capture the original signature
+    original_signature = dev.get_signature()
+
+    await app.shutdown()
+
+    # Create a quirk that modifies the device structure
+    (
+        QuirkBuilder(
+            "some manufacturer", "some model", registry=zigpy.quirks.DEVICE_REGISTRY
+        )
+        .adds_endpoint(99)
+        .adds(Basic.cluster_id, endpoint_id=99)
+        .adds(Identify.cluster_id, endpoint_id=1)
+        .removes(OnOff.cluster_id, cluster_type=ClusterType.Client, endpoint_id=1)
+        .add_to_registry()
+    )
+
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+
+    # The quirk modified the device object
+    assert 99 in dev2.endpoints
+    assert Identify.cluster_id in dev2.endpoints[1].in_clusters
+    assert OnOff.cluster_id not in dev2.endpoints[1].out_clusters
+
+    # But the signature remained the same
+    assert (
+        dev2.original_signature
+        == original_signature
+        == {
+            SIG_MANUFACTURER: "some manufacturer",
+            SIG_MODEL: "some model",
+            SIG_NODE_DESC: {
+                "logical_type": zdo_t.LogicalType.Router,
+                "complex_descriptor_available": 0,
+                "user_descriptor_available": 0,
+                "reserved": 0,
+                "aps_flags": 0,
+                "frequency_band": zdo_t.NodeDescriptor.FrequencyBand.Freq2400MHz,
+                "mac_capability_flags": zdo_t.NodeDescriptor.MACCapabilityFlags.AllocateAddress,
+                "manufacturer_code": 4174,
+                "maximum_buffer_size": 82,
+                "maximum_incoming_transfer_size": 82,
+                "server_mask": 0,
+                "maximum_outgoing_transfer_size": 82,
+                "descriptor_capability_field": zdo_t.NodeDescriptor.DescriptorCapability.NONE,
+            },
+            SIG_ENDPOINTS: {
+                1: {
+                    SIG_EP_PROFILE: 260,
+                    SIG_EP_TYPE: profiles.zha.DeviceType.PUMP,
+                    SIG_EP_INPUT: [Basic.cluster_id],
+                    SIG_EP_OUTPUT: [OnOff.cluster_id],
+                },
+            },
+        }
+    )
+
+    await app2.shutdown()

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1576,6 +1576,46 @@ async def test_attribute_cache_null_manufacturer_code_uniqueness(tmp_path):
 @patch("zigpy.quirks.DEVICE_REGISTRY", new=DeviceRegistry())
 async def test_device_signature_ignores_quirks(tmp_path) -> None:
     """Test that `device.original_signature` is populated before quirks modify the device."""
+
+    (
+        QuirkBuilder(
+            "some manufacturer", "some model", registry=zigpy.quirks.DEVICE_REGISTRY
+        )
+        .adds_endpoint(99)
+        .adds(Basic.cluster_id, endpoint_id=99)
+        .adds(Identify.cluster_id, endpoint_id=1)
+        .removes(OnOff.cluster_id, cluster_type=ClusterType.Client, endpoint_id=1)
+        .add_to_registry()
+    )
+
+    expected_signature = {
+        SIG_MANUFACTURER: "some manufacturer",
+        SIG_MODEL: "some model",
+        SIG_NODE_DESC: {
+            "logical_type": zdo_t.LogicalType.Router,
+            "complex_descriptor_available": 0,
+            "user_descriptor_available": 0,
+            "reserved": 0,
+            "aps_flags": 0,
+            "frequency_band": zdo_t.NodeDescriptor.FrequencyBand.Freq2400MHz,
+            "mac_capability_flags": zdo_t.NodeDescriptor.MACCapabilityFlags.AllocateAddress,
+            "manufacturer_code": 4174,
+            "maximum_buffer_size": 82,
+            "maximum_incoming_transfer_size": 82,
+            "server_mask": 0,
+            "maximum_outgoing_transfer_size": 82,
+            "descriptor_capability_field": zdo_t.NodeDescriptor.DescriptorCapability.NONE,
+        },
+        SIG_ENDPOINTS: {
+            1: {
+                SIG_EP_PROFILE: 260,
+                SIG_EP_TYPE: profiles.zha.DeviceType.PUMP,
+                SIG_EP_INPUT: [Basic.cluster_id],
+                SIG_EP_OUTPUT: [OnOff.cluster_id],
+            },
+        },
+    }
+
     db = tmp_path / "test.db"
     app = await make_app_with_db(db)
 
@@ -1596,25 +1636,21 @@ async def test_device_signature_ignores_quirks(tmp_path) -> None:
     dev.model = "some model"
     dev.manufacturer = "some manufacturer"
 
+    # When a device joins at runtime, `device_initialized` applies quirks
     app.device_initialized(dev)
+    dev = app.get_device(t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
 
-    # Capture the original signature
-    original_signature = dev.get_signature()
+    # The quirk modified the device object
+    assert 99 in dev.endpoints
+    assert Identify.cluster_id in dev.endpoints[1].in_clusters
+    assert OnOff.cluster_id not in dev.endpoints[1].out_clusters
+
+    # But the original signature was captured before quirks were applied
+    assert dev.original_signature == expected_signature
 
     await app.shutdown()
 
-    # Create a quirk that modifies the device structure
-    (
-        QuirkBuilder(
-            "some manufacturer", "some model", registry=zigpy.quirks.DEVICE_REGISTRY
-        )
-        .adds_endpoint(99)
-        .adds(Basic.cluster_id, endpoint_id=99)
-        .adds(Identify.cluster_id, endpoint_id=1)
-        .removes(OnOff.cluster_id, cluster_type=ClusterType.Client, endpoint_id=1)
-        .add_to_registry()
-    )
-
+    # Also verify loading from the database preserves the original signature
     app2 = await make_app_with_db(db)
     dev2 = app2.get_device(t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
 
@@ -1623,37 +1659,7 @@ async def test_device_signature_ignores_quirks(tmp_path) -> None:
     assert Identify.cluster_id in dev2.endpoints[1].in_clusters
     assert OnOff.cluster_id not in dev2.endpoints[1].out_clusters
 
-    # But the signature remained the same
-    assert (
-        dev2.original_signature
-        == original_signature
-        == {
-            SIG_MANUFACTURER: "some manufacturer",
-            SIG_MODEL: "some model",
-            SIG_NODE_DESC: {
-                "logical_type": zdo_t.LogicalType.Router,
-                "complex_descriptor_available": 0,
-                "user_descriptor_available": 0,
-                "reserved": 0,
-                "aps_flags": 0,
-                "frequency_band": zdo_t.NodeDescriptor.FrequencyBand.Freq2400MHz,
-                "mac_capability_flags": zdo_t.NodeDescriptor.MACCapabilityFlags.AllocateAddress,
-                "manufacturer_code": 4174,
-                "maximum_buffer_size": 82,
-                "maximum_incoming_transfer_size": 82,
-                "server_mask": 0,
-                "maximum_outgoing_transfer_size": 82,
-                "descriptor_capability_field": zdo_t.NodeDescriptor.DescriptorCapability.NONE,
-            },
-            SIG_ENDPOINTS: {
-                1: {
-                    SIG_EP_PROFILE: 260,
-                    SIG_EP_TYPE: profiles.zha.DeviceType.PUMP,
-                    SIG_EP_INPUT: [Basic.cluster_id],
-                    SIG_EP_OUTPUT: [OnOff.cluster_id],
-                },
-            },
-        }
-    )
+    # The original signature is still preserved
+    assert dev2.original_signature == expected_signature
 
     await app2.shutdown()

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -670,7 +670,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         for device in self._application.devices.values():
             # Populate the device signature before we apply any quirks, which can modify
             # the device structure (for now)
-            device.signature = device.get_signature()
+            device.original_signature = device.get_signature()
 
             device = zigpy.quirks.get_device(device)
             self._application.devices[device.ieee] = device

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -668,6 +668,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._load_attributes()
 
         for device in self._application.devices.values():
+            # Populate the device signature before we apply any quirks, which can modify
+            # the device structure (for now)
+            device.signature = device.get_signature()
+
             device = zigpy.quirks.get_device(device)
             self._application.devices[device.ieee] = device
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -599,6 +599,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     def device_initialized(self, device: zigpy.device.Device) -> None:
         """Used by a device to signal that it is initialized"""
         LOGGER.debug("Device is initialized %s", device)
+        device.original_signature = device.get_signature()
 
         self.listener_event("raw_device_initialized", device)
         device = zigpy.quirks.get_device(device)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -135,6 +135,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
         )
 
+        self._signature: dict[str, Any] | None = None
+
     def create_task(
         self, target: Coroutine[Any, Any, _R], name: str | None = None
     ) -> asyncio.Task[_R]:
@@ -978,6 +980,17 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def model(self, value) -> None:
         if isinstance(value, str):
             self._model = value
+
+    @property
+    def signature(self) -> dict[str, Any] | None:
+        return self._signature
+
+    @signature.setter
+    def signature(self, value: str | None) -> None:
+        if self._signature is not None:
+            raise AttributeError("Signature is already set and cannot be modified")
+
+        self._signature = value
 
     @property
     def skip_configuration(self) -> bool:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -135,7 +135,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
         )
 
-        self._signature: dict[str, Any] | None = None
+        # Persist the original signature information for the device, before quirks are
+        # applied
+        self._original_signature: dict[str, Any] | None = None
 
     def create_task(
         self, target: Coroutine[Any, Any, _R], name: str | None = None
@@ -982,15 +984,15 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self._model = value
 
     @property
-    def signature(self) -> dict[str, Any] | None:
-        return self._signature
+    def original_signature(self) -> dict[str, Any] | None:
+        return self._original_signature
 
-    @signature.setter
-    def signature(self, value: str | None) -> None:
-        if self._signature is not None:
+    @original_signature.setter
+    def original_signature(self, value: str | None) -> None:
+        if self._original_signature is not None:
             raise AttributeError("Signature is already set and cannot be modified")
 
-        self._signature = value
+        self._original_signature = value
 
     @property
     def skip_configuration(self) -> bool:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -990,7 +990,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     @original_signature.setter
     def original_signature(self, value: str | None) -> None:
         if self._original_signature is not None:
-            raise AttributeError("Signature is already set and cannot be modified")
+            return
 
         self._original_signature = value
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -988,7 +988,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return self._original_signature
 
     @original_signature.setter
-    def original_signature(self, value: str | None) -> None:
+    def original_signature(self, value: dict[str, Any] | None) -> None:
         if self._original_signature is not None:
             return
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -92,6 +92,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.nwk: t.NWK = t.NWK(nwk)
         self.zdo: zdo.ZDO = zdo.ZDO(self)
         self.endpoints: dict[int, zdo.ZDO | zigpy.endpoint.Endpoint] = {0: self.zdo}
+
+        # Persist the original signature for the device, before quirks are applied
+        self._original_signature: dict[str, Any] | None = None
+
         self.lqi: int | None = None
         self.rssi: int | None = None
         self.ota_in_progress: bool = False
@@ -134,10 +138,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 callback=self.poll_control_checkin_callback,
             )
         )
-
-        # Persist the original signature information for the device, before quirks are
-        # applied
-        self._original_signature: dict[str, Any] | None = None
 
     def create_task(
         self, target: Coroutine[Any, Any, _R], name: str | None = None

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -79,14 +79,17 @@ class BaseCustomDevice(zigpy.device.Device):
     ) -> None:
         super().__init__(application, ieee, nwk)
 
+        self.lqi = replaces.lqi
+        self.rssi = replaces.rssi
+        self.last_seen = replaces.last_seen
+        self.relays = replaces.relays
+        self.original_signature = replaces.original_signature
+
         def set_device_attr(attr):
             if attr in self.replacement:
                 setattr(self, attr, self.replacement[attr])
             else:
                 setattr(self, attr, getattr(replaces, attr))
-
-        for attr in ("lqi", "rssi", "last_seen", "relays"):
-            setattr(self, attr, getattr(replaces, attr))
 
         set_device_attr("status")
         set_device_attr(SIG_NODE_DESC)


### PR DESCRIPTION
This won't help our existing diagnostics but it will help future diagnostics contain the correct information, even when v2 quirks are used.

ZHA will need to be modified to dump `.original_signature` and use it for loaded devices.