### PR TITLE
Check for _db.join method before execution

### DIFF
--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -225,7 +225,11 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._db.close()
 
         # FIXME: aiosqlite's thread won't always be closed immediately
-        await asyncio.get_running_loop().run_in_executor(None, self._db.join)
+        if hasattr(self._db, "join"):
+            await asyncio.get_running_loop().run_in_executor(None, self._db.join)
+        else:
+            # No join available, skip for compatibility with Windows/SQLite
+            pass
 
     def register_cluster_events(self, cluster) -> None:
         cluster.on_event(AttributeReadEvent.event_type, self.on_attribute_read)


### PR DESCRIPTION
Add compatibility check for _db.join method in appdb.py