### PR TITLE
Allow attribute writes to skip updating cache or emitting events

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1926,6 +1926,7 @@ async def test_zcl_write_attributes_update_cache(app_mock) -> None:
             {Basic.AttributeDefs.location_desc: "Test"},
         )
 
+    # The cache updated
     assert cluster._attr_cache.get(Basic.AttributeDefs.location_desc) == "Test"
 
     # But this can be overridden
@@ -1941,7 +1942,8 @@ async def test_zcl_write_attributes_update_cache(app_mock) -> None:
             update_cache=False,
         )
 
-        assert cluster._attr_cache.get(Basic.AttributeDefs.location_desc) == "Test"
+    # The cache never updated to `Test 2`
+    assert cluster._attr_cache.get(Basic.AttributeDefs.location_desc) == "Test"
 
     # No events should have been emitted
     assert events == []

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -13,6 +13,7 @@ from tests.conftest import (
     make_ieee,
     mock_attribute_reads,
     mock_attribute_report,
+    mock_attribute_writes,
 )
 from zigpy import zcl
 import zigpy.device
@@ -1907,3 +1908,40 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
         ),
         # No AttributeUpdatedEvent for passthrough_attr since value wasn't transformed
     ]
+
+
+async def test_zcl_write_attributes_update_cache(app_mock) -> None:
+    """Test that `write_attributes` can skip updating the attribute cache."""
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+
+    cluster = Basic(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(Basic.cluster_id, cluster)
+
+    # The cache updates by default
+    with mock_attribute_writes(
+        cluster,
+        {Basic.AttributeDefs.location_desc: foundation.Status.SUCCESS},
+    ):
+        await cluster.write_attributes(
+            {Basic.AttributeDefs.location_desc: "Test"},
+        )
+
+    assert cluster._attr_cache.get(Basic.AttributeDefs.location_desc) == "Test"
+
+    # But this can be overridden
+    events = []
+    cluster.on_all_events(events.append)
+
+    with mock_attribute_writes(
+        cluster,
+        {Basic.AttributeDefs.location_desc: foundation.Status.SUCCESS},
+    ):
+        await cluster.write_attributes(
+            {Basic.AttributeDefs.location_desc: "Test 2"},
+            update_cache=False,
+        )
+
+        assert cluster._attr_cache.get(Basic.AttributeDefs.location_desc) == "Test"
+
+    # No events should have been emitted
+    assert events == []

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1917,33 +1917,58 @@ async def test_zcl_write_attributes_update_cache(app_mock) -> None:
     cluster = Basic(dev.endpoints[1])
     dev.endpoints[1].add_input_cluster(Basic.cluster_id, cluster)
 
+    cluster.add_unsupported_attribute(Basic.AttributeDefs.product_url)
+
     # The cache updates by default
     with mock_attribute_writes(
         cluster,
-        {Basic.AttributeDefs.location_desc: foundation.Status.SUCCESS},
+        {
+            Basic.AttributeDefs.location_desc: foundation.Status.SUCCESS,
+            Basic.AttributeDefs.serial_number: foundation.Status.UNSUPPORTED_ATTRIBUTE,
+            Basic.AttributeDefs.product_url: foundation.Status.SUCCESS,
+        },
     ):
         await cluster.write_attributes(
-            {Basic.AttributeDefs.location_desc: "Test"},
+            {
+                Basic.AttributeDefs.location_desc: "Test",
+                Basic.AttributeDefs.serial_number: "1234",
+                Basic.AttributeDefs.product_url: "5678",
+            }
         )
 
-    # The cache updated
+    # The cache updated and all attribute state makes sense
     assert cluster._attr_cache.get(Basic.AttributeDefs.location_desc) == "Test"
+    assert cluster.is_attribute_unsupported(Basic.AttributeDefs.serial_number) is True
+    assert not cluster.is_attribute_unsupported(Basic.AttributeDefs.product_url)
+    assert cluster._attr_cache.get(Basic.AttributeDefs.product_url) == "5678"
 
-    # But this can be overridden
     events = []
     cluster.on_all_events(events.append)
 
     with mock_attribute_writes(
         cluster,
-        {Basic.AttributeDefs.location_desc: foundation.Status.SUCCESS},
+        {
+            Basic.AttributeDefs.location_desc: foundation.Status.SUCCESS,
+            # We flip things around: `serial_number` is reported as supported
+            Basic.AttributeDefs.serial_number: foundation.Status.SUCCESS,
+            # And `product_url` is now unsupported
+            Basic.AttributeDefs.product_url: foundation.Status.UNSUPPORTED_ATTRIBUTE,
+        },
     ):
         await cluster.write_attributes(
-            {Basic.AttributeDefs.location_desc: "Test 2"},
+            {
+                Basic.AttributeDefs.location_desc: "Test 2",
+                Basic.AttributeDefs.serial_number: "abcd",
+                Basic.AttributeDefs.product_url: "efgh",
+            },
             update_cache=False,
         )
 
-    # The cache never updated to `Test 2`
+    # Nothing changes, however
     assert cluster._attr_cache.get(Basic.AttributeDefs.location_desc) == "Test"
+    assert cluster.is_attribute_unsupported(Basic.AttributeDefs.serial_number) is True
+    assert not cluster.is_attribute_unsupported(Basic.AttributeDefs.product_url)
+    assert cluster._attr_cache.get(Basic.AttributeDefs.product_url) == "5678"
 
     # No events should have been emitted
     assert events == []

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1075,11 +1075,15 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
         return success, failure
 
-    def update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
+    def update_attribute(
+        self, attrid: int | t.uint16_t | foundation.ZCLAttributeDef, value: Any
+    ) -> None:
         """Update specified attribute with specified value"""
         self._update_attribute(attrid, value)
 
-    def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
+    def _update_attribute(
+        self, attrid: int | t.uint16_t | foundation.ZCLAttributeDef, value: Any
+    ) -> None:
         # Check if AttributeUpdatedEvent should be suppressed for this attribute.
         # This is used during Report_Attributes handling to allow quirks that update
         # other clusters or attributes to emit their own events.

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1156,6 +1156,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         self,
         attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
         manufacturer: int | UndefinedType | None = UNDEFINED,
+        *,
+        update_cache: bool = True,
         **kwargs,
     ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Write attributes to device with internal 'attributes' validation."""
@@ -1233,6 +1235,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     for zcl_attr in zcl_attrs
                 )
 
+            results.extend(records_group)
+
+            if not update_cache:
+                continue
+
             # Finally, emit events for the group
             for record in records_group:
                 attr_def = attr_defs[record.attrid]
@@ -1270,8 +1277,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         status=record.status,
                     ),
                 )
-
-            results.extend(records_group)
 
         # TODO: ditch the low-level return type
         return [results]


### PR DESCRIPTION
To support the use case in https://github.com/zigpy/zha-device-handlers/pull/4697#discussion_r2743753215, we should allow attribute updates to opt out of any state changes or events being generated.