### PR TITLE
Accept `None` in `Device.last_seen` setter

### DIFF
--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -223,7 +223,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return self._last_seen.timestamp() if self._last_seen is not None else None
 
     @last_seen.setter
-    def last_seen(self, value: datetime | float):
+    def last_seen(self, value: datetime | float | None):
         if isinstance(value, int | float):
             value = datetime.fromtimestamp(value, UTC)
 


### PR DESCRIPTION
It looks like https://github.com/zigpy/zigpy/pull/1751 should have been merged and https://github.com/zigpy/zigpy/pull/1750 rebased on top of it. There's a new type error introduced by the latter PR. This fixes it.