### PR TITLE
Suppress ZCL read/update events more granularly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,15 +475,30 @@ async def mock_attribute_report(
     manufacturer_codes: set[int | None] = set()
 
     for attr, value in attributes.items():
-        attr_def = cluster.find_attribute(attr)
-        manufacturer_codes.add(cluster._get_effective_manufacturer_code(attr_def, None))
-
-        reports.append(
-            foundation.Attribute(
-                attrid=attr_def.id,
-                value=foundation.TypeValue(type=attr_def.zcl_type, value=value),
+        if isinstance(attr, int):
+            # Raw attribute ID for unknown attributes
+            manufacturer_codes.add(None)
+            reports.append(
+                foundation.Attribute(
+                    attrid=attr,
+                    value=foundation.TypeValue(
+                        type=foundation.DataType.from_python_type(type(value)).type_id,
+                        value=value,
+                    ),
+                )
             )
-        )
+        else:
+            attr_def = cluster.find_attribute(attr)
+            manufacturer_codes.add(
+                cluster._get_effective_manufacturer_code(attr_def, None)
+            )
+
+            reports.append(
+                foundation.Attribute(
+                    attrid=attr_def.id,
+                    value=foundation.TypeValue(type=attr_def.zcl_type, value=value),
+                )
+            )
 
     if len(manufacturer_codes) != 1:
         raise ValueError(

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1823,16 +1823,19 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
         {
             DoublingCluster.AttributeDefs.test_attr: t.uint8_t(25),
             DoublingCluster.AttributeDefs.passthrough_attr: t.uint8_t(77),
+            DoublingCluster.AttributeDefs.swallowed_attr: t.uint8_t(99),
         },
     ):
         await cluster.read_attributes(
             [
                 DoublingCluster.AttributeDefs.test_attr,
                 DoublingCluster.AttributeDefs.passthrough_attr,
+                DoublingCluster.AttributeDefs.swallowed_attr,
             ]
         )
 
     assert events == [
+        # No event for swallowed_attr since quirk swallows it entirely
         # No AttributeReadEvent for test_attr since the value was transformed
         # AttributeUpdatedEvent for other_attr (quirk side-effect)
         AttributeUpdatedEvent(

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1683,6 +1683,9 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             other_attr = foundation.ZCLAttributeDef(
                 id=0x0002, type=t.uint8_t, access="r"
             )
+            passthrough_attr = foundation.ZCLAttributeDef(
+                id=0x0003, type=t.uint8_t, access="r"
+            )
 
         def _update_attribute(self, attrid, value):
             if attrid == self.AttributeDefs.test_attr.id:
@@ -1690,12 +1693,14 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
                 value = value * 2
                 super()._update_attribute(attrid, value)
 
-            # Also update a different attribute
-            if attrid == self.AttributeDefs.test_attr.id:
+                # Also update a different attribute
                 super()._update_attribute(self.AttributeDefs.other_attr.id, 123)
 
-            # Update an attribute that doesn't have a definition
-            super()._update_attribute(0xABCD, 45)
+                # Update an attribute that doesn't have a definition
+                super()._update_attribute(0xABCD, 45)
+            else:
+                # Pass through unchanged
+                super()._update_attribute(attrid, value)
 
     dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
     cluster = DoublingCluster(dev.endpoints[1])
@@ -1707,11 +1712,15 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
     cluster.on_event(AttributeUpdatedEvent.event_type, events.append)
 
     await mock_attribute_report(
-        cluster, {DoublingCluster.AttributeDefs.test_attr: t.uint8_t(50)}
+        cluster,
+        {
+            DoublingCluster.AttributeDefs.test_attr: t.uint8_t(50),
+            DoublingCluster.AttributeDefs.passthrough_attr: t.uint8_t(99),
+        },
     )
 
     assert events == [
-        # AttributeReportedEvent with raw value (50)
+        # AttributeReportedEvent for test_attr with raw value (50)
         AttributeReportedEvent(
             device_ieee=str(dev.ieee),
             endpoint_id=1,
@@ -1741,7 +1750,7 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             cluster_type=zcl.ClusterType.Server,
             cluster_id=DoublingCluster.cluster_id,
             attribute_name=None,
-            attribute_id=43981,
+            attribute_id=0xABCD,
             manufacturer_code=None,
             value=45,
         ),
@@ -1756,18 +1765,40 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             manufacturer_code=None,
             value=100,
         ),
+        # AttributeReportedEvent for passthrough_attr (no transformation)
+        AttributeReportedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name="passthrough_attr",
+            attribute_id=DoublingCluster.AttributeDefs.passthrough_attr.id,
+            manufacturer_code=None,
+            raw_value=99,
+            value=99,
+        ),
+        # No AttributeUpdatedEvent for passthrough_attr since value wasn't transformed
     ]
 
     # Now test the read path
     events.clear()
 
     with mock_attribute_reads(
-        cluster, {DoublingCluster.AttributeDefs.test_attr: t.uint8_t(25)}
+        cluster,
+        {
+            DoublingCluster.AttributeDefs.test_attr: t.uint8_t(25),
+            DoublingCluster.AttributeDefs.passthrough_attr: t.uint8_t(77),
+        },
     ):
-        await cluster.read_attributes([DoublingCluster.AttributeDefs.test_attr])
+        await cluster.read_attributes(
+            [
+                DoublingCluster.AttributeDefs.test_attr,
+                DoublingCluster.AttributeDefs.passthrough_attr,
+            ]
+        )
 
     assert events == [
-        # AttributeReadEvent with raw value (25)
+        # AttributeReadEvent for test_attr with raw value (25)
         AttributeReadEvent(
             device_ieee=str(dev.ieee),
             endpoint_id=1,
@@ -1812,4 +1843,17 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             manufacturer_code=None,
             value=50,  # Doubled from 25
         ),
+        # AttributeReadEvent for passthrough_attr (no transformation)
+        AttributeReadEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name="passthrough_attr",
+            attribute_id=DoublingCluster.AttributeDefs.passthrough_attr.id,
+            manufacturer_code=None,
+            raw_value=77,
+            value=77,
+        ),
+        # No AttributeUpdatedEvent for passthrough_attr since value wasn't transformed
     ]

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1689,6 +1689,9 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             passthrough_attr = foundation.ZCLAttributeDef(
                 id=0x0003, type=t.uint8_t, access="r"
             )
+            swallowed_attr = foundation.ZCLAttributeDef(
+                id=0x0004, type=t.uint8_t, access="r"
+            )
 
         def _update_attribute(self, attrid, value):
             if attrid == self.AttributeDefs.test_attr.id:
@@ -1708,6 +1711,9 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
                     OccupancySensing.AttributeDefs.occupancy.id,
                     OccupancySensing.Occupancy.Occupied,
                 )
+            elif attrid == self.AttributeDefs.swallowed_attr.id:
+                # Swallow the attribute update entirely (no super() call)
+                return
             else:
                 # Pass through unchanged
                 super()._update_attribute(attrid, value)
@@ -1730,11 +1736,13 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
         {
             DoublingCluster.AttributeDefs.test_attr: t.uint8_t(50),
             DoublingCluster.AttributeDefs.passthrough_attr: t.uint8_t(99),
+            DoublingCluster.AttributeDefs.swallowed_attr: t.uint8_t(42),
             MOTION_ATTRIBUTE: t.uint8_t(1),  # Unknown attribute (raw ID)
         },
     )
 
     assert events == [
+        # No event for swallowed_attr since quirk swallows it entirely
         # No AttributeReportedEvent for test_attr since the value was transformed
         # AttributeUpdatedEvent for other_attr (quirk side-effect)
         AttributeUpdatedEvent(

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -11,6 +11,7 @@ from tests.conftest import (
     add_initialized_device,
     make_app,
     make_ieee,
+    mock_attribute_reads,
     mock_attribute_report,
 )
 from zigpy import zcl
@@ -19,6 +20,7 @@ import zigpy.endpoint
 import zigpy.profiles.zha
 import zigpy.types as t
 from zigpy.zcl import (
+    AttributeReadEvent,
     AttributeReportedEvent,
     AttributeUpdatedEvent,
     AttributeWrittenEvent,
@@ -1692,11 +1694,15 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             if attrid == self.AttributeDefs.test_attr.id:
                 super()._update_attribute(self.AttributeDefs.other_attr.id, 123)
 
+            # Update an attribute that doesn't have a definition
+            super()._update_attribute(0xABCD, 45)
+
     dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
     cluster = DoublingCluster(dev.endpoints[1])
     dev.endpoints[1].add_input_cluster(DoublingCluster.cluster_id, cluster)
 
     events = []
+    cluster.on_event(AttributeReadEvent.event_type, events.append)
     cluster.on_event(AttributeReportedEvent.event_type, events.append)
     cluster.on_event(AttributeUpdatedEvent.event_type, events.append)
 
@@ -1705,7 +1711,7 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
     )
 
     assert events == [
-        # First: AttributeReportedEvent with raw value (50)
+        # AttributeReportedEvent with raw value (50)
         AttributeReportedEvent(
             device_ieee=str(dev.ieee),
             endpoint_id=1,
@@ -1717,7 +1723,7 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             raw_value=50,
             value=50,
         ),
-        # Second: AttributeUpdatedEvent for other_attr (quirk side-effect)
+        # AttributeUpdatedEvent for other_attr (quirk side-effect)
         AttributeUpdatedEvent(
             device_ieee=str(dev.ieee),
             endpoint_id=1,
@@ -1728,7 +1734,18 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             manufacturer_code=None,
             value=123,
         ),
-        # Third: AttributeUpdatedEvent for test_attr with transformed value (doubled)
+        # AttributeUpdatedEvent for unknown attribute
+        AttributeUpdatedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name=None,
+            attribute_id=43981,
+            manufacturer_code=None,
+            value=45,
+        ),
+        # AttributeUpdatedEvent for test_attr with transformed value (doubled)
         AttributeUpdatedEvent(
             device_ieee=str(dev.ieee),
             endpoint_id=1,
@@ -1738,5 +1755,61 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             attribute_id=DoublingCluster.AttributeDefs.test_attr.id,
             manufacturer_code=None,
             value=100,
+        ),
+    ]
+
+    # Now test the read path
+    events.clear()
+
+    with mock_attribute_reads(
+        cluster, {DoublingCluster.AttributeDefs.test_attr: t.uint8_t(25)}
+    ):
+        await cluster.read_attributes([DoublingCluster.AttributeDefs.test_attr])
+
+    assert events == [
+        # AttributeReadEvent with raw value (25)
+        AttributeReadEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name="test_attr",
+            attribute_id=DoublingCluster.AttributeDefs.test_attr.id,
+            manufacturer_code=None,
+            raw_value=25,
+            value=25,
+        ),
+        # AttributeUpdatedEvent for other_attr (quirk side-effect)
+        AttributeUpdatedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name="other_attr",
+            attribute_id=DoublingCluster.AttributeDefs.other_attr.id,
+            manufacturer_code=None,
+            value=123,
+        ),
+        # AttributeUpdatedEvent for unknown attribute
+        AttributeUpdatedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name=None,
+            attribute_id=0xABCD,
+            manufacturer_code=None,
+            value=45,
+        ),
+        # AttributeUpdatedEvent for test_attr with transformed value (doubled)
+        AttributeUpdatedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name="test_attr",
+            attribute_id=DoublingCluster.AttributeDefs.test_attr.id,
+            manufacturer_code=None,
+            value=50,  # Doubled from 25
         ),
     ]

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -7,13 +7,23 @@ from unittest.mock import AsyncMock, MagicMock, call, patch, sentinel
 
 import pytest
 
-from tests.conftest import add_initialized_device, make_app
+from tests.conftest import (
+    add_initialized_device,
+    make_app,
+    make_ieee,
+    mock_attribute_report,
+)
 from zigpy import zcl
 import zigpy.device
 import zigpy.endpoint
 import zigpy.profiles.zha
 import zigpy.types as t
-from zigpy.zcl import AttributeWrittenEvent, foundation
+from zigpy.zcl import (
+    AttributeReportedEvent,
+    AttributeUpdatedEvent,
+    AttributeWrittenEvent,
+    foundation,
+)
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota
 from zigpy.zcl.helpers import ReportingConfig
 
@@ -1653,3 +1663,80 @@ async def test_command_explicit_manufacturer():
         await cluster.command(0x00, manufacturer=0x9999)
 
     assert mock_request.mock_calls[0].kwargs["manufacturer"] == 0x9999
+
+
+async def test_report_attributes_quirk_transforms_value(app_mock):
+    """Test that quirks transforming values emit both reported and updated events."""
+
+    class DoublingCluster(zcl.Cluster):
+        """A quirk cluster that doubles reported values."""
+
+        cluster_id = 0xABCD
+        ep_attribute = "doubling"
+
+        class AttributeDefs(zcl.foundation.BaseAttributeDefs):
+            test_attr = foundation.ZCLAttributeDef(
+                id=0x0001, type=t.uint8_t, access="r"
+            )
+            other_attr = foundation.ZCLAttributeDef(
+                id=0x0002, type=t.uint8_t, access="r"
+            )
+
+        def _update_attribute(self, attrid, value):
+            if attrid == self.AttributeDefs.test_attr.id:
+                # Double the value
+                value = value * 2
+                super()._update_attribute(attrid, value)
+
+            # Also update a different attribute
+            if attrid == self.AttributeDefs.test_attr.id:
+                super()._update_attribute(self.AttributeDefs.other_attr.id, 123)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = DoublingCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(DoublingCluster.cluster_id, cluster)
+
+    events = []
+    cluster.on_event(AttributeReportedEvent.event_type, events.append)
+    cluster.on_event(AttributeUpdatedEvent.event_type, events.append)
+
+    await mock_attribute_report(
+        cluster, {DoublingCluster.AttributeDefs.test_attr: t.uint8_t(50)}
+    )
+
+    assert events == [
+        # First: AttributeReportedEvent with raw value (50)
+        AttributeReportedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name="test_attr",
+            attribute_id=DoublingCluster.AttributeDefs.test_attr.id,
+            manufacturer_code=None,
+            raw_value=50,
+            value=50,
+        ),
+        # Second: AttributeUpdatedEvent for other_attr (quirk side-effect)
+        AttributeUpdatedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name="other_attr",
+            attribute_id=DoublingCluster.AttributeDefs.other_attr.id,
+            manufacturer_code=None,
+            value=123,
+        ),
+        # Third: AttributeUpdatedEvent for test_attr with transformed value (doubled)
+        AttributeUpdatedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name="test_attr",
+            attribute_id=DoublingCluster.AttributeDefs.test_attr.id,
+            manufacturer_code=None,
+            value=100,
+        ),
+    ]

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1669,6 +1669,9 @@ async def test_command_explicit_manufacturer():
 
 async def test_report_attributes_quirk_transforms_value(app_mock):
     """Test that quirks transforming values emit both reported and updated events."""
+    from zigpy.zcl.clusters.measurement import OccupancySensing
+
+    MOTION_ATTRIBUTE = 0x0112  # Unknown attribute that triggers motion
 
     class DoublingCluster(zcl.Cluster):
         """A quirk cluster that doubles reported values."""
@@ -1698,24 +1701,36 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
 
                 # Update an attribute that doesn't have a definition
                 super()._update_attribute(0xABCD, 45)
+            elif attrid == MOTION_ATTRIBUTE:
+                # Unknown attribute that updates a different cluster (like motion sensors)
+                super()._update_attribute(attrid, value)
+                self.endpoint.occupancy.update_attribute(
+                    OccupancySensing.AttributeDefs.occupancy.id,
+                    OccupancySensing.Occupancy.Occupied,
+                )
             else:
                 # Pass through unchanged
                 super()._update_attribute(attrid, value)
 
     dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
     cluster = DoublingCluster(dev.endpoints[1])
+    occupancy_cluster = OccupancySensing(dev.endpoints[1])
     dev.endpoints[1].add_input_cluster(DoublingCluster.cluster_id, cluster)
+    dev.endpoints[1].add_input_cluster(OccupancySensing.cluster_id, occupancy_cluster)
 
     events = []
     cluster.on_event(AttributeReadEvent.event_type, events.append)
     cluster.on_event(AttributeReportedEvent.event_type, events.append)
     cluster.on_event(AttributeUpdatedEvent.event_type, events.append)
+    occupancy_cluster.on_event(AttributeReportedEvent.event_type, events.append)
+    occupancy_cluster.on_event(AttributeUpdatedEvent.event_type, events.append)
 
     await mock_attribute_report(
         cluster,
         {
             DoublingCluster.AttributeDefs.test_attr: t.uint8_t(50),
             DoublingCluster.AttributeDefs.passthrough_attr: t.uint8_t(99),
+            MOTION_ATTRIBUTE: t.uint8_t(1),  # Unknown attribute (raw ID)
         },
     )
 
@@ -1767,6 +1782,29 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
             value=99,
         ),
         # No AttributeUpdatedEvent for passthrough_attr since value wasn't transformed
+        # AttributeUpdatedEvent for occupancy (quirk updates different cluster)
+        AttributeUpdatedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=OccupancySensing.cluster_id,
+            attribute_name="occupancy",
+            attribute_id=OccupancySensing.AttributeDefs.occupancy.id,
+            manufacturer_code=None,
+            value=OccupancySensing.Occupancy.Occupied,
+        ),
+        # AttributeReportedEvent for unknown MOTION_ATTRIBUTE (no transformation)
+        AttributeReportedEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=DoublingCluster.cluster_id,
+            attribute_name=None,
+            attribute_id=MOTION_ATTRIBUTE,
+            manufacturer_code=None,
+            raw_value=1,
+            value=1,
+        ),
     ]
 
     # Now test the read path

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1720,18 +1720,7 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
     )
 
     assert events == [
-        # AttributeReportedEvent for test_attr with raw value (50)
-        AttributeReportedEvent(
-            device_ieee=str(dev.ieee),
-            endpoint_id=1,
-            cluster_type=zcl.ClusterType.Server,
-            cluster_id=DoublingCluster.cluster_id,
-            attribute_name="test_attr",
-            attribute_id=DoublingCluster.AttributeDefs.test_attr.id,
-            manufacturer_code=None,
-            raw_value=50,
-            value=50,
-        ),
+        # No AttributeReportedEvent for test_attr since the value was transformed
         # AttributeUpdatedEvent for other_attr (quirk side-effect)
         AttributeUpdatedEvent(
             device_ieee=str(dev.ieee),
@@ -1798,18 +1787,7 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
         )
 
     assert events == [
-        # AttributeReadEvent for test_attr with raw value (25)
-        AttributeReadEvent(
-            device_ieee=str(dev.ieee),
-            endpoint_id=1,
-            cluster_type=zcl.ClusterType.Server,
-            cluster_id=DoublingCluster.cluster_id,
-            attribute_name="test_attr",
-            attribute_id=DoublingCluster.AttributeDefs.test_attr.id,
-            manufacturer_code=None,
-            raw_value=25,
-            value=25,
-        ),
+        # No AttributeReadEvent for test_attr since the value was transformed
         # AttributeUpdatedEvent for other_attr (quirk side-effect)
         AttributeUpdatedEvent(
             device_ieee=str(dev.ieee),

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -796,35 +796,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     ),
                 )
 
-                # Suppress only this specific attribute's events during update.
-                # This allows quirks that update other clusters or other attributes
-                # on this cluster to emit their own AttributeUpdatedEvent.
-                with _suppress_attribute_update_event(self.cluster_id, attr.attrid):
-                    self._update_attribute(attr.attrid, value)
-
-                # If a quirk transformed the value, emit AttributeUpdatedEvent
-                if attr_def is None:
-                    continue
-
-                try:
-                    cached_value = self._attr_cache.get_value(attr_def)
-                except KeyError:
-                    continue
-
-                if cached_value != value:
-                    self.emit(
-                        AttributeUpdatedEvent.event_type,
-                        AttributeUpdatedEvent(
-                            device_ieee=str(self.endpoint.device.ieee),
-                            endpoint_id=self.endpoint.endpoint_id,
-                            cluster_type=self._type,
-                            cluster_id=self.cluster_id,
-                            attribute_name=attr_def.name,
-                            attribute_id=attr_def.id,
-                            manufacturer_code=attr_def.manufacturer_code,
-                            value=cached_value,
-                        ),
-                    )
+                if attr_def is not None:
+                    self._update_attribute_with_event(attr_def, value)
 
         if not hdr.frame_control.disable_default_response:
             self.send_default_rsp(
@@ -977,34 +950,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                             ),
                         )
 
-                        # Suppress only this specific attribute's events during
-                        # update. This allows quirks that update other clusters or
-                        # other attributes to emit their own AttributeUpdatedEvent.
-                        with _suppress_attribute_update_event(
-                            self.cluster_id, attr_def.id
-                        ):
-                            self._update_attribute(attr_def.id, value)
-
-                        try:
-                            cached_value = self._attr_cache.get_value(attr_def)
-                        except KeyError:
-                            cached_value = None
-
-                        # If a quirk transformed the value, emit AttributeUpdatedEvent
-                        if cached_value != value:
-                            self.emit(
-                                AttributeUpdatedEvent.event_type,
-                                AttributeUpdatedEvent(
-                                    device_ieee=str(self.endpoint.device.ieee),
-                                    endpoint_id=self.endpoint.endpoint_id,
-                                    cluster_type=self._type,
-                                    cluster_id=self.cluster_id,
-                                    attribute_name=attr_def.name,
-                                    attribute_id=attr_def.id,
-                                    manufacturer_code=attr_def.manufacturer_code,
-                                    value=cached_value,
-                                ),
-                            )
+                        self._update_attribute_with_event(attr_def, value)
                     else:
                         if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
                             self._attr_cache.mark_unsupported(attr_def)
@@ -1099,6 +1045,37 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 self.listener_event(
                     "attribute_updated", attrid, value, datetime.now(UTC)
                 )
+
+    def _update_attribute_with_event(
+        self, attr_def: foundation.ZCLAttributeDef, value: Any
+    ) -> None:
+        """Update an attribute and emit AttributeUpdatedEvent if a quirk transformed it."""
+
+        # Suppress only this specific attribute's events during update. This allows
+        # quirks that update other clusters or other attributes to emit their own
+        # AttributeUpdatedEvent.
+        with _suppress_attribute_update_event(self.cluster_id, attr_def.id):
+            self._update_attribute(attr_def.id, value)
+
+        try:
+            cached_value = self._attr_cache.get_value(attr_def)
+        except KeyError:
+            return
+
+        if cached_value != value:
+            self.emit(
+                AttributeUpdatedEvent.event_type,
+                AttributeUpdatedEvent(
+                    device_ieee=str(self.endpoint.device.ieee),
+                    endpoint_id=self.endpoint.endpoint_id,
+                    cluster_type=self._type,
+                    cluster_id=self.cluster_id,
+                    attribute_name=attr_def.name,
+                    attribute_id=attr_def.id,
+                    manufacturer_code=attr_def.manufacturer_code,
+                    value=cached_value,
+                ),
+            )
 
     async def write_attributes(
         self,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -775,10 +775,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         attr.attrid, manufacturer_code=hdr.manufacturer
                     )
                 except KeyError:
-                    attr_name = None
+                    attr_def = None
                     value = attr.value.value
                 else:
-                    attr_name = attr_def.name
                     value = attr_def.type(attr.value.value)
 
                 # Emit the reported event with the raw value from the device
@@ -789,7 +788,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         endpoint_id=self.endpoint.endpoint_id,
                         cluster_type=self._type,
                         cluster_id=self.cluster_id,
-                        attribute_name=attr_name,
+                        attribute_name=attr_def.name if attr_def else None,
                         attribute_id=attr.attrid,
                         manufacturer_code=hdr.manufacturer,
                         raw_value=attr.value.value,
@@ -804,7 +803,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     self._update_attribute(attr.attrid, value)
 
                 # If a quirk transformed the value, emit AttributeUpdatedEvent
-                cached_value = self._attr_cache.get(attr.attrid)
+                if attr_def is None:
+                    continue
+
+                try:
+                    cached_value = self._attr_cache.get_value(attr_def)
+                except KeyError:
+                    continue
+
                 if cached_value != value:
                     self.emit(
                         AttributeUpdatedEvent.event_type,
@@ -813,9 +819,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                             endpoint_id=self.endpoint.endpoint_id,
                             cluster_type=self._type,
                             cluster_id=self.cluster_id,
-                            attribute_name=attr_name,
-                            attribute_id=attr.attrid,
-                            manufacturer_code=hdr.manufacturer,
+                            attribute_name=attr_def.name,
+                            attribute_id=attr_def.id,
+                            manufacturer_code=attr_def.manufacturer_code,
                             value=cached_value,
                         ),
                     )

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -17,7 +17,7 @@ import warnings
 
 from zigpy import util
 from zigpy.const import APS_REPLY_TIMEOUT
-from zigpy.event import EventBase, suppress_events
+from zigpy.event import EventBase
 import zigpy.types as t
 from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import foundation
@@ -40,7 +40,7 @@ _suppressed_attribute_updates: ContextVar[frozenset[tuple[int, int]]] = ContextV
 
 
 @contextlib.contextmanager
-def _suppress_attribute_update(
+def _suppress_attribute_update_event(
     cluster_id: int, attrid: int
 ) -> Generator[None, None, None]:
     """Suppress AttributeUpdatedEvent for a specific (cluster, attribute) pair."""
@@ -799,7 +799,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 # Suppress only this specific attribute's events during update.
                 # This allows quirks that update other clusters or other attributes
                 # on this cluster to emit their own AttributeUpdatedEvent.
-                with _suppress_attribute_update(self.cluster_id, attr.attrid):
+                with _suppress_attribute_update_event(self.cluster_id, attr.attrid):
                     self._update_attribute(attr.attrid, value)
 
                 # If a quirk transformed the value, emit AttributeUpdatedEvent
@@ -962,13 +962,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
                         success[attribute_map[attr_def]] = value
 
-                        # We suppress events because we want to emit
-                        # `AttributeReadEvent` directly. `_update_attribute` will
-                        # update the attribute cache but is structured to be called
-                        # directly from quirks and will emit an `AttributeUpdatedEvent
-                        with suppress_events():
-                            self._update_attribute(attr_def.id, value)
-
                         self.emit(
                             AttributeReadEvent.event_type,
                             AttributeReadEvent(
@@ -983,6 +976,35 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                                 value=value,
                             ),
                         )
+
+                        # Suppress only this specific attribute's events during
+                        # update. This allows quirks that update other clusters or
+                        # other attributes to emit their own AttributeUpdatedEvent.
+                        with _suppress_attribute_update_event(
+                            self.cluster_id, attr_def.id
+                        ):
+                            self._update_attribute(attr_def.id, value)
+
+                        try:
+                            cached_value = self._attr_cache.get_value(attr_def)
+                        except KeyError:
+                            cached_value = None
+
+                        # If a quirk transformed the value, emit AttributeUpdatedEvent
+                        if cached_value != value:
+                            self.emit(
+                                AttributeUpdatedEvent.event_type,
+                                AttributeUpdatedEvent(
+                                    device_ieee=str(self.endpoint.device.ieee),
+                                    endpoint_id=self.endpoint.endpoint_id,
+                                    cluster_type=self._type,
+                                    cluster_id=self.cluster_id,
+                                    attribute_name=attr_def.name,
+                                    attribute_id=attr_def.id,
+                                    manufacturer_code=attr_def.manufacturer_code,
+                                    value=cached_value,
+                                ),
+                            )
                     else:
                         if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
                             self._attr_cache.mark_unsupported(attr_def)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -429,19 +429,28 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
     def _legacy_apply_quirk_attribute_update(
         self, attr_def: foundation.ZCLAttributeDef, value: Any
-    ) -> Any:
-        """Update an attribute and return the cached value (possibly transformed)."""
+    ) -> Any | None:
+        """Update an attribute and return the cached value (possibly transformed).
+
+        Returns None if the quirk swallowed the attribute (no super() call).
+        """
         with _suppress_attribute_update_event(self.cluster_id, attr_def.id):
             self._update_attribute(attr_def.id, value)
 
         try:
             return self._attr_cache.get_value(attr_def)
         except KeyError:
-            # When multiple attrs share an ID (different manufacturer codes),
-            # `_update_attribute` stores in legacy cache. Move it to typed cache.
+            pass
+
+        # When multiple attrs share an ID (different manufacturer codes),
+        # `_update_attribute` stores in legacy cache. Move it to typed cache.
+        if attr_def.id in self._attr_cache._legacy_cache:
             cached_value = self._attr_cache._legacy_cache.pop(attr_def.id).value
             self._attr_cache.set_value(attr_def, cached_value)
             return cached_value
+
+        # Quirk swallowed the attribute
+        return None
 
     @classmethod
     def find_attribute(
@@ -821,7 +830,10 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     attr_def, value
                 )
 
-                if cached_value != value:
+                if cached_value is None:
+                    # Quirk swallowed the attribute
+                    continue
+                elif cached_value != value:
                     # Quirk transformed the value, emit AttributeUpdatedEvent
                     self.emit(
                         AttributeUpdatedEvent.event_type,
@@ -993,7 +1005,10 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                             attr_def, value
                         )
 
-                        if cached_value != value:
+                        if cached_value is None:
+                            # Quirk swallowed the attribute
+                            continue
+                        elif cached_value != value:
                             # Quirk transformed the value, emit AttributeUpdatedEvent
                             self.emit(
                                 AttributeUpdatedEvent.event_type,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import collections
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Generator, Iterable, Sequence
+import contextlib
+from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import enum
@@ -28,6 +30,27 @@ if TYPE_CHECKING:
 
 
 LOGGER = logging.getLogger(__name__)
+
+# Tracks (cluster_id, attrid) pairs for which AttributeUpdatedEvent should be suppressed.
+# Used during Report_Attributes handling to allow quirks that update other clusters or
+# other attributes to emit their own events while suppressing the direct report's event.
+_suppressed_attribute_updates: ContextVar[frozenset[tuple[int, int]]] = ContextVar(
+    "_suppressed_attribute_updates", default=frozenset()
+)
+
+
+@contextlib.contextmanager
+def _suppress_attribute_update(
+    cluster_id: int, attrid: int
+) -> Generator[None, None, None]:
+    """Suppress AttributeUpdatedEvent for a specific (cluster, attribute) pair."""
+    current = _suppressed_attribute_updates.get()
+    token = _suppressed_attribute_updates.set(current | {(cluster_id, attrid)})
+
+    try:
+        yield
+    finally:
+        _suppressed_attribute_updates.reset(token)
 
 
 class ClusterType(enum.IntEnum):
@@ -758,13 +781,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     attr_name = attr_def.name
                     value = attr_def.type(attr.value.value)
 
-                # We suppress events because we want to emit `AttributeReportedEvent`
-                # directly. `_update_attribute` will update the attribute cache but is
-                # structured to be called directly from quirks and will emit an
-                # `AttributeUpdatedEvent by default.
-                with suppress_events():
-                    self._update_attribute(attr.attrid, value)
-
+                # Emit the reported event with the raw value from the device
                 self.emit(
                     AttributeReportedEvent.event_type,
                     AttributeReportedEvent(
@@ -779,6 +796,29 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         value=value,
                     ),
                 )
+
+                # Suppress only this specific attribute's events during update.
+                # This allows quirks that update other clusters or other attributes
+                # on this cluster to emit their own AttributeUpdatedEvent.
+                with _suppress_attribute_update(self.cluster_id, attr.attrid):
+                    self._update_attribute(attr.attrid, value)
+
+                # If a quirk transformed the value, emit AttributeUpdatedEvent
+                cached_value = self._attr_cache.get(attr.attrid)
+                if cached_value != value:
+                    self.emit(
+                        AttributeUpdatedEvent.event_type,
+                        AttributeUpdatedEvent(
+                            device_ieee=str(self.endpoint.device.ieee),
+                            endpoint_id=self.endpoint.endpoint_id,
+                            cluster_type=self._type,
+                            cluster_id=self.cluster_id,
+                            attribute_name=attr_name,
+                            attribute_id=attr.attrid,
+                            manufacturer_code=hdr.manufacturer,
+                            value=cached_value,
+                        ),
+                    )
 
         if not hdr.frame_control.disable_default_response:
             self.send_default_rsp(
@@ -962,29 +1002,36 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         self._update_attribute(attrid, value)
 
     def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
+        # Check if AttributeUpdatedEvent should be suppressed for this attribute.
+        # This is used during Report_Attributes handling to allow quirks that update
+        # other clusters or attributes to emit their own events.
+        suppressed = (self.cluster_id, attrid) in _suppressed_attribute_updates.get()
+
         try:
             attr_def = self.find_attribute(attrid)
         except KeyError:
             if value is not None:
                 self._attr_cache.set_legacy_value(attrid, value)
-                self.emit(
-                    AttributeUpdatedEvent.event_type,
-                    AttributeUpdatedEvent(
-                        device_ieee=str(self.endpoint.device.ieee),
-                        endpoint_id=self.endpoint.endpoint_id,
-                        cluster_type=self._type,
-                        cluster_id=self.cluster_id,
-                        attribute_name=None,
-                        attribute_id=attrid,
-                        manufacturer_code=None,
-                        value=value,
-                    ),
-                )
 
-                # Legacy `listener_event`, will be removed in the near future
-                self.listener_event(
-                    "attribute_updated", attrid, value, datetime.now(UTC)
-                )
+                if not suppressed:
+                    self.emit(
+                        AttributeUpdatedEvent.event_type,
+                        AttributeUpdatedEvent(
+                            device_ieee=str(self.endpoint.device.ieee),
+                            endpoint_id=self.endpoint.endpoint_id,
+                            cluster_type=self._type,
+                            cluster_id=self.cluster_id,
+                            attribute_name=None,
+                            attribute_id=attrid,
+                            manufacturer_code=None,
+                            value=value,
+                        ),
+                    )
+
+                    # Legacy `listener_event`, will be removed in the near future
+                    self.listener_event(
+                        "attribute_updated", attrid, value, datetime.now(UTC)
+                    )
 
             return
 
@@ -1004,22 +1051,26 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             )
         else:
             self._attr_cache.set_value(attr_def, value)
-            self.emit(
-                AttributeUpdatedEvent.event_type,
-                AttributeUpdatedEvent(
-                    device_ieee=str(self.endpoint.device.ieee),
-                    endpoint_id=self.endpoint.endpoint_id,
-                    cluster_type=self._type,
-                    cluster_id=self.cluster_id,
-                    attribute_name=attr_def.name,
-                    attribute_id=attr_def.id,
-                    manufacturer_code=attr_def.manufacturer_code,
-                    value=value,
-                ),
-            )
 
-            # Legacy `listener_event`, will be removed in the near future
-            self.listener_event("attribute_updated", attrid, value, datetime.now(UTC))
+            if not suppressed:
+                self.emit(
+                    AttributeUpdatedEvent.event_type,
+                    AttributeUpdatedEvent(
+                        device_ieee=str(self.endpoint.device.ieee),
+                        endpoint_id=self.endpoint.endpoint_id,
+                        cluster_type=self._type,
+                        cluster_id=self.cluster_id,
+                        attribute_name=attr_def.name,
+                        attribute_id=attr_def.id,
+                        manufacturer_code=attr_def.manufacturer_code,
+                        value=value,
+                    ),
+                )
+
+                # Legacy `listener_event`, will be removed in the near future
+                self.listener_event(
+                    "attribute_updated", attrid, value, datetime.now(UTC)
+                )
 
     async def write_attributes(
         self,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -427,6 +427,22 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         for key, value in new_value.items():
             self._update_attribute(key, value)
 
+    def _legacy_apply_quirk_attribute_update(
+        self, attr_def: foundation.ZCLAttributeDef, value: Any
+    ) -> Any:
+        """Update an attribute and return the cached value (possibly transformed)."""
+        with _suppress_attribute_update_event(self.cluster_id, attr_def.id):
+            self._update_attribute(attr_def.id, value)
+
+        try:
+            return self._attr_cache.get_value(attr_def)
+        except KeyError:
+            # When multiple attrs share an ID (different manufacturer codes),
+            # `_update_attribute` stores in legacy cache. Move it to typed cache.
+            cached_value = self._attr_cache._legacy_cache.pop(attr_def.id).value
+            self._attr_cache.set_value(attr_def, cached_value)
+            return cached_value
+
     @classmethod
     def find_attribute(
         cls,
@@ -780,12 +796,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 else:
                     value = attr_def.type(attr.value.value)
 
-                # Update the attribute with suppression for this specific attribute
-                with _suppress_attribute_update_event(self.cluster_id, attr.attrid):
-                    self._update_attribute(attr.attrid, value)
-
                 if attr_def is None:
-                    # Unknown attribute, emit reported event
+                    # Unknown attribute, update and emit reported event
+                    with _suppress_attribute_update_event(self.cluster_id, attr.attrid):
+                        self._update_attribute(attr.attrid, value)
+
                     self.emit(
                         AttributeReportedEvent.event_type,
                         AttributeReportedEvent(
@@ -802,8 +817,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     )
                     continue
 
-                # Check if quirk transformed the value
-                cached_value = self._attr_cache.get_value(attr_def)
+                cached_value = self._legacy_apply_quirk_attribute_update(
+                    attr_def, value
+                )
 
                 if cached_value != value:
                     # Quirk transformed the value, emit AttributeUpdatedEvent
@@ -973,19 +989,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
                         success[attribute_map[attr_def]] = value
 
-                        # Update the attribute with suppression for this specific attr
-                        with _suppress_attribute_update_event(
-                            self.cluster_id, attr_def.id
-                        ):
-                            self._update_attribute(attr_def.id, value)
-
-                        # Check if quirk transformed the value
-                        try:
-                            cached_value = self._attr_cache.get_value(attr_def)
-                        except KeyError:
-                            # When multiple attrs share an ID (different manufacturer
-                            # codes), `_update_attribute` stores in the wrong location
-                            continue
+                        cached_value = self._legacy_apply_quirk_attribute_update(
+                            attr_def, value
+                        )
 
                         if cached_value != value:
                             # Quirk transformed the value, emit AttributeUpdatedEvent

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -780,24 +780,62 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 else:
                     value = attr_def.type(attr.value.value)
 
-                # Emit the reported event with the raw value from the device
-                self.emit(
-                    AttributeReportedEvent.event_type,
-                    AttributeReportedEvent(
-                        device_ieee=str(self.endpoint.device.ieee),
-                        endpoint_id=self.endpoint.endpoint_id,
-                        cluster_type=self._type,
-                        cluster_id=self.cluster_id,
-                        attribute_name=attr_def.name if attr_def else None,
-                        attribute_id=attr.attrid,
-                        manufacturer_code=hdr.manufacturer,
-                        raw_value=attr.value.value,
-                        value=value,
-                    ),
-                )
+                # Update the attribute with suppression for this specific attribute
+                with _suppress_attribute_update_event(self.cluster_id, attr.attrid):
+                    self._update_attribute(attr.attrid, value)
 
-                if attr_def is not None:
-                    self._update_attribute_with_event(attr_def, value)
+                if attr_def is None:
+                    # Unknown attribute, emit reported event
+                    self.emit(
+                        AttributeReportedEvent.event_type,
+                        AttributeReportedEvent(
+                            device_ieee=str(self.endpoint.device.ieee),
+                            endpoint_id=self.endpoint.endpoint_id,
+                            cluster_type=self._type,
+                            cluster_id=self.cluster_id,
+                            attribute_name=None,
+                            attribute_id=attr.attrid,
+                            manufacturer_code=hdr.manufacturer,
+                            raw_value=attr.value.value,
+                            value=value,
+                        ),
+                    )
+                    continue
+
+                # Check if quirk transformed the value
+                cached_value = self._attr_cache.get_value(attr_def)
+
+                if cached_value != value:
+                    # Quirk transformed the value, emit AttributeUpdatedEvent
+                    self.emit(
+                        AttributeUpdatedEvent.event_type,
+                        AttributeUpdatedEvent(
+                            device_ieee=str(self.endpoint.device.ieee),
+                            endpoint_id=self.endpoint.endpoint_id,
+                            cluster_type=self._type,
+                            cluster_id=self.cluster_id,
+                            attribute_name=attr_def.name,
+                            attribute_id=attr_def.id,
+                            manufacturer_code=attr_def.manufacturer_code,
+                            value=cached_value,
+                        ),
+                    )
+                else:
+                    # Value unchanged, emit AttributeReportedEvent
+                    self.emit(
+                        AttributeReportedEvent.event_type,
+                        AttributeReportedEvent(
+                            device_ieee=str(self.endpoint.device.ieee),
+                            endpoint_id=self.endpoint.endpoint_id,
+                            cluster_type=self._type,
+                            cluster_id=self.cluster_id,
+                            attribute_name=attr_def.name,
+                            attribute_id=attr.attrid,
+                            manufacturer_code=hdr.manufacturer,
+                            raw_value=attr.value.value,
+                            value=value,
+                        ),
+                    )
 
         if not hdr.frame_control.disable_default_response:
             self.send_default_rsp(
@@ -935,22 +973,51 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
                         success[attribute_map[attr_def]] = value
 
-                        self.emit(
-                            AttributeReadEvent.event_type,
-                            AttributeReadEvent(
-                                device_ieee=str(self.endpoint.device.ieee),
-                                endpoint_id=self.endpoint.endpoint_id,
-                                cluster_type=self._type,
-                                cluster_id=self.cluster_id,
-                                attribute_name=attr_def.name,
-                                attribute_id=attr_def.id,
-                                manufacturer_code=attr_def.manufacturer_code,
-                                raw_value=record.value.value,
-                                value=value,
-                            ),
-                        )
+                        # Update the attribute with suppression for this specific attr
+                        with _suppress_attribute_update_event(
+                            self.cluster_id, attr_def.id
+                        ):
+                            self._update_attribute(attr_def.id, value)
 
-                        self._update_attribute_with_event(attr_def, value)
+                        # Check if quirk transformed the value
+                        try:
+                            cached_value = self._attr_cache.get_value(attr_def)
+                        except KeyError:
+                            # When multiple attrs share an ID (different manufacturer
+                            # codes), `_update_attribute` stores in the wrong location
+                            continue
+
+                        if cached_value != value:
+                            # Quirk transformed the value, emit AttributeUpdatedEvent
+                            self.emit(
+                                AttributeUpdatedEvent.event_type,
+                                AttributeUpdatedEvent(
+                                    device_ieee=str(self.endpoint.device.ieee),
+                                    endpoint_id=self.endpoint.endpoint_id,
+                                    cluster_type=self._type,
+                                    cluster_id=self.cluster_id,
+                                    attribute_name=attr_def.name,
+                                    attribute_id=attr_def.id,
+                                    manufacturer_code=attr_def.manufacturer_code,
+                                    value=cached_value,
+                                ),
+                            )
+                        else:
+                            # Value unchanged, emit AttributeReadEvent
+                            self.emit(
+                                AttributeReadEvent.event_type,
+                                AttributeReadEvent(
+                                    device_ieee=str(self.endpoint.device.ieee),
+                                    endpoint_id=self.endpoint.endpoint_id,
+                                    cluster_type=self._type,
+                                    cluster_id=self.cluster_id,
+                                    attribute_name=attr_def.name,
+                                    attribute_id=attr_def.id,
+                                    manufacturer_code=attr_def.manufacturer_code,
+                                    raw_value=record.value.value,
+                                    value=value,
+                                ),
+                            )
                     else:
                         if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
                             self._attr_cache.mark_unsupported(attr_def)
@@ -1045,37 +1112,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 self.listener_event(
                     "attribute_updated", attrid, value, datetime.now(UTC)
                 )
-
-    def _update_attribute_with_event(
-        self, attr_def: foundation.ZCLAttributeDef, value: Any
-    ) -> None:
-        """Update an attribute and emit AttributeUpdatedEvent if a quirk transformed it."""
-
-        # Suppress only this specific attribute's events during update. This allows
-        # quirks that update other clusters or other attributes to emit their own
-        # AttributeUpdatedEvent.
-        with _suppress_attribute_update_event(self.cluster_id, attr_def.id):
-            self._update_attribute(attr_def.id, value)
-
-        try:
-            cached_value = self._attr_cache.get_value(attr_def)
-        except KeyError:
-            return
-
-        if cached_value != value:
-            self.emit(
-                AttributeUpdatedEvent.event_type,
-                AttributeUpdatedEvent(
-                    device_ieee=str(self.endpoint.device.ieee),
-                    endpoint_id=self.endpoint.endpoint_id,
-                    cluster_type=self._type,
-                    cluster_id=self.cluster_id,
-                    attribute_name=attr_def.name,
-                    attribute_id=attr_def.id,
-                    manufacturer_code=attr_def.manufacturer_code,
-                    value=cached_value,
-                ),
-            )
 
     async def write_attributes(
         self,


### PR DESCRIPTION
To support use cases like this (until we find a better API to migrate to):

```python
class DoublingCluster(zcl.Cluster):
    def _update_attribute(self, attrid, value):
        if attrid == self.AttributeDefs.test_attr.id:
            # Double the value
            value = value * 2
            super()._update_attribute(attrid, value)

        # Also update a different attribute
        if attrid == self.AttributeDefs.test_attr.id:
            super()._update_attribute(self.AttributeDefs.other_attr.id, 123)
```

We need to filter with more granularity than just globally suppressing events in a context manager. Instead, we suppress events only for a given cluster ID and attribute ID and emit an attribute update event independently if the value changes.