### PR TITLE
Cluster data type cleanup

### DIFF
--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -12,7 +12,15 @@ from zigpy import device, types, zcl
 import zigpy.endpoint
 from zigpy.ota import OTA, OtaImagesResult
 from zigpy.zcl import OtaImageAvailableEvent, OtaQueryCacheUpdatedEvent, foundation
-from zigpy.zcl.clusters.general import Basic, KeepAlive, Ota, Time
+from zigpy.zcl.clusters.general import (
+    Basic,
+    KeepAlive,
+    Ota,
+    Partition,
+    PartitionAckOptions,
+    PartitionFragmentationOptions,
+    Time,
+)
 import zigpy.zcl.clusters.security as sec
 from zigpy.zdo import types as zdo_t
 
@@ -763,3 +771,64 @@ def test_ias_zone_enum_subclass_zcl_type():
     """Test `IasZone.zone_type` is an enum16, not a uint16."""
 
     assert sec.IasZone.AttributeDefs.zone_type.zcl_type == foundation.DataTypeId.enum16
+
+
+@pytest.mark.parametrize(
+    ("fragmentation_options", "partition_indicator", "serialized"),
+    [
+        (PartitionFragmentationOptions.First_Block, 0x07, "010702aabb"),
+        (
+            PartitionFragmentationOptions.First_Block
+            | PartitionFragmentationOptions.Indicator_Length_16bit,
+            0x0107,
+            "03070102aabb",
+        ),
+    ],
+)
+def test_partition_indicator_width(
+    fragmentation_options: PartitionFragmentationOptions,
+    partition_indicator: int,
+    serialized: str,
+) -> None:
+    """`partition_indicator` is 1 or 2 octets wide, per ZCL R8 Figure 9-8."""
+    schema = Partition.ServerCommandDefs.transfer_partitioned_frame.schema
+    command = schema(
+        fragmentation_options=fragmentation_options,
+        partition_indicator=partition_indicator,
+        partitioned_frame=b"\xaa\xbb",
+    )
+
+    assert command.serialize() == bytes.fromhex(serialized)
+    assert schema.deserialize(bytes.fromhex(serialized)) == (command, b"")
+
+
+@pytest.mark.parametrize(
+    ("ack_options", "first_frame_id", "nack_ids", "serialized"),
+    [
+        (PartitionAckOptions(0), 0x03, [], "0003"),
+        (PartitionAckOptions(0), 0x03, [0x04, 0x05], "00030405"),
+        (
+            PartitionAckOptions.NACKId_Length_16bit,
+            0x0103,
+            [0x0104, 0x0105],
+            "01030104010501",
+        ),
+        (PartitionAckOptions.NACKId_Length_16bit, 0x0103, [], "010301"),
+    ],
+)
+def test_partition_nack_id_width(
+    ack_options: PartitionAckOptions,
+    first_frame_id: int,
+    nack_ids: list[int],
+    serialized: str,
+) -> None:
+    """`first_frame_id` and NACK ids are 1 or 2 octets wide, per ZCL R8 Figure 9-13."""
+    schema = Partition.ClientCommandDefs.multiple_ack.schema
+    command = schema(
+        ack_options=ack_options,
+        first_frame_id=first_frame_id,
+        nack_ids=nack_ids,
+    )
+
+    assert command.serialize() == bytes.fromhex(serialized)
+    assert schema.deserialize(bytes.fromhex(serialized)) == (command, b"")

--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -23,7 +23,7 @@ class ShadeStatus(t.bitmap8):
 
 class ShadeMode(t.enum8):
     Normal = 0x00
-    Configure = 0x00
+    Configure = 0x01
     Unknown = 0xFF
 
 

--- a/zigpy/zcl/clusters/closures.py
+++ b/zigpy/zcl/clusters/closures.py
@@ -51,7 +51,7 @@ class Shade(Cluster):
             id=0x0010, type=t.uint16_t, access="rw", mandatory=True
         )
         mode: Final = ZCLAttributeDef(
-            id=0x0012, type=ShadeMode, access="rw", mandatory=True
+            id=0x0011, type=ShadeMode, access="rw", mandatory=True
         )
 
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1962,7 +1962,7 @@ class RestartDeviceOptions(t.bitmap8):
 
     # Bits 0-2: Startup Mode
     Restart_using_startup_params = 0x00
-    Restart_using_surrent_ptate = 0x01
+    Restart_using_current_state = 0x01
     # Bit 3: Immediate
     Immediate = 0x08
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -105,6 +105,7 @@ class PhysicalEnvironment(t.enum8):
     Workshop = 0x30
     Guest_Bedroom = 0x31
     Guest_Bath = 0x32
+    Powder_Room = 0x33
     Back_Yard = 0x34
     Front_Yard = 0x35
     Patio = 0x36
@@ -309,6 +310,33 @@ class BatterySize(t.enum8):
     Unknown = 0xFF
 
 
+class BatteryAlarmMask(t.bitmap8):
+    Battery_Voltage_Too_Low = 0b00000001
+    Battery_Alarm_1 = 0b00000010
+    Battery_Alarm_2 = 0b00000100
+    Battery_Alarm_3 = 0b00001000
+
+
+class BatteryAlarmState(t.bitmap32):
+    # Battery Source 1
+    Battery_1_Min_Threshold = 0x00000001
+    Battery_1_Threshold_1 = 0x00000002
+    Battery_1_Threshold_2 = 0x00000004
+    Battery_1_Threshold_3 = 0x00000008
+    # Battery Source 2
+    Battery_2_Min_Threshold = 0x00000400
+    Battery_2_Threshold_1 = 0x00000800
+    Battery_2_Threshold_2 = 0x00001000
+    Battery_2_Threshold_3 = 0x00002000
+    # Battery Source 3
+    Battery_3_Min_Threshold = 0x00100000
+    Battery_3_Threshold_1 = 0x00200000
+    Battery_3_Threshold_2 = 0x00400000
+    Battery_3_Threshold_3 = 0x00800000
+    # Mains power supply
+    Mains_Power_Supply_Lost = 0x04000000
+
+
 class PowerConfiguration(Cluster):
     """Attributes for determining more detailed information
     about a device’s power source(s), and for configuring
@@ -317,6 +345,8 @@ class PowerConfiguration(Cluster):
 
     MainsAlarmMask: Final = MainsAlarmMask
     BatterySize: Final = BatterySize
+    BatteryAlarmMask: Final = BatteryAlarmMask
+    BatteryAlarmState: Final = BatteryAlarmState
 
     cluster_id: Final[t.uint16_t] = 0x0001
     name: Final = "Power Configuration"
@@ -361,19 +391,19 @@ class PowerConfiguration(Cluster):
         )
         # measured in units of 100mV
         battery_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0035, type=t.bitmap8, access="rw"
+            id=0x0035, type=BatteryAlarmMask, access="rw"
         )
         battery_volt_min_thres: Final = ZCLAttributeDef(
             id=0x0036, type=t.uint8_t, access="rw"
         )
         battery_volt_thres1: Final = ZCLAttributeDef(
-            id=0x0037, type=t.uint16_t, access="r*w"
+            id=0x0037, type=t.uint8_t, access="r*w"
         )
         battery_volt_thres2: Final = ZCLAttributeDef(
-            id=0x0038, type=t.uint16_t, access="r*w"
+            id=0x0038, type=t.uint8_t, access="r*w"
         )
         battery_volt_thres3: Final = ZCLAttributeDef(
-            id=0x0039, type=t.uint16_t, access="r*w"
+            id=0x0039, type=t.uint8_t, access="r*w"
         )
         battery_percent_min_thres: Final = ZCLAttributeDef(
             id=0x003A, type=t.uint8_t, access="r*w"
@@ -388,7 +418,7 @@ class PowerConfiguration(Cluster):
             id=0x003D, type=t.uint8_t, access="r*w"
         )
         battery_alarm_state: Final = ZCLAttributeDef(
-            id=0x003E, type=t.bitmap32, access="rp"
+            id=0x003E, type=BatteryAlarmState, access="rp"
         )
         # Battery 2 Information
         battery_2_voltage: Final = ZCLAttributeDef(
@@ -414,19 +444,19 @@ class PowerConfiguration(Cluster):
             id=0x0054, type=t.uint8_t, access="rw"
         )
         battery_2_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0055, type=t.bitmap8, access="rw"
+            id=0x0055, type=BatteryAlarmMask, access="rw"
         )
         battery_2_volt_min_thres: Final = ZCLAttributeDef(
             id=0x0056, type=t.uint8_t, access="rw"
         )
         battery_2_volt_thres1: Final = ZCLAttributeDef(
-            id=0x0057, type=t.uint16_t, access="r*w"
+            id=0x0057, type=t.uint8_t, access="r*w"
         )
         battery_2_volt_thres2: Final = ZCLAttributeDef(
-            id=0x0058, type=t.uint16_t, access="r*w"
+            id=0x0058, type=t.uint8_t, access="r*w"
         )
         battery_2_volt_thres3: Final = ZCLAttributeDef(
-            id=0x0059, type=t.uint16_t, access="r*w"
+            id=0x0059, type=t.uint8_t, access="r*w"
         )
         battery_2_percent_min_thres: Final = ZCLAttributeDef(
             id=0x005A, type=t.uint8_t, access="r*w"
@@ -441,7 +471,7 @@ class PowerConfiguration(Cluster):
             id=0x005D, type=t.uint8_t, access="r*w"
         )
         battery_2_alarm_state: Final = ZCLAttributeDef(
-            id=0x005E, type=t.bitmap32, access="rp"
+            id=0x005E, type=BatteryAlarmState, access="rp"
         )
         # Battery 3 Information
         battery_3_voltage: Final = ZCLAttributeDef(
@@ -467,19 +497,19 @@ class PowerConfiguration(Cluster):
             id=0x0074, type=t.uint8_t, access="rw"
         )
         battery_3_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0075, type=t.bitmap8, access="rw"
+            id=0x0075, type=BatteryAlarmMask, access="rw"
         )
         battery_3_volt_min_thres: Final = ZCLAttributeDef(
             id=0x0076, type=t.uint8_t, access="rw"
         )
         battery_3_volt_thres1: Final = ZCLAttributeDef(
-            id=0x0077, type=t.uint16_t, access="r*w"
+            id=0x0077, type=t.uint8_t, access="r*w"
         )
         battery_3_volt_thres2: Final = ZCLAttributeDef(
-            id=0x0078, type=t.uint16_t, access="r*w"
+            id=0x0078, type=t.uint8_t, access="r*w"
         )
         battery_3_volt_thres3: Final = ZCLAttributeDef(
-            id=0x0079, type=t.uint16_t, access="r*w"
+            id=0x0079, type=t.uint8_t, access="r*w"
         )
         battery_3_percent_min_thres: Final = ZCLAttributeDef(
             id=0x007A, type=t.uint8_t, access="r*w"
@@ -494,7 +524,7 @@ class PowerConfiguration(Cluster):
             id=0x007D, type=t.uint8_t, access="r*w"
         )
         battery_3_alarm_state: Final = ZCLAttributeDef(
-            id=0x007E, type=t.bitmap32, access="rp"
+            id=0x007E, type=BatteryAlarmState, access="rp"
         )
         cluster_revision: Final = foundation.ZCL_CLUSTER_REVISION_ATTR
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -10,6 +10,7 @@ from zigpy.zcl import Cluster, OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
+    CommandSchema,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
@@ -334,7 +335,7 @@ class BatteryAlarmState(t.bitmap32):
     Battery_3_Threshold_2 = 0x00400000
     Battery_3_Threshold_3 = 0x00800000
     # Mains power supply
-    Mains_Power_Supply_Lost = 0x04000000
+    Mains_Power_Supply_Lost = 0x40000000
 
 
 class PowerConfiguration(Cluster):
@@ -2109,6 +2110,85 @@ class PartitionAckOptions(t.bitmap8):
     NACKId_Length_16bit = 0x01
 
 
+# Figure 9-8. `partition_indicator` is one octet wide unless the options say otherwise,
+# so the frame cannot be described with a static schema.
+class TransferPartitionedFrameSchema(CommandSchema):
+    fragmentation_options: PartitionFragmentationOptions
+    partition_indicator: t.uint16_t
+    partitioned_frame: t.LVBytes
+
+    @staticmethod
+    def _indicator_type(
+        options: PartitionFragmentationOptions,
+    ) -> type[t.uint8_t | t.uint16_t]:
+        if PartitionFragmentationOptions.Indicator_Length_16bit in options:
+            return t.uint16_t
+        else:
+            return t.uint8_t
+
+    def serialize(self) -> bytes:
+        options = PartitionFragmentationOptions(self.fragmentation_options)
+        indicator_type = self._indicator_type(options)
+
+        return (
+            options.serialize()
+            + indicator_type(self.partition_indicator).serialize()
+            + t.LVBytes(self.partitioned_frame).serialize()
+        )
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
+        options, data = PartitionFragmentationOptions.deserialize(data)
+        indicator, data = cls._indicator_type(options).deserialize(data)
+        frame, data = t.LVBytes.deserialize(data)
+
+        return cls(
+            fragmentation_options=options,
+            partition_indicator=indicator,
+            partitioned_frame=frame,
+        ), data
+
+
+# Figure 9-13. `first_frame_id` and every NACK id are one octet wide unless the ACK
+# options (Figure 9-14) say otherwise.
+class MultipleAckSchema(CommandSchema):
+    ack_options: PartitionAckOptions
+    first_frame_id: t.uint16_t
+    nack_ids: t.List[t.uint16_t]
+
+    @staticmethod
+    def _frame_id_types(
+        options: PartitionAckOptions,
+    ) -> tuple[type[t.uint8_t | t.uint16_t], type[t.List]]:
+        if PartitionAckOptions.NACKId_Length_16bit in options:
+            return t.uint16_t, t.List[t.uint16_t]
+        else:
+            return t.uint8_t, t.List[t.uint8_t]
+
+    def serialize(self) -> bytes:
+        options = PartitionAckOptions(self.ack_options)
+        frame_id_type, nack_ids_type = self._frame_id_types(options)
+
+        return (
+            options.serialize()
+            + frame_id_type(self.first_frame_id).serialize()
+            + nack_ids_type(self.nack_ids).serialize()
+        )
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
+        options, data = PartitionAckOptions.deserialize(data)
+        frame_id_type, nack_ids_type = cls._frame_id_types(options)
+        first_frame_id, data = frame_id_type.deserialize(data)
+        nack_ids, data = nack_ids_type.deserialize(data)
+
+        return cls(
+            ack_options=options,
+            first_frame_id=first_frame_id,
+            nack_ids=nack_ids,
+        ), data
+
+
 class Partition(Cluster):
     PartitionFragmentationOptions: Final = PartitionFragmentationOptions
     PartitionAckOptions: Final = PartitionAckOptions
@@ -2158,12 +2238,7 @@ class Partition(Cluster):
 
     class ServerCommandDefs(BaseCommandDefs):
         transfer_partitioned_frame: Final = ZCLCommandDef(
-            id=0x00,
-            schema={
-                "fragmentation_options": PartitionFragmentationOptions,
-                "partition_indicator": t.uint16_t,
-                "partitioned_frame": t.LVBytes,
-            },
+            id=0x00, schema=TransferPartitionedFrameSchema
         )
         read_handshake_param: Final = ZCLCommandDef(
             id=0x01,
@@ -2181,14 +2256,7 @@ class Partition(Cluster):
         )
 
     class ClientCommandDefs(BaseCommandDefs):
-        multiple_ack: Final = ZCLCommandDef(
-            id=0x00,
-            schema={
-                "ack_options": PartitionAckOptions,
-                "first_frame_id": t.uint16_t,
-                "nack_ids": t.List[t.uint16_t],
-            },
-        )
+        multiple_ack: Final = ZCLCommandDef(id=0x00, schema=MultipleAckSchema)
         read_handshake_param_response: Final = ZCLCommandDef(
             id=0x01,
             schema={

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1961,8 +1961,8 @@ class RestartDeviceOptions(t.bitmap8):
     """Restart Device command options bitmap."""
 
     # Bits 0-2: Startup Mode
-    StartupMode_RestartUsingStartupParams = 0x00
-    StartupMode_RestartUsingCurrentState = 0x01
+    Restart_using_startup_params = 0x00
+    Restart_using_surrent_ptate = 0x01
     # Bit 3: Immediate
     Immediate = 0x08
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1957,6 +1957,16 @@ class NetworkKeyType(t.enum8):
     Standard = 0x01
 
 
+class RestartDeviceOptions(t.bitmap8):
+    """Restart Device command options bitmap."""
+
+    # Bits 0-2: Startup Mode
+    StartupMode_RestartUsingStartupParams = 0x00
+    StartupMode_RestartUsingCurrentState = 0x01
+    # Bit 3: Immediate
+    Immediate = 0x08
+
+
 class Commissioning(Cluster):
     """Attributes and commands for commissioning and
     managing a Zigbee device.
@@ -2047,8 +2057,13 @@ class Commissioning(Cluster):
     class ServerCommandDefs(BaseCommandDefs):
         restart_device: Final = ZCLCommandDef(
             id=0x00,
-            schema={"options": t.bitmap8, "delay": t.uint8_t, "jitter": t.uint8_t},
+            schema={
+                "options": RestartDeviceOptions,
+                "delay": t.uint8_t,
+                "jitter": t.uint8_t,
+            },
         )
+        # Options field is reserved for save/restore/reset commands
         save_startup_parameters: Final = ZCLCommandDef(
             id=0x01,
             schema={"options": t.bitmap8, "index": t.uint8_t},
@@ -2081,7 +2096,23 @@ class Commissioning(Cluster):
         )
 
 
+class PartitionFragmentationOptions(t.bitmap8):
+    """Fragmentation options for TransferPartitionedFrame command."""
+
+    First_Block = 0x01
+    Indicator_Length_16bit = 0x02
+
+
+class PartitionAckOptions(t.bitmap8):
+    """ACK options for MultipleACK command."""
+
+    NACKId_Length_16bit = 0x01
+
+
 class Partition(Cluster):
+    PartitionFragmentationOptions: Final = PartitionFragmentationOptions
+    PartitionAckOptions: Final = PartitionAckOptions
+
     cluster_id: Final[t.uint16_t] = 0x0016
     ep_attribute: Final = "partition"
 
@@ -2124,6 +2155,47 @@ class Partition(Cluster):
         )
         cluster_revision: Final = foundation.ZCL_CLUSTER_REVISION_ATTR
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
+
+    class ServerCommandDefs(BaseCommandDefs):
+        transfer_partitioned_frame: Final = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "fragmentation_options": PartitionFragmentationOptions,
+                "partition_indicator": t.uint16_t,
+                "partitioned_frame": t.LVBytes,
+            },
+        )
+        read_handshake_param: Final = ZCLCommandDef(
+            id=0x01,
+            schema={
+                "partitioned_cluster_id": t.ClusterId,
+                "attribute_ids": t.List[t.uint16_t],
+            },
+        )
+        write_handshake_param: Final = ZCLCommandDef(
+            id=0x02,
+            schema={
+                "partitioned_cluster_id": t.ClusterId,
+                "write_attribute_records": t.List[foundation.Attribute],
+            },
+        )
+
+    class ClientCommandDefs(BaseCommandDefs):
+        multiple_ack: Final = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "ack_options": PartitionAckOptions,
+                "first_frame_id": t.uint16_t,
+                "nack_ids": t.List[t.uint16_t],
+            },
+        )
+        read_handshake_param_response: Final = ZCLCommandDef(
+            id=0x01,
+            schema={
+                "partitioned_cluster_id": t.ClusterId,
+                "read_attribute_status_records": t.List[foundation.ReadAttributeRecord],
+            },
+        )
 
 
 class ImageUpgradeStatus(t.enum8):
@@ -2640,7 +2712,55 @@ class PowerProfile(Cluster):
         )
 
 
+class ApplianceCommandId(t.enum8):
+    """Command identification for Appliance Control."""
+
+    Start = 0x01
+    Stop = 0x02
+    Pause = 0x03
+    Start_Superfreezing = 0x04
+    Stop_Superfreezing = 0x05
+    Start_Supercooling = 0x06
+    Stop_Supercooling = 0x07
+    Disable_Gas = 0x08
+    Enable_Gas = 0x09
+
+
+class ApplianceWarningEvent(t.enum8):
+    """Warning event enumeration for Appliance Control."""
+
+    Warning_1_OverallPowerAboveAvailable = 0x00
+    Warning_2_OverallPowerAboveThreshold = 0x01
+    Warning_3_OverallPowerBackBelowAvailable = 0x02
+    Warning_4_OverallPowerBackBelowThreshold = 0x03
+    Warning_5_OverallPowerWillBeAboveAvailable = 0x04
+
+
+class ApplianceStatus(t.enum8):
+    """Appliance status enumeration."""
+
+    Off = 0x01
+    Stand_By = 0x02
+    Programmed = 0x03
+    Programmed_Waiting_To_Start = 0x04
+    Running = 0x05
+    Pause = 0x06
+    End_Programmed = 0x07
+    Failure = 0x08
+    Programme_Interrupted = 0x09
+    Idle = 0x0A
+    Rinse_Hold = 0x0B
+    Service = 0x0C
+    Superfreezing = 0x0D
+    Supercooling = 0x0E
+    Superheating = 0x0F
+
+
 class ApplianceControl(Cluster):
+    ApplianceCommandId: Final = ApplianceCommandId
+    ApplianceWarningEvent: Final = ApplianceWarningEvent
+    ApplianceStatus: Final = ApplianceStatus
+
     cluster_id: Final[t.uint16_t] = 0x001B
     ep_attribute: Final = "appliance_control"
 
@@ -2654,6 +2774,41 @@ class ApplianceControl(Cluster):
         remaining_time: Final = ZCLAttributeDef(id=0x0002, type=t.uint16_t, access="rp")
         cluster_revision: Final = foundation.ZCL_CLUSTER_REVISION_ATTR
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
+
+    class ServerCommandDefs(BaseCommandDefs):
+        execution_of_a_command: Final = ZCLCommandDef(
+            id=0x00,
+            schema={"command_id": ApplianceCommandId},
+        )
+        signal_state: Final = ZCLCommandDef(id=0x01, schema={})
+        write_functions: Final = ZCLCommandDef(
+            id=0x02,
+            schema={"function_data": t.LVBytes},
+        )
+        overload_pause_resume: Final = ZCLCommandDef(id=0x03, schema={})
+        overload_pause: Final = ZCLCommandDef(id=0x04, schema={})
+        overload_warning: Final = ZCLCommandDef(
+            id=0x05,
+            schema={"warning_event": ApplianceWarningEvent},
+        )
+
+    class ClientCommandDefs(BaseCommandDefs):
+        signal_state_response: Final = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "appliance_status": ApplianceStatus,
+                "remote_enable_flags": t.uint8_t,
+                "appliance_status_2?": t.uint24_t,
+            },
+        )
+        signal_state_notification: Final = ZCLCommandDef(
+            id=0x01,
+            schema={
+                "appliance_status": ApplianceStatus,
+                "remote_enable_flags": t.uint8_t,
+                "appliance_status_2?": t.uint24_t,
+            },
+        )
 
 
 class PollControl(Cluster):

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1853,7 +1853,7 @@ class MultistateInput(Cluster):
             id=0x001C, type=t.CharacterString, access="r*w"
         )
         number_of_states: Final = ZCLAttributeDef(
-            id=0x004A, type=t.uint16_t, access="r*w"
+            id=0x004A, type=t.uint16_t, access="r*w", mandatory=True
         )
         out_of_service: Final = ZCLAttributeDef(
             id=0x0051, type=t.Bool, access="r*w", mandatory=True

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1195,6 +1195,19 @@ class Time(Cluster):
     TimeStatus: Final = TimeStatus
 
 
+class CoordinateSystem(t.enum2):
+    Rectangular = 0b00
+
+
+# Table 3-73. The wire type is `data8`, but that is not constructible from an int, so
+# this is modelled as an int struct and the attribute carries an explicit `zcl_type`.
+class LocationType(t.IntStruct, t.uint8_t):
+    absolute: t.uint1_t
+    two_dimensional: t.uint1_t
+    coordinate_system: CoordinateSystem
+    _reserved: t.uint4_t
+
+
 class LocationMethod(t.enum8):
     Lateration = 0x00
     Signposting = 0x01
@@ -1218,6 +1231,8 @@ class RSSILocation(Cluster):
     among devices.
     """
 
+    LocationType: Final = LocationType
+    CoordinateSystem: Final = CoordinateSystem
     LocationMethod: Final = LocationMethod
     NeighborInfo: Final = NeighborInfo
 
@@ -1227,7 +1242,11 @@ class RSSILocation(Cluster):
     class AttributeDefs(BaseAttributeDefs):
         # Location Information
         type: Final = ZCLAttributeDef(
-            id=0x0000, type=t.data8, access="rw", mandatory=True
+            id=0x0000,
+            type=LocationType,
+            zcl_type=foundation.DataTypeId.data8,
+            access="rw",
+            mandatory=True,
         )
         method: Final = ZCLAttributeDef(
             id=0x0001, type=LocationMethod, access="rw", mandatory=True
@@ -1339,7 +1358,7 @@ class RSSILocation(Cluster):
             id=0x01,
             schema={
                 "status": foundation.Status,
-                "location_type?": t.data8,
+                "location_type?": LocationType,
                 "coordinate1?": t.int16s,
                 "coordinate2?": t.int16s,
                 "coordinate3?": t.int16s,
@@ -1354,7 +1373,7 @@ class RSSILocation(Cluster):
         compact_location_data_notification: Final = ZCLCommandDef(id=0x03, schema={})
         rssi_ping: Final = ZCLCommandDef(
             id=0x04,
-            schema={"location_type": t.data8},
+            schema={"location_type": LocationType},
         )
         rssi_req: Final = ZCLCommandDef(id=0x05, schema={})
         report_rssi_measurements: Final = ZCLCommandDef(
@@ -2849,9 +2868,11 @@ class ApplianceControl(Cluster):
             schema={"command_id": ApplianceCommandId},
         )
         signal_state: Final = ZCLCommandDef(id=0x01, schema={})
+        # Figures 15-3 and 15-4: a single record whose function identifier "i.e.,
+        # attribute identifier", data type and data match `foundation.Attribute`
         write_functions: Final = ZCLCommandDef(
             id=0x02,
-            schema={"function_data": t.LVBytes},
+            schema={"function": foundation.Attribute},
         )
         overload_pause_resume: Final = ZCLCommandDef(id=0x03, schema={})
         overload_pause: Final = ZCLCommandDef(id=0x04, schema={})

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1005,7 +1005,7 @@ class LevelControl(Cluster):
         )
         min_frequency: Final = ZCLAttributeDef(id=0x0005, type=t.uint16_t, access="r")
         max_frequency: Final = ZCLAttributeDef(id=0x0006, type=t.uint16_t, access="r")
-        options: Final = ZCLAttributeDef(id=0x000F, type=t.bitmap8, access="rw")
+        options: Final = ZCLAttributeDef(id=0x000F, type=Options, access="rw")
         on_off_transition_time: Final = ZCLAttributeDef(
             id=0x0010, type=t.uint16_t, access="rw"
         )
@@ -1370,21 +1370,251 @@ class RSSILocation(Cluster):
 
 
 class Reliability(t.enum8):
-    No_fault_detected = 0
-    No_sensor = 1
-    Over_range = 2
-    Under_range = 3
-    Open_loop = 4
-    Shorted_loop = 5
-    No_output = 6
-    Unreliable_other = 7
-    Process_error = 8
-    Multi_state_fault = 9
-    Configuration_error = 10
+    No_fault_detected = 0x00
+    No_sensor = 0x01
+    Over_range = 0x02
+    Under_range = 0x03
+    Open_loop = 0x04
+    Shorted_loop = 0x05
+    No_output = 0x06
+    Unreliable_other = 0x07
+    Process_error = 0x08
+    Multi_state_fault = 0x09
+    Configuration_error = 0x0A
+
+
+class StatusFlags(t.bitmap8):
+    """Status flags for Input/Output/Value clusters."""
+
+    In_Alarm = 0b0001
+    Fault = 0b0010
+    Overridden = 0b0100
+    Out_Of_Service = 0b1000
+
+
+class Polarity(t.enum8):
+    """Polarity for Binary Input/Output clusters."""
+
+    Normal = 0x00
+    Reverse = 0x01
+
+
+class BACnetEngineeringUnits(t.enum16):
+    """BACnet Engineering Units per ASHRAE 135-2004."""
+
+    Square_Meters = 0
+    Square_Feet = 1
+    Milliamperes = 2
+    Amperes = 3
+    Ohms = 4
+    Volts = 5
+    Kilovolts = 6
+    Megavolts = 7
+    Volt_Amperes = 8
+    Kilovolt_Amperes = 9
+    Megavolt_Amperes = 10
+    Volt_Amperes_Reactive = 11
+    Kilovolt_Amperes_Reactive = 12
+    Megavolt_Amperes_Reactive = 13
+    Degrees_Phase = 14
+    Power_Factor = 15
+    Joules = 16
+    Kilojoules = 17
+    Watt_Hours = 18
+    Kilowatt_Hours = 19
+    Btus = 20
+    Therms = 21
+    Ton_Hours = 22
+    Joules_Per_Kilogram_Dry_Air = 23
+    Btus_Per_Pound_Dry_Air = 24
+    Cycles_Per_Hour = 25
+    Cycles_Per_Minute = 26
+    Hertz = 27
+    Grams_Of_Water_Per_Kilogram_Dry_Air = 28
+    Percent_Relative_Humidity = 29
+    Millimeters = 30
+    Meters = 31
+    Inches = 32
+    Feet = 33
+    Watts_Per_Square_Foot = 34
+    Watts_Per_Square_Meter = 35
+    Lumens = 36
+    Luxes = 37
+    Foot_Candles = 38
+    Kilograms = 39
+    Pounds_Mass = 40
+    Tons = 41
+    Kilograms_Per_Second = 42
+    Kilograms_Per_Minute = 43
+    Kilograms_Per_Hour = 44
+    Pounds_Mass_Per_Minute = 45
+    Pounds_Mass_Per_Hour = 46
+    Watts = 47
+    Kilowatts = 48
+    Megawatts = 49
+    Btus_Per_Hour = 50
+    Horsepower = 51
+    Tons_Refrigeration = 52
+    Pascals = 53
+    Kilopascals = 54
+    Bars = 55
+    Pounds_Force_Per_Square_Inch = 56
+    Centimeters_Of_Water = 57
+    Inches_Of_Water = 58
+    Millimeters_Of_Mercury = 59
+    Centimeters_Of_Mercury = 60
+    Inches_Of_Mercury = 61
+    Degrees_Celsius = 62
+    Degrees_Kelvin = 63
+    Degrees_Fahrenheit = 64
+    Degree_Days_Celsius = 65
+    Degree_Days_Fahrenheit = 66
+    Years = 67
+    Months = 68
+    Weeks = 69
+    Days = 70
+    Hours = 71
+    Minutes = 72
+    Seconds = 73
+    Meters_Per_Second = 74
+    Kilometers_Per_Hour = 75
+    Feet_Per_Second = 76
+    Feet_Per_Minute = 77
+    Miles_Per_Hour = 78
+    Cubic_Feet = 79
+    Cubic_Meters = 80
+    Imperial_Gallons = 81
+    Liters = 82
+    Us_Gallons = 83
+    Cubic_Feet_Per_Minute = 84
+    Cubic_Meters_Per_Second = 85
+    Imperial_Gallons_Per_Minute = 86
+    Liters_Per_Second = 87
+    Liters_Per_Minute = 88
+    Us_Gallons_Per_Minute = 89
+    Degrees_Angular = 90
+    Degrees_Celsius_Per_Hour = 91
+    Degrees_Celsius_Per_Minute = 92
+    Degrees_Fahrenheit_Per_Hour = 93
+    Degrees_Fahrenheit_Per_Minute = 94
+    No_Units = 95
+    Parts_Per_Million = 96
+    Parts_Per_Billion = 97
+    Percent = 98
+    Percent_Per_Second = 99
+    Per_Minute = 100
+    Per_Second = 101
+    Psi_Per_Degree_Fahrenheit = 102
+    Radians = 103
+    Revolutions_Per_Minute = 104
+    Currency1 = 105
+    Currency2 = 106
+    Currency3 = 107
+    Currency4 = 108
+    Currency5 = 109
+    Currency6 = 110
+    Currency7 = 111
+    Currency8 = 112
+    Currency9 = 113
+    Currency10 = 114
+    Square_Inches = 115
+    Square_Centimeters = 116
+    Btus_Per_Pound = 117
+    Centimeters = 118
+    Pounds_Mass_Per_Second = 119
+    Delta_Degrees_Fahrenheit = 120
+    Delta_Degrees_Kelvin = 121
+    Kilohms = 122
+    Megohms = 123
+    Millivolts = 124
+    Kilojoules_Per_Kilogram = 125
+    Megajoules = 126
+    Joules_Per_Degree_Kelvin = 127
+    Joules_Per_Kilogram_Degree_Kelvin = 128
+    Kilohertz = 129
+    Megahertz = 130
+    Per_Hour = 131
+    Milliwatts = 132
+    Hectopascals = 133
+    Millibars = 134
+    Cubic_Meters_Per_Hour = 135
+    Liters_Per_Hour = 136
+    Kw_Hours_Per_Square_Meter = 137
+    Kw_Hours_Per_Square_Foot = 138
+    Megajoules_Per_Square_Meter = 139
+    Megajoules_Per_Square_Foot = 140
+    Watts_Per_Square_Meter_Degree_Kelvin = 141
+    Cubic_Feet_Per_Second = 142
+    Percent_Obscuration_Per_Foot = 143
+    Percent_Obscuration_Per_Meter = 144
+    Milliohms = 145
+    Megawatt_Hours = 146
+    Kilo_Btus = 147
+    Mega_Btus = 148
+    Kilojoules_Per_Kilogram_Dry_Air = 149
+    Megajoules_Per_Kilogram_Dry_Air = 150
+    Kilojoules_Per_Degree_Kelvin = 151
+    Megajoules_Per_Degree_Kelvin = 152
+    Newton = 153
+    Grams_Per_Second = 154
+    Grams_Per_Minute = 155
+    Tons_Per_Hour = 156
+    Kilo_Btus_Per_Hour = 157
+    Hundredths_Seconds = 158
+    Milliseconds = 159
+    Newton_Meters = 160
+    Millimeters_Per_Second = 161
+    Millimeters_Per_Minute = 162
+    Meters_Per_Minute = 163
+    Meters_Per_Hour = 164
+    Cubic_Meters_Per_Minute = 165
+    Meters_Per_Second_Per_Second = 166
+    Amperes_Per_Meter = 167
+    Amperes_Per_Square_Meter = 168
+    Ampere_Square_Meters = 169
+    Farads = 170
+    Henrys = 171
+    Ohm_Meters = 172
+    Siemens = 173
+    Siemens_Per_Meter = 174
+    Teslas = 175
+    Volts_Per_Degree_Kelvin = 176
+    Volts_Per_Meter = 177
+    Webers = 178
+    Candelas = 179
+    Candelas_Per_Square_Meter = 180
+    Degrees_Kelvin_Per_Hour = 181
+    Degrees_Kelvin_Per_Minute = 182
+    Joule_Seconds = 183
+    Radians_Per_Second = 184
+    Square_Meters_Per_Newton = 185
+    Kilograms_Per_Cubic_Meter = 186
+    Newton_Seconds = 187
+    Newtons_Per_Meter = 188
+    Watts_Per_Meter_Per_Degree_Kelvin = 189
+    Microsiemens = 190
+    Cubic_Feet_Per_Hour = 191
+    Us_Gallons_Per_Hour = 192
+    Kilometers = 193
+    Micrometers = 194
+    Grams = 195
+    Milligrams = 196
+    Milliliters = 197
+    Milliliters_Per_Second = 198
+    Decibels = 199
+    Decibels_Millivolt = 200
+    Decibels_Volt = 201
+    Millisiemens = 202
+    Watt_Hours_Reactive = 203
+    Kilowatt_Hours_Reactive = 204
+    Megawatt_Hours_Reactive = 205
+    Millimeters_Of_Water = 206
+    Other = 0x00FF
 
 
 class AnalogInput(Cluster):
     Reliability: Final = Reliability
+    StatusFlags: Final = StatusFlags
 
     cluster_id: Final[t.uint16_t] = 0x000C
     ep_attribute: Final = "analog_input"
@@ -1408,10 +1638,10 @@ class AnalogInput(Cluster):
         reliability: Final = ZCLAttributeDef(id=0x0067, type=Reliability, access="r*w")
         resolution: Final = ZCLAttributeDef(id=0x006A, type=t.Single, access="r*w")
         status_flags: Final = ZCLAttributeDef(
-            id=0x006F, type=t.bitmap8, access="rp", mandatory=True
+            id=0x006F, type=StatusFlags, access="rp", mandatory=True
         )
         engineering_units: Final = ZCLAttributeDef(
-            id=0x0075, type=t.enum16, access="r*w"
+            id=0x0075, type=BACnetEngineeringUnits, access="r*w"
         )
         application_type: Final = ZCLAttributeDef(
             id=0x0100, type=t.uint32_t, access="r"
@@ -1442,16 +1672,16 @@ class AnalogOutput(Cluster):
         )
         # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        reliability: Final = ZCLAttributeDef(id=0x0067, type=t.enum8, access="r*w")
+        reliability: Final = ZCLAttributeDef(id=0x0067, type=Reliability, access="r*w")
         relinquish_default: Final = ZCLAttributeDef(
             id=0x0068, type=t.Single, access="r*w"
         )
         resolution: Final = ZCLAttributeDef(id=0x006A, type=t.Single, access="r*w")
         status_flags: Final = ZCLAttributeDef(
-            id=0x006F, type=t.bitmap8, access="rp", mandatory=True
+            id=0x006F, type=StatusFlags, access="rp", mandatory=True
         )
         engineering_units: Final = ZCLAttributeDef(
-            id=0x0075, type=t.enum16, access="r*w"
+            id=0x0075, type=BACnetEngineeringUnits, access="r*w"
         )
         application_type: Final = ZCLAttributeDef(
             id=0x0100, type=t.uint32_t, access="r"
@@ -1476,15 +1706,15 @@ class AnalogValue(Cluster):
         )
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        reliability: Final = ZCLAttributeDef(id=0x0067, type=t.enum8, access="r*w")
+        reliability: Final = ZCLAttributeDef(id=0x0067, type=Reliability, access="r*w")
         relinquish_default: Final = ZCLAttributeDef(
             id=0x0068, type=t.Single, access="r*w"
         )
         status_flags: Final = ZCLAttributeDef(
-            id=0x006F, type=t.bitmap8, access="r", mandatory=True
+            id=0x006F, type=StatusFlags, access="r", mandatory=True
         )
         engineering_units: Final = ZCLAttributeDef(
-            id=0x0075, type=t.enum16, access="r*w"
+            id=0x0075, type=BACnetEngineeringUnits, access="r*w"
         )
         application_type: Final = ZCLAttributeDef(
             id=0x0100, type=t.uint32_t, access="r"
@@ -1511,13 +1741,13 @@ class BinaryInput(Cluster):
         out_of_service: Final = ZCLAttributeDef(
             id=0x0051, type=t.Bool, access="r*w", mandatory=True
         )
-        polarity: Final = ZCLAttributeDef(id=0x0054, type=t.enum8, access="r")
+        polarity: Final = ZCLAttributeDef(id=0x0054, type=Polarity, access="r")
         present_value: Final = ZCLAttributeDef(
             id=0x0055, type=t.Bool, access="r*w", mandatory=True
         )
-        reliability: Final = ZCLAttributeDef(id=0x0067, type=t.enum8, access="r*w")
+        reliability: Final = ZCLAttributeDef(id=0x0067, type=Reliability, access="r*w")
         status_flags: Final = ZCLAttributeDef(
-            id=0x006F, type=t.bitmap8, access="r", mandatory=True
+            id=0x006F, type=StatusFlags, access="r", mandatory=True
         )
         application_type: Final = ZCLAttributeDef(
             id=0x0100, type=t.uint32_t, access="r"
@@ -1549,18 +1779,18 @@ class BinaryOutput(Cluster):
         out_of_service: Final = ZCLAttributeDef(
             id=0x0051, type=t.Bool, access="r*w", mandatory=True
         )
-        polarity: Final = ZCLAttributeDef(id=0x0054, type=t.enum8, access="r")
+        polarity: Final = ZCLAttributeDef(id=0x0054, type=Polarity, access="r")
         present_value: Final = ZCLAttributeDef(
             id=0x0055, type=t.Bool, access="r*w", mandatory=True
         )
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        reliability: Final = ZCLAttributeDef(id=0x0067, type=t.enum8, access="r*w")
+        reliability: Final = ZCLAttributeDef(id=0x0067, type=Reliability, access="r*w")
         relinquish_default: Final = ZCLAttributeDef(
             id=0x0068, type=t.Bool, access="r*w"
         )
         status_flags: Final = ZCLAttributeDef(
-            id=0x006F, type=t.bitmap8, access="r", mandatory=True
+            id=0x006F, type=StatusFlags, access="r", mandatory=True
         )
         application_type: Final = ZCLAttributeDef(
             id=0x0100, type=t.uint32_t, access="r"
@@ -1597,12 +1827,12 @@ class BinaryValue(Cluster):
         )
         # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # boolean)
-        reliability: Final = ZCLAttributeDef(id=0x0067, type=t.enum8, access="r*w")
+        reliability: Final = ZCLAttributeDef(id=0x0067, type=Reliability, access="r*w")
         relinquish_default: Final = ZCLAttributeDef(
             id=0x0068, type=t.Bool, access="r*w"
         )
         status_flags: Final = ZCLAttributeDef(
-            id=0x006F, type=t.bitmap8, access="r", mandatory=True
+            id=0x006F, type=StatusFlags, access="r", mandatory=True
         )
         application_type: Final = ZCLAttributeDef(
             id=0x0100, type=t.uint32_t, access="r"
@@ -1633,9 +1863,9 @@ class MultistateInput(Cluster):
         )
         # 0x0057: ('priority_array', TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        reliability: Final = ZCLAttributeDef(id=0x0067, type=t.enum8, access="r*w")
+        reliability: Final = ZCLAttributeDef(id=0x0067, type=Reliability, access="r*w")
         status_flags: Final = ZCLAttributeDef(
-            id=0x006F, type=t.bitmap8, access="r", mandatory=True
+            id=0x006F, type=StatusFlags, access="r", mandatory=True
         )
         application_type: Final = ZCLAttributeDef(
             id=0x0100, type=t.uint32_t, access="r"
@@ -1666,12 +1896,12 @@ class MultistateOutput(Cluster):
         )
         # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        reliability: Final = ZCLAttributeDef(id=0x0067, type=t.enum8, access="r*w")
+        reliability: Final = ZCLAttributeDef(id=0x0067, type=Reliability, access="r*w")
         relinquish_default: Final = ZCLAttributeDef(
             id=0x0068, type=t.uint16_t, access="r*w"
         )
         status_flags: Final = ZCLAttributeDef(
-            id=0x006F, type=t.bitmap8, access="r", mandatory=True
+            id=0x006F, type=StatusFlags, access="r", mandatory=True
         )
         application_type: Final = ZCLAttributeDef(
             id=0x0100, type=t.uint32_t, access="r"
@@ -1702,12 +1932,12 @@ class MultistateValue(Cluster):
         )
         # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
         # single precision)
-        reliability: Final = ZCLAttributeDef(id=0x0067, type=t.enum8, access="r*w")
+        reliability: Final = ZCLAttributeDef(id=0x0067, type=Reliability, access="r*w")
         relinquish_default: Final = ZCLAttributeDef(
             id=0x0068, type=t.uint16_t, access="r*w"
         )
         status_flags: Final = ZCLAttributeDef(
-            id=0x006F, type=t.bitmap8, access="r", mandatory=True
+            id=0x006F, type=StatusFlags, access="r", mandatory=True
         )
         application_type: Final = ZCLAttributeDef(
             id=0x0100, type=t.uint32_t, access="r"
@@ -2237,10 +2467,27 @@ class PowerProfileType(t.Struct):
     power_profile_state: t.uint8_t
 
 
+class EnergyFormatting(t.bitmap8):
+    """Energy formatting bitmap for PowerProfile cluster."""
+
+    # Bits 0-2: Number of Digits to the right of the Decimal Point
+    # Bits 3-6: Number of Digits to the left of the Decimal Point
+    Suppress_Leading_Zeros = 0b10000000
+
+
+class ScheduleMode(t.bitmap8):
+    """Schedule mode bitmap for PowerProfile cluster."""
+
+    Cheapest = 0b00000001
+    Greenest = 0b00000010
+
+
 class PowerProfile(Cluster):
     ScheduleRecord: Final = ScheduleRecord
     PowerProfilePhase: Final = PowerProfilePhase
     PowerProfile: Final = PowerProfileType
+    EnergyFormatting: Final = EnergyFormatting
+    ScheduleMode: Final = ScheduleMode
 
     cluster_id: Final[t.uint16_t] = 0x001A
     ep_attribute: Final = "power_profile"
@@ -2253,13 +2500,13 @@ class PowerProfile(Cluster):
             id=0x0001, type=t.Bool, access="r", mandatory=True
         )
         energy_formatting: Final = ZCLAttributeDef(
-            id=0x0002, type=t.bitmap8, access="r", mandatory=True
+            id=0x0002, type=EnergyFormatting, access="r", mandatory=True
         )
         energy_remote: Final = ZCLAttributeDef(
             id=0x0003, type=t.Bool, access="r", mandatory=True
         )
         schedule_mode: Final = ZCLAttributeDef(
-            id=0x0004, type=t.bitmap8, access="rwp", mandatory=True
+            id=0x0004, type=ScheduleMode, access="rwp", mandatory=True
         )
         cluster_revision: Final = foundation.ZCL_CLUSTER_REVISION_ATTR
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1196,7 +1196,7 @@ class RSSILocation(Cluster):
     class AttributeDefs(BaseAttributeDefs):
         # Location Information
         type: Final = ZCLAttributeDef(
-            id=0x0000, type=t.uint8_t, access="rw", mandatory=True
+            id=0x0000, type=t.data8, access="rw", mandatory=True
         )
         method: Final = ZCLAttributeDef(
             id=0x0001, type=LocationMethod, access="rw", mandatory=True
@@ -1308,13 +1308,13 @@ class RSSILocation(Cluster):
             id=0x01,
             schema={
                 "status": foundation.Status,
-                "location_type?": t.uint8_t,
+                "location_type?": t.data8,
                 "coordinate1?": t.int16s,
                 "coordinate2?": t.int16s,
                 "coordinate3?": t.int16s,
-                "power?": t.uint16_t,
-                "path_loss_exponent?": t.uint8_t,
-                "location_method?": t.uint8_t,
+                "power?": t.int16s,
+                "path_loss_exponent?": t.uint16_t,
+                "location_method?": LocationMethod,
                 "quality_measure?": t.uint8_t,
                 "location_age?": t.uint16_t,
             },
@@ -1323,7 +1323,7 @@ class RSSILocation(Cluster):
         compact_location_data_notification: Final = ZCLCommandDef(id=0x03, schema={})
         rssi_ping: Final = ZCLCommandDef(
             id=0x04,
-            schema={"location_type": t.uint8_t},
+            schema={"location_type": t.data8},
         )
         rssi_req: Final = ZCLCommandDef(id=0x05, schema={})
         report_rssi_measurements: Final = ZCLCommandDef(
@@ -1563,13 +1563,13 @@ class BinaryValue(Cluster):
             id=0x0051, type=t.Bool, access="r*w", mandatory=True
         )
         present_value: Final = ZCLAttributeDef(
-            id=0x0055, type=t.Single, access="r*w", mandatory=True
+            id=0x0055, type=t.Bool, access="r*w", mandatory=True
         )
         # 0x0057: ZCLAttributeDef('priority_array', type=TODO.array),  # Array of 16 structures of (boolean,
-        # single precision)
+        # boolean)
         reliability: Final = ZCLAttributeDef(id=0x0067, type=t.enum8, access="r*w")
         relinquish_default: Final = ZCLAttributeDef(
-            id=0x0068, type=t.Single, access="r*w"
+            id=0x0068, type=t.Bool, access="r*w"
         )
         status_flags: Final = ZCLAttributeDef(
             id=0x006F, type=t.bitmap8, access="r", mandatory=True

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -323,7 +323,7 @@ class GreenPowerProxy(Cluster):
         functionality: Final = ZCLAttributeDef(
             id=0x0006,
             type=GPSFunctionality,
-            access="rw",
+            access="r",
             mandatory=True,
         )
         active_functionality: Final = ZCLAttributeDef(
@@ -333,21 +333,45 @@ class GreenPowerProxy(Cluster):
             mandatory=True,
         )
         gpp_max_table_entries: Final = ZCLAttributeDef(
-            id=0x0010, type=t.uint8_t, access="r"
+            id=0x0010,
+            type=t.uint8_t,
+            access="r",
+            mandatory=True,
         )
         gpp_proxy_table: Final = ZCLAttributeDef(
-            id=0x0011, type=t.LongOctetString, access="r"
+            id=0x0011,
+            type=t.LongOctetString,
+            access="r",
+            mandatory=True,
         )
         gpp_functionality: Final = ZCLAttributeDef(
-            id=0x0016, type=GPPFunctionality, access="r"
+            id=0x0016,
+            type=GPPFunctionality,
+            access="r",
+            mandatory=True,
         )
         gpp_active_functionality: Final = ZCLAttributeDef(
-            id=0x0017, type=GPPFunctionality, access="r"
+            id=0x0017,
+            type=GPPFunctionality,
+            access="r",
+            mandatory=True,
+        )
+        gp_shared_security_key_type: Final = ZCLAttributeDef(
+            id=0x0020,
+            type=t.bitmap8,
+            access="rw",
+            mandatory=True,
+        )
+        gp_shared_security_key: Final = ZCLAttributeDef(
+            id=0x0021,
+            type=t.KeyData,
+            access="rw",
+            mandatory=True,
         )
         link_key: Final = ZCLAttributeDef(
             id=0x0022,
             type=t.KeyData,
-            access="r",
+            access="rw",
             mandatory=True,
         )
 

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -53,8 +53,8 @@ class GPSFunctionality(t.bitmap24):
     Proximity_Bidirectional_Operation = 0x000040
     Multi_Hop_Bidirectional_Operation = 0x000080
     Proxy_Table_Maintenance = 0x000100
-    # b9 Reserved
-    GP_Commissioning = 0x000400
+    Proximity_Commissioning = 0x000200
+    Multi_Hop_Commissioning = 0x000400
     CT_Based_Commissioning = 0x000800
     Maintenance_Of_GPD = 0x001000
     GPD_SecurityLevel_0b00 = 0x002000
@@ -64,7 +64,8 @@ class GPSFunctionality(t.bitmap24):
     Sink_Table_Based_Groupcast_Forwarding = 0x020000
     Translation_Table = 0x040000
     GPD_IEEE_Address = 0x080000
-    # b20-b23 Reserved
+    Compact_Attribute_Reporting = 0x100000
+    # b21-b23 Reserved
 
 
 # Figure 31 — 16 bits total

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -16,6 +16,57 @@ from zigpy.zcl.foundation import (
 import zigpy.zgp.types as zgptypes
 
 
+class GPPFunctionality(t.bitmap24):
+    """Green Power Proxy functionality bitmap."""
+
+    GP_Feature = 0x000001
+    Direct_Communication = 0x000002
+    Derived_Groupcast_Communication = 0x000004
+    Pre_Commissioned_Groupcast_Communication = 0x000008
+    Full_Unicast_Communication = 0x000010
+    Lightweight_Unicast_Communication = 0x000020
+    # b6 Reserved
+    Bidirectional_Operation = 0x000080
+    Proxy_Table_Maintenance = 0x000100
+    # b9 Reserved
+    GP_Commissioning = 0x000400
+    CT_Based_Commissioning = 0x000800
+    Maintenance_Of_GPD = 0x001000
+    GPD_SecurityLevel_0b00 = 0x002000
+    # b14 Deprecated
+    GPD_SecurityLevel_0b10 = 0x008000
+    GPD_SecurityLevel_0b11 = 0x010000
+    # b17-b18 Reserved
+    GPD_IEEE_Address = 0x080000
+    # b20-b23 Reserved
+
+
+class GPSFunctionality(t.bitmap24):
+    """Green Power Sink functionality bitmap."""
+
+    GP_Feature = 0x000001
+    Direct_Communication = 0x000002
+    Derived_Groupcast_Communication = 0x000004
+    Pre_Commissioned_Groupcast_Communication = 0x000008
+    Full_Unicast_Communication = 0x000010
+    Lightweight_Unicast_Communication = 0x000020
+    Proximity_Bidirectional_Operation = 0x000040
+    Multi_Hop_Bidirectional_Operation = 0x000080
+    Proxy_Table_Maintenance = 0x000100
+    # b9 Reserved
+    GP_Commissioning = 0x000400
+    CT_Based_Commissioning = 0x000800
+    Maintenance_Of_GPD = 0x001000
+    GPD_SecurityLevel_0b00 = 0x002000
+    # b14 Deprecated
+    GPD_SecurityLevel_0b10 = 0x008000
+    GPD_SecurityLevel_0b11 = 0x010000
+    Sink_Table_Based_Groupcast_Forwarding = 0x020000
+    Translation_Table = 0x040000
+    GPD_IEEE_Address = 0x080000
+    # b20-b23 Reserved
+
+
 # Figure 31 — 16 bits total
 class CommissioningNotificationOptions(t.Struct):
     application_id: zgptypes.ApplicationID
@@ -230,6 +281,8 @@ class GreenPowerProxy(Cluster):
     CommissioningNotificationSchema: Final = CommissioningNotificationSchema
     NotificationResponseSchema: Final = NotificationResponseSchema
     ProxyCommissioningModeSchema: Final = ProxyCommissioningModeSchema
+    GPSFunctionality: Final = GPSFunctionality
+    GPPFunctionality: Final = GPPFunctionality
 
     class AttributeDefs(BaseAttributeDefs):
         max_sink_table_entries: Final = ZCLAttributeDef(
@@ -269,13 +322,13 @@ class GreenPowerProxy(Cluster):
         )
         functionality: Final = ZCLAttributeDef(
             id=0x0006,
-            type=t.bitmap24,
+            type=GPSFunctionality,
             access="rw",
             mandatory=True,
         )
         active_functionality: Final = ZCLAttributeDef(
             id=0x0007,
-            type=t.bitmap24,
+            type=GPSFunctionality,
             access="r",
             mandatory=True,
         )
@@ -286,10 +339,10 @@ class GreenPowerProxy(Cluster):
             id=0x0011, type=t.LongOctetString, access="r"
         )
         gpp_functionality: Final = ZCLAttributeDef(
-            id=0x0016, type=t.bitmap24, access="r"
+            id=0x0016, type=GPPFunctionality, access="r"
         )
         gpp_active_functionality: Final = ZCLAttributeDef(
-            id=0x0017, type=t.bitmap24, access="r"
+            id=0x0017, type=GPPFunctionality, access="r"
         )
         link_key: Final = ZCLAttributeDef(
             id=0x0022,

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -285,6 +285,8 @@ class ElectricalMeasurement(Cluster):
             id=0x0405, type=t.int8s, access="rp"
         )
         # AC (Single Phase or Phase A) Measurements
+        # Note: 0x0500 and 0x0504 are not formally defined in ZCL R8 Table 4-35,
+        # but are referenced in the ACVoltageMultiplier/ACPowerMultiplier descriptions.
         instantaneous_voltage: Final = ZCLAttributeDef(
             id=0x0500, type=t.int16s, access="rp"
         )

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -107,9 +107,18 @@ class ApplianceEventAlerts(Cluster):
         get_alerts: Final = ZCLCommandDef(id=0x00, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
-        get_alerts_response: Final = ZCLCommandDef(id=0x00, schema={})
-        alerts_notification: Final = ZCLCommandDef(id=0x01, schema={})
-        event_notification: Final = ZCLCommandDef(id=0x02, schema={})
+        get_alerts_response: Final = ZCLCommandDef(
+            id=0x00,
+            schema={"alerts_count": t.uint8_t, "alerts": t.LVList[t.uint24_t]},
+        )
+        alerts_notification: Final = ZCLCommandDef(
+            id=0x01,
+            schema={"alerts_count": t.uint8_t, "alerts": t.LVList[t.uint24_t]},
+        )
+        event_notification: Final = ZCLCommandDef(
+            id=0x02,
+            schema={"event_header": t.uint8_t, "event_id": t.uint8_t},
+        )
 
 
 class ApplianceStatistics(Cluster):
@@ -128,14 +137,36 @@ class ApplianceStatistics(Cluster):
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
 
     class ServerCommandDefs(BaseCommandDefs):
-        log: Final = ZCLCommandDef(id=0x00, schema={})
-        log_queue: Final = ZCLCommandDef(id=0x01, schema={})
+        log_request: Final = ZCLCommandDef(id=0x00, schema={"log_id": t.uint32_t})
+        log_queue_request: Final = ZCLCommandDef(id=0x01, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
-        log_notification: Final = ZCLCommandDef(id=0x00, schema={})
-        log_response: Final = ZCLCommandDef(id=0x01, schema={})
-        log_queue_response: Final = ZCLCommandDef(id=0x02, schema={})
-        statistics_available: Final = ZCLCommandDef(id=0x03, schema={})
+        log_notification: Final = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "time_stamp": t.UTCTime,
+                "log_id": t.uint32_t,
+                "log_length": t.uint32_t,
+                "log_payload": t.LVList[t.uint8_t],
+            },
+        )
+        log_response: Final = ZCLCommandDef(
+            id=0x01,
+            schema={
+                "time_stamp": t.UTCTime,
+                "log_id": t.uint32_t,
+                "log_length": t.uint32_t,
+                "log_payload": t.LVList[t.uint8_t],
+            },
+        )
+        log_queue_response: Final = ZCLCommandDef(
+            id=0x02,
+            schema={"log_queue_size": t.uint8_t, "log_ids": t.LVList[t.uint32_t]},
+        )
+        statistics_available: Final = ZCLCommandDef(
+            id=0x03,
+            schema={"log_queue_size": t.uint8_t, "log_ids": t.LVList[t.uint32_t]},
+        )
 
 
 class MeasurementType(t.bitmap32):
@@ -531,11 +562,36 @@ class ElectricalMeasurement(Cluster):
 
     class ServerCommandDefs(BaseCommandDefs):
         get_profile_info: Final = ZCLCommandDef(id=0x00, schema={})
-        get_measurement_profile: Final = ZCLCommandDef(id=0x01, schema={})
+        get_measurement_profile: Final = ZCLCommandDef(
+            id=0x01,
+            schema={
+                "attribute_id": t.uint16_t,
+                "start_time": t.UTCTime,
+                "number_of_intervals": t.uint8_t,
+            },
+        )
 
     class ClientCommandDefs(BaseCommandDefs):
-        get_profile_info_response: Final = ZCLCommandDef(id=0x00, schema={})
-        get_measurement_profile_response: Final = ZCLCommandDef(id=0x01, schema={})
+        get_profile_info_response: Final = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "profile_count": t.uint8_t,
+                "profile_interval_period": t.enum8,
+                "max_number_of_intervals": t.uint8_t,
+                "attributes": t.LVList[t.uint16_t],
+            },
+        )
+        get_measurement_profile_response: Final = ZCLCommandDef(
+            id=0x01,
+            schema={
+                "start_time": t.UTCTime,
+                "status": t.enum8,
+                "profile_interval_period": t.enum8,
+                "number_of_intervals_delivered": t.uint8_t,
+                "attribute_id": t.uint16_t,
+                "intervals": t.LVList[t.uint16_t],
+            },
+        )
 
 
 class Diagnostic(Cluster):

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -94,6 +94,20 @@ class MeterIdentification(Cluster):
         reporting_status: Final = foundation.ZCL_REPORTING_STATUS_ATTR
 
 
+# Figure 15-8, with the Alerts Count field split up per Table 15-19
+class GetAlertsResponseSchema(foundation.CommandSchema):
+    number_of_alerts: t.uint4_t
+    alert_structure_type: t.uint4_t
+    alerts: t.List[t.uint24_t] = t.StructField(length=lambda s: s.number_of_alerts)
+
+
+# Figure 15-9
+class AlertsNotificationSchema(foundation.CommandSchema):
+    number_of_alerts: t.uint4_t
+    alert_structure_type: t.uint4_t
+    alerts: t.List[t.uint24_t] = t.StructField(length=lambda s: s.number_of_alerts)
+
+
 class ApplianceEventAlerts(Cluster):
     cluster_id: Final[t.uint16_t] = 0x0B02
     name: Final = "Appliance Event Alerts"
@@ -108,17 +122,43 @@ class ApplianceEventAlerts(Cluster):
 
     class ClientCommandDefs(BaseCommandDefs):
         get_alerts_response: Final = ZCLCommandDef(
-            id=0x00,
-            schema={"alerts_count": t.uint8_t, "alerts": t.LVList[t.uint24_t]},
+            id=0x00, schema=GetAlertsResponseSchema
         )
         alerts_notification: Final = ZCLCommandDef(
-            id=0x01,
-            schema={"alerts_count": t.uint8_t, "alerts": t.LVList[t.uint24_t]},
+            id=0x01, schema=AlertsNotificationSchema
         )
         event_notification: Final = ZCLCommandDef(
             id=0x02,
             schema={"event_header": t.uint8_t, "event_id": t.uint8_t},
         )
+
+
+# Figure 15-11
+class LogNotificationSchema(foundation.CommandSchema):
+    time_stamp: t.UTCTime
+    log_id: t.uint32_t
+    log_length: t.uint32_t
+    log_payload: t.List[t.uint8_t] = t.StructField(length=lambda s: s.log_length)
+
+
+# Figure 15-13
+class LogResponseSchema(foundation.CommandSchema):
+    time_stamp: t.UTCTime
+    log_id: t.uint32_t
+    log_length: t.uint32_t
+    log_payload: t.List[t.uint8_t] = t.StructField(length=lambda s: s.log_length)
+
+
+# Figure 15-14
+class LogQueueResponseSchema(foundation.CommandSchema):
+    log_queue_size: t.uint8_t
+    log_ids: t.List[t.uint32_t] = t.StructField(length=lambda s: s.log_queue_size)
+
+
+# Figure 15-15
+class StatisticsAvailableSchema(foundation.CommandSchema):
+    log_queue_size: t.uint8_t
+    log_ids: t.List[t.uint32_t] = t.StructField(length=lambda s: s.log_queue_size)
 
 
 class ApplianceStatistics(Cluster):
@@ -141,31 +181,13 @@ class ApplianceStatistics(Cluster):
         log_queue_request: Final = ZCLCommandDef(id=0x01, schema={})
 
     class ClientCommandDefs(BaseCommandDefs):
-        log_notification: Final = ZCLCommandDef(
-            id=0x00,
-            schema={
-                "time_stamp": t.UTCTime,
-                "log_id": t.uint32_t,
-                "log_length": t.uint32_t,
-                "log_payload": t.LVList[t.uint8_t],
-            },
-        )
-        log_response: Final = ZCLCommandDef(
-            id=0x01,
-            schema={
-                "time_stamp": t.UTCTime,
-                "log_id": t.uint32_t,
-                "log_length": t.uint32_t,
-                "log_payload": t.LVList[t.uint8_t],
-            },
-        )
+        log_notification: Final = ZCLCommandDef(id=0x00, schema=LogNotificationSchema)
+        log_response: Final = ZCLCommandDef(id=0x01, schema=LogResponseSchema)
         log_queue_response: Final = ZCLCommandDef(
-            id=0x02,
-            schema={"log_queue_size": t.uint8_t, "log_ids": t.LVList[t.uint32_t]},
+            id=0x02, schema=LogQueueResponseSchema
         )
         statistics_available: Final = ZCLCommandDef(
-            id=0x03,
-            schema={"log_queue_size": t.uint8_t, "log_ids": t.LVList[t.uint32_t]},
+            id=0x03, schema=StatisticsAvailableSchema
         )
 
 

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -356,13 +356,13 @@ class ElectricalMeasurement(Cluster):
         )
         # DC Manufacturer Threshold Alarms
         dc_overload_alarms_mask: Final = ZCLAttributeDef(
-            id=0x0700, type=DCOverloadAlarmMark, access="rp"
+            id=0x0700, type=DCOverloadAlarmMark, access="rw"
         )
         dc_voltage_overload: Final = ZCLAttributeDef(
-            id=0x0701, type=t.int16s, access="rp"
+            id=0x0701, type=t.int16s, access="r"
         )
         dc_current_overload: Final = ZCLAttributeDef(
-            id=0x0702, type=t.int16s, access="rp"
+            id=0x0702, type=t.int16s, access="r"
         )
         # AC Manufacturer Threshold Alarms
         ac_alarms_mask: Final = ZCLAttributeDef(

--- a/zigpy/zcl/clusters/homeautomation.py
+++ b/zigpy/zcl/clusters/homeautomation.py
@@ -221,6 +221,46 @@ class ACAlarmsMask(t.bitmap16):
     RMS_Voltage_Swell = 1 << 9
 
 
+class ProfileIntervalPeriod(t.enum8):
+    """Profile interval period timeframes per Figure 4-7.
+
+    Unlike the Metering cluster's equivalent, this one defines no 1 minute timeframe.
+    """
+
+    Daily = 0x00
+    Minutes_60 = 0x01
+    Minutes_30 = 0x02
+    Minutes_15 = 0x03
+    Minutes_10 = 0x04
+    Minutes_7_5 = 0x05
+    Minutes_5 = 0x06
+    Minutes_2_5 = 0x07
+
+
+class GetMeasurementProfileStatus(t.enum8):
+    """Get Measurement Profile Response status values per Table 4-42."""
+
+    Success = 0x00
+    Attribute_Profile_Not_Supported = 0x01
+    Invalid_Start_Time = 0x02
+    More_Intervals_Requested_Than_Can_Be_Returned = 0x03
+    No_Intervals_Available_For_The_Requested_Time = 0x04
+
+
+# Figure 4-8. The interval width really follows the profiled attribute's own type
+# ("For scaling and data type use the respective attribute set"), but the spec also
+# marks invalid intervals as 0xFFFF, so uint16 is used as an approximation.
+class GetMeasurementProfileResponseSchema(foundation.CommandSchema):
+    start_time: t.UTCTime
+    status: GetMeasurementProfileStatus
+    profile_interval_period: ProfileIntervalPeriod
+    number_of_intervals_delivered: t.uint8_t
+    attribute_id: t.uint16_t
+    intervals: t.List[t.uint16_t] = t.StructField(
+        length=lambda s: s.number_of_intervals_delivered
+    )
+
+
 class ElectricalMeasurement(Cluster):
     cluster_id: Final[t.uint16_t] = 0x0B04
     name: Final = "Electrical Measurement"
@@ -229,6 +269,8 @@ class ElectricalMeasurement(Cluster):
     MeasurementType: Final = MeasurementType
     DCOverloadAlarmMark: Final = DCOverloadAlarmMark
     ACAlarmsMask: Final = ACAlarmsMask
+    ProfileIntervalPeriod: Final = ProfileIntervalPeriod
+    GetMeasurementProfileStatus: Final = GetMeasurementProfileStatus
 
     class AttributeDefs(BaseAttributeDefs):
         # Basic Information
@@ -594,25 +636,19 @@ class ElectricalMeasurement(Cluster):
         )
 
     class ClientCommandDefs(BaseCommandDefs):
+        # Figure 4-6. `attributes` runs to the end of the frame: the spec has no count
+        # field for it, despite zigbee-herdsman carrying one.
         get_profile_info_response: Final = ZCLCommandDef(
             id=0x00,
             schema={
                 "profile_count": t.uint8_t,
-                "profile_interval_period": t.enum8,
+                "profile_interval_period": ProfileIntervalPeriod,
                 "max_number_of_intervals": t.uint8_t,
-                "attributes": t.LVList[t.uint16_t],
+                "attributes": t.List[t.uint16_t],
             },
         )
         get_measurement_profile_response: Final = ZCLCommandDef(
-            id=0x01,
-            schema={
-                "start_time": t.UTCTime,
-                "status": t.enum8,
-                "profile_interval_period": t.enum8,
-                "number_of_intervals_delivered": t.uint8_t,
-                "attribute_id": t.uint16_t,
-                "intervals": t.LVList[t.uint16_t],
-            },
+            id=0x01, schema=GetMeasurementProfileResponseSchema
         )
 
 

--- a/zigpy/zcl/clusters/hvac.py
+++ b/zigpy/zcl/clusters/hvac.py
@@ -569,9 +569,11 @@ class Fan(Cluster):
     ep_attribute: Final = "fan"
 
     class AttributeDefs(BaseAttributeDefs):
-        fan_mode: Final = ZCLAttributeDef(id=0x0000, type=FanMode, access="")
+        fan_mode: Final = ZCLAttributeDef(
+            id=0x0000, type=FanMode, access="rw", mandatory=True
+        )
         fan_mode_sequence: Final = ZCLAttributeDef(
-            id=0x0001, type=FanModeSequence, access=""
+            id=0x0001, type=FanModeSequence, access="rw", mandatory=True
         )
 
 

--- a/zigpy/zcl/clusters/hvac.py
+++ b/zigpy/zcl/clusters/hvac.py
@@ -645,7 +645,7 @@ class KeypadLockout(t.enum8):
 
 class ScheduleProgrammingVisibility(t.enum8):
     Enabled = 0x00
-    Disabled = 0x02
+    Disabled = 0x01
 
 
 class UserInterface(Cluster):

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -304,8 +304,8 @@ class Color(Cluster):
         move_color: Final = ZCLCommandDef(
             id=0x08,
             schema={
-                "rate_x": t.uint16_t,
-                "rate_y": t.uint16_t,
+                "rate_x": t.int16s,
+                "rate_y": t.int16s,
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },
@@ -313,9 +313,9 @@ class Color(Cluster):
         step_color: Final = ZCLCommandDef(
             id=0x09,
             schema={
-                "step_x": t.uint16_t,
-                "step_y": t.uint16_t,
-                "duration": t.uint16_t,
+                "step_x": t.int16s,
+                "step_y": t.int16s,
+                "transition_time": t.uint16_t,
                 "options_mask?": OptionsMask,
                 "options_override?": Options,
             },

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -75,8 +75,8 @@ class DriftCompensation(t.enum8):
     NONE = 0x00
     Other_or_unknown = 0x01
     Temperature_monitoring = 0x02
-    Luminance_monitoring = 0x03
-    Color_monitoring = 0x03
+    Optical_luminance_monitoring_and_feedback = 0x03
+    Optical_color_monitoring_and_feedback = 0x04
 
 
 class OptionsMask(t.bitmap8):

--- a/zigpy/zcl/clusters/lighting.py
+++ b/zigpy/zcl/clusters/lighting.py
@@ -133,7 +133,9 @@ class Color(Cluster):
             id=0x000F, type=Options, access="rw", mandatory=True
         )
         # Defined Primaries Information
-        num_primaries: Final = ZCLAttributeDef(id=0x0010, type=t.uint8_t, access="r")
+        num_primaries: Final = ZCLAttributeDef(
+            id=0x0010, type=t.uint8_t, access="r", mandatory=True
+        )
         primary1_x: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t, access="r")
         primary1_y: Final = ZCLAttributeDef(id=0x0012, type=t.uint16_t, access="r")
         primary1_intensity: Final = ZCLAttributeDef(
@@ -166,22 +168,34 @@ class Color(Cluster):
             id=0x002A, type=t.uint8_t, access="r"
         )
         # Defined Color Point Settings
-        white_point_x: Final = ZCLAttributeDef(id=0x0030, type=t.uint16_t, access="r")
-        white_point_y: Final = ZCLAttributeDef(id=0x0031, type=t.uint16_t, access="r")
-        color_point_r_x: Final = ZCLAttributeDef(id=0x0032, type=t.uint16_t, access="r")
-        color_point_r_y: Final = ZCLAttributeDef(id=0x0033, type=t.uint16_t, access="r")
+        white_point_x: Final = ZCLAttributeDef(id=0x0030, type=t.uint16_t, access="rw")
+        white_point_y: Final = ZCLAttributeDef(id=0x0031, type=t.uint16_t, access="rw")
+        color_point_r_x: Final = ZCLAttributeDef(
+            id=0x0032, type=t.uint16_t, access="rw"
+        )
+        color_point_r_y: Final = ZCLAttributeDef(
+            id=0x0033, type=t.uint16_t, access="rw"
+        )
         color_point_r_intensity: Final = ZCLAttributeDef(
-            id=0x0034, type=t.uint8_t, access="r"
+            id=0x0034, type=t.uint8_t, access="rw"
         )
-        color_point_g_x: Final = ZCLAttributeDef(id=0x0036, type=t.uint16_t, access="r")
-        color_point_g_y: Final = ZCLAttributeDef(id=0x0037, type=t.uint16_t, access="r")
+        color_point_g_x: Final = ZCLAttributeDef(
+            id=0x0036, type=t.uint16_t, access="rw"
+        )
+        color_point_g_y: Final = ZCLAttributeDef(
+            id=0x0037, type=t.uint16_t, access="rw"
+        )
         color_point_g_intensity: Final = ZCLAttributeDef(
-            id=0x0038, type=t.uint8_t, access="r"
+            id=0x0038, type=t.uint8_t, access="rw"
         )
-        color_point_b_x: Final = ZCLAttributeDef(id=0x003A, type=t.uint16_t, access="r")
-        color_point_b_y: Final = ZCLAttributeDef(id=0x003B, type=t.uint16_t, access="r")
+        color_point_b_x: Final = ZCLAttributeDef(
+            id=0x003A, type=t.uint16_t, access="rw"
+        )
+        color_point_b_y: Final = ZCLAttributeDef(
+            id=0x003B, type=t.uint16_t, access="rw"
+        )
         color_point_b_intensity: Final = ZCLAttributeDef(
-            id=0x003C, type=t.uint8_t, access="r"
+            id=0x003C, type=t.uint8_t, access="rw"
         )
         # ...
         enhanced_current_hue: Final = ZCLAttributeDef(

--- a/zigpy/zcl/clusters/lightlink.py
+++ b/zigpy/zcl/clusters/lightlink.py
@@ -52,7 +52,7 @@ class ScanResponseInformation(t.Struct):
 class DeviceInfoRecord(t.Struct):
     ieee: t.EUI64
     endpoint_id: t.uint8_t
-    profile_id: t.uint8_t
+    profile_id: t.uint16_t
     device_id: t.uint16_t
     version: t.uint8_t
     group_id_count: t.uint8_t

--- a/zigpy/zcl/clusters/measurement.py
+++ b/zigpy/zcl/clusters/measurement.py
@@ -56,7 +56,7 @@ class IlluminanceLevelSensing(Cluster):
 
     class AttributeDefs(BaseAttributeDefs):
         level_status: Final = ZCLAttributeDef(
-            id=0x0000, type=LevelStatus, access="r", mandatory=True
+            id=0x0000, type=LevelStatus, access="rp", mandatory=True
         )
         light_sensor_type: Final = ZCLAttributeDef(
             id=0x0001, type=LightSensorType, access="r"
@@ -193,8 +193,11 @@ class OccupancySensing(Cluster):
         occupancy: Final = ZCLAttributeDef(
             id=0x0000, type=Occupancy, access="rp", mandatory=True
         )
+        occupancy_sensor_type: Final = ZCLAttributeDef(
+            id=0x0001, type=OccupancySensorType, access="r", mandatory=True
+        )
         occupancy_sensor_type_bitmap: Final = ZCLAttributeDef(
-            id=0x0001, type=t.bitmap8, access="r", mandatory=True
+            id=0x0002, type=OccupancySensorTypeBitmap, access="r", mandatory=True
         )
         # PIR Configuration
         pir_o_to_u_delay: Final = ZCLAttributeDef(

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -179,7 +179,6 @@ class AnalogOutputRegular(Cluster):
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
         object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
-        update_interval: Final = ZCLAttributeDef(id=0x0076, type=t.uint8_t)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -113,11 +113,18 @@ class GenericTunnel(Cluster):
         protocol_addr: Final = ZCLAttributeDef(id=0x0003, type=t.LVBytes)
 
     class ServerCommandDefs(BaseCommandDefs):
-        match_protocol_addr: Final = ZCLCommandDef(id=0x00, schema={})
+        match_protocol_addr: Final = ZCLCommandDef(
+            id=0x00, schema={"protocol_address": t.LVBytes}
+        )
 
     class ClientCommandDefs(BaseCommandDefs):
-        match_protocol_addr_response: Final = ZCLCommandDef(id=0x00, schema={})
-        advertise_protocol_address: Final = ZCLCommandDef(id=0x01, schema={})
+        match_protocol_addr_response: Final = ZCLCommandDef(
+            id=0x00,
+            schema={"device_ieee_address": t.EUI64, "protocol_address": t.LVBytes},
+        )
+        advertise_protocol_address: Final = ZCLCommandDef(
+            id=0x01, schema={"protocol_address": t.LVBytes}
+        )
 
 
 class BacnetProtocolTunnel(Cluster):
@@ -161,12 +168,6 @@ class AnalogInputExtended(Cluster):
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # event_time_stamps: Final = ZCLAttributeDef(id=0x0082, type=t.Array[3, t.uint32_t])
         # integer, time of day, or structure of (date, time of day))
-
-    class ServerCommandDefs(BaseCommandDefs):
-        transfer_apdu: Final = ZCLCommandDef(id=0x00, schema={})
-        connect_req: Final = ZCLCommandDef(id=0x01, schema={})
-        disconnect_req: Final = ZCLCommandDef(id=0x02, schema={})
-        connect_status_noti: Final = ZCLCommandDef(id=0x03, schema={})
 
 
 class AnalogOutputRegular(Cluster):
@@ -427,3 +428,70 @@ class MultistateValueExtended(Cluster):
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
+
+
+class IEEE11073ConnectStatus(t.enum8):
+    """Connect status values for 11073 Protocol Tunnel."""
+
+    Disconnected = 0x00
+    Connected = 0x01
+    Not_Authorized = 0x02
+    Reconnect_Request = 0x03
+    Already_Connected = 0x04
+
+
+class IEEEProtocolTunnel11073(Cluster):
+    """11073 Protocol Tunnel cluster."""
+
+    IEEE11073ConnectStatus: Final = IEEE11073ConnectStatus
+
+    cluster_id: Final[t.uint16_t] = 0x0614
+    ep_attribute: Final = "ieee11073_tunnel"
+
+    class AttributeDefs(BaseAttributeDefs):
+        device_id_list: Final = ZCLAttributeDef(
+            id=0x0000, type=t.List[t.uint16_t], access="r"
+        )
+        manager_target: Final = ZCLAttributeDef(id=0x0001, type=t.EUI64, access="r")
+        manager_endpoint: Final = ZCLAttributeDef(id=0x0002, type=t.uint8_t, access="r")
+        connected: Final = ZCLAttributeDef(id=0x0003, type=t.Bool, access="r")
+        preemptible: Final = ZCLAttributeDef(id=0x0004, type=t.Bool, access="r")
+        idle_timeout: Final = ZCLAttributeDef(id=0x0005, type=t.uint16_t, access="r")
+
+    class ServerCommandDefs(BaseCommandDefs):
+        transfer_apdu: Final = ZCLCommandDef(
+            id=0x00, schema={"apdu": t.LongOctetString}
+        )
+        connect_req: Final = ZCLCommandDef(
+            id=0x01,
+            schema={
+                "connect_control": t.bitmap8,
+                "idle_timeout": t.uint16_t,
+                "manager_target": t.EUI64,
+                "manager_endpoint": t.uint8_t,
+            },
+        )
+        disconnect_req: Final = ZCLCommandDef(
+            id=0x02, schema={"manager_ieee_address": t.EUI64}
+        )
+        connect_status_noti: Final = ZCLCommandDef(
+            id=0x03, schema={"connect_status": IEEE11073ConnectStatus}
+        )
+
+
+class ISO7816Tunnel(Cluster):
+    """ISO 7816 Protocol Tunnel cluster."""
+
+    cluster_id: Final[t.uint16_t] = 0x0615
+    ep_attribute: Final = "iso7816_tunnel"
+
+    class AttributeDefs(BaseAttributeDefs):
+        status: Final = ZCLAttributeDef(id=0x0001, type=t.uint8_t, access="r")
+
+    class ServerCommandDefs(BaseCommandDefs):
+        transfer_apdu: Final = ZCLCommandDef(id=0x00, schema={"apdu": t.LVBytes})
+        insert_smart_card: Final = ZCLCommandDef(id=0x01, schema={})
+        extract_smart_card: Final = ZCLCommandDef(id=0x02, schema={})
+
+    class ClientCommandDefs(BaseCommandDefs):
+        transfer_apdu: Final = ZCLCommandDef(id=0x00, schema={"apdu": t.LVBytes})

--- a/zigpy/zcl/clusters/protocol.py
+++ b/zigpy/zcl/clusters/protocol.py
@@ -19,6 +19,90 @@ class DateTime(t.Struct):
     time: t.uint32_t
 
 
+class BACnetEventState(t.enum8):
+    """BACnet event state enumeration."""
+
+    Normal = 0x00
+    Fault = 0x01
+    Offnormal = 0x02
+    High_Limit = 0x03
+    Low_Limit = 0x04
+
+
+class BACnetNotifyType(t.enum8):
+    """BACnet notify type enumeration."""
+
+    Events = 0x00
+    Alarms = 0x01
+
+
+class BACnetAckedTransitions(t.bitmap8):
+    """BACnet acked transitions bitmap."""
+
+    To_Offnormal = 0b001
+    To_Fault = 0b010
+    To_Normal = 0b100
+
+
+class BACnetEventEnable(t.bitmap8):
+    """BACnet event enable bitmap."""
+
+    To_Offnormal = 0b001
+    To_Fault = 0b010
+    To_Normal = 0b100
+
+
+class BACnetLimitEnable(t.bitmap8):
+    """BACnet limit enable bitmap."""
+
+    Low_Limit = 0b01
+    High_Limit = 0b10
+
+
+class BACnetFeedBackValue(t.enum8):
+    """BACnet feedback value enumeration."""
+
+    Inactive = 0x00
+    Active = 0x01
+
+
+class BACnetObjectType(t.enum16):
+    """BACnet object type enumeration per ASHRAE 135-2004."""
+
+    Analog_Input = 0
+    Analog_Output = 1
+    Analog_Value = 2
+    Binary_Input = 3
+    Binary_Output = 4
+    Binary_Value = 5
+    Calendar = 6
+    Command = 7
+    Device = 8
+    Event_Enrollment = 9
+    File = 10
+    Group = 11
+    Loop = 12
+    Multi_State_Input = 13
+    Multi_State_Output = 14
+    Notification_Class = 15
+    Program = 16
+    Schedule = 17
+    Averaging = 18
+    Multi_State_Value = 19
+    Trend_Log = 20
+    Life_Safety_Point = 21
+    Life_Safety_Zone = 22
+    Accumulator = 23
+    Pulse_Converter = 24
+    Event_Log = 25
+    Global_Group = 26
+    Trend_Log_Multiple = 27
+    Load_Control = 28
+    Structured_View = 29
+    Access_Door = 30
+    Timer = 31
+
+
 class GenericTunnel(Cluster):
     cluster_id: Final[t.uint16_t] = 0x0600
     ep_attribute: Final = "generic_tunnel"
@@ -53,7 +137,7 @@ class AnalogInputRegular(Cluster):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
-        object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
+        object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
         update_interval: Final = ZCLAttributeDef(id=0x0076, type=t.uint8_t)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
@@ -63,15 +147,17 @@ class AnalogInputExtended(Cluster):
     ep_attribute: Final = "bacnet_extended_analog_input"
 
     class AttributeDefs(BaseAttributeDefs):
-        acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
+        acked_transitions: Final = ZCLAttributeDef(
+            id=0x0000, type=BACnetAckedTransitions
+        )
         notification_class: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t)
         deadband: Final = ZCLAttributeDef(id=0x0019, type=t.Single)
-        event_enable: Final = ZCLAttributeDef(id=0x0023, type=t.bitmap8)
-        event_state: Final = ZCLAttributeDef(id=0x0024, type=t.enum8)
+        event_enable: Final = ZCLAttributeDef(id=0x0023, type=BACnetEventEnable)
+        event_state: Final = ZCLAttributeDef(id=0x0024, type=BACnetEventState)
         high_limit: Final = ZCLAttributeDef(id=0x002D, type=t.Single)
-        limit_enable: Final = ZCLAttributeDef(id=0x0034, type=t.bitmap8)
+        limit_enable: Final = ZCLAttributeDef(id=0x0034, type=BACnetLimitEnable)
         low_limit: Final = ZCLAttributeDef(id=0x003B, type=t.Single)
-        notify_type: Final = ZCLAttributeDef(id=0x0048, type=t.enum8)
+        notify_type: Final = ZCLAttributeDef(id=0x0048, type=BACnetNotifyType)
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # event_time_stamps: Final = ZCLAttributeDef(id=0x0082, type=t.Array[3, t.uint32_t])
         # integer, time of day, or structure of (date, time of day))
@@ -92,7 +178,7 @@ class AnalogOutputRegular(Cluster):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
-        object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
+        object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
         update_interval: Final = ZCLAttributeDef(id=0x0076, type=t.uint8_t)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
@@ -102,15 +188,17 @@ class AnalogOutputExtended(Cluster):
     ep_attribute: Final = "bacnet_extended_analog_output"
 
     class AttributeDefs(BaseAttributeDefs):
-        acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
+        acked_transitions: Final = ZCLAttributeDef(
+            id=0x0000, type=BACnetAckedTransitions
+        )
         notification_class: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t)
         deadband: Final = ZCLAttributeDef(id=0x0019, type=t.Single)
-        event_enable: Final = ZCLAttributeDef(id=0x0023, type=t.bitmap8)
-        event_state: Final = ZCLAttributeDef(id=0x0024, type=t.enum8)
+        event_enable: Final = ZCLAttributeDef(id=0x0023, type=BACnetEventEnable)
+        event_state: Final = ZCLAttributeDef(id=0x0024, type=BACnetEventState)
         high_limit: Final = ZCLAttributeDef(id=0x002D, type=t.Single)
-        limit_enable: Final = ZCLAttributeDef(id=0x0034, type=t.bitmap8)
+        limit_enable: Final = ZCLAttributeDef(id=0x0034, type=BACnetLimitEnable)
         low_limit: Final = ZCLAttributeDef(id=0x003B, type=t.Single)
-        notify_type: Final = ZCLAttributeDef(id=0x0048, type=t.enum8)
+        notify_type: Final = ZCLAttributeDef(id=0x0048, type=BACnetNotifyType)
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # event_time_stamps: Final = ZCLAttributeDef(id=0x0082, type=t.Array[3, t.uint32_t])
         # integer, time of day, or structure of (date, time of day))
@@ -124,7 +212,7 @@ class AnalogValueRegular(Cluster):
         cov_increment: Final = ZCLAttributeDef(id=0x0016, type=t.Single)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
-        object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
+        object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
@@ -133,15 +221,17 @@ class AnalogValueExtended(Cluster):
     ep_attribute: Final = "bacnet_extended_analog_value"
 
     class AttributeDefs(BaseAttributeDefs):
-        acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
+        acked_transitions: Final = ZCLAttributeDef(
+            id=0x0000, type=BACnetAckedTransitions
+        )
         notification_class: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t)
         deadband: Final = ZCLAttributeDef(id=0x0019, type=t.Single)
-        event_enable: Final = ZCLAttributeDef(id=0x0023, type=t.bitmap8)
-        event_state: Final = ZCLAttributeDef(id=0x0024, type=t.enum8)
+        event_enable: Final = ZCLAttributeDef(id=0x0023, type=BACnetEventEnable)
+        event_state: Final = ZCLAttributeDef(id=0x0024, type=BACnetEventState)
         high_limit: Final = ZCLAttributeDef(id=0x002D, type=t.Single)
-        limit_enable: Final = ZCLAttributeDef(id=0x0034, type=t.bitmap8)
+        limit_enable: Final = ZCLAttributeDef(id=0x0034, type=BACnetLimitEnable)
         low_limit: Final = ZCLAttributeDef(id=0x003B, type=t.Single)
-        notify_type: Final = ZCLAttributeDef(id=0x0048, type=t.enum8)
+        notify_type: Final = ZCLAttributeDef(id=0x0048, type=BACnetNotifyType)
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
 
 
@@ -156,7 +246,7 @@ class BinaryInputRegular(Cluster):
         elapsed_active_time: Final = ZCLAttributeDef(id=0x0021, type=t.uint32_t)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
-        object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
+        object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
         time_of_at_reset: Final = ZCLAttributeDef(id=0x0072, type=DateTime)
         time_of_sc_reset: Final = ZCLAttributeDef(id=0x0073, type=DateTime)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
@@ -167,12 +257,14 @@ class BinaryInputExtended(Cluster):
     ep_attribute: Final = "bacnet_extended_binary_input"
 
     class AttributeDefs(BaseAttributeDefs):
-        acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
+        acked_transitions: Final = ZCLAttributeDef(
+            id=0x0000, type=BACnetAckedTransitions
+        )
         alarm_value: Final = ZCLAttributeDef(id=0x0006, type=t.Bool)
         notification_class: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t)
-        event_enable: Final = ZCLAttributeDef(id=0x0023, type=t.bitmap8)
-        event_state: Final = ZCLAttributeDef(id=0x0024, type=t.enum8)
-        notify_type: Final = ZCLAttributeDef(id=0x0048, type=t.enum8)
+        event_enable: Final = ZCLAttributeDef(id=0x0023, type=BACnetEventEnable)
+        event_state: Final = ZCLAttributeDef(id=0x0024, type=BACnetEventState)
+        notify_type: Final = ZCLAttributeDef(id=0x0048, type=BACnetNotifyType)
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
@@ -187,10 +279,10 @@ class BinaryOutputRegular(Cluster):
         change_of_state_time: Final = ZCLAttributeDef(id=0x0010, type=DateTime)
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         elapsed_active_time: Final = ZCLAttributeDef(id=0x0021, type=t.uint32_t)
-        feed_back_value: Final = ZCLAttributeDef(id=0x0028, type=t.enum8)
+        feed_back_value: Final = ZCLAttributeDef(id=0x0028, type=BACnetFeedBackValue)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
-        object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
+        object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
         time_of_at_reset: Final = ZCLAttributeDef(id=0x0072, type=DateTime)
         time_of_sc_reset: Final = ZCLAttributeDef(id=0x0073, type=DateTime)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
@@ -201,11 +293,13 @@ class BinaryOutputExtended(Cluster):
     ep_attribute: Final = "bacnet_extended_binary_output"
 
     class AttributeDefs(BaseAttributeDefs):
-        acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
+        acked_transitions: Final = ZCLAttributeDef(
+            id=0x0000, type=BACnetAckedTransitions
+        )
         notification_class: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t)
-        event_enable: Final = ZCLAttributeDef(id=0x0023, type=t.bitmap8)
-        event_state: Final = ZCLAttributeDef(id=0x0024, type=t.enum8)
-        notify_type: Final = ZCLAttributeDef(id=0x0048, type=t.enum8)
+        event_enable: Final = ZCLAttributeDef(id=0x0023, type=BACnetEventEnable)
+        event_state: Final = ZCLAttributeDef(id=0x0024, type=BACnetEventState)
+        notify_type: Final = ZCLAttributeDef(id=0x0048, type=BACnetNotifyType)
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
@@ -221,7 +315,7 @@ class BinaryValueRegular(Cluster):
         elapsed_active_time: Final = ZCLAttributeDef(id=0x0021, type=t.uint32_t)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
-        object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
+        object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
         time_of_at_reset: Final = ZCLAttributeDef(id=0x0072, type=DateTime)
         time_of_sc_reset: Final = ZCLAttributeDef(id=0x0073, type=DateTime)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
@@ -232,12 +326,14 @@ class BinaryValueExtended(Cluster):
     ep_attribute: Final = "bacnet_extended_binary_value"
 
     class AttributeDefs(BaseAttributeDefs):
-        acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
+        acked_transitions: Final = ZCLAttributeDef(
+            id=0x0000, type=BACnetAckedTransitions
+        )
         alarm_value: Final = ZCLAttributeDef(id=0x0006, type=t.Bool)
         notification_class: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t)
-        event_enable: Final = ZCLAttributeDef(id=0x0023, type=t.bitmap8)
-        event_state: Final = ZCLAttributeDef(id=0x0024, type=t.enum8)
-        notify_type: Final = ZCLAttributeDef(id=0x0048, type=t.enum8)
+        event_enable: Final = ZCLAttributeDef(id=0x0023, type=BACnetEventEnable)
+        event_state: Final = ZCLAttributeDef(id=0x0024, type=BACnetEventState)
+        notify_type: Final = ZCLAttributeDef(id=0x0048, type=BACnetNotifyType)
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
@@ -251,7 +347,7 @@ class MultistateInputRegular(Cluster):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
-        object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
+        object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
@@ -260,13 +356,15 @@ class MultistateInputExtended(Cluster):
     ep_attribute: Final = "bacnet_extended_multistate_input"
 
     class AttributeDefs(BaseAttributeDefs):
-        acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
+        acked_transitions: Final = ZCLAttributeDef(
+            id=0x0000, type=BACnetAckedTransitions
+        )
         alarm_value: Final = ZCLAttributeDef(id=0x0006, type=t.uint16_t)
         notification_class: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t)
-        event_enable: Final = ZCLAttributeDef(id=0x0023, type=t.bitmap8)
-        event_state: Final = ZCLAttributeDef(id=0x0024, type=t.enum8)
+        event_enable: Final = ZCLAttributeDef(id=0x0023, type=BACnetEventEnable)
+        event_state: Final = ZCLAttributeDef(id=0x0024, type=BACnetEventState)
         fault_values: Final = ZCLAttributeDef(id=0x0025, type=t.uint16_t)
-        notify_type: Final = ZCLAttributeDef(id=0x0048, type=t.enum8)
+        notify_type: Final = ZCLAttributeDef(id=0x0048, type=BACnetNotifyType)
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
@@ -278,10 +376,10 @@ class MultistateOutputRegular(Cluster):
 
     class AttributeDefs(BaseAttributeDefs):
         device_type: Final = ZCLAttributeDef(id=0x001F, type=t.CharacterString)
-        feed_back_value: Final = ZCLAttributeDef(id=0x0028, type=t.enum8)
+        feed_back_value: Final = ZCLAttributeDef(id=0x0028, type=BACnetFeedBackValue)
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
-        object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
+        object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
@@ -290,11 +388,13 @@ class MultistateOutputExtended(Cluster):
     ep_attribute: Final = "bacnet_extended_multistate_output"
 
     class AttributeDefs(BaseAttributeDefs):
-        acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
+        acked_transitions: Final = ZCLAttributeDef(
+            id=0x0000, type=BACnetAckedTransitions
+        )
         notification_class: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t)
-        event_enable: Final = ZCLAttributeDef(id=0x0023, type=t.bitmap8)
-        event_state: Final = ZCLAttributeDef(id=0x0024, type=t.enum8)
-        notify_type: Final = ZCLAttributeDef(id=0x0048, type=t.enum8)
+        event_enable: Final = ZCLAttributeDef(id=0x0023, type=BACnetEventEnable)
+        event_state: Final = ZCLAttributeDef(id=0x0024, type=BACnetEventState)
+        notify_type: Final = ZCLAttributeDef(id=0x0048, type=BACnetNotifyType)
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))
@@ -307,7 +407,7 @@ class MultistateValueRegular(Cluster):
     class AttributeDefs(BaseAttributeDefs):
         object_id: Final = ZCLAttributeDef(id=0x004B, type=t.uint32_t)
         object_name: Final = ZCLAttributeDef(id=0x004D, type=t.CharacterString)
-        object_type: Final = ZCLAttributeDef(id=0x004F, type=t.enum16)
+        object_type: Final = ZCLAttributeDef(id=0x004F, type=BACnetObjectType)
         profile_name: Final = ZCLAttributeDef(id=0x00A8, type=t.CharacterString)
 
 
@@ -316,13 +416,15 @@ class MultistateValueExtended(Cluster):
     ep_attribute: Final = "bacnet_extended_multistate_value"
 
     class AttributeDefs(BaseAttributeDefs):
-        acked_transitions: Final = ZCLAttributeDef(id=0x0000, type=t.bitmap8)
+        acked_transitions: Final = ZCLAttributeDef(
+            id=0x0000, type=BACnetAckedTransitions
+        )
         alarm_value: Final = ZCLAttributeDef(id=0x0006, type=t.uint16_t)
         notification_class: Final = ZCLAttributeDef(id=0x0011, type=t.uint16_t)
-        event_enable: Final = ZCLAttributeDef(id=0x0023, type=t.bitmap8)
-        event_state: Final = ZCLAttributeDef(id=0x0024, type=t.enum8)
+        event_enable: Final = ZCLAttributeDef(id=0x0023, type=BACnetEventEnable)
+        event_state: Final = ZCLAttributeDef(id=0x0024, type=BACnetEventState)
         fault_values: Final = ZCLAttributeDef(id=0x0025, type=t.uint16_t)
-        notify_type: Final = ZCLAttributeDef(id=0x0048, type=t.enum8)
+        notify_type: Final = ZCLAttributeDef(id=0x0048, type=BACnetNotifyType)
         time_delay: Final = ZCLAttributeDef(id=0x0071, type=t.uint8_t)
         # 0x0082: ZCLAttributeDef('event_time_stamps', type=TODO.array),  # Array[3] of (16-bit unsigned
         # integer, time of day, or structure of (date, time of day))

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -522,7 +522,7 @@ class IasWd(Cluster):
                 "warning": WarningType,
                 "warning_duration": t.uint16_t,
                 "strobe_duty_cycle": t.uint8_t,
-                "stobe_level": StrobeLevel,
+                "strobe_level": StrobeLevel,
             },
         )
         squawk: Final = ZCLCommandDef(

--- a/zigpy/zcl/clusters/security.py
+++ b/zigpy/zcl/clusters/security.py
@@ -32,6 +32,7 @@ class ZoneType(t.enum16):
     Standard_CIE = 0x0000
     Motion_Sensor = 0x000D
     Contact_Switch = 0x0015
+    Door_Window_Handle = 0x0016
     Fire_Sensor = 0x0028
     Water_Sensor = 0x002A
     Carbon_Monoxide_Sensor = 0x002B

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -962,7 +962,7 @@ class Metering(Cluster):
         extended_generic_alarm_mask: Final = ZCLAttributeDef(
             id=0x0806, type=ExtendedGenericAlarmMask, access="rw"
         )
-        manufacture_alarm_mask: Final = ZCLAttributeDef(
+        manufacturer_alarm_mask: Final = ZCLAttributeDef(
             id=0x0807, type=ManufacturerAlarmMask, access="rw"
         )
         bill_to_date: Final = ZCLAttributeDef(id=0x0A00, type=t.uint32_t, access="r")

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -7,6 +7,7 @@ from zigpy.zcl import Cluster
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
+    CommandSchema,
     DataTypeId,
     ZCLAttributeDef,
     ZCLCommandDef,
@@ -253,11 +254,11 @@ class GenericFlowPressureAlarmMask(t.bitmap16):
 
 
 class WaterSpecificAlarmMask(t.bitmap16):
-    """Water specific alarm mask - bits correspond to alarm codes 0x40-0x4F."""
+    """Water specific alarm mask - bits correspond to alarm codes 0x40-0x4F.
 
-    Water_Pipe_Empty = 0x0001
-    Water_Valve_Fraud = 0x0002
-    Water_Valve_Moving = 0x0004
+    Table D-38 defines the whole Water Specific Alarm Group as reserved, so no bit in
+    this mask has a meaning assigned to it yet.
+    """
 
 
 class HeatCoolingSpecificAlarmMask(t.bitmap16):
@@ -499,6 +500,37 @@ class NotificationFlags5(t.bitmap32):
     Reset_Battery_Counter = 0x00000080
     Update_CIN = 0x00000100
     # Bits 9-31: Reserved
+
+
+class GetProfileResponseSchema(CommandSchema):
+    end_time: t.UTCTime
+    status: t.uint8_t
+    profile_interval_period: t.uint8_t
+    number_of_periods_delivered: t.uint8_t
+    intervals: t.List[t.uint24_t] = t.StructField(
+        length=lambda s: s.number_of_periods_delivered
+    )
+
+
+class GetSampledDataResponseSchema(CommandSchema):
+    sample_id: t.uint16_t
+    sample_start_time: t.UTCTime
+    sample_type: t.uint8_t
+    sample_request_interval: t.uint16_t
+    number_of_samples: t.uint16_t
+    samples: t.List[t.uint24_t] = t.StructField(length=lambda s: s.number_of_samples)
+
+
+class ConfigureNotificationFlagSchema(CommandSchema):
+    issuer_event_id: t.uint32_t
+    notification_scheme: t.uint8_t
+    notification_flag_attribute_id: t.uint16_t
+    cluster_id: t.uint16_t
+    manufacturer_code: t.uint16_t
+    number_of_commands: t.uint8_t
+    command_ids: t.List[t.uint8_t] = t.StructField(
+        length=lambda s: s.number_of_commands
+    )
 
 
 class Metering(Cluster):
@@ -1043,7 +1075,7 @@ class Metering(Cluster):
             id=0x09,
             schema={
                 "notification_scheme": t.uint8_t,
-                "notification_flags": t.LVBytes,
+                "notification_flags": t.List[t.bitmap32],
             },
         )
         reset_load_limit_counter: Final = ZCLCommandDef(
@@ -1094,14 +1126,7 @@ class Metering(Cluster):
 
     class ClientCommandDefs(BaseCommandDefs):
         get_profile_response: Final = ZCLCommandDef(
-            id=0x00,
-            schema={
-                "end_time": t.UTCTime,
-                "status": t.uint8_t,
-                "profile_interval_period": t.uint8_t,
-                "number_of_periods_delivered": t.uint8_t,
-                "intervals": t.LVBytes,
-            },
+            id=0x00, schema=GetProfileResponseSchema
         )
         request_mirror: Final = ZCLCommandDef(id=0x01, schema={})
         remove_mirror: Final = ZCLCommandDef(id=0x02, schema={})
@@ -1140,15 +1165,7 @@ class Metering(Cluster):
             },
         )
         get_sampled_data_response: Final = ZCLCommandDef(
-            id=0x07,
-            schema={
-                "sample_id": t.uint16_t,
-                "sample_start_time": t.UTCTime,
-                "sample_type": t.uint8_t,
-                "sample_request_interval": t.uint16_t,
-                "number_of_samples": t.uint16_t,
-                "samples": t.LVBytes,
-            },
+            id=0x07, schema=GetSampledDataResponseSchema
         )
         configure_mirror: Final = ZCLCommandDef(
             id=0x08,
@@ -1168,16 +1185,7 @@ class Metering(Cluster):
             },
         )
         configure_notification_flag: Final = ZCLCommandDef(
-            id=0x0A,
-            schema={
-                "issuer_event_id": t.uint32_t,
-                "notification_scheme": t.uint8_t,
-                "notification_flag_attribute_id": t.uint16_t,
-                "cluster_id": t.uint16_t,
-                "manufacturer_code": t.uint16_t,
-                "number_of_commands": t.uint8_t,
-                "command_ids": t.LVBytes,
-            },
+            id=0x0A, schema=ConfigureNotificationFlagSchema
         )
         get_notified_message: Final = ZCLCommandDef(
             id=0x0B,

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -472,7 +472,7 @@ class Metering(Cluster):
             id=0x001D, type=t.uint48_t, access="r"
         )
         current_block_received: Final = ZCLAttributeDef(
-            id=0x001E, type=t.uint48_t, access="r"
+            id=0x001E, type=CurrentBlock, access="r"
         )
         dft_summation_received: Final = ZCLAttributeDef(
             id=0x001F, type=t.uint48_t, access="r"
@@ -735,10 +735,10 @@ class Metering(Cluster):
             id=0x0404, type=t.uint24_t, access="r"
         )
         cur_part_profile_int_start_time_delivered: Final = ZCLAttributeDef(
-            id=0x0405, type=t.uint32_t, access="r"
+            id=0x0405, type=t.UTCTime, access="r"
         )
         cur_part_profile_int_start_time_received: Final = ZCLAttributeDef(
-            id=0x0406, type=t.uint32_t, access="r"
+            id=0x0406, type=t.UTCTime, access="r"
         )
         cur_part_profile_int_value_delivered: Final = ZCLAttributeDef(
             id=0x0407, type=t.uint24_t, access="r"
@@ -830,11 +830,11 @@ class Metering(Cluster):
         )
         bill_to_date: Final = ZCLAttributeDef(id=0x0A00, type=t.uint32_t, access="r")
         bill_to_date_time_stamp: Final = ZCLAttributeDef(
-            id=0x0A01, type=t.uint32_t, access="r"
+            id=0x0A01, type=t.UTCTime, access="r"
         )
         projected_bill: Final = ZCLAttributeDef(id=0x0A02, type=t.uint32_t, access="r")
         projected_bill_time_stamp: Final = ZCLAttributeDef(
-            id=0x0A03, type=t.uint32_t, access="r"
+            id=0x0A03, type=t.UTCTime, access="r"
         )
 
     class ServerCommandDefs(BaseCommandDefs):

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -399,7 +399,7 @@ class Metering(Cluster):
 
     class AttributeDefs(BaseAttributeDefs):
         current_summ_delivered: Final = ZCLAttributeDef(
-            id=0x0000, type=t.uint48_t, access="r"
+            id=0x0000, type=t.uint48_t, access="r", mandatory=True
         )
         current_summ_received: Final = ZCLAttributeDef(
             id=0x0001, type=t.uint48_t, access="r"
@@ -444,7 +444,7 @@ class Metering(Cluster):
         preset_reading_time: Final = ZCLAttributeDef(
             id=0x0011, type=t.uint16_t, access="r"
         )
-        volume_per_report: Final = ZCLAttributeDef(
+        summation_delivered_per_report: Final = ZCLAttributeDef(
             id=0x0012, type=t.uint16_t, access="r"
         )
         flow_restriction: Final = ZCLAttributeDef(id=0x0013, type=t.uint8_t, access="r")
@@ -467,6 +467,9 @@ class Metering(Cluster):
         )
         current_out_energy_carrier_demand: Final = ZCLAttributeDef(
             id=0x001B, type=t.int24s, access="r"
+        )
+        previous_block_period_consumption_delivered: Final = ZCLAttributeDef(
+            id=0x001C, type=t.uint48_t, access="r"
         )
         current_block_period_consumption_received: Final = ZCLAttributeDef(
             id=0x001D, type=t.uint48_t, access="r"
@@ -577,7 +580,9 @@ class Metering(Cluster):
         current_tier15_summ_received: Final = ZCLAttributeDef(
             id=0x011D, type=t.uint48_t, access="r"
         )
-        status: Final = ZCLAttributeDef(id=0x0200, type=MeteringStatus, access="r")
+        status: Final = ZCLAttributeDef(
+            id=0x0200, type=MeteringStatus, access="r", mandatory=True
+        )
         remaining_battery_life: Final = ZCLAttributeDef(
             id=0x0201, type=t.uint8_t, access="r"
         )
@@ -596,7 +601,7 @@ class Metering(Cluster):
             id=0x0207, type=AmbientConsumptionIndicator, access="r"
         )
         unit_of_measure: Final = ZCLAttributeDef(
-            id=0x0300, type=MeteringUnitofMeasure, access="r"
+            id=0x0300, type=MeteringUnitofMeasure, access="r", mandatory=True
         )
         multiplier: Final = ZCLAttributeDef(id=0x0301, type=t.uint24_t, access="r")
         divisor: Final = ZCLAttributeDef(id=0x0302, type=t.uint24_t, access="r")
@@ -609,7 +614,11 @@ class Metering(Cluster):
         # • DFTSummation
         # • Block Information attributes
         summation_formatting: Final = ZCLAttributeDef(
-            id=0x0303, zcl_type=DataTypeId.map8, type=NumberFormatting, access="r"
+            id=0x0303,
+            zcl_type=DataTypeId.map8,
+            type=NumberFormatting,
+            access="r",
+            mandatory=True,
         )
 
         # This attribute shall be used against the following attributes:
@@ -652,6 +661,7 @@ class Metering(Cluster):
             # be treated like an enum
             zcl_type=DataTypeId.map8,
             access="r",
+            mandatory=True,
         )
         site_id: Final = ZCLAttributeDef(
             id=0x0307, type=t.LimitedLVBytes(32), access="r"
@@ -805,28 +815,28 @@ class Metering(Cluster):
             id=0x0604, type=t.uint16_t, access="r"
         )
         generic_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0800, type=GenericAlarmMask, access="r"
+            id=0x0800, type=GenericAlarmMask, access="rw"
         )
         electricity_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0801, type=ElectricityAlarmMask, access="r"
+            id=0x0801, type=ElectricityAlarmMask, access="rw"
         )
         gen_flow_pressure_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0802, type=GenericFlowPressureAlarmMask, access="r"
+            id=0x0802, type=GenericFlowPressureAlarmMask, access="rw"
         )
         water_specific_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0803, type=WaterSpecificAlarmMask, access="r"
+            id=0x0803, type=WaterSpecificAlarmMask, access="rw"
         )
         heat_cool_specific_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0804, type=HeatCoolingSpecificAlarmMask, access="r"
+            id=0x0804, type=HeatCoolingSpecificAlarmMask, access="rw"
         )
         gas_specific_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0805, type=GasSpecificAlarmMask, access="r"
+            id=0x0805, type=GasSpecificAlarmMask, access="rw"
         )
         extended_generic_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0806, type=ExtendedGenericAlarmMask, access="r"
+            id=0x0806, type=ExtendedGenericAlarmMask, access="rw"
         )
         manufacture_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0807, type=ManufacturerAlarmMask, access="r"
+            id=0x0807, type=ManufacturerAlarmMask, access="rw"
         )
         bill_to_date: Final = ZCLAttributeDef(id=0x0A00, type=t.uint32_t, access="r")
         bill_to_date_time_stamp: Final = ZCLAttributeDef(

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -135,11 +135,264 @@ class MeteringStatus(t.bitmap8):
     Reserved = 0b10000000
 
 
+class CurrentBlock(t.enum8):
+    """Block enumeration for CurrentBlock attribute."""
+
+    No_Blocks_In_Use = 0x00
+    Block1 = 0x01
+    Block2 = 0x02
+    Block3 = 0x03
+    Block4 = 0x04
+    Block5 = 0x05
+    Block6 = 0x06
+    Block7 = 0x07
+    Block8 = 0x08
+    Block9 = 0x09
+    Block10 = 0x0A
+    Block11 = 0x0B
+    Block12 = 0x0C
+    Block13 = 0x0D
+    Block14 = 0x0E
+    Block15 = 0x0F
+    Block16 = 0x10
+
+
+class ProfileIntervalPeriod(t.enum8):
+    """Profile interval period timeframes."""
+
+    Daily = 0x00
+    Minutes_60 = 0x01
+    Minutes_30 = 0x02
+    Minutes_15 = 0x03
+    Minutes_10 = 0x04
+    Minutes_7_5 = 0x05
+    Minutes_5 = 0x06
+    Minutes_2_5 = 0x07
+    Minutes_1 = 0x08
+
+
+class SupplyStatus(t.enum8):
+    """Supply status at customer premises."""
+
+    Supply_Off = 0x00
+    Supply_Off_Armed = 0x01
+    Supply_On = 0x02
+
+
+class AmbientConsumptionIndicator(t.enum8):
+    """Ambient consumption indicator - low/medium/high."""
+
+    Low_Energy_Usage = 0x00
+    Medium_Energy_Usage = 0x01
+    High_Energy_Usage = 0x02
+
+
+class GenericAlarmMask(t.bitmap16):
+    """Generic alarm mask - bits correspond to alarm codes 0x00-0x0F."""
+
+    Check_Meter = 0x0001
+    Low_Battery = 0x0002
+    Tamper_Detect = 0x0004
+    Power_Failure = 0x0008
+    Power_Quality = 0x0010
+    Leak_Detect = 0x0020
+    Service_Disconnect = 0x0040
+    Reserved_0x07 = 0x0080
+    Meter_Cover_Removed = 0x0100
+    Meter_Cover_Closed = 0x0200
+    Strong_Magnetic_Field = 0x0400
+    No_Strong_Magnetic_Field = 0x0800
+    Battery_Failure = 0x1000
+    Program_Memory_Error = 0x2000
+    RAM_Error = 0x4000
+    NV_Memory_Error = 0x8000
+
+
+class ElectricityAlarmMask(t.bitmap32):
+    """Electricity alarm mask - bits correspond to alarm codes 0x10-0x2F."""
+
+    Low_Voltage_L1 = 0x00000001
+    High_Voltage_L1 = 0x00000002
+    Low_Voltage_L2 = 0x00000004
+    High_Voltage_L2 = 0x00000008
+    Low_Voltage_L3 = 0x00000010
+    High_Voltage_L3 = 0x00000020
+    Over_Current_L1 = 0x00000040
+    Over_Current_L2 = 0x00000080
+    Over_Current_L3 = 0x00000100
+    Frequency_Too_Low_L1 = 0x00000200
+    Frequency_Too_High_L1 = 0x00000400
+    Frequency_Too_Low_L2 = 0x00000800
+    Frequency_Too_High_L2 = 0x00001000
+    Frequency_Too_Low_L3 = 0x00002000
+    Frequency_Too_High_L3 = 0x00004000
+    Ground_Fault = 0x00008000
+    Electric_Tamper_Detect = 0x00010000
+    Incorrect_Polarity = 0x00020000
+    Current_No_Voltage = 0x00040000
+    Under_Voltage = 0x00080000
+    Over_Voltage = 0x00100000
+    Normal_Voltage = 0x00200000
+    PF_Below_Threshold = 0x00400000
+    PF_Above_Threshold = 0x00800000
+    Terminal_Cover_Removed = 0x01000000
+    Terminal_Cover_Closed = 0x02000000
+
+
+class GenericFlowPressureAlarmMask(t.bitmap16):
+    """Generic flow/pressure alarm mask - bits correspond to alarm codes 0x30-0x3F."""
+
+    Burst_Detect = 0x0001
+    Pressure_Too_Low = 0x0002
+    Pressure_Too_High = 0x0004
+    Flow_Sensor_Communication_Error = 0x0008
+    Flow_Sensor_Measurement_Fault = 0x0010
+    Flow_Sensor_Reverse_Flow = 0x0020
+    Flow_Sensor_Air_Detect = 0x0040
+    Pipe_Empty = 0x0080
+
+
+class WaterSpecificAlarmMask(t.bitmap16):
+    """Water specific alarm mask - bits correspond to alarm codes 0x40-0x4F."""
+
+    Water_Pipe_Empty = 0x0001
+    Water_Valve_Fraud = 0x0002
+    Water_Valve_Moving = 0x0004
+
+
+class HeatCoolingSpecificAlarmMask(t.bitmap16):
+    """Heat and cooling specific alarm mask - bits correspond to alarm codes 0x50-0x5F."""
+
+    Inlet_Temperature_Sensor_Fault = 0x0001
+    Outlet_Temperature_Sensor_Fault = 0x0002
+
+
+class GasSpecificAlarmMask(t.bitmap16):
+    """Gas specific alarm mask - bits correspond to alarm codes 0x60-0x6F."""
+
+    Tilt_Tamper = 0x0001
+    Battery_Cover_Removed = 0x0002
+    Battery_Cover_Closed = 0x0004
+    Excess_Flow = 0x0008
+    Tilt_Tamper_Ended = 0x0010
+
+
+class ExtendedStatus(t.bitmap64):
+    """Extended status bitmap for Metering cluster."""
+
+    # General flags (bits 0-13)
+    Meter_Cover_Removed = 0x0000000000000001
+    Strong_Magnetic_Field_Detected = 0x0000000000000002
+    Battery_Failure = 0x0000000000000004
+    Program_Memory_Error = 0x0000000000000008
+    RAM_Error = 0x0000000000000010
+    NV_Memory_Error = 0x0000000000000020
+    Measurement_System_Error = 0x0000000000000040
+    Watchdog_Error = 0x0000000000000080
+    Supply_Disconnect_Failure = 0x0000000000000100
+    Supply_Connect_Failure = 0x0000000000000200
+    Measurement_SW_Changed_Tampered = 0x0000000000000400
+    Clock_Invalid = 0x0000000000000800
+    Temperature_Exceeded = 0x0000000000001000
+    Moisture_Detected = 0x0000000000002000
+    # bits 14-23 Reserved
+    # Electricity-meter specific flags (bits 24-29)
+    Terminal_Cover_Removed = 0x0000000001000000
+    Incorrect_Polarity = 0x0000000002000000
+    Current_With_No_Voltage = 0x0000000004000000
+    Limit_Threshold_Exceeded = 0x0000000008000000
+    Under_Voltage = 0x0000000010000000
+    Over_Voltage = 0x0000000020000000
+    # Gas-meter specific flags (bits 24-26) - shared bit positions with electricity
+    # Battery_Cover_Removed_Gas = 0x0000000001000000  # Same as Terminal_Cover_Removed
+    # Tilt_Tamper_Gas = 0x0000000002000000  # Same as Incorrect_Polarity
+    # Excess_Flow_Gas = 0x0000000004000000  # Same as Current_With_No_Voltage
+
+
+class ExtendedGenericAlarmMask(t.bitmap48):
+    """Extended generic alarm mask - bits for alarm codes 0x70-0x9F.
+
+    Note: Table D-34 defines the Extended Generic Alarm Group range as 0x70-0xAF
+    (64 codes), but the attribute type in Table D-33 is a 48-bit bitmap which can
+    only represent codes 0x70-0x9F. Codes 0xA0-0xAF cannot be represented.
+    """
+
+    Measurement_System_Error = 0x000000000001  # 0x70
+    Watchdog_Error = 0x000000000002  # 0x71
+    Supply_Disconnect_Failure = 0x000000000004  # 0x72
+    Supply_Connect_Failure = 0x000000000008  # 0x73
+    Measurement_Software_Changed = 0x000000000010  # 0x74
+    DST_Enabled = 0x000000000020  # 0x75
+    DST_Disabled = 0x000000000040  # 0x76
+    Clock_Adj_Backward = 0x000000000080  # 0x77
+    Clock_Adj_Forward = 0x000000000100  # 0x78
+    Clock_Invalid = 0x000000000200  # 0x79
+    Communication_Error_HAN = 0x000000000400  # 0x7A
+    Communication_OK_HAN = 0x000000000800  # 0x7B
+    Meter_Fraud_Attempt = 0x000000001000  # 0x7C
+    Power_Loss = 0x000000002000  # 0x7D
+    Unusual_HAN_Traffic = 0x000000004000  # 0x7E
+    Unexpected_Clock_Change = 0x000000008000  # 0x7F
+    Comms_Using_Unauthenticated_Component = 0x000000010000  # 0x80
+    Error_Reg_Clear = 0x000000020000  # 0x81
+    Alarm_Reg_Clear = 0x000000040000  # 0x82
+    Unexpected_HW_Reset = 0x000000080000  # 0x83
+    Unexpected_Program_Execution = 0x000000100000  # 0x84
+    EventLog_Cleared = 0x000000200000  # 0x85
+    Limit_Threshold_Exceeded = 0x000000400000  # 0x86
+    Limit_Threshold_OK = 0x000000800000  # 0x87
+    Limit_Threshold_Changed = 0x000001000000  # 0x88
+    Maximum_Demand_Exceeded = 0x000002000000  # 0x89
+    Profile_Cleared = 0x000004000000  # 0x8A
+    Sampling_Buffer_Cleared = 0x000008000000  # 0x8B
+    Battery_Warning = 0x000010000000  # 0x8C
+    Wrong_Signature = 0x000020000000  # 0x8D
+    No_Signature = 0x000040000000  # 0x8E
+    Unauthorized_Action_From_HAN = 0x000080000000  # 0x8F
+    Fast_Polling_Start = 0x000100000000  # 0x90
+    Fast_Polling_End = 0x000200000000  # 0x91
+    Meter_Reporting_Interval_Changed = 0x000400000000  # 0x92
+    Disconnect_Due_To_Load_Limit = 0x000800000000  # 0x93
+    Meter_Supply_Status_Register_Changed = 0x001000000000  # 0x94
+    Meter_Alarm_Status_Register_Changed = 0x002000000000  # 0x95
+    Extended_Meter_Alarm_Status_Register_Changed = 0x004000000000  # 0x96
+    # 0x97-0x9F Reserved (bits 39-47)
+
+
+class ManufacturerAlarmMask(t.bitmap16):
+    """Manufacturer specific alarm mask - bits for alarm codes 0xB0-0xBF."""
+
+    Manufacturer_Specific_A = 0x0001  # 0xB0
+    Manufacturer_Specific_B = 0x0002  # 0xB1
+    Manufacturer_Specific_C = 0x0004  # 0xB2
+    Manufacturer_Specific_D = 0x0008  # 0xB3
+    Manufacturer_Specific_E = 0x0010  # 0xB4
+    Manufacturer_Specific_F = 0x0020  # 0xB5
+    Manufacturer_Specific_G = 0x0040  # 0xB6
+    Manufacturer_Specific_H = 0x0080  # 0xB7
+    Manufacturer_Specific_I = 0x0100  # 0xB8
+    # 0xB9-0xBF Reserved (bits 9-15)
+
+
 class Metering(Cluster):
     RegisteredTier: Final = RegisteredTier
     MeteringDeviceType: Final = MeteringDeviceType
     MeteringUnitofMeasure: Final = MeteringUnitofMeasure
     NumberFormatting: Final = NumberFormatting
+    MeteringStatus: Final = MeteringStatus
+    CurrentBlock: Final = CurrentBlock
+    ProfileIntervalPeriod: Final = ProfileIntervalPeriod
+    SupplyStatus: Final = SupplyStatus
+    AmbientConsumptionIndicator: Final = AmbientConsumptionIndicator
+    GenericAlarmMask: Final = GenericAlarmMask
+    ElectricityAlarmMask: Final = ElectricityAlarmMask
+    GenericFlowPressureAlarmMask: Final = GenericFlowPressureAlarmMask
+    WaterSpecificAlarmMask: Final = WaterSpecificAlarmMask
+    HeatCoolingSpecificAlarmMask: Final = HeatCoolingSpecificAlarmMask
+    GasSpecificAlarmMask: Final = GasSpecificAlarmMask
+    ExtendedStatus: Final = ExtendedStatus
+    ExtendedGenericAlarmMask: Final = ExtendedGenericAlarmMask
+    ManufacturerAlarmMask: Final = ManufacturerAlarmMask
 
     cluster_id: Final[t.uint16_t] = 0x0702
     ep_attribute: Final = "smartenergy_metering"
@@ -183,9 +436,9 @@ class Metering(Cluster):
         daily_consumption_target: Final = ZCLAttributeDef(
             id=0x000D, type=t.uint24_t, access="r"
         )
-        current_block: Final = ZCLAttributeDef(id=0x000E, type=t.enum8, access="r")
+        current_block: Final = ZCLAttributeDef(id=0x000E, type=CurrentBlock, access="r")
         profile_interval_period: Final = ZCLAttributeDef(
-            id=0x000F, type=t.enum8, access="r"
+            id=0x000F, type=ProfileIntervalPeriod, access="r"
         )
         # 0x0010: ('interval_read_reporting_period', UNKNOWN), # Deprecated
         preset_reading_time: Final = ZCLAttributeDef(
@@ -195,7 +448,7 @@ class Metering(Cluster):
             id=0x0012, type=t.uint16_t, access="r"
         )
         flow_restriction: Final = ZCLAttributeDef(id=0x0013, type=t.uint8_t, access="r")
-        supply_status: Final = ZCLAttributeDef(id=0x0014, type=t.enum8, access="r")
+        supply_status: Final = ZCLAttributeDef(id=0x0014, type=SupplyStatus, access="r")
         current_in_energy_carrier_summ: Final = ZCLAttributeDef(
             id=0x0015, type=t.uint48_t, access="r"
         )
@@ -332,13 +585,15 @@ class Metering(Cluster):
             id=0x0202, type=t.uint24_t, access="r"
         )
         hours_in_fault: Final = ZCLAttributeDef(id=0x0203, type=t.uint24_t, access="r")
-        extended_status: Final = ZCLAttributeDef(id=0x0204, type=t.bitmap64, access="r")
+        extended_status: Final = ZCLAttributeDef(
+            id=0x0204, type=ExtendedStatus, access="r"
+        )
         remaining_battery_life_days: Final = ZCLAttributeDef(
             id=0x0205, type=t.uint16_t, access="r"
         )
         current_meter_id: Final = ZCLAttributeDef(id=0x0206, type=t.LVBytes, access="r")
         iambient_consumption_indicator: Final = ZCLAttributeDef(
-            id=0x0207, type=t.enum8, access="r"
+            id=0x0207, type=AmbientConsumptionIndicator, access="r"
         )
         unit_of_measure: Final = ZCLAttributeDef(
             id=0x0300, type=MeteringUnitofMeasure, access="r"
@@ -550,28 +805,28 @@ class Metering(Cluster):
             id=0x0604, type=t.uint16_t, access="r"
         )
         generic_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0800, type=t.bitmap16, access="r"
+            id=0x0800, type=GenericAlarmMask, access="r"
         )
         electricity_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0801, type=t.bitmap32, access="r"
+            id=0x0801, type=ElectricityAlarmMask, access="r"
         )
         gen_flow_pressure_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0802, type=t.bitmap16, access="r"
+            id=0x0802, type=GenericFlowPressureAlarmMask, access="r"
         )
         water_specific_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0803, type=t.bitmap16, access="r"
+            id=0x0803, type=WaterSpecificAlarmMask, access="r"
         )
         heat_cool_specific_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0804, type=t.bitmap16, access="r"
+            id=0x0804, type=HeatCoolingSpecificAlarmMask, access="r"
         )
         gas_specific_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0805, type=t.bitmap16, access="r"
+            id=0x0805, type=GasSpecificAlarmMask, access="r"
         )
         extended_generic_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0806, type=t.bitmap48, access="r"
+            id=0x0806, type=ExtendedGenericAlarmMask, access="r"
         )
         manufacture_alarm_mask: Final = ZCLAttributeDef(
-            id=0x0807, type=t.bitmap16, access="r"
+            id=0x0807, type=ManufacturerAlarmMask, access="r"
         )
         bill_to_date: Final = ZCLAttributeDef(id=0x0A00, type=t.uint32_t, access="r")
         bill_to_date_time_stamp: Final = ZCLAttributeDef(

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -374,6 +374,31 @@ class ManufacturerAlarmMask(t.bitmap16):
     # 0xB9-0xBF Reserved (bits 9-15)
 
 
+class SnapshotCause(t.bitmap32):
+    """Snapshot cause bitmap per SE 1.4a Table D-52."""
+
+    General = 0x00000001
+    End_Of_Billing_Period = 0x00000002
+    End_Of_Block_Period = 0x00000004
+    Change_Of_Tariff_Information = 0x00000008
+    Change_Of_Price_Matrix = 0x00000010
+    Change_Of_Block_Thresholds = 0x00000020
+    Change_Of_CV = 0x00000040
+    Change_Of_CF = 0x00000080
+    Change_Of_Calendar = 0x00000100
+    Critical_Peak_Pricing = 0x00000200
+    Manually_Triggered_From_Client = 0x00000400
+    End_Of_Resolve_Period = 0x00000800
+    Change_Of_Tenancy = 0x00001000
+    Change_Of_Supplier = 0x00002000
+    Change_Of_Meter_Mode = 0x00004000
+    Debt_Payment = 0x00008000
+    Scheduled_Snapshot = 0x00010000
+    OTA_Firmware_Download = 0x00020000
+    # Bits 18-19: Reserved for Prepayment cluster
+    # Bits 20-31: Reserved
+
+
 class Metering(Cluster):
     RegisteredTier: Final = RegisteredTier
     MeteringDeviceType: Final = MeteringDeviceType
@@ -848,20 +873,231 @@ class Metering(Cluster):
         )
 
     class ServerCommandDefs(BaseCommandDefs):
-        get_profile: Final = ZCLCommandDef(id=0x00, schema={})
-        req_mirror: Final = ZCLCommandDef(id=0x01, schema={})
-        mirror_rem: Final = ZCLCommandDef(id=0x02, schema={})
-        req_fast_poll_mode: Final = ZCLCommandDef(id=0x03, schema={})
-        get_snapshot: Final = ZCLCommandDef(id=0x04, schema={})
-        take_snapshot: Final = ZCLCommandDef(id=0x05, schema={})
-        mirror_report_attr_response: Final = ZCLCommandDef(id=0x06, schema={})
+        get_profile: Final = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "interval_channel": t.uint8_t,
+                "end_time": t.UTCTime,
+                "number_of_periods": t.uint8_t,
+            },
+        )
+        request_mirror_response: Final = ZCLCommandDef(
+            id=0x01,
+            schema={"endpoint_id": t.uint16_t},
+        )
+        mirror_removed: Final = ZCLCommandDef(
+            id=0x02,
+            schema={"removed_endpoint_id": t.uint16_t},
+        )
+        request_fast_poll_mode: Final = ZCLCommandDef(
+            id=0x03,
+            schema={
+                "fast_poll_update_period": t.uint8_t,
+                "duration": t.uint8_t,
+            },
+        )
+        schedule_snapshot: Final = ZCLCommandDef(
+            id=0x04,
+            schema={
+                "issuer_event_id": t.uint32_t,
+                "command_index": t.uint8_t,
+                "total_number_of_commands": t.uint8_t,
+                "snapshot_schedule_payload": t.LVBytes,
+            },
+        )
+        take_snapshot: Final = ZCLCommandDef(
+            id=0x05,
+            schema={"snapshot_cause": SnapshotCause},
+        )
+        get_snapshot: Final = ZCLCommandDef(
+            id=0x06,
+            schema={
+                "earliest_start_time": t.UTCTime,
+                "latest_end_time": t.UTCTime,
+                "snapshot_offset": t.uint8_t,
+                "snapshot_cause": SnapshotCause,
+            },
+        )
+        start_sampling: Final = ZCLCommandDef(
+            id=0x07,
+            schema={
+                "issuer_event_id": t.uint32_t,
+                "start_sampling_time": t.UTCTime,
+                "sample_type": t.uint8_t,
+                "sample_request_interval": t.uint16_t,
+                "max_number_of_samples": t.uint16_t,
+            },
+        )
+        get_sampled_data: Final = ZCLCommandDef(
+            id=0x08,
+            schema={
+                "sample_id": t.uint16_t,
+                "earliest_sample_time": t.UTCTime,
+                "sample_type": t.uint8_t,
+                "number_of_samples": t.uint16_t,
+            },
+        )
+        mirror_report_attribute_response: Final = ZCLCommandDef(
+            id=0x09,
+            schema={
+                "notification_scheme": t.uint8_t,
+                "notification_flags": t.LVBytes,
+            },
+        )
+        reset_load_limit_counter: Final = ZCLCommandDef(
+            id=0x0A,
+            schema={
+                "provider_id": t.uint32_t,
+                "issuer_event_id": t.uint32_t,
+            },
+        )
+        change_supply: Final = ZCLCommandDef(
+            id=0x0B,
+            schema={
+                "provider_id": t.uint32_t,
+                "issuer_event_id": t.uint32_t,
+                "request_date_time": t.UTCTime,
+                "implementation_date_time": t.UTCTime,
+                "proposed_supply_status": t.uint8_t,
+                "supply_control_bits": t.bitmap8,
+            },
+        )
+        local_change_supply: Final = ZCLCommandDef(
+            id=0x0C,
+            schema={"proposed_supply_status": t.uint8_t},
+        )
+        set_supply_status: Final = ZCLCommandDef(
+            id=0x0D,
+            schema={
+                "issuer_event_id": t.uint32_t,
+                "supply_tamper_state": t.uint8_t,
+                "supply_depletion_state": t.uint8_t,
+                "supply_uncontrolled_flow_state": t.uint8_t,
+                "load_limit_supply_state": t.uint8_t,
+            },
+        )
+        set_uncontrolled_flow_threshold: Final = ZCLCommandDef(
+            id=0x0E,
+            schema={
+                "provider_id": t.uint32_t,
+                "issuer_event_id": t.uint32_t,
+                "uncontrolled_flow_threshold": t.uint16_t,
+                "unit_of_measure": t.uint8_t,
+                "multiplier": t.uint16_t,
+                "divisor": t.uint16_t,
+                "stabilisation_period": t.uint8_t,
+                "measurement_period": t.uint16_t,
+            },
+        )
 
     class ClientCommandDefs(BaseCommandDefs):
-        get_profile_response: Final = ZCLCommandDef(id=0x00, schema={})
-        req_mirror_response: Final = ZCLCommandDef(id=0x01, schema={})
-        mirror_rem_response: Final = ZCLCommandDef(id=0x02, schema={})
-        req_fast_poll_mode_response: Final = ZCLCommandDef(id=0x03, schema={})
-        get_snapshot_response: Final = ZCLCommandDef(id=0x04, schema={})
+        get_profile_response: Final = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "end_time": t.UTCTime,
+                "status": t.uint8_t,
+                "profile_interval_period": t.uint8_t,
+                "number_of_periods_delivered": t.uint8_t,
+                "intervals": t.LVBytes,
+            },
+        )
+        request_mirror: Final = ZCLCommandDef(id=0x01, schema={})
+        remove_mirror: Final = ZCLCommandDef(id=0x02, schema={})
+        request_fast_poll_mode_response: Final = ZCLCommandDef(
+            id=0x03,
+            schema={
+                "applied_update_period": t.uint8_t,
+                "fast_poll_mode_end_time": t.UTCTime,
+            },
+        )
+        schedule_snapshot_response: Final = ZCLCommandDef(
+            id=0x04,
+            schema={
+                "issuer_event_id": t.uint32_t,
+                "snapshot_response_payload": t.LVBytes,
+            },
+        )
+        take_snapshot_response: Final = ZCLCommandDef(
+            id=0x05,
+            schema={
+                "snapshot_id": t.uint32_t,
+                "snapshot_confirmation": t.uint8_t,
+            },
+        )
+        publish_snapshot: Final = ZCLCommandDef(
+            id=0x06,
+            schema={
+                "snapshot_id": t.uint32_t,
+                "snapshot_time": t.UTCTime,
+                "total_snapshots_found": t.uint8_t,
+                "command_index": t.uint8_t,
+                "total_number_of_commands": t.uint8_t,
+                "snapshot_cause": SnapshotCause,
+                "snapshot_payload_type": t.uint8_t,
+                "snapshot_payload": t.LVBytes,
+            },
+        )
+        get_sampled_data_response: Final = ZCLCommandDef(
+            id=0x07,
+            schema={
+                "sample_id": t.uint16_t,
+                "sample_start_time": t.UTCTime,
+                "sample_type": t.uint8_t,
+                "sample_request_interval": t.uint16_t,
+                "number_of_samples": t.uint16_t,
+                "samples": t.LVBytes,
+            },
+        )
+        configure_mirror: Final = ZCLCommandDef(
+            id=0x08,
+            schema={
+                "issuer_event_id": t.uint32_t,
+                "reporting_interval": t.uint24_t,
+                "mirror_notification_reporting": t.Bool,
+                "notification_scheme": t.uint8_t,
+            },
+        )
+        configure_notification_scheme: Final = ZCLCommandDef(
+            id=0x09,
+            schema={
+                "issuer_event_id": t.uint32_t,
+                "notification_scheme": t.uint8_t,
+                "notification_flag_order": t.bitmap32,
+            },
+        )
+        configure_notification_flag: Final = ZCLCommandDef(
+            id=0x0A,
+            schema={
+                "issuer_event_id": t.uint32_t,
+                "notification_scheme": t.uint8_t,
+                "notification_flag_attribute_id": t.uint16_t,
+                "cluster_id": t.uint16_t,
+                "manufacturer_code": t.uint16_t,
+                "number_of_commands": t.uint8_t,
+                "command_ids": t.LVBytes,
+            },
+        )
+        get_notified_message: Final = ZCLCommandDef(
+            id=0x0B,
+            schema={
+                "notification_scheme": t.uint8_t,
+                "notification_flag_attribute_id": t.uint16_t,
+                "notification_flags": t.bitmap32,
+            },
+        )
+        supply_status_response: Final = ZCLCommandDef(
+            id=0x0C,
+            schema={
+                "provider_id": t.uint32_t,
+                "issuer_event_id": t.uint32_t,
+                "implementation_date_time": t.UTCTime,
+                "supply_status": t.uint8_t,
+            },
+        )
+        start_sampling_response: Final = ZCLCommandDef(
+            id=0x0D,
+            schema={"sample_id": t.uint16_t},
+        )
 
 
 class Messaging(Cluster):

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -502,6 +502,46 @@ class NotificationFlags5(t.bitmap32):
     # Bits 9-31: Reserved
 
 
+class SnapshotPayloadType(t.enum8):
+    """Snapshot payload type per Table 10-99."""
+
+    TOU_Information_Set_Delivered_Registers = 0x00
+    TOU_Information_Set_Received_Registers = 0x01
+    Block_Tier_Information_Set_Delivered = 0x02
+    Block_Tier_Information_Set_Received = 0x03
+    TOU_Information_Set_Delivered_No_Billing = 0x04
+    TOU_Information_Set_Received_No_Billing = 0x05
+    Block_Tier_Information_Set_Delivered_No_Billing = 0x06
+    Block_Tier_Information_Set_Received_No_Billing = 0x07
+    Data_Unavailable = 0x80
+
+
+class SnapshotScheduleConfirmation(t.enum8):
+    """Snapshot schedule confirmation per Table 10-96."""
+
+    Accepted = 0x00
+    Snapshot_Type_Not_Supported = 0x01
+    Snapshot_Cause_Not_Supported = 0x02
+    Snapshot_Schedule_Not_Currently_Available = 0x03
+    Snapshot_Schedules_Not_Supported_By_Device = 0x04
+    Insufficient_Space_For_Snapshot_Schedule = 0x05
+
+
+# Figure 10-86
+class SnapshotSchedulePayload(t.Struct):
+    snapshot_schedule_id: t.uint8_t
+    snapshot_start_time: t.UTCTime
+    snapshot_schedule: t.uint24_t
+    snapshot_payload_type: SnapshotPayloadType
+    snapshot_cause: SnapshotCause
+
+
+# Figure 10-58
+class SnapshotResponsePayload(t.Struct):
+    snapshot_schedule_id: t.uint8_t
+    snapshot_schedule_confirmation: SnapshotScheduleConfirmation
+
+
 class GetProfileResponseSchema(CommandSchema):
     end_time: t.UTCTime
     status: t.uint8_t
@@ -521,16 +561,22 @@ class GetSampledDataResponseSchema(CommandSchema):
     samples: t.List[t.uint24_t] = t.StructField(length=lambda s: s.number_of_samples)
 
 
-class ConfigureNotificationFlagSchema(CommandSchema):
-    issuer_event_id: t.uint32_t
-    notification_scheme: t.uint8_t
-    notification_flag_attribute_id: t.uint16_t
+# Figure 10-77
+class BitFieldAllocation(t.Struct):
     cluster_id: t.uint16_t
     manufacturer_code: t.uint16_t
     number_of_commands: t.uint8_t
     command_ids: t.List[t.uint8_t] = t.StructField(
         length=lambda s: s.number_of_commands
     )
+
+
+class ConfigureNotificationFlagSchema(CommandSchema):
+    issuer_event_id: t.uint32_t
+    notification_scheme: t.uint8_t
+    notification_flag_attribute_id: t.uint16_t
+    # One sub-payload per notification flag bit, in bit order
+    bit_field_allocations: t.List[BitFieldAllocation]
 
 
 class Metering(Cluster):
@@ -552,6 +598,8 @@ class Metering(Cluster):
     ExtendedStatus: Final = ExtendedStatus
     ExtendedGenericAlarmMask: Final = ExtendedGenericAlarmMask
     ManufacturerAlarmMask: Final = ManufacturerAlarmMask
+    SnapshotPayloadType: Final = SnapshotPayloadType
+    SnapshotScheduleConfirmation: Final = SnapshotScheduleConfirmation
 
     cluster_id: Final[t.uint16_t] = 0x0702
     ep_attribute: Final = "smartenergy_metering"
@@ -1036,7 +1084,7 @@ class Metering(Cluster):
                 "issuer_event_id": t.uint32_t,
                 "command_index": t.uint8_t,
                 "total_number_of_commands": t.uint8_t,
-                "snapshot_schedule_payload": t.LVBytes,
+                "snapshot_schedule_payloads": t.List[SnapshotSchedulePayload],
             },
         )
         take_snapshot: Final = ZCLCommandDef(
@@ -1141,7 +1189,7 @@ class Metering(Cluster):
             id=0x04,
             schema={
                 "issuer_event_id": t.uint32_t,
-                "snapshot_response_payload": t.LVBytes,
+                "snapshot_response_payloads": t.List[SnapshotResponsePayload],
             },
         )
         take_snapshot_response: Final = ZCLCommandDef(
@@ -1160,8 +1208,10 @@ class Metering(Cluster):
                 "command_index": t.uint8_t,
                 "total_number_of_commands": t.uint8_t,
                 "snapshot_cause": SnapshotCause,
-                "snapshot_payload_type": t.uint8_t,
-                "snapshot_payload": t.LVBytes,
+                "snapshot_payload_type": SnapshotPayloadType,
+                # Contents depend on `snapshot_payload_type` (Figures 10-62 onward) and
+                # run to the end of the frame, so it is left opaque for now
+                "snapshot_payload": t.Bytes,
             },
         )
         get_sampled_data_response: Final = ZCLCommandDef(

--- a/zigpy/zcl/clusters/smartenergy.py
+++ b/zigpy/zcl/clusters/smartenergy.py
@@ -399,6 +399,108 @@ class SnapshotCause(t.bitmap32):
     # Bits 20-31: Reserved
 
 
+class FunctionalNotificationFlags(t.bitmap32):
+    """Functional notification flags bitmap per SE 1.4a Table D-59."""
+
+    New_OTA_Firmware = 0x00000001
+    CBKE_Update_Request = 0x00000002
+    Time_Sync = 0x00000004
+    # Bit 3: Reserved
+    Stay_Awake_Request_HAN = 0x00000010
+    Stay_Awake_Request_WAN = 0x00000020
+    # Bits 6-8: Push Historical Metering Data Attribute Set (3 bits)
+    Push_Historical_Metering_Data_Day = 0x00000040
+    Push_Historical_Metering_Data_Week = 0x00000080
+    Push_Historical_Metering_Data_Month = 0x00000100
+    # Bits 9-11: Push Historical Prepayment Data Attribute Set (3 bits)
+    Push_Historical_Prepayment_Data_Day = 0x00000200
+    Push_Historical_Prepayment_Data_Week = 0x00000400
+    Push_Historical_Prepayment_Data_Month = 0x00000800
+    Push_All_Static_Data_Basic_Cluster = 0x00001000
+    Push_All_Static_Data_Metering_Cluster = 0x00002000
+    Push_All_Static_Data_Prepayment_Cluster = 0x00004000
+    NetworkKeyActive = 0x00008000
+    Display_Message = 0x00010000
+    Cancel_All_Messages = 0x00020000
+    Change_Supply = 0x00040000
+    Local_Change_Supply = 0x00080000
+    Set_Uncontrolled_Flow_Threshold = 0x00100000
+    Tunnel_Message_Pending = 0x00200000
+    Get_Snapshot = 0x00400000
+    Get_Sampled_Data = 0x00800000
+    New_Sub_GHz_Channel_Masks_Available = 0x01000000
+    Energy_Scan_Pending = 0x02000000
+    Channel_Change_Pending = 0x04000000
+    # Bits 27-31: Reserved
+
+
+class NotificationFlags2(t.bitmap32):
+    """Notification flags 2 bitmap (Price cluster) per SE 1.4a Table D-69."""
+
+    Publish_Price = 0x00000001
+    Publish_Block_Period = 0x00000002
+    Publish_Tariff_Information = 0x00000004
+    Publish_Conversion_Factor = 0x00000008
+    Publish_Calorific_Value = 0x00000010
+    Publish_CO2_Value = 0x00000020
+    Publish_Billing_Period = 0x00000040
+    Publish_Consolidated_Bill = 0x00000080
+    Publish_Price_Matrix = 0x00000100
+    Publish_Block_Thresholds = 0x00000200
+    Publish_Currency_Conversion = 0x00000400
+    # Bit 11: Reserved
+    Publish_Credit_Payment_Info = 0x00001000
+    Publish_CPP_Event = 0x00002000
+    Publish_Tier_Labels = 0x00004000
+    Cancel_Tariff = 0x00008000
+    # Bits 16-31: Reserved
+
+
+class NotificationFlags3(t.bitmap32):
+    """Notification flags 3 bitmap (Calendar cluster) per SE 1.4a Table D-70."""
+
+    Publish_Calendar = 0x00000001
+    Publish_Special_Days = 0x00000002
+    Publish_Seasons = 0x00000004
+    Publish_Week = 0x00000008
+    Publish_Day = 0x00000010
+    Cancel_Calendar = 0x00000020
+    # Bits 6-31: Reserved
+
+
+class NotificationFlags4(t.bitmap32):
+    """Notification flags 4 bitmap (Prepayment cluster) per SE 1.4a Table D-71."""
+
+    Select_Available_Emergency_Credit = 0x00000001
+    Change_Debt = 0x00000002
+    Emergency_Credit_Setup = 0x00000004
+    Consumer_Top_Up = 0x00000008
+    Credit_Adjustment = 0x00000010
+    Change_Payment_Mode = 0x00000020
+    Get_Prepay_Snapshot = 0x00000040
+    Get_Top_Up_Log = 0x00000080
+    Set_Low_Credit_Warning_Level = 0x00000100
+    Get_Debt_Repayment_Log = 0x00000200
+    Set_Maximum_Credit_Limit = 0x00000400
+    Set_Overall_Debt_Cap = 0x00000800
+    # Bits 12-31: Reserved
+
+
+class NotificationFlags5(t.bitmap32):
+    """Notification flags 5 bitmap (Device Management cluster) per SE 1.4a Table D-72."""
+
+    Publish_Change_Of_Tenancy = 0x00000001
+    Publish_Change_Of_Supplier = 0x00000002
+    Request_New_Password_1_Response = 0x00000004
+    Request_New_Password_2_Response = 0x00000008
+    Request_New_Password_3_Response = 0x00000010
+    Request_New_Password_4_Response = 0x00000020
+    Update_Site_ID = 0x00000040
+    Reset_Battery_Counter = 0x00000080
+    Update_CIN = 0x00000100
+    # Bits 9-31: Reserved
+
+
 class Metering(Cluster):
     RegisteredTier: Final = RegisteredTier
     MeteringDeviceType: Final = MeteringDeviceType
@@ -1082,7 +1184,7 @@ class Metering(Cluster):
             schema={
                 "notification_scheme": t.uint8_t,
                 "notification_flag_attribute_id": t.uint16_t,
-                "notification_flags": t.bitmap32,
+                "notification_flags": FunctionalNotificationFlags,
             },
         )
         supply_status_response: Final = ZCLCommandDef(


### PR DESCRIPTION
I've made a second pass through our cluster definitions and implemented every enum and bitmap properly. This migrates zigpy itself away from using `t.enum8` or `t.bitmap8` internally, in preparation for slowly deprecating the generic types.