### PR TITLE
Fix type annotations for Core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -413,6 +413,14 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
+module = "zigpy.types.struct"
+disable_error_code = [
+    "arg-type",  # 2
+    "attr-defined",  # 19
+    "misc",  # 2
+]
+
+[[tool.mypy.overrides]]
 module = "zigpy.zdo.types"
 disable_error_code = [
     "assignment",  # 18
@@ -437,14 +445,6 @@ disable_error_code = [
     "attr-defined",  # 7
     "method-assign",  # 5
     "misc",  # 10
-]
-
-[[tool.mypy.overrides]]
-module = "zigpy.types.struct"
-disable_error_code = [
-    "arg-type",  # 2
-    "attr-defined",  # 34
-    "misc",  # 2
 ]
 
 [[tool.mypy.overrides]]

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import typing
-from typing import TYPE_CHECKING, Self, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 import zigpy.types as t
 
@@ -31,7 +31,7 @@ class EmptyObject:
 @dataclasses.dataclass(frozen=True)
 class StructField:
     name: str | None = None
-    type: type | None = None
+    type: type[Any] | None = None
 
     requires: typing.Callable[[Struct], bool] | None = dataclasses.field(
         default=None, repr=False
@@ -64,12 +64,14 @@ if TYPE_CHECKING:
         """`StructField` instance with name and type resolved."""
 
         name: str
-        type: type
+        type: type[Any]
 else:
     ResolvedStructField = StructField
 
 
 class Struct:
+    fields: list[ResolvedStructField]
+
     @classmethod
     def _real_cls(cls) -> type:
         # The "Optional" subclass is dynamically created and breaks types.

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import typing
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 
 import zigpy.types as t
 
@@ -70,7 +70,7 @@ else:
 
 
 class Struct:
-    fields: list[ResolvedStructField]
+    fields: ClassVar[list[ResolvedStructField]]
 
     @classmethod
     def _real_cls(cls) -> type:
@@ -154,6 +154,10 @@ class Struct:
         #      order them with respect to annotation-only fields.
         #      Every struct field must be annotated.
         for name, annotation in annotations.items():
+            # Skip ClassVar annotations (e.g. inherited from Struct base class)
+            if typing.get_origin(annotation) is ClassVar:
+                continue
+
             field = getattr(cls, name, StructField())
 
             if not isinstance(field, StructField):


### PR DESCRIPTION
`StructField.type` was too broad. In zigpy, we assume all types accept a "copy constructor" and can accept a single argument.