### PR TITLE
Correctly handle `manufacturer_code=None` for attributes and commands

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -489,9 +489,7 @@ async def mock_attribute_report(
             )
         else:
             attr_def = cluster.find_attribute(attr)
-            manufacturer_codes.add(
-                cluster._get_effective_manufacturer_code(attr_def, None)
-            )
+            manufacturer_codes.add(cluster._get_effective_manufacturer_code(attr_def))
 
             reports.append(
                 foundation.Attribute(

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -12,7 +12,11 @@ from tests.test_appdb import auto_kill_aiosqlite, make_app_with_db  # noqa: F401
 import zigpy.appdb
 from zigpy.appdb import sqlite3
 import zigpy.appdb_schemas
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.registry import DeviceRegistry
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
 
 
@@ -538,3 +542,46 @@ async def test_unknown_manufacturer_code_migration(test_db, caplog):
         after_total = cur.fetchone()[0]
 
         assert after_total == before_total
+
+
+async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
+    """Test that attributes on manufacturer-specific clusters get the device's manufacturer_id."""
+
+    # Simple quirk for Third Reality night light with is_manufacturer_specific=True
+    class TestCluster(CustomCluster):
+        cluster_id = 0xFC00
+
+        class AttributeDefs(BaseAttributeDefs):
+            test_attr = ZCLAttributeDef(
+                id=0x0002,
+                type=t.uint8_t,
+                is_manufacturer_specific=True,
+            )
+
+    registry = DeviceRegistry()
+
+    (
+        QuirkBuilder("Third Reality, Inc", "3RSNL02043Z", registry=registry)
+        .replaces(TestCluster)
+        .add_to_registry()
+    )
+
+    test_db_path = test_db("zigbee_puddly2.db")
+
+    with patch("zigpy.quirks.DEVICE_REGISTRY", registry):
+        app = await make_app_with_db(test_db_path)
+        await app.shutdown()
+
+    # Check that attributes on 0xFC00 got the device's manufacturer_id (0x130D = 4877)
+    with sqlite3.connect(test_db_path) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT manufacturer_code
+            FROM attributes_cache_v14
+            WHERE cluster_id = 0xFC00 AND attr_id = 0x0002
+            """
+        )
+        rows = cur.fetchall()
+
+    assert rows == [(0x130D,), (0x130D,), (0x130D,)]

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -27,6 +27,7 @@ from zigpy.zcl import (
     foundation,
 )
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota
+from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.helpers import ReportingConfig
 
 DEFAULT_TSN = 123
@@ -1667,10 +1668,32 @@ async def test_command_explicit_manufacturer():
     assert mock_request.mock_calls[0].kwargs["manufacturer"] == 0x9999
 
 
+async def test_read_attribute_manufacturer_code_none_on_manuf_cluster():
+    """Test that manufacturer_code=None suppresses manufacturer code on manuf clusters."""
+
+    class ManufCluster(zcl.Cluster):
+        cluster_id = 0xFC11  # Manufacturer-specific cluster range
+        ep_attribute = "manuf_cluster"
+
+        class AttributeDefs(zcl.BaseAttributeDefs):
+            # Explicitly no manufacturer code, even though cluster is manufacturer-specific
+            valve_opening = foundation.ZCLAttributeDef(
+                id=0x600B, type=t.uint8_t, manufacturer_code=None
+            )
+
+    endpoint = MagicMock(spec=zigpy.endpoint.Endpoint)
+    cluster = ManufCluster(endpoint)
+
+    with mock_attribute_reads(
+        cluster, {ManufCluster.AttributeDefs.valve_opening: t.uint8_t(100)}
+    ) as (mock_read, _):
+        await cluster.read_attributes([ManufCluster.AttributeDefs.valve_opening])
+
+    assert mock_read.mock_calls == [call([0x600B], manufacturer=None)]
+
+
 async def test_report_attributes_quirk_transforms_value(app_mock):
     """Test that quirks transforming values emit both reported and updated events."""
-    from zigpy.zcl.clusters.measurement import OccupancySensing
-
     MOTION_ATTRIBUTE = 0x0112  # Unknown attribute that triggers motion
 
     class DoublingCluster(zcl.Cluster):

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -1476,9 +1476,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     )
                     continue
 
-                manufacturer_code = cluster._get_effective_manufacturer_code(
-                    attr_def, manufacturer=None
-                )
+                manufacturer_code = cluster._get_effective_manufacturer_code(attr_def)
 
                 await self.execute(
                     """

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1420,7 +1420,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         command = self.server_commands[command_id]
 
         # Quirks override `def command` but provide their own signature that has
-        # `manufacturer` default to `None`. We treat this is UNDEFINED.
+        # `manufacturer` default to `None`. We treat this as UNDEFINED.
         if manufacturer is None:
             manufacturer = UNDEFINED
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -227,8 +227,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
     # to remove the need to create 1024 "ManufacturerSpecificCluster" instances.
     cluster_id_range: tuple[t.uint16_t, t.uint16_t] = None
 
-    attributes_by_id: dict[
-        int, dict[int | UndefinedType | None, foundation.ZCLAttributeDef]
+    # Internal cache to speed up attribute finding. Nested layering, keyed by:
+    # attr_id, is_manufacturer_specific, manufacturer_code
+    _attributes_by_id: dict[
+        int,
+        dict[
+            bool,
+            dict[int | UndefinedType | None, foundation.ZCLAttributeDef],
+        ],
     ] = {}
 
     # Deprecated: clusters contain attributes and both client and server commands
@@ -370,14 +376,17 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 if isinstance(definition, foundation.ZCLCommandDef):
                     setattr(defs, definition.name, definition.with_compiled_schema())
 
-        # Create a way to look up attributes (with manufacturer_code)
-        cls.attributes_by_id = {}
+        # Create a way to look up attributes (with manufacturer_code) internally
+        cls._attributes_by_id = {}
 
         for attr_def in cls.AttributeDefs:
-            if attr_def.id not in cls.attributes_by_id:
-                cls.attributes_by_id[attr_def.id] = {}
+            if attr_def.id not in cls._attributes_by_id:
+                cls._attributes_by_id[attr_def.id] = {True: {}, False: {}}
 
-            cls.attributes_by_id[attr_def.id][attr_def.manufacturer_code] = attr_def
+            is_manuf = attr_def.is_manufacturer_specific
+            cls._attributes_by_id[attr_def.id][is_manuf][attr_def.manufacturer_code] = (
+                attr_def
+            )
 
         # Recreate the old structures using the new-style definitions
         cls.attributes = {attr.id: attr for attr in cls.AttributeDefs}
@@ -464,41 +473,50 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         elif isinstance(name_or_id, str):
             return cls.attributes_by_name[name_or_id]
         elif isinstance(name_or_id, int):
-            candidates = cls.attributes_by_id[name_or_id]
+            candidates = cls._attributes_by_id[name_or_id]
+            manuf_specific = candidates[True]
+            non_manuf_specific = candidates[False]
 
             if manufacturer_code is not UNDEFINED:
-                # Try exact match first
-                if manufacturer_code in candidates:
-                    return candidates[manufacturer_code]
+                if manufacturer_code is None:
+                    # Explicitly no manufacturer code
+                    if None in non_manuf_specific:
+                        return non_manuf_specific[None]
 
-                # If no ambiguous candidates exist, we immediately error
-                if UNDEFINED not in candidates:
-                    raise KeyError(manufacturer_code)
+                    # Fall back to unspecified
+                    if UNDEFINED in non_manuf_specific:
+                        return non_manuf_specific[UNDEFINED]
+                else:
+                    # Try exact manufacturer-specific match
+                    if manufacturer_code in manuf_specific:
+                        return manuf_specific[manufacturer_code]
 
-                # Otherwise, fall back to the undefined candidate
-                attr_def = candidates[UNDEFINED]
-                manuf_code_str = (
-                    f"0x{manufacturer_code:04X}"
-                    if manufacturer_code is not None
-                    else "None"
-                )
-                warnings.warn(
-                    f"Attribute {attr_def.name!r} has `is_manufacturer_specific`"
-                    f" without an explicit `manufacturer_code`. Please set"
-                    f" `manufacturer_code={manuf_code_str}`.",
-                    DeprecationWarning,
-                    stacklevel=3,
-                )
-                return attr_def
+                    # Try manufacturer-specific without explicit code (deprecation)
+                    if UNDEFINED in manuf_specific:
+                        attr_def = manuf_specific[UNDEFINED]
+                        warnings.warn(
+                            f"Attribute {attr_def.name!r} has `is_manufacturer_specific`"
+                            f" without an explicit `manufacturer_code`. Please set"
+                            f" `manufacturer_code=0x{manufacturer_code:04X}`.",
+                            DeprecationWarning,
+                            stacklevel=3,
+                        )
+                        return attr_def
 
-            if len(candidates) > 1:
+                raise KeyError(manufacturer_code)
+
+            all_candidates = list(manuf_specific.values()) + list(
+                non_manuf_specific.values()
+            )
+
+            if len(all_candidates) > 1:
                 raise KeyError(
                     f"Multiple definitions exist for attribute ID {name_or_id:#06x},"
                     f" please specify a manufacturer code: {candidates!r}"
                 )
 
             # Pick the only one
-            return next(iter(candidates.values()))
+            return all_candidates[0]
         else:
             raise TypeError(  # noqa: TRY004
                 f"Attribute must be a definition, string, or integer,"
@@ -844,7 +862,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                             cluster_id=self.cluster_id,
                             attribute_name=attr_def.name,
                             attribute_id=attr_def.id,
-                            manufacturer_code=attr_def.manufacturer_code,
+                            manufacturer_code=hdr.manufacturer,
                             value=cached_value,
                         ),
                     )
@@ -881,15 +899,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
     def _get_effective_manufacturer_code(
         self,
         definition: foundation.ZCLAttributeDef | foundation.ZCLCommandDef,
-        manufacturer: int | UndefinedType | None,
+        manufacturer: int | UndefinedType | None = UNDEFINED,
     ) -> int | None:
         """Get the effective manufacturer code for an attribute or command."""
-        if manufacturer not in (None, UNDEFINED):
-            assert not isinstance(manufacturer, UndefinedType)
+        if manufacturer is not UNDEFINED:
             return manufacturer
 
-        if definition.manufacturer_code not in (None, UNDEFINED):
-            assert not isinstance(definition.manufacturer_code, UndefinedType)
+        if definition.manufacturer_code is not UNDEFINED:
             return definition.manufacturer_code
 
         # In the future, we should migrate to explicit `manufacturer_code` for every
@@ -959,7 +975,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     continue
 
             # Otherwise, populate the groups of attributes to read
-            effective_manuf = self._get_effective_manufacturer_code(attr_def, None)
+            effective_manuf = self._get_effective_manufacturer_code(attr_def)
             reads_by_manuf_code[effective_manuf].append(attr_def)
 
         if only_cache:
@@ -1019,7 +1035,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                                     cluster_id=self.cluster_id,
                                     attribute_name=attr_def.name,
                                     attribute_id=attr_def.id,
-                                    manufacturer_code=attr_def.manufacturer_code,
+                                    manufacturer_code=manufacturer_code,
                                     value=cached_value,
                                 ),
                             )
@@ -1034,7 +1050,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                                     cluster_id=self.cluster_id,
                                     attribute_name=attr_def.name,
                                     attribute_id=attr_def.id,
-                                    manufacturer_code=attr_def.manufacturer_code,
+                                    manufacturer_code=manufacturer_code,
                                     raw_value=record.value.value,
                                     value=value,
                                 ),
@@ -1108,7 +1124,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     cluster_id=self.cluster_id,
                     attribute_name=attr_def.name,
                     attribute_id=attr_def.id,
-                    manufacturer_code=attr_def.manufacturer_code,
+                    manufacturer_code=self._get_effective_manufacturer_code(attr_def),
                 ),
             )
         else:
@@ -1124,7 +1140,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         cluster_id=self.cluster_id,
                         attribute_name=attr_def.name,
                         attribute_id=attr_def.id,
-                        manufacturer_code=attr_def.manufacturer_code,
+                        manufacturer_code=self._get_effective_manufacturer_code(
+                            attr_def
+                        ),
                         value=value,
                     ),
                 )
@@ -1149,7 +1167,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
         for attr, value in attributes.items():
             attr_def = self.find_attribute(attr, manufacturer_code=manufacturer)
-            effective_manuf = self._get_effective_manufacturer_code(attr_def, None)
+            effective_manuf = self._get_effective_manufacturer_code(attr_def)
             writes_by_manuf_code[effective_manuf].append((attr_def, value))
 
         # Write each group separately and merge results
@@ -1309,7 +1327,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             cfg.max_interval = reporting_config.max_interval
             cfg.reportable_change = reporting_config.reportable_change
 
-            effective_manuf = self._get_effective_manufacturer_code(attr_def, None)
+            effective_manuf = self._get_effective_manufacturer_code(attr_def)
             reporting_by_manuf_code[effective_manuf].append((attr_def, cfg))
 
         results: list[foundation.ConfigureReportingResponseRecord] = []
@@ -1395,11 +1413,16 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         self,
         command_id: foundation.GeneralCommand | int | t.uint8_t,
         *args,
-        manufacturer: int | t.uint16_t | None = None,
+        manufacturer: int | t.uint16_t | UndefinedType | None = None,
         expect_reply: bool = True,
         **kwargs,
     ):
         command = self.server_commands[command_id]
+
+        # Quirks override `def command` but provide their own signature that has
+        # `manufacturer` default to `None`. We treat this is UNDEFINED.
+        if manufacturer is None:
+            manufacturer = UNDEFINED
 
         return self.request(
             False,
@@ -1415,7 +1438,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         self,
         command_id: foundation.GeneralCommand | int | t.uint8_t,
         *args,
-        manufacturer: int | t.uint16_t | None = None,
+        manufacturer: int | t.uint16_t | UndefinedType | None = UNDEFINED,
         **kwargs,
     ):
         command = self.client_commands[command_id]
@@ -1425,6 +1448,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             command_id,
             command.schema,
             *args,
+            # No quirks override or touch `client_command` so we can keep this simple
             manufacturer=self._get_effective_manufacturer_code(command, manufacturer),
             **kwargs,
         )
@@ -1595,7 +1619,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 cluster_id=self.cluster_id,
                 attribute_name=attr_def.name,
                 attribute_id=attr_def.id,
-                manufacturer_code=attr_def.manufacturer_code,
+                manufacturer_code=self._get_effective_manufacturer_code(attr_def),
             ),
         )
 

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -9,7 +9,7 @@ import typing
 from typing import Final, Self
 
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
+from zigpy.typing import UNDEFINED, UndefinedType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1113,7 +1113,7 @@ class ZCLCommandDef(t.BaseDataclassMixin):
 
     # set later
     name: str = None
-    manufacturer_code: t.uint16_t | None = None
+    manufacturer_code: t.uint16_t | UndefinedType | None = UNDEFINED
 
     def __post_init__(self) -> None:
         # Backwards compatibility with positional syntax where the name was first
@@ -1260,7 +1260,7 @@ class ZCLAttributeDef(t.BaseDataclassMixin):
 
     # These are (optionally) computed later in the ZCL cluster subclass hook
     name: str = None
-    manufacturer_code: t.uint16_t | None = None
+    manufacturer_code: t.uint16_t | UndefinedType | None = UNDEFINED
 
     def __post_init__(self) -> None:
         # Backwards compatibility with positional syntax where the name was first
@@ -1281,8 +1281,14 @@ class ZCLAttributeDef(t.BaseDataclassMixin):
 
         ensure_valid_name(self.name)
 
+        if (
+            self.manufacturer_code not in (None, UNDEFINED)
+            and not self.is_manufacturer_specific
+        ):
+            object.__setattr__(self, "is_manufacturer_specific", True)
+
         # Use UNDEFINED for manufacturer-specific attributes without explicit code
-        if self.is_manufacturer_specific and self.manufacturer_code is None:
+        if self.is_manufacturer_specific is True and self.manufacturer_code is None:
             object.__setattr__(self, "manufacturer_code", UNDEFINED)
 
     def __repr__(self) -> str:

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1287,10 +1287,6 @@ class ZCLAttributeDef(t.BaseDataclassMixin):
         ):
             object.__setattr__(self, "is_manufacturer_specific", True)
 
-        # Use UNDEFINED for manufacturer-specific attributes without explicit code
-        if self.is_manufacturer_specific is True and self.manufacturer_code is None:
-            object.__setattr__(self, "manufacturer_code", UNDEFINED)
-
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}("

--- a/zigpy/zcl/helpers.py
+++ b/zigpy/zcl/helpers.py
@@ -6,12 +6,22 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from zigpy.typing import UNDEFINED
+
 from .foundation import ZCLAttributeDef
 
 if TYPE_CHECKING:
     from . import Cluster
 
 CacheKey = tuple[int, int | None]  # attribute id, manufacturer code
+
+
+def _cache_key(attr_def: ZCLAttributeDef) -> CacheKey:
+    """Create a cache key, resolving UNDEFINED to None."""
+    manuf_code = attr_def.manufacturer_code
+    if manuf_code is UNDEFINED:
+        manuf_code = None
+    return (attr_def.id, manuf_code)
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -39,31 +49,30 @@ class AttributeCache:
         self._legacy_cache: dict[int, CacheItem] = {}
 
     def remove(self, attr_def: ZCLAttributeDef) -> None:
-        key = (attr_def.id, attr_def.manufacturer_code)
+        key = _cache_key(attr_def)
         self._cache.pop(key, None)
         self._unsupported.discard(key)
 
     def _raise_if_unsupported(self, attr_def: ZCLAttributeDef) -> None:
-        key = (attr_def.id, attr_def.manufacturer_code)
-        if key in self._unsupported:
+        if _cache_key(attr_def) in self._unsupported:
             raise UnsupportedAttribute(attr_def)
 
     def remove_unsupported(self, attr_def: ZCLAttributeDef) -> None:
-        self._unsupported.discard((attr_def.id, attr_def.manufacturer_code))
+        self._unsupported.discard(_cache_key(attr_def))
 
     def mark_unsupported(self, attr_def: ZCLAttributeDef) -> None:
-        self._unsupported.add((attr_def.id, attr_def.manufacturer_code))
+        self._unsupported.add(_cache_key(attr_def))
 
     def is_unsupported(self, attr_def: ZCLAttributeDef) -> bool:
-        return (attr_def.id, attr_def.manufacturer_code) in self._unsupported
+        return _cache_key(attr_def) in self._unsupported
 
     def get_value(self, attr_def: ZCLAttributeDef) -> Any:
         self._raise_if_unsupported(attr_def)
-        return self._cache[attr_def.id, attr_def.manufacturer_code].value
+        return self._cache[_cache_key(attr_def)].value
 
     def get_last_updated(self, attr_def: ZCLAttributeDef) -> datetime:
         self._raise_if_unsupported(attr_def)
-        return self._cache[attr_def.id, attr_def.manufacturer_code].last_updated
+        return self._cache[_cache_key(attr_def)].last_updated
 
     def set_value(
         self,
@@ -73,7 +82,7 @@ class AttributeCache:
         last_updated: datetime | None = None,
     ) -> None:
         self.remove_unsupported(attr_def)
-        self._cache[attr_def.id, attr_def.manufacturer_code] = CacheItem(
+        self._cache[_cache_key(attr_def)] = CacheItem(
             value=value,
             last_updated=datetime.now(UTC) if last_updated is None else last_updated,
         )


### PR DESCRIPTION
See https://github.com/zigpy/zha-device-handlers/issues/4694 for more context.

`manufacturer_code` in the ZCL attribute definitions should have `None` mean "do not provide a manufacturer code". A specific value should be used otherwise. `UNDEFINED`, the default, allows for auto-detection from the cluster ID and other context (e.g. just `is_manufacturer_specific=True`).