### PR TITLE
Fix `configure_reporting_multiple` not returning responses

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -870,7 +870,7 @@ async def test_configure_reporting_multiple_def_rsp(cluster):
         zcl.foundation.GeneralCommand.Configure_Reporting,
         zcl.foundation.Status.UNSUP_GENERAL_COMMAND,
     )
-    await cluster.configure_reporting_multiple(
+    results = await cluster.configure_reporting_multiple(
         {
             Basic.AttributeDefs.hw_version: ReportingConfig(
                 min_interval=5, max_interval=15, reportable_change=20
@@ -881,6 +881,8 @@ async def test_configure_reporting_multiple_def_rsp(cluster):
         }
     )
     assert cluster.endpoint.request.await_count == 1
+    assert len(results) == 2
+    assert all(r.status == zcl.foundation.Status.UNSUP_GENERAL_COMMAND for r in results)
 
 
 def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status]):
@@ -901,7 +903,7 @@ async def test_configure_reporting_multiple_single_success(cluster):
         {0: zcl.foundation.Status.SUCCESS}
     )
 
-    await cluster.configure_reporting_multiple(
+    results = await cluster.configure_reporting_multiple(
         {
             Basic.AttributeDefs.hw_version: ReportingConfig(
                 min_interval=5, max_interval=15, reportable_change=20
@@ -914,6 +916,8 @@ async def test_configure_reporting_multiple_single_success(cluster):
     assert cluster.endpoint.request.await_count == 1
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
+    assert len(results) == 2
+    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
 
 
 async def test_configure_reporting_multiple_single_fail(cluster):
@@ -982,7 +986,7 @@ async def test_configure_reporting_multiple_both_unsupp(cluster):
         }
     )
 
-    await cluster.configure_reporting_multiple(
+    results = await cluster.configure_reporting_multiple(
         {
             Basic.AttributeDefs.hw_version: ReportingConfig(
                 min_interval=5, max_interval=15, reportable_change=20
@@ -995,6 +999,8 @@ async def test_configure_reporting_multiple_both_unsupp(cluster):
     assert cluster.endpoint.request.await_count == 1
     assert cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
     assert cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
+    assert len(results) == 2
+    assert all(r.status == zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE for r in results)
 
     cluster.endpoint.request.return_value = _mk_cfg_rsp(
         {
@@ -1003,7 +1009,7 @@ async def test_configure_reporting_multiple_both_unsupp(cluster):
         }
     )
 
-    await cluster.configure_reporting_multiple(
+    results = await cluster.configure_reporting_multiple(
         {
             Basic.AttributeDefs.hw_version: ReportingConfig(
                 min_interval=5, max_interval=15, reportable_change=20
@@ -1016,6 +1022,8 @@ async def test_configure_reporting_multiple_both_unsupp(cluster):
     assert cluster.endpoint.request.await_count == 2
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
+    assert len(results) == 2
+    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
 
 
 def test_unsupported_attr_add(cluster):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -840,9 +840,11 @@ async def test_handle_cluster_general_request_not_attr_report(cluster):
 
 
 async def test_configure_reporting_multiple(cluster):
-    cluster.endpoint.request.return_value = _mk_cfg_rsp(
-        {0: zcl.foundation.Status.SUCCESS}
+    cfg_response = zcl.foundation.ConfigureReportingResponse()
+    cfg_response.append(
+        zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)
     )
+    cluster.endpoint.request.return_value = [cfg_response]
 
     await cluster.configure_reporting(
         attribute=3,
@@ -850,7 +852,7 @@ async def test_configure_reporting_multiple(cluster):
         max_interval=15,
         reportable_change=20,
     )
-    await cluster.configure_reporting_multiple(
+    results = await cluster.configure_reporting_multiple(
         {
             Basic.AttributeDefs.hw_version: ReportingConfig(
                 min_interval=5, max_interval=15, reportable_change=20
@@ -858,6 +860,8 @@ async def test_configure_reporting_multiple(cluster):
         }
     )
     assert cluster.endpoint.request.call_count == 2
+    assert len(results) == 1
+    assert results[0].status == zcl.foundation.Status.SUCCESS
     # Both methods should produce equivalent requests
     assert (
         cluster.endpoint.request.mock_calls[0] == cluster.endpoint.request.mock_calls[1]
@@ -898,10 +902,12 @@ def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status]):
 
 
 async def test_configure_reporting_multiple_single_success(cluster):
-    """Configure reporting returned a single success response."""
-    cluster.endpoint.request.return_value = _mk_cfg_rsp(
-        {0: zcl.foundation.Status.SUCCESS}
+    """Configure reporting returned a single global success response."""
+    cfg_response = zcl.foundation.ConfigureReportingResponse()
+    cfg_response.append(
+        zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)
     )
+    cluster.endpoint.request.return_value = [cfg_response]
 
     results = await cluster.configure_reporting_multiple(
         {
@@ -921,12 +927,16 @@ async def test_configure_reporting_multiple_single_success(cluster):
 
 
 async def test_configure_reporting_multiple_single_fail(cluster):
-    """Configure reporting returned a single failure response."""
+    """Configure reporting returned a single failure response.
+
+    Per ZCL spec, only the failed attribute is in the response; the other
+    attribute implicitly succeeded.
+    """
     cluster.endpoint.request.return_value = _mk_cfg_rsp(
         {3: zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE}
     )
 
-    await cluster.configure_reporting_multiple(
+    results = await cluster.configure_reporting_multiple(
         {
             Basic.AttributeDefs.hw_version: ReportingConfig(
                 min_interval=5, max_interval=15, reportable_change=20
@@ -938,11 +948,22 @@ async def test_configure_reporting_multiple_single_fail(cluster):
     )
     assert cluster.endpoint.request.await_count == 1
     assert cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
+    assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
+    assert len(results) == 2
+    results_by_attrid = {r.attrid: r for r in results}
+    assert (
+        results_by_attrid[Basic.AttributeDefs.hw_version.id].status
+        == zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE
+    )
+    assert (
+        results_by_attrid[Basic.AttributeDefs.manufacturer.id].status
+        == zcl.foundation.Status.SUCCESS
+    )
 
     cluster.endpoint.request.return_value = _mk_cfg_rsp(
         {3: zcl.foundation.Status.SUCCESS}
     )
-    await cluster.configure_reporting_multiple(
+    results = await cluster.configure_reporting_multiple(
         {
             Basic.AttributeDefs.hw_version: ReportingConfig(
                 min_interval=5, max_interval=15, reportable_change=20
@@ -954,6 +975,8 @@ async def test_configure_reporting_multiple_single_fail(cluster):
     )
     assert cluster.endpoint.request.await_count == 2
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
+    assert len(results) == 2
+    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
 
 
 async def test_configure_reporting_multiple_single_unreportable(cluster):
@@ -962,7 +985,7 @@ async def test_configure_reporting_multiple_single_unreportable(cluster):
         {4: zcl.foundation.Status.UNREPORTABLE_ATTRIBUTE}
     )
 
-    await cluster.configure_reporting_multiple(
+    results = await cluster.configure_reporting_multiple(
         {
             Basic.AttributeDefs.hw_version: ReportingConfig(
                 min_interval=5, max_interval=15, reportable_change=20
@@ -975,6 +998,16 @@ async def test_configure_reporting_multiple_single_unreportable(cluster):
     assert cluster.endpoint.request.await_count == 1
     # UNREPORTABLE_ATTRIBUTE doesn't mark the attribute as unsupported
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
+    assert len(results) == 2
+    results_by_attrid = {r.attrid: r for r in results}
+    assert (
+        results_by_attrid[Basic.AttributeDefs.manufacturer.id].status
+        == zcl.foundation.Status.UNREPORTABLE_ATTRIBUTE
+    )
+    assert (
+        results_by_attrid[Basic.AttributeDefs.hw_version.id].status
+        == zcl.foundation.Status.SUCCESS
+    )
 
 
 async def test_configure_reporting_multiple_both_unsupp(cluster):
@@ -1024,6 +1057,40 @@ async def test_configure_reporting_multiple_both_unsupp(cluster):
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
     assert len(results) == 2
     assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
+
+
+async def test_configure_reporting_multiple_partial_failure(cluster):
+    """Per ZCL spec, only failed attributes are returned in the response."""
+    cluster.endpoint.request.return_value = _mk_cfg_rsp(
+        {4: zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE}
+    )
+
+    results = await cluster.configure_reporting_multiple(
+        {
+            Basic.AttributeDefs.hw_version: ReportingConfig(
+                min_interval=5, max_interval=15, reportable_change=20
+            ),
+            Basic.AttributeDefs.manufacturer: ReportingConfig(
+                min_interval=6, max_interval=16, reportable_change=26
+            ),
+        }
+    )
+
+    # Only the failed attribute is in the device response; SUCCESS is synthesized
+    # for hw_version which was omitted (implicitly succeeded per ZCL spec)
+    assert len(results) == 2
+    results_by_attrid = {r.attrid: r for r in results}
+    assert (
+        results_by_attrid[Basic.AttributeDefs.manufacturer.id].status
+        == zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE
+    )
+    assert (
+        results_by_attrid[Basic.AttributeDefs.hw_version.id].status
+        == zcl.foundation.Status.SUCCESS
+    )
+
+    assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
+    assert cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
 
 
 def test_unsupported_attr_add(cluster):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1380,17 +1380,28 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             if isinstance(rsp[0], list):
                 records = rsp[0]
 
-                # Single status report for all attributes
-                if len(records) == 1:
+                # Single SUCCESS means all attributes succeeded
+                if len(records) == 1 and records[0].status == foundation.Status.SUCCESS:
                     for attr_def, _cfg in reporting_configs:
                         reporting_results.append(
                             foundation.ConfigureReportingResponseRecord(
-                                status=records[0].status,
+                                status=foundation.Status.SUCCESS,
                                 attrid=attr_def.id,
                             )
                         )
                 else:
-                    reporting_results = records
+                    # Per ZCL spec, only failed attributes are returned, so
+                    # synthesize SUCCESS for attributes omitted from the response
+                    failed_attrids = {r.attrid for r in records}
+                    reporting_results = list(records)
+                    for attr_def, _cfg in reporting_configs:
+                        if attr_def.id not in failed_attrids:
+                            reporting_results.append(
+                                foundation.ConfigureReportingResponseRecord(
+                                    status=foundation.Status.SUCCESS,
+                                    attrid=attr_def.id,
+                                )
+                            )
             else:
                 # Default response: apply status to all attributes in this group
                 status = rsp[1]

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1440,6 +1440,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     # Is this even possible?
                     pass
 
+            results.extend(reporting_results)
+
         return results
 
     def command(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1398,9 +1398,12 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     # Only failed reports are in the response. Attributes not
                     # present implicitly succeeded.
                     failed_attrids = {r.attrid for r in records}
-                    reporting_results = list(records)
                     for attr_def, _cfg in reporting_configs:
-                        if attr_def.id not in failed_attrids:
+                        if attr_def.id in failed_attrids:
+                            reporting_results.extend(
+                                r for r in records if r.attrid == attr_def.id
+                            )
+                        else:
                             reporting_results.append(
                                 foundation.ConfigureReportingResponseRecord(
                                     status=foundation.Status.SUCCESS,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1380,8 +1380,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             if isinstance(rsp[0], list):
                 records = rsp[0]
 
-                # Single SUCCESS means all attributes succeeded
-                if len(records) == 1 and records[0].status == foundation.Status.SUCCESS:
+                # Check for global success (status=SUCCESS, attrid=None)
+                if (
+                    len(records) == 1
+                    and records[0].status == foundation.Status.SUCCESS
+                    and records[0].attrid is None
+                ):
+                    # Global success: all attributes succeeded
                     for attr_def, _cfg in reporting_configs:
                         reporting_results.append(
                             foundation.ConfigureReportingResponseRecord(
@@ -1390,8 +1395,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                             )
                         )
                 else:
-                    # Per ZCL spec, only failed attributes are returned, so
-                    # synthesize SUCCESS for attributes omitted from the response
+                    # Only failed reports are in the response. Attributes not
+                    # present implicitly succeeded.
                     failed_attrids = {r.attrid for r in records}
                     reporting_results = list(records)
                     for attr_def, _cfg in reporting_configs:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1413,13 +1413,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             else:
                 # Default response: apply status to all attributes in this group
                 status = rsp[1]
-                for attr_def, _cfg in reporting_configs:
-                    reporting_results.append(
-                        foundation.ConfigureReportingResponseRecord(
-                            status=status,
-                            attrid=attr_def.id,
-                        )
+                reporting_results.extend(
+                    foundation.ConfigureReportingResponseRecord(
+                        status=status,
+                        attrid=attr_def.id,
                     )
+                    for attr_def, _cfg in reporting_configs
+                )
 
             for result in reporting_results:
                 attr_def = attr_defs_by_id[result.attrid]


### PR DESCRIPTION
## Proposed change

This PR fixes numerous issues in the `configure_reporting_multiple` method:
- The `reporting_results` are now correctly added to the `results` list that's returned at the end.
- Partial failures now cause other attributes to be syntactically added with a SUCCESS status.
- The method is now more similar to `write_attributes`.
- Test coverage is improved, including for partial failures. 

## Additional information

Seen in:
- https://github.com/zigpy/zha/pull/648

Related:
- https://github.com/zigpy/zigpy/pull/1719