### PR TITLE
Add writing and report config tests for manufacturer groups

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2164,14 +2164,20 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
     # First call: standard attribute (no manufacturer code)
     std_call = mock_configure.call_args_list[0]
     assert std_call.kwargs["manufacturer"] is None
-    assert [c.attrid for c in std_call.args[0]] == [Basic.AttributeDefs.hw_version.id]
+    assert len(std_call.args[0]) == 1
+    assert std_call.args[0][0].attrid == Basic.AttributeDefs.hw_version.id
+    assert std_call.args[0][0].min_interval == 5
+    assert std_call.args[0][0].max_interval == 15
+    assert std_call.args[0][0].reportable_change == 20
 
     # Second call: manufacturer-specific attribute
     manuf_call = mock_configure.call_args_list[1]
     assert manuf_call.kwargs["manufacturer"] == 0x5678
-    assert [c.attrid for c in manuf_call.args[0]] == [
-        TestCluster.AttributeDefs.manuf_attr.id
-    ]
+    assert len(manuf_call.args[0]) == 1
+    assert manuf_call.args[0][0].attrid == TestCluster.AttributeDefs.manuf_attr.id
+    assert manuf_call.args[0][0].min_interval == 10
+    assert manuf_call.args[0][0].max_interval == 30
+    assert manuf_call.args[0][0].reportable_change == 5
 
 
 def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -840,7 +840,10 @@ async def test_handle_cluster_general_request_not_attr_report(cluster):
 
 
 async def test_configure_reporting_multiple(cluster):
-    cluster.endpoint.request.return_value = _mk_cfg_rsp()
+    cfg_response = zcl.foundation.ConfigureReportingResponse(
+        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
+    )
+    cluster.endpoint.request.return_value = [cfg_response]
 
     await cluster.configure_reporting(
         attribute=3,
@@ -885,37 +888,24 @@ async def test_configure_reporting_multiple_def_rsp(cluster):
     assert all(r.status == zcl.foundation.Status.UNSUP_GENERAL_COMMAND for r in results)
 
 
-def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status] | None = None):
-    """A helper to create a configure reporting response.
-
-    If responses is None or empty, returns a global success response.
-    """
-    if not responses:
-        return [
-            zcl.foundation.ConfigureReportingResponse(
-                [
-                    zcl.foundation.ConfigureReportingResponseRecord(
-                        zcl.foundation.Status.SUCCESS
-                    )
-                ]
+def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status]):
+    """A helper to create a configure response record."""
+    cfg_response = zcl.foundation.ConfigureReportingResponse()
+    for attrid, status in responses.items():
+        cfg_response.append(
+            zcl.foundation.ConfigureReportingResponseRecord(
+                status, zcl.foundation.ReportingDirection.ReceiveReports, attrid
             )
-        ]
-
-    return [
-        zcl.foundation.ConfigureReportingResponse(
-            [
-                zcl.foundation.ConfigureReportingResponseRecord(
-                    status, zcl.foundation.ReportingDirection.ReceiveReports, attrid
-                )
-                for attrid, status in responses.items()
-            ]
         )
-    ]
+    return [cfg_response]
 
 
 async def test_configure_reporting_multiple_single_success(cluster):
     """Configure reporting returned a single global success response."""
-    cluster.endpoint.request.return_value = _mk_cfg_rsp()
+    cfg_response = zcl.foundation.ConfigureReportingResponse(
+        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
+    )
+    cluster.endpoint.request.return_value = [cfg_response]
 
     results = await cluster.configure_reporting_multiple(
         {
@@ -2132,11 +2122,15 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
     cluster = TestCluster(dev.endpoints[1])
     dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
 
+    cfg_response = zcl.foundation.ConfigureReportingResponse(
+        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
+    )
+
     with patch.object(
         cluster,
         "_configure_reporting",
         new_callable=AsyncMock,
-        return_value=_mk_cfg_rsp(),
+        return_value=[cfg_response],
     ) as mock_configure:
         results = await cluster.configure_reporting_multiple(
             {

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2131,12 +2131,13 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
             }
         )
 
+    assert len(results) == 2
+    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
+
     # Two separate requests should have been made (one per manufacturer group)
     assert mock_configure.await_count == 2
     manufacturers = [c.kwargs["manufacturer"] for c in mock_configure.call_args_list]
     assert manufacturers == [None, 0x5678]
-    assert len(results) == 2
-    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
 
 
 def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -840,9 +840,8 @@ async def test_handle_cluster_general_request_not_attr_report(cluster):
 
 
 async def test_configure_reporting_multiple(cluster):
-    cfg_response = zcl.foundation.ConfigureReportingResponse()
-    cfg_response.append(
-        zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)
+    cfg_response = zcl.foundation.ConfigureReportingResponse(
+        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
     )
     cluster.endpoint.request.return_value = [cfg_response]
 
@@ -903,9 +902,8 @@ def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status]):
 
 async def test_configure_reporting_multiple_single_success(cluster):
     """Configure reporting returned a single global success response."""
-    cfg_response = zcl.foundation.ConfigureReportingResponse()
-    cfg_response.append(
-        zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)
+    cfg_response = zcl.foundation.ConfigureReportingResponse(
+        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
     )
     cluster.endpoint.request.return_value = [cfg_response]
 
@@ -2112,9 +2110,8 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
     cluster = TestCluster(dev.endpoints[1])
     dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
 
-    cfg_response = zcl.foundation.ConfigureReportingResponse()
-    cfg_response.append(
-        zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)
+    cfg_response = zcl.foundation.ConfigureReportingResponse(
+        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
     )
 
     with patch.object(

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2085,19 +2085,31 @@ async def test_write_attributes_multiple_manufacturer_groups(app_mock) -> None:
 
     # Two separate requests, one per manufacturer group
     assert mock_write.call_count == 2
-
-    # First call: standard attribute (no manufacturer code)
-    std_call = mock_write.call_args_list[0]
-    assert std_call.kwargs["manufacturer"] is None
-    assert [a.attrid for a in std_call.args[0]] == [
-        Basic.AttributeDefs.location_desc.id
-    ]
-
-    # Second call: manufacturer-specific attribute
-    manuf_call = mock_write.call_args_list[1]
-    assert manuf_call.kwargs["manufacturer"] == 0x5678
-    assert [a.attrid for a in manuf_call.args[0]] == [
-        TestCluster.AttributeDefs.manuf_attr.id
+    assert mock_write.call_args_list == [
+        call(
+            [
+                foundation.Attribute(
+                    attrid=Basic.AttributeDefs.location_desc.id,
+                    value=foundation.TypeValue(
+                        type=Basic.AttributeDefs.location_desc.zcl_type,
+                        value=Basic.AttributeDefs.location_desc.type("Test"),
+                    ),
+                )
+            ],
+            manufacturer=None,
+        ),
+        call(
+            [
+                foundation.Attribute(
+                    attrid=TestCluster.AttributeDefs.manuf_attr.id,
+                    value=foundation.TypeValue(
+                        type=TestCluster.AttributeDefs.manuf_attr.zcl_type,
+                        value=TestCluster.AttributeDefs.manuf_attr.type(42),
+                    ),
+                )
+            ],
+            manufacturer=0x5678,
+        ),
     ]
 
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2088,7 +2088,7 @@ async def test_write_attributes_multiple_manufacturer_groups(app_mock) -> None:
     # Two separate requests, one per manufacturer group
     assert mock_write.call_count == 2
     manufacturers = [c.kwargs["manufacturer"] for c in mock_write.call_args_list]
-    assert sorted(manufacturers, key=lambda x: (x is not None, x)) == [None, 0x5678]
+    assert manufacturers == [None, 0x5678]
 
 
 async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> None:
@@ -2137,7 +2137,7 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
     # Two separate requests should have been made (one per manufacturer group)
     assert mock_configure.await_count == 2
     manufacturers = [c.kwargs["manufacturer"] for c in mock_configure.call_args_list]
-    assert sorted(manufacturers, key=lambda x: (x is not None, x)) == [None, 0x5678]
+    assert manufacturers == [None, 0x5678]
     assert len(results) == 2
     assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2049,6 +2049,99 @@ async def test_zcl_write_attributes_update_cache(app_mock) -> None:
     assert events == []
 
 
+async def test_write_attributes_multiple_manufacturer_groups(app_mock) -> None:
+    """Test write_attributes with attributes spanning multiple manufacturer groups."""
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            manuf_attr = foundation.ZCLAttributeDef(
+                id=0xB001,
+                type=t.uint8_t,
+                manufacturer_code=0x5678,
+            )
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    dev.node_desc.manufacturer_code = 0x1234
+
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    with mock_attribute_writes(
+        cluster,
+        {
+            Basic.AttributeDefs.location_desc: foundation.Status.SUCCESS,
+            TestCluster.AttributeDefs.manuf_attr: foundation.Status.SUCCESS,
+        },
+    ) as (mock_write, _):
+        [results] = await cluster.write_attributes(
+            {
+                Basic.AttributeDefs.location_desc: "Test",
+                TestCluster.AttributeDefs.manuf_attr: 42,
+            }
+        )
+
+    assert len(results) == 2
+    assert all(r.status == foundation.Status.SUCCESS for r in results)
+
+    # Two separate requests, one per manufacturer group
+    assert mock_write.call_count == 2
+    manufacturers = [c.kwargs["manufacturer"] for c in mock_write.call_args_list]
+    assert sorted(manufacturers, key=lambda x: (x is not None, x)) == [None, 0x5678]
+
+
+async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> None:
+    """Test configure_reporting_multiple with attributes spanning
+    multiple manufacturer groups.
+    """
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            manuf_attr = foundation.ZCLAttributeDef(
+                id=0xB001,
+                type=t.uint8_t,
+                manufacturer_code=0x5678,
+            )
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    dev.node_desc.manufacturer_code = 0x1234
+
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    cfg_response = zcl.foundation.ConfigureReportingResponse()
+    cfg_response.append(
+        zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)
+    )
+
+    with patch.object(
+        cluster,
+        "_configure_reporting",
+        new_callable=AsyncMock,
+        return_value=[cfg_response],
+    ) as mock_configure:
+        results = await cluster.configure_reporting_multiple(
+            {
+                Basic.AttributeDefs.hw_version: ReportingConfig(
+                    min_interval=5, max_interval=15, reportable_change=20
+                ),
+                TestCluster.AttributeDefs.manuf_attr: ReportingConfig(
+                    min_interval=10, max_interval=30, reportable_change=5
+                ),
+            }
+        )
+
+    # Two separate requests should have been made (one per manufacturer group)
+    assert mock_configure.await_count == 2
+    manufacturers = [c.kwargs["manufacturer"] for c in mock_configure.call_args_list]
+    assert sorted(manufacturers, key=lambda x: (x is not None, x)) == [None, 0x5678]
+    assert len(results) == 2
+    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
+
+
 def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:
     """Test class-level `manufacturer_id_override` for custom clusters."""
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -840,10 +840,7 @@ async def test_handle_cluster_general_request_not_attr_report(cluster):
 
 
 async def test_configure_reporting_multiple(cluster):
-    cfg_response = zcl.foundation.ConfigureReportingResponse(
-        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
-    )
-    cluster.endpoint.request.return_value = [cfg_response]
+    cluster.endpoint.request.return_value = _mk_cfg_rsp()
 
     await cluster.configure_reporting(
         attribute=3,
@@ -888,24 +885,37 @@ async def test_configure_reporting_multiple_def_rsp(cluster):
     assert all(r.status == zcl.foundation.Status.UNSUP_GENERAL_COMMAND for r in results)
 
 
-def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status]):
-    """A helper to create a configure response record."""
-    cfg_response = zcl.foundation.ConfigureReportingResponse()
-    for attrid, status in responses.items():
-        cfg_response.append(
-            zcl.foundation.ConfigureReportingResponseRecord(
-                status, zcl.foundation.ReportingDirection.ReceiveReports, attrid
+def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status] | None = None):
+    """A helper to create a configure reporting response.
+
+    If responses is None or empty, returns a global success response.
+    """
+    if not responses:
+        return [
+            zcl.foundation.ConfigureReportingResponse(
+                [
+                    zcl.foundation.ConfigureReportingResponseRecord(
+                        zcl.foundation.Status.SUCCESS
+                    )
+                ]
             )
+        ]
+
+    return [
+        zcl.foundation.ConfigureReportingResponse(
+            [
+                zcl.foundation.ConfigureReportingResponseRecord(
+                    status, zcl.foundation.ReportingDirection.ReceiveReports, attrid
+                )
+                for attrid, status in responses.items()
+            ]
         )
-    return [cfg_response]
+    ]
 
 
 async def test_configure_reporting_multiple_single_success(cluster):
     """Configure reporting returned a single global success response."""
-    cfg_response = zcl.foundation.ConfigureReportingResponse(
-        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
-    )
-    cluster.endpoint.request.return_value = [cfg_response]
+    cluster.endpoint.request.return_value = _mk_cfg_rsp()
 
     results = await cluster.configure_reporting_multiple(
         {
@@ -2110,15 +2120,11 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
     cluster = TestCluster(dev.endpoints[1])
     dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
 
-    cfg_response = zcl.foundation.ConfigureReportingResponse(
-        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
-    )
-
     with patch.object(
         cluster,
         "_configure_reporting",
         new_callable=AsyncMock,
-        return_value=[cfg_response],
+        return_value=_mk_cfg_rsp(),
     ) as mock_configure:
         results = await cluster.configure_reporting_multiple(
             {

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2095,8 +2095,20 @@ async def test_write_attributes_multiple_manufacturer_groups(app_mock) -> None:
 
     # Two separate requests, one per manufacturer group
     assert mock_write.call_count == 2
-    manufacturers = [c.kwargs["manufacturer"] for c in mock_write.call_args_list]
-    assert manufacturers == [None, 0x5678]
+
+    # First call: standard attribute (no manufacturer code)
+    std_call = mock_write.call_args_list[0]
+    assert std_call.kwargs["manufacturer"] is None
+    assert [a.attrid for a in std_call.args[0]] == [
+        Basic.AttributeDefs.location_desc.id
+    ]
+
+    # Second call: manufacturer-specific attribute
+    manuf_call = mock_write.call_args_list[1]
+    assert manuf_call.kwargs["manufacturer"] == 0x5678
+    assert [a.attrid for a in manuf_call.args[0]] == [
+        TestCluster.AttributeDefs.manuf_attr.id
+    ]
 
 
 async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> None:
@@ -2142,8 +2154,18 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
 
     # Two separate requests should have been made (one per manufacturer group)
     assert mock_configure.await_count == 2
-    manufacturers = [c.kwargs["manufacturer"] for c in mock_configure.call_args_list]
-    assert manufacturers == [None, 0x5678]
+
+    # First call: standard attribute (no manufacturer code)
+    std_call = mock_configure.call_args_list[0]
+    assert std_call.kwargs["manufacturer"] is None
+    assert [c.attrid for c in std_call.args[0]] == [Basic.AttributeDefs.hw_version.id]
+
+    # Second call: manufacturer-specific attribute
+    manuf_call = mock_configure.call_args_list[1]
+    assert manuf_call.kwargs["manufacturer"] == 0x5678
+    assert [c.attrid for c in manuf_call.args[0]] == [
+        TestCluster.AttributeDefs.manuf_attr.id
+    ]
 
 
 def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:


### PR DESCRIPTION
As suggested in https://github.com/zigpy/zigpy/pull/1764, this adds tests that verify the grouping of calls per manufacturer for `write_attributes` and `configure_reporting_multiple`.