### PR TITLE
Fix interaction between `is_manufacturer_specific` and `manufacturer_id_override`

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2016,17 +2016,17 @@ def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:
 
         class ServerCommandDefs(zcl.BaseCommandDefs):
             test_cmd1 = foundation.ZCLCommandDef(
-                id=0xB001, schema={}, manufacturer_code=0xABCD
+                id=0xB1, schema={}, manufacturer_code=0xABCD
             )
             test_cmd2 = foundation.ZCLCommandDef(
-                id=0xB002, schema={}, manufacturer_code=None
+                id=0xB2, schema={}, manufacturer_code=None
             )
             test_cmd3 = foundation.ZCLCommandDef(
-                id=0xB003, schema={}, is_manufacturer_specific=True
+                id=0xB3, schema={}, is_manufacturer_specific=True
             )
-            test_cmd4 = foundation.ZCLCommandDef(id=0xB004, schema={})
+            test_cmd4 = foundation.ZCLCommandDef(id=0xB4, schema={})
             test_cmd5 = foundation.ZCLCommandDef(
-                id=0xB005, schema={}, is_manufacturer_specific=False
+                id=0xB5, schema={}, is_manufacturer_specific=False
             )
 
     dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
@@ -2089,17 +2089,17 @@ def test_manufacturer_id_override_extended_zcl_cluster(app_mock) -> None:
 
         class ServerCommandDefs(Basic.ServerCommandDefs):
             test_cmd1 = foundation.ZCLCommandDef(
-                id=0xB001, schema={}, manufacturer_code=0xABCD
+                id=0xB1, schema={}, manufacturer_code=0xABCD
             )
             test_cmd2 = foundation.ZCLCommandDef(
-                id=0xB002, schema={}, manufacturer_code=None
+                id=0xB2, schema={}, manufacturer_code=None
             )
             test_cmd3 = foundation.ZCLCommandDef(
-                id=0xB003, schema={}, is_manufacturer_specific=True
+                id=0xB3, schema={}, is_manufacturer_specific=True
             )
-            test_cmd4 = foundation.ZCLCommandDef(id=0xB004, schema={})
+            test_cmd4 = foundation.ZCLCommandDef(id=0xB4, schema={})
             test_cmd5 = foundation.ZCLCommandDef(
-                id=0xB005, schema={}, is_manufacturer_specific=False
+                id=0xB5, schema={}, is_manufacturer_specific=False
             )
 
     dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1972,3 +1972,121 @@ async def test_zcl_write_attributes_update_cache(app_mock) -> None:
 
     # No events should have been emitted
     assert events == []
+
+
+def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:
+    """Test class-level `manufacturer_id_override` for custom clusters."""
+
+    class TestCluster(zcl.Cluster):
+        cluster_id = 0xFEED  # Manufacturer-specific cluster range
+        ep_attribute = "test_cluster"
+        manufacturer_id_override = 0x5678
+
+        class AttributeDefs(zcl.BaseAttributeDefs):
+            test_attr1 = foundation.ZCLAttributeDef(
+                id=0xB001,
+                type=t.uint8_t,
+                # Definition-level override takes priority
+                manufacturer_code=0xABCD,
+            )
+            test_attr2 = foundation.ZCLAttributeDef(
+                id=0xB002,
+                type=t.uint8_t,
+                # Definition-level override takes priority
+                manufacturer_code=None,
+            )
+            test_attr3 = foundation.ZCLAttributeDef(
+                id=0xB003,
+                type=t.uint8_t,
+                # While not strictly necessary, it is correct
+                is_manufacturer_specific=True,
+            )
+            test_attr4 = foundation.ZCLAttributeDef(
+                id=0xB004,
+                type=t.uint8_t,
+                # This is technically incorrect but since this cluster ID is in the
+                # manufacturer range, the default value of `is_manufacturer_specific`
+                # is effectively ignored, it must be
+            )
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    dev.node_desc.manufacturer_code = 0x1234
+
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr1)
+        == 0xABCD
+    )
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr2)
+        is None
+    )
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr3)
+        == 0x5678
+    )
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr4)
+        == 0x5678
+    )
+
+
+def test_manufacturer_id_override_extended_zcl_cluster(app_mock) -> None:
+    """Test class-level `manufacturer_id_override` for extended ZCL clusters."""
+
+    class TestCluster(Basic):
+        manufacturer_id_override = 0x5678
+
+        class AttributeDefs(Basic.AttributeDefs):
+            test_attr1 = foundation.ZCLAttributeDef(
+                id=0xB001,
+                type=t.uint8_t,
+                # Definition-level override takes priority
+                manufacturer_code=0xABCD,
+            )
+            test_attr2 = foundation.ZCLAttributeDef(
+                id=0xB002,
+                type=t.uint8_t,
+                # Definition-level override takes priority
+                manufacturer_code=None,
+            )
+            test_attr3 = foundation.ZCLAttributeDef(
+                id=0xB003,
+                type=t.uint8_t,
+                # While not strictly necessary, it is correct
+                is_manufacturer_specific=True,
+            )
+            test_attr4 = foundation.ZCLAttributeDef(
+                id=0xB004,
+                type=t.uint8_t,
+                # A normal attribute
+            )
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    dev.node_desc.manufacturer_code = 0x1234
+
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr1)
+        == 0xABCD
+    )
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr2)
+        is None
+    )
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr3)
+        == 0x5678
+    )
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr4)
+        is None
+    )
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.model)
+        is None
+    )

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2014,32 +2014,40 @@ def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:
                 # is effectively ignored, it must be
             )
 
+        class ServerCommandDefs(zcl.BaseCommandDefs):
+            test_cmd1 = foundation.ZCLCommandDef(
+                id=0xB001, schema={}, manufacturer_code=0xABCD
+            )
+            test_cmd2 = foundation.ZCLCommandDef(
+                id=0xB002, schema={}, manufacturer_code=None
+            )
+            test_cmd3 = foundation.ZCLCommandDef(
+                id=0xB003, schema={}, is_manufacturer_specific=True
+            )
+            test_cmd4 = foundation.ZCLCommandDef(id=0xB004, schema={})
+            test_cmd5 = foundation.ZCLCommandDef(
+                id=0xB005, schema={}, is_manufacturer_specific=False
+            )
+
     dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
     dev.node_desc.manufacturer_code = 0x1234
 
     cluster = TestCluster(dev.endpoints[1])
     dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
 
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr1)
-        == 0xABCD
-    )
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr2)
-        is None
-    )
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr3)
-        == 0x5678
-    )
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr4)
-        == 0x5678
-    )
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr5)
-        is None
-    )
+    for definition, expected in [
+        (TestCluster.AttributeDefs.test_attr1, 0xABCD),
+        (TestCluster.ServerCommandDefs.test_cmd1, 0xABCD),
+        (TestCluster.AttributeDefs.test_attr2, None),
+        (TestCluster.ServerCommandDefs.test_cmd2, None),
+        (TestCluster.AttributeDefs.test_attr3, 0x5678),
+        (TestCluster.ServerCommandDefs.test_cmd3, 0x5678),
+        (TestCluster.AttributeDefs.test_attr4, 0x5678),
+        (TestCluster.ServerCommandDefs.test_cmd4, 0x5678),
+        (TestCluster.AttributeDefs.test_attr5, None),
+        (TestCluster.ServerCommandDefs.test_cmd5, None),
+    ]:
+        assert cluster._get_effective_manufacturer_code(definition) is expected
 
 
 def test_manufacturer_id_override_extended_zcl_cluster(app_mock) -> None:
@@ -2072,10 +2080,25 @@ def test_manufacturer_id_override_extended_zcl_cluster(app_mock) -> None:
                 # A normal attribute
             )
             test_attr5 = foundation.ZCLAttributeDef(
-                id=0xB003,
+                id=0xB005,
                 type=t.uint8_t,
                 # While not strictly necessary, it is correct
                 is_manufacturer_specific=False,
+            )
+
+        class ServerCommandDefs(Basic.ServerCommandDefs):
+            test_cmd1 = foundation.ZCLCommandDef(
+                id=0xB001, schema={}, manufacturer_code=0xABCD
+            )
+            test_cmd2 = foundation.ZCLCommandDef(
+                id=0xB002, schema={}, manufacturer_code=None
+            )
+            test_cmd3 = foundation.ZCLCommandDef(
+                id=0xB003, schema={}, is_manufacturer_specific=True
+            )
+            test_cmd4 = foundation.ZCLCommandDef(id=0xB004, schema={})
+            test_cmd5 = foundation.ZCLCommandDef(
+                id=0xB005, schema={}, is_manufacturer_specific=False
             )
 
     dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
@@ -2084,27 +2107,18 @@ def test_manufacturer_id_override_extended_zcl_cluster(app_mock) -> None:
     cluster = TestCluster(dev.endpoints[1])
     dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
 
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr1)
-        == 0xABCD
-    )
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr2)
-        is None
-    )
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr3)
-        == 0x5678
-    )
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr4)
-        is None
-    )
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr5)
-        is None
-    )
-    assert (
-        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.model)
-        is None
-    )
+    for definition, expected in [
+        (TestCluster.AttributeDefs.test_attr1, 0xABCD),
+        (TestCluster.ServerCommandDefs.test_cmd1, 0xABCD),
+        (TestCluster.AttributeDefs.test_attr2, None),
+        (TestCluster.ServerCommandDefs.test_cmd2, None),
+        (TestCluster.AttributeDefs.test_attr3, 0x5678),
+        (TestCluster.ServerCommandDefs.test_cmd3, 0x5678),
+        (TestCluster.AttributeDefs.test_attr4, None),
+        (TestCluster.ServerCommandDefs.test_cmd4, None),
+        (TestCluster.AttributeDefs.test_attr5, None),
+        (TestCluster.ServerCommandDefs.test_cmd5, None),
+        (TestCluster.AttributeDefs.model, None),
+        (TestCluster.ServerCommandDefs.reset_fact_default, None),
+    ]:
+        assert cluster._get_effective_manufacturer_code(definition) is expected

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2004,6 +2004,11 @@ def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:
             test_attr4 = foundation.ZCLAttributeDef(
                 id=0xB004,
                 type=t.uint8_t,
+            )
+            test_attr5 = foundation.ZCLAttributeDef(
+                id=0xB005,
+                type=t.uint8_t,
+                is_manufacturer_specific=False,
                 # This is technically incorrect but since this cluster ID is in the
                 # manufacturer range, the default value of `is_manufacturer_specific`
                 # is effectively ignored, it must be
@@ -2030,6 +2035,10 @@ def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:
     assert (
         cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr4)
         == 0x5678
+    )
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr5)
+        is None
     )
 
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2055,13 +2055,18 @@ def test_manufacturer_id_override_extended_zcl_cluster(app_mock) -> None:
             test_attr3 = foundation.ZCLAttributeDef(
                 id=0xB003,
                 type=t.uint8_t,
-                # While not strictly necessary, it is correct
                 is_manufacturer_specific=True,
             )
             test_attr4 = foundation.ZCLAttributeDef(
                 id=0xB004,
                 type=t.uint8_t,
                 # A normal attribute
+            )
+            test_attr5 = foundation.ZCLAttributeDef(
+                id=0xB003,
+                type=t.uint8_t,
+                # While not strictly necessary, it is correct
+                is_manufacturer_specific=False,
             )
 
     dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
@@ -2084,6 +2089,10 @@ def test_manufacturer_id_override_extended_zcl_cluster(app_mock) -> None:
     )
     assert (
         cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr4)
+        is None
+    )
+    assert (
+        cluster._get_effective_manufacturer_code(TestCluster.AttributeDefs.test_attr5)
         is None
     )
     assert (

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2054,6 +2054,7 @@ def test_manufacturer_id_override_extended_zcl_cluster(app_mock) -> None:
     """Test class-level `manufacturer_id_override` for extended ZCL clusters."""
 
     class TestCluster(Basic):
+        _skip_registry = True
         manufacturer_id_override = 0x5678
 
         class AttributeDefs(Basic.AttributeDefs):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -232,7 +232,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
     _attributes_by_id: dict[
         int,
         dict[
-            bool,
+            bool | None,
             dict[int | UndefinedType | None, foundation.ZCLAttributeDef],
         ],
     ] = {}
@@ -381,7 +381,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
         for attr_def in cls.AttributeDefs:
             if attr_def.id not in cls._attributes_by_id:
-                cls._attributes_by_id[attr_def.id] = {True: {}, False: {}}
+                cls._attributes_by_id[attr_def.id] = {True: {}, False: {}, None: {}}
 
             is_manuf = attr_def.is_manufacturer_specific
             cls._attributes_by_id[attr_def.id][is_manuf][attr_def.manufacturer_code] = (
@@ -473,10 +473,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         elif isinstance(name_or_id, str):
             return cls.attributes_by_name[name_or_id]
         elif isinstance(name_or_id, int):
+            # Integer lookups are the most complicated, since we know the ID of an
+            # attribute not there may be multiple candidates sharing it
             candidates = cls._attributes_by_id[name_or_id]
             manuf_specific = candidates[True]
             non_manuf_specific = candidates[False]
+            maybe_manuf_specific = candidates[None]
 
+            # If a manufacturer code is explicitly provided, we can narrow things down
             if manufacturer_code is not UNDEFINED:
                 if manufacturer_code is None:
                     # Explicitly no manufacturer code
@@ -486,6 +490,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     # Fall back to unspecified
                     if UNDEFINED in non_manuf_specific:
                         return non_manuf_specific[UNDEFINED]
+
+                    if UNDEFINED in maybe_manuf_specific:
+                        return maybe_manuf_specific[UNDEFINED]
                 else:
                     # Try exact manufacturer-specific match
                     if manufacturer_code in manuf_specific:
@@ -505,8 +512,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
                 raise KeyError(manufacturer_code)
 
-            all_candidates = list(manuf_specific.values()) + list(
-                non_manuf_specific.values()
+            # Otherwise, we pick the first one and hope there is only a single choice
+            all_candidates = (
+                list(manuf_specific.values())
+                + list(non_manuf_specific.values())
+                + list(maybe_manuf_specific.values())
             )
 
             if len(all_candidates) > 1:
@@ -902,18 +912,29 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         manufacturer: int | UndefinedType | None = UNDEFINED,
     ) -> int | None:
         """Get the effective manufacturer code for an attribute or command."""
+
+        # If a command overrides the manufacturer code, it takes priority
         if manufacturer is not UNDEFINED:
             return manufacturer
 
+        # Otherwise, use what the definition has set explicitly
         if definition.manufacturer_code is not UNDEFINED:
             return definition.manufacturer_code
 
-        # In the future, we should migrate to explicit `manufacturer_code` for every
-        # attribute and command
-        if 0xFC00 <= self.cluster_id <= 0xFFFF or (
-            definition.is_manufacturer_specific
-            and self.manufacturer_id_override is not UNDEFINED
-        ):
+        # Or implicitly
+        if definition.is_manufacturer_specific is not None:
+            if not definition.is_manufacturer_specific:
+                return None
+
+            return (
+                self.manufacturer_id_override
+                if self.manufacturer_id_override is not UNDEFINED
+                else self.endpoint.device.manufacturer_id
+            )
+
+        # Finally, fall back to spec-compliant behavior and use a manufacturer code for
+        # any commands destined for a manufacturer-specific cluster
+        if 0xFC00 <= self.cluster_id <= 0xFFFF:
             return (
                 self.manufacturer_id_override
                 if self.manufacturer_id_override is not UNDEFINED

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -474,7 +474,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             return cls.attributes_by_name[name_or_id]
         elif isinstance(name_or_id, int):
             # Integer lookups are the most complicated, since we know the ID of an
-            # attribute not there may be multiple candidates sharing it
+            # attribute but there may be multiple candidates sharing it
             candidates = cls._attributes_by_id[name_or_id]
             manuf_specific = candidates[True]
             non_manuf_specific = candidates[False]

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -910,7 +910,10 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
         # In the future, we should migrate to explicit `manufacturer_code` for every
         # attribute and command
-        if 0xFC00 <= self.cluster_id <= 0xFFFF or definition.is_manufacturer_specific:
+        if 0xFC00 <= self.cluster_id <= 0xFFFF or (
+            definition.is_manufacturer_specific
+            and self.manufacturer_id_override is not UNDEFINED
+        ):
             return (
                 self.manufacturer_id_override
                 if self.manufacturer_id_override is not UNDEFINED

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1109,7 +1109,7 @@ class ZCLCommandDef(t.BaseDataclassMixin):
     id: t.uint8_t = None
     schema: type[CommandSchema] = None
     direction: Direction = None
-    is_manufacturer_specific: bool = None
+    is_manufacturer_specific: bool | None = None
 
     # set later
     name: str = None
@@ -1128,9 +1128,10 @@ class ZCLCommandDef(t.BaseDataclassMixin):
                 self, "direction", Direction._from_is_reply(self.direction)
             )
 
-        # Use UNDEFINED for manufacturer-specific commands without explicit code
-        if self.is_manufacturer_specific and self.manufacturer_code is None:
-            object.__setattr__(self, "manufacturer_code", UNDEFINED)
+        if self.manufacturer_code is not UNDEFINED:
+            object.__setattr__(
+                self, "is_manufacturer_specific", self.manufacturer_code is not None
+            )
 
     def with_compiled_schema(self) -> ZCLCommandDef:
         """Return a copy of the ZCL command definition object with its dictionary command
@@ -1256,7 +1257,7 @@ class ZCLAttributeDef(t.BaseDataclassMixin):
         ZCLAttributeAccess.Read | ZCLAttributeAccess.Write | ZCLAttributeAccess.Report
     )
     mandatory: bool = False
-    is_manufacturer_specific: bool = False
+    is_manufacturer_specific: bool | None = None
 
     # These are (optionally) computed later in the ZCL cluster subclass hook
     name: str = None
@@ -1281,11 +1282,10 @@ class ZCLAttributeDef(t.BaseDataclassMixin):
 
         ensure_valid_name(self.name)
 
-        if (
-            self.manufacturer_code not in (None, UNDEFINED)
-            and not self.is_manufacturer_specific
-        ):
-            object.__setattr__(self, "is_manufacturer_specific", True)
+        if self.manufacturer_code is not UNDEFINED:
+            object.__setattr__(
+                self, "is_manufacturer_specific", self.manufacturer_code is not None
+            )
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
This PR changes the `is_manufacturer_specific` default from `False` to `None`, allowing us to use overrides of the default as a hint when computing the manufacturer code for commands and attribute reads/writes.

- If disabled with `False`, we do not send a manufacturer code, even if the attribute is part of a cluster in a manufacturer-specific range.
- If enabled with `True`, we always send one, preferring the cluster-level `manufacturer_id_override` if it exists, falling back to the node descriptor otherwise.
- Both are overridden by `manufacturer_code`, the preferred way to set this value. It respects both `None` and specific values.