### PR TITLE
Always prefer manufacturer specific attributes when running a data migration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,9 @@ def make_ieee(start=0):
 
 
 def make_node_desc(
-    *, logical_type: zdo_t.LogicalType = zdo_t.LogicalType.Router
+    *,
+    logical_type: zdo_t.LogicalType = zdo_t.LogicalType.Router,
+    manufacturer_code: int = 4174,
 ) -> zdo_t.NodeDescriptor:
     return zdo_t.NodeDescriptor(
         logical_type=logical_type,
@@ -218,7 +220,7 @@ def make_node_desc(
         aps_flags=0,
         frequency_band=zdo_t.NodeDescriptor.FrequencyBand.Freq2400MHz,
         mac_capability_flags=zdo_t.NodeDescriptor.MACCapabilityFlags.AllocateAddress,
-        manufacturer_code=4174,
+        manufacturer_code=manufacturer_code,
         maximum_buffer_size=82,
         maximum_incoming_transfer_size=82,
         server_mask=0,

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -663,21 +663,21 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
         conn.execute(insert_sql, (str(dev.ieee), 1, 0, 0xFC02, 0x0020, b"\x99", 0))
         conn.commit()
 
-    # Migration runs during load: attr cache is populated in the same open
     with patch("zigpy.quirks.DEVICE_REGISTRY", registry):
         app = await make_app_with_db(db_path)
-
         dev = app.get_device(ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
-        disambiguated = dev.endpoints[1].in_clusters[0xFC01]
-        ambiguous = dev.endpoints[1].in_clusters[0xFC02]
 
-        # 2 candidates (1 manuf + 1 non-manuf): picked manuf-specific
-        assert disambiguated.get("manuf_attr") == b"\x42"
-        assert disambiguated.get("standard_attr") is None
+    # Migration runs during load
+    disambiguated = dev.endpoints[1].in_clusters[0xFC01]
+    ambiguous = dev.endpoints[1].in_clusters[0xFC02]
 
-        # 3 candidates: ambiguous, skipped
-        assert ambiguous.get("attr_a") is None
-        assert ambiguous.get("attr_b") is None
-        assert ambiguous.get("attr_c") is None
+    # 2 candidates (1 manuf + 1 non-manuf): picked manuf-specific
+    assert disambiguated.get("manuf_attr") == b"\x42"
+    assert disambiguated.get("standard_attr") is None
 
-        await app.shutdown()
+    # 3 candidates: ambiguous, skipped
+    assert ambiguous.get("attr_a") is None
+    assert ambiguous.get("attr_b") is None
+    assert ambiguous.get("attr_c") is None
+
+    await app.shutdown()

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -19,7 +19,7 @@ from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.zcl.foundation import BaseAttributeDefs, Status, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
 
 
@@ -550,13 +550,20 @@ async def test_unknown_manufacturer_code_migration(test_db, caplog):
 async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     """Test that attributes on manufacturer-specific clusters get the device's manufacturer_id."""
 
-    # Simple quirk for Third Reality night light with is_manufacturer_specific=True
+    # Simple quirk for Third Reality night light with is_manufacturer_specific=True.
+    # The real device (f4:42:50:c3:96:14:00:00) has cached attrs 2-5 on 0xFC00 and
+    # attr 4 is also in unsupported_attributes_v13.
     class TestCluster(CustomCluster):
         cluster_id = 0xFC00
 
         class AttributeDefs(BaseAttributeDefs):
             test_attr = ZCLAttributeDef(
                 id=0x0002,
+                type=t.uint8_t,
+                is_manufacturer_specific=True,
+            )
+            unsupported_attr = ZCLAttributeDef(
+                id=0x0004,
                 type=t.uint8_t,
                 is_manufacturer_specific=True,
             )
@@ -570,12 +577,12 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     )
 
     test_db_path = test_db("zigbee_puddly2.db")
+    third_reality_ieee = "f4:42:50:c3:96:14:00:00"
 
     with patch("zigpy.quirks.DEVICE_REGISTRY", registry):
         app = await make_app_with_db(test_db_path)
-        await app.shutdown()
 
-    # Check that attributes on 0xFC00 got the device's manufacturer_id (0x130D = 4877)
+    # Check that cached attributes on 0xFC00 got the device's manufacturer_id
     with sqlite3.connect(test_db_path) as conn:
         cur = conn.cursor()
         cur.execute(
@@ -583,11 +590,33 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
             SELECT manufacturer_code
             FROM attributes_cache_v14
             WHERE cluster_id = 0xFC00 AND attr_id = 0x0002
-            """
+            """,
         )
         rows = cur.fetchall()
 
     assert rows == [(0x130D,), (0x130D,), (0x130D,)]
+
+    # The unsupported manufacturer-specific attr also got the correct manufacturer code
+    with sqlite3.connect(test_db_path) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT manufacturer_code, status
+            FROM attributes_cache_v14
+            WHERE ieee = ? AND cluster_id = 0xFC00 AND attr_id = 0x0004
+            """,
+            (third_reality_ieee,),
+        )
+        row = cur.fetchone()
+
+    assert row == (0x130D, Status.UNSUPPORTED_ATTRIBUTE)
+
+    # Confirm it's loaded as unsupported in the device's attribute cache
+    dev = app.get_device(ieee=t.EUI64.convert(third_reality_ieee))
+    cluster = dev.endpoints[1].in_clusters[0xFC00]
+    assert cluster.is_attribute_unsupported(TestCluster.AttributeDefs.unsupported_attr)
+
+    await app.shutdown()
 
 
 async def test_data_migration_ambiguous_attributes(tmp_path):

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -616,7 +616,7 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     cluster = dev.endpoints[1].in_clusters[0xFC00]
     assert cluster.is_attribute_unsupported(TestCluster.AttributeDefs.unsupported_attr)
 
-    # Attr 0x0003 has no definition in our quirk but exist in the DB. It should be
+    # Attr 0x0003 has no definition in our quirk but exists in the DB. It should be
     # stored in the legacy cache regardless.
     with pytest.raises(KeyError):
         cluster.find_attribute(0x0003)

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -616,6 +616,14 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     cluster = dev.endpoints[1].in_clusters[0xFC00]
     assert cluster.is_attribute_unsupported(TestCluster.AttributeDefs.unsupported_attr)
 
+    # Attr 0x0003 has  no definition in our quirk but exist in the DB. It should be
+    # stored in the legacy cache regardless.
+    with pytest.raises(KeyError):
+        cluster.find_attribute(0x0003)
+
+    assert 0x0003 in cluster._attr_cache._legacy_cache
+    assert cluster._attr_cache.get(0x0003) == 20
+
     await app.shutdown()
 
 

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -7,15 +7,18 @@ from aiosqlite.context import contextmanager
 import pytest
 
 from tests.async_mock import AsyncMock, MagicMock, patch
-from tests.conftest import app  # noqa: F401
+from tests.conftest import app, make_node_desc  # noqa: F401
 from tests.test_appdb import auto_kill_aiosqlite, make_app_with_db  # noqa: F401
 import zigpy.appdb
 from zigpy.appdb import sqlite3
 import zigpy.appdb_schemas
+import zigpy.endpoint
+from zigpy.profiles import zha as zha_profile
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
 
@@ -585,3 +588,96 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
         rows = cur.fetchall()
 
     assert rows == [(0x130D,), (0x130D,), (0x130D,)]
+
+
+async def test_data_migration_ambiguous_attributes(tmp_path):
+    """Test _run_data_migrations disambiguation when find_attributes returns multiple."""
+
+    class DisambiguatedCluster(CustomCluster):
+        cluster_id = 0xFC01
+
+        class AttributeDefs(BaseAttributeDefs):
+            standard_attr = ZCLAttributeDef(
+                id=0x0010, type=t.uint8_t, is_manufacturer_specific=False
+            )
+            manuf_attr = ZCLAttributeDef(
+                id=0x0010, type=t.uint8_t, is_manufacturer_specific=True
+            )
+
+    class AmbiguousCluster(CustomCluster):
+        cluster_id = 0xFC02
+
+        class AttributeDefs(BaseAttributeDefs):
+            attr_a = ZCLAttributeDef(
+                id=0x0020, type=t.uint8_t, is_manufacturer_specific=True
+            )
+            attr_b = ZCLAttributeDef(
+                id=0x0020, type=t.uint8_t, manufacturer_code=0x1111
+            )
+            attr_c = ZCLAttributeDef(
+                id=0x0020, type=t.uint8_t, manufacturer_code=0x2222
+            )
+
+    registry = DeviceRegistry()
+
+    (
+        QuirkBuilder("manufacturer", "model", registry=registry)
+        .replaces(DisambiguatedCluster)
+        .replaces(AmbiguousCluster)
+        .add_to_registry()
+    )
+
+    db_path = str(tmp_path / "test.db")
+
+    app = await make_app_with_db(db_path)
+
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+    dev.node_desc = make_node_desc(manufacturer_code=0xABCD)
+
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = zha_profile.PROFILE_ID
+    ep.device_type = zha_profile.DeviceType.PUMP
+
+    ep.add_input_cluster(Basic.cluster_id)
+    ep.add_input_cluster(DisambiguatedCluster.cluster_id)
+    ep.add_input_cluster(AmbiguousCluster.cluster_id)
+
+    basic = dev.endpoints[1].basic
+    basic.update_attribute(Basic.AttributeDefs.manufacturer, "manufacturer")
+    basic.update_attribute(Basic.AttributeDefs.model, "model")
+
+    app.device_initialized(dev)
+    await app.shutdown()
+
+    # Insert unmigrated attribute rows (manufacturer_code=-1)
+    with sqlite3.connect(db_path) as conn:
+        insert_sql = (
+            "INSERT INTO attributes_cache_v14"
+            " (ieee, endpoint_id, cluster_type, cluster_id,"
+            "  attr_id, manufacturer_code, status, value, last_updated)"
+            " VALUES (?, ?, ?, ?, ?, -1, 0, ?, ?)"
+        )
+
+        conn.execute(insert_sql, (str(dev.ieee), 1, 0, 0xFC01, 0x0010, b"\x42", 0))
+        conn.execute(insert_sql, (str(dev.ieee), 1, 0, 0xFC02, 0x0020, b"\x99", 0))
+        conn.commit()
+
+    # Migration runs during load: attr cache is populated in the same open
+    with patch("zigpy.quirks.DEVICE_REGISTRY", registry):
+        app = await make_app_with_db(db_path)
+
+        dev = app.get_device(ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+        disambiguated = dev.endpoints[1].in_clusters[0xFC01]
+        ambiguous = dev.endpoints[1].in_clusters[0xFC02]
+
+        # 2 candidates (1 manuf + 1 non-manuf): picked manuf-specific
+        assert disambiguated.get("manuf_attr") == b"\x42"
+        assert disambiguated.get("standard_attr") is None
+
+        # 3 candidates: ambiguous, skipped
+        assert ambiguous.get("attr_a") is None
+        assert ambiguous.get("attr_b") is None
+        assert ambiguous.get("attr_c") is None
+
+        await app.shutdown()

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -616,7 +616,7 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     cluster = dev.endpoints[1].in_clusters[0xFC00]
     assert cluster.is_attribute_unsupported(TestCluster.AttributeDefs.unsupported_attr)
 
-    # Attr 0x0003 has  no definition in our quirk but exist in the DB. It should be
+    # Attr 0x0003 has no definition in our quirk but exist in the DB. It should be
     # stored in the legacy cache regardless.
     with pytest.raises(KeyError):
         cluster.find_attribute(0x0003)

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -591,7 +591,7 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
 
 
 async def test_data_migration_ambiguous_attributes(tmp_path):
-    """Test _run_data_migrations disambiguation when find_attributes returns multiple."""
+    """Test data migration disambiguation when find_attributes returns multiple."""
 
     class DisambiguatedCluster(CustomCluster):
         cluster_id = 0xFC01

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
-from zigpy.event import EventBase
+from zigpy.event import EventBase, suppress_events
 from zigpy.event.event_base import EventListener
 
 
@@ -201,6 +201,30 @@ def test_handle_event_protocol():
 
     assert event_handler.handle_test.called
     assert event_handler.handle_test.call_args[0] == (event,)
+
+
+def test_suppress_events() -> None:
+    """Test suppress_events context manager."""
+    emitter = EventGenerator()
+    received = []
+
+    emitter.on_event("test", lambda data: received.append(data))
+
+    emitter.emit("test", "before")
+
+    with suppress_events():
+        emitter.emit("test", "during")
+
+        with pytest.raises(RuntimeError):  # noqa: PT012
+            with suppress_events():
+                emitter.emit("test", "during (nested)")
+                raise RuntimeError()
+
+        emitter.emit("test", "during (nested, after)")
+
+    emitter.emit("test", "after")
+
+    assert received == ["before", "after"]
 
 
 def test_handle_event_protocol_no_event(caplog: pytest.LogCaptureFixture):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1483,6 +1483,7 @@ async def test_cluster_definition_invalid_direction():
         class TestCluster2(zcl.Cluster):
             cluster_id = 0xDEF0
             ep_attribute = "test_cluster2"
+            _skip_registry = True
 
             class ClientCommandDefs(zcl.BaseCommandDefs):
                 client_command = foundation.ZCLCommandDef(
@@ -1682,6 +1683,7 @@ def test_find_attributes() -> None:
     class TestCluster(zcl.Cluster):
         cluster_id = 0xABCD
         ep_attribute = "test_cluster"
+        _skip_registry = True
 
         class AttributeDefs(zcl.BaseAttributeDefs):
             explicit_none = foundation.ZCLAttributeDef(
@@ -1904,6 +1906,7 @@ async def test_read_attribute_manufacturer_code_none_on_manuf_cluster():
     class ManufCluster(zcl.Cluster):
         cluster_id = 0xFC11  # Manufacturer-specific cluster range
         ep_attribute = "manuf_cluster"
+        _skip_registry = True
 
         class AttributeDefs(zcl.BaseAttributeDefs):
             # Explicitly no manufacturer code, even though cluster is manufacturer-specific
@@ -1931,6 +1934,7 @@ async def test_report_attributes_quirk_transforms_value(app_mock):
 
         cluster_id = 0xABCD
         ep_attribute = "doubling"
+        _skip_registry = True
 
         class AttributeDefs(zcl.foundation.BaseAttributeDefs):
             test_attr = foundation.ZCLAttributeDef(
@@ -2342,6 +2346,7 @@ def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:
     class TestCluster(zcl.Cluster):
         cluster_id = 0xFEED  # Manufacturer-specific cluster range
         ep_attribute = "test_cluster"
+        _skip_registry = True
         manufacturer_id_override = 0x5678
 
         class AttributeDefs(zcl.BaseAttributeDefs):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1676,6 +1676,73 @@ def test_find_attribute_unspecified_manufacturer_code() -> None:
         TestCluster.find_attribute(0x0003, manufacturer_code=0x5678)
 
 
+def test_find_attributes_non_manuf_specific_undefined() -> None:
+    """Test find_attributes across all attribute specificity combinations."""
+
+    class TestCluster(zcl.Cluster):
+        cluster_id = 0xABCD
+        ep_attribute = "test_cluster"
+
+        class AttributeDefs(zcl.BaseAttributeDefs):
+            explicit_none = foundation.ZCLAttributeDef(
+                id=0x0001, type=t.EUI64, manufacturer_code=None
+            )
+            explicit_false = foundation.ZCLAttributeDef(
+                id=0x0001, type=t.EUI64, is_manufacturer_specific=False
+            )
+            default = foundation.ZCLAttributeDef(id=0x0001, type=t.EUI64)
+            manuf_no_code = foundation.ZCLAttributeDef(
+                id=0x0001, type=t.EUI64, is_manufacturer_specific=True
+            )
+            manuf_1234 = foundation.ZCLAttributeDef(
+                id=0x0001, type=t.EUI64, manufacturer_code=0x1234
+            )
+            manuf_5678 = foundation.ZCLAttributeDef(
+                id=0x0001, type=t.EUI64, manufacturer_code=0x5678
+            )
+
+    assert TestCluster.find_attributes(0x0001, manufacturer_code=None) == [
+        TestCluster.AttributeDefs.explicit_none,
+        TestCluster.AttributeDefs.explicit_false,
+        TestCluster.AttributeDefs.default,
+    ]
+
+    assert TestCluster.find_attributes(0x0001, manufacturer_code=0x1234) == [
+        TestCluster.AttributeDefs.manuf_1234,
+        TestCluster.AttributeDefs.manuf_no_code,
+    ]
+    assert TestCluster.find_attributes(0x0001, manufacturer_code=0x5678) == [
+        TestCluster.AttributeDefs.manuf_5678,
+        TestCluster.AttributeDefs.manuf_no_code,
+    ]
+
+    assert TestCluster.find_attributes(0x0001, manufacturer_code=0x9999) == [
+        TestCluster.AttributeDefs.manuf_no_code,
+    ]
+
+    assert TestCluster.find_attributes(0x0001) == [
+        TestCluster.AttributeDefs.manuf_1234,
+        TestCluster.AttributeDefs.manuf_5678,
+        TestCluster.AttributeDefs.manuf_no_code,
+        TestCluster.AttributeDefs.explicit_false,
+        TestCluster.AttributeDefs.explicit_none,
+        TestCluster.AttributeDefs.default,
+    ]
+
+    assert TestCluster.find_attributes("explicit_false") == [
+        TestCluster.AttributeDefs.explicit_false,
+    ]
+    assert TestCluster.find_attributes("manuf_1234") == [
+        TestCluster.AttributeDefs.manuf_1234,
+    ]
+    assert TestCluster.find_attributes(TestCluster.AttributeDefs.manuf_5678) == [
+        TestCluster.AttributeDefs.manuf_5678,
+    ]
+
+    with pytest.raises(KeyError):
+        TestCluster.find_attributes(0x9999)
+
+
 async def test_read_attributes_complex() -> None:
     """Test reading attributes, complex scenario."""
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1676,7 +1676,7 @@ def test_find_attribute_unspecified_manufacturer_code() -> None:
         TestCluster.find_attribute(0x0003, manufacturer_code=0x5678)
 
 
-def test_find_attributes_non_manuf_specific_undefined() -> None:
+def test_find_attributes() -> None:
     """Test find_attributes across all attribute specificity combinations."""
 
     class TestCluster(zcl.Cluster):
@@ -1700,13 +1700,19 @@ def test_find_attributes_non_manuf_specific_undefined() -> None:
             manuf_5678 = foundation.ZCLAttributeDef(
                 id=0x0001, type=t.EUI64, manufacturer_code=0x5678
             )
+            specific_unique = foundation.ZCLAttributeDef(
+                id=0x0002, type=t.EUI64, manufacturer_code=0x1234
+            )
 
+    # An explicitly disabled manufacturer code
     assert TestCluster.find_attributes(0x0001, manufacturer_code=None) == [
         TestCluster.AttributeDefs.explicit_none,
         TestCluster.AttributeDefs.explicit_false,
         TestCluster.AttributeDefs.default,
     ]
 
+    # A specific manufacturer code will match the specific attribute for that code and
+    # a generic manufacturer-specific one
     assert TestCluster.find_attributes(0x0001, manufacturer_code=0x1234) == [
         TestCluster.AttributeDefs.manuf_1234,
         TestCluster.AttributeDefs.manuf_no_code,
@@ -1716,10 +1722,12 @@ def test_find_attributes_non_manuf_specific_undefined() -> None:
         TestCluster.AttributeDefs.manuf_no_code,
     ]
 
+    # An unknown manufacturer code will match only the generic attribute
     assert TestCluster.find_attributes(0x0001, manufacturer_code=0x9999) == [
         TestCluster.AttributeDefs.manuf_no_code,
     ]
 
+    # No code will match all attributes with the ID
     assert TestCluster.find_attributes(0x0001) == [
         TestCluster.AttributeDefs.manuf_1234,
         TestCluster.AttributeDefs.manuf_5678,
@@ -1729,6 +1737,7 @@ def test_find_attributes_non_manuf_specific_undefined() -> None:
         TestCluster.AttributeDefs.default,
     ]
 
+    # Names and definition objects are unique
     assert TestCluster.find_attributes("explicit_false") == [
         TestCluster.AttributeDefs.explicit_false,
     ]
@@ -1739,8 +1748,12 @@ def test_find_attributes_non_manuf_specific_undefined() -> None:
         TestCluster.AttributeDefs.manuf_5678,
     ]
 
+    # Missing attributes and bad combinations raise errors
     with pytest.raises(KeyError):
         TestCluster.find_attributes(0x9999)
+
+    with pytest.raises(KeyError):
+        TestCluster.find_attributes(0x0002, manufacturer_code=0xABCD)
 
 
 async def test_read_attributes_complex() -> None:

--- a/tests/test_zcl_helpers.py
+++ b/tests/test_zcl_helpers.py
@@ -17,6 +17,7 @@ from zigpy.zcl.helpers import UnsupportedAttribute
 class HelperCluster(zcl.Cluster):
     cluster_id = 0xABCD
     ep_attribute = "helper_cluster"
+    _skip_registry = True
 
     class AttributeDefs(zcl.BaseAttributeDefs):
         attr1 = foundation.ZCLAttributeDef(id=0x0001, type=t.uint8_t)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 import types
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
@@ -61,6 +61,10 @@ MIN_UPDATE_DELTA = timedelta(seconds=30).total_seconds()
 # attributes safely at runtime, once a device quirk has loaded and we can tell for sure
 # if the device has "colliding" attributes.
 UNMIGRATED_MANUFACTURER_CODE = -1
+
+# ieee, endpoint_id, cluster_type, cluster_id, attr_id, manufacturer_code
+# manufacturer_code_idx, status, value, last_updated
+AttributeRow = tuple[t.EUI64, int, int, int, int, int | None, int, Any, float]
 
 
 def _import_compatible_sqlite3(min_version: tuple[int, int, int]) -> types.ModuleType:
@@ -660,7 +664,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
     async def _read_all_attributes(
         self,
-    ) -> list[tuple[t.EUI64, int, int, int, int, int, int, bytes, float]]:
+    ) -> list[AttributeRow]:
         """Read all attribute rows from the database."""
         async with self.execute(
             f"""
@@ -717,7 +721,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
     async def _populate_attribute_cache(
         self,
-        rows: list[tuple[t.EUI64, int, int, int, int, int, int, bytes, float]],
+        rows: list[AttributeRow],
         *,
         migrate: bool = False,
     ) -> None:

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -864,12 +864,13 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     def _resolve_unmigrated_attribute(
         cluster: Cluster,
         attr_id: int,
-        value: bytes,
+        value: Any,
         dev: Device,
     ) -> int | None | zigpy.typing.UndefinedType:
         """Try to resolve the manufacturer code for an unmigrated attribute.
 
-        Returns the resolved manufacturer code, or UNDEFINED if unresolvable.
+        Returns the resolved manufacturer code (including `None`), or UNDEFINED if
+        unresolvable.
         """
         try:
             attr_defs = cluster.find_attributes(attr_id)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -687,7 +687,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             FROM attributes_cache{DB_V}
             """
         ) as cursor:
-            return await cursor.fetchall()
+            return [AttributeCacheRow(*row) for row in await cursor.fetchall()]
 
     async def load(self) -> None:
         LOGGER.debug("Loading application state")

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -274,6 +274,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         # XXX: This will break if you use a semicolon anywhere but at the end of a line
         for statement in sql.split(";"):
+            # Strip SQL comments so that pysqlite3's implicit transaction DML detection
+            # (which doesn't skip comments) sees the actual statement keyword
+            statement = re.sub(r"--[^\n]*", "", statement)
+
             await self.execute(statement)
 
     def device_joined(self, device: Device) -> None:

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -747,56 +747,50 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         resolved using the (now-quirked) cluster definitions and the database is
         updated to match.
         """
-        for (
-            ieee,
-            endpoint_id,
-            cluster_type,
-            cluster_id,
-            attr_id,
-            manufacturer_code,
-            status,
-            value,
-            last_updated,
-        ) in rows:
-            dev = self._application.get_device(ieee)
+        for row in rows:
+            dev = self._application.get_device(row.ieee)
 
             LOGGER.debug(
                 "[0x%04x:%s:0x%04x] Loading attribute %s=%r status=%r mfg_code=%r",
                 dev.nwk,
-                endpoint_id,
-                cluster_id,
-                (attr_id if isinstance(attr_id, str) else f"0x{attr_id:04x}"),
-                value,
-                status,
-                manufacturer_code,
+                row.endpoint_id,
+                row.cluster_id,
+                (
+                    row.attr_id
+                    if isinstance(row.attr_id, str)
+                    else f"0x{row.attr_id:04x}"
+                ),
+                row.value,
+                row.status,
+                row.manufacturer_code,
             )
 
-            if endpoint_id not in dev.endpoints:
+            if row.endpoint_id not in dev.endpoints:
                 continue
 
-            ep = dev.endpoints[endpoint_id]
+            ep = dev.endpoints[row.endpoint_id]
             clusters = (
                 ep.in_clusters
-                if cluster_type == ClusterType.Server
+                if row.cluster_type == ClusterType.Server
                 else ep.out_clusters
             )
 
-            if cluster_id not in clusters:
+            if row.cluster_id not in clusters:
                 LOGGER.debug("Unknown ZCL cluster, skipping")
                 continue
 
-            cluster = clusters[cluster_id]
+            cluster = clusters[row.cluster_id]
 
             # Handle unsupported attributes
-            if status != Status.SUCCESS:
+            if row.status != Status.SUCCESS:
                 try:
                     with suppress_events():
                         cluster.add_unsupported_attribute(
-                            attr_id,
+                            row.attr_id,
                             manufacturer_code=(
                                 UNDEFINED
-                                if manufacturer_code == UNMIGRATED_MANUFACTURER_CODE
-                                else manufacturer_code
+                                if row.manufacturer_code == UNMIGRATED_MANUFACTURER_CODE
+                                else row.manufacturer_code
                             ),
                         )
                 except KeyError:
@@ -805,11 +799,13 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
             # For unmigrated rows on the second pass, try to resolve the
             # manufacturer code using the full quirk cluster definitions
-            if migrate and manufacturer_code == UNMIGRATED_MANUFACTURER_CODE:
+            manufacturer_code = row.manufacturer_code
+
+            if migrate and row.manufacturer_code == UNMIGRATED_MANUFACTURER_CODE:
                 resolved_manufacturer_code = self._resolve_unmigrated_attribute(
                     cluster=cluster,
-                    attr_id=attr_id,
-                    value=value,
+                    attr_id=row.attr_id,
+                    value=row.value,
                     dev=dev,
                 )
 
@@ -830,18 +826,18 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                         """,
                         {
                             "manufacturer_code": manufacturer_code,
-                            "ieee": ieee,
-                            "endpoint_id": endpoint_id,
-                            "cluster_type": cluster_type,
-                            "cluster_id": cluster_id,
-                            "attr_id": attr_id,
+                            "ieee": row.ieee,
+                            "endpoint_id": row.endpoint_id,
+                            "cluster_type": row.cluster_type,
+                            "cluster_id": row.cluster_id,
+                            "attr_id": row.attr_id,
                             "old_manufacturer_code": UNMIGRATED_MANUFACTURER_CODE,
                         },
                     )
 
             try:
                 attr_def = cluster.find_attribute(
-                    attr_id,
+                    row.attr_id,
                     manufacturer_code=(
                         UNDEFINED
                         if manufacturer_code == UNMIGRATED_MANUFACTURER_CODE
@@ -851,28 +847,29 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             except KeyError:
                 LOGGER.debug("Unknown ZCL attribute, skipping")
                 cluster._attr_cache.set_legacy_value(
-                    attr_id,
-                    value,
-                    last_updated=datetime.fromtimestamp(last_updated, UTC),
+                    row.attr_id,
+                    row.value,
+                    last_updated=datetime.fromtimestamp(row.last_updated, UTC),
                 )
                 continue
 
             cluster._attr_cache.set_value(
                 attr_def,
-                value,
-                last_updated=datetime.fromtimestamp(last_updated, UTC),
+                row.value,
+                last_updated=datetime.fromtimestamp(row.last_updated, UTC),
             )
 
             # Populate the device's manufacturer and model attributes
             if (
-                cluster_id == Basic.cluster_id
+                row.cluster_id == Basic.cluster_id
                 and attr_def == Basic.AttributeDefs.manufacturer
             ):
-                dev.manufacturer = decode_str_attribute(value)
+                dev.manufacturer = decode_str_attribute(row.value)
             elif (
-                cluster_id == Basic.cluster_id and attr_def == Basic.AttributeDefs.model
+                row.cluster_id == Basic.cluster_id
+                and attr_def == Basic.AttributeDefs.model
             ):
-                dev.model = decode_str_attribute(value)
+                dev.model = decode_str_attribute(row.value)
 
     @staticmethod
     def _resolve_unmigrated_attribute(

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -17,7 +17,6 @@ import zigpy.device
 from zigpy.device import Device, Status as DeviceStatus
 import zigpy.endpoint
 from zigpy.endpoint import Endpoint, Status as EndpointStatus
-from zigpy.event import suppress_events
 import zigpy.exceptions
 import zigpy.group
 import zigpy.profiles
@@ -781,22 +780,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
             cluster = clusters[row.cluster_id]
 
-            # Handle unsupported attributes
-            if row.status != Status.SUCCESS:
-                try:
-                    with suppress_events():
-                        cluster.add_unsupported_attribute(
-                            row.attr_id,
-                            manufacturer_code=(
-                                UNDEFINED
-                                if row.manufacturer_code == UNMIGRATED_MANUFACTURER_CODE
-                                else row.manufacturer_code
-                            ),
-                        )
-                except KeyError:
-                    LOGGER.debug("Unknown ZCL attribute, skipping")
-                continue
-
             # For unmigrated rows on the second pass, try to resolve the
             # manufacturer code using the full quirk cluster definitions
             manufacturer_code = row.manufacturer_code
@@ -846,18 +829,25 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 )
             except KeyError:
                 LOGGER.debug("Unknown ZCL attribute, skipping")
-                cluster._attr_cache.set_legacy_value(
-                    row.attr_id,
+
+                if row.status == Status.SUCCESS:
+                    cluster._attr_cache.set_legacy_value(
+                        row.attr_id,
+                        row.value,
+                        last_updated=datetime.fromtimestamp(row.last_updated, UTC),
+                    )
+
+                continue
+
+            if row.status == Status.SUCCESS:
+                cluster._attr_cache.set_value(
+                    attr_def,
                     row.value,
                     last_updated=datetime.fromtimestamp(row.last_updated, UTC),
                 )
+            else:
+                cluster._attr_cache.mark_unsupported(attr_def)
                 continue
-
-            cluster._attr_cache.set_value(
-                attr_def,
-                row.value,
-                last_updated=datetime.fromtimestamp(row.last_updated, UTC),
-            )
 
             # Populate the device's manufacturer and model attributes
             if (

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -1465,14 +1465,34 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     continue
 
                 try:
-                    attr_def = cluster.find_attribute(attr_id)
+                    attr_defs = cluster.find_attributes(attr_id)
                 except KeyError:
                     LOGGER.debug(
-                        "Unable to find attribute %r=%r on cluster %r for %r for data migration, skipping",
+                        "Unable to find any attributes %r=%r on cluster %r for %r for data migration, skipping",
                         attr_id,
                         value,
                         cluster,
                         dev,
+                    )
+                    continue
+
+                if len(attr_defs) == 1:
+                    attr_def = attr_defs[0]
+                elif (
+                    len(attr_defs) == 2
+                    and attr_defs[0].is_manufacturer_specific
+                    != attr_defs[1].is_manufacturer_specific
+                ):
+                    # Prefer the manufacturer specific one
+                    attr_def = next(a for a in attr_defs if a.is_manufacturer_specific)
+                else:
+                    LOGGER.debug(
+                        "Unable to find unique attribute %r=%r on cluster %r for %r for data migration, skipping (candidates: %r)",
+                        attr_id,
+                        value,
+                        cluster,
+                        dev,
+                        attr_defs,
                     )
                     continue
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -830,6 +830,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             except KeyError:
                 LOGGER.debug("Unknown ZCL attribute, skipping")
 
+                # Unsupported unknown attributes are dropped
                 if row.status == Status.SUCCESS:
                     cluster._attr_cache.set_legacy_value(
                         row.attr_id,
@@ -870,6 +871,11 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     ) -> int | None | zigpy.typing.UndefinedType:
         """Try to resolve the manufacturer code for an unmigrated attribute.
 
+        When multiple attribute definitions share an ID, the manufacturer-specific one
+        is preferred if there are exactly two candidates (one standard, one
+        manufacturer-specific). Otherwise the attribute is considered ambiguous and
+        skipped (left unmigrated).
+
         Returns the resolved manufacturer code (including `None`), or UNDEFINED if
         unresolvable.
         """
@@ -895,6 +901,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         if len(attr_defs) == 1:
             attr_def = attr_defs[0]
         elif len(attr_defs) == 2 and len(manuf_attrs) == 1:
+            # One standard + one manufacturer-specific: prefer manufacturer-specific
             attr_def = manuf_attrs[0]
         else:
             LOGGER.debug(

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -895,14 +895,16 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             )
             return UNDEFINED
 
+        manuf_attrs = [
+            a
+            for a in attr_defs
+            if cluster._get_effective_manufacturer_code(a) is not None
+        ]
+
         if len(attr_defs) == 1:
             attr_def = attr_defs[0]
-        elif (
-            len(attr_defs) == 2
-            and attr_defs[0].is_manufacturer_specific
-            != attr_defs[1].is_manufacturer_specific
-        ):
-            attr_def = next(a for a in attr_defs if a.is_manufacturer_specific)
+        elif len(attr_defs) == 2 and len(manuf_attrs) == 1:
+            attr_def = manuf_attrs[0]
         else:
             LOGGER.debug(
                 "Unable to find unique attribute %r=%r on cluster %r for %r"

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 import types
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import aiosqlite
 
@@ -62,9 +62,19 @@ MIN_UPDATE_DELTA = timedelta(seconds=30).total_seconds()
 # if the device has "colliding" attributes.
 UNMIGRATED_MANUFACTURER_CODE = -1
 
-# ieee, endpoint_id, cluster_type, cluster_id, attr_id, manufacturer_code
-# manufacturer_code_idx, status, value, last_updated
-AttributeRow = tuple[t.EUI64, int, int, int, int, int | None, int, Any, float]
+
+class AttributeCacheRow(NamedTuple):
+    """A row from the attribute cache table. This format is internal and will change."""
+
+    ieee: t.EUI64
+    endpoint_id: int
+    cluster_type: ClusterType
+    cluster_id: int
+    attr_id: int
+    manufacturer_code: int | None
+    status: Status
+    value: Any
+    last_updated: float
 
 
 def _import_compatible_sqlite3(min_version: tuple[int, int, int]) -> types.ModuleType:
@@ -664,7 +674,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
     async def _read_all_attributes(
         self,
-    ) -> list[AttributeRow]:
+    ) -> list[AttributeCacheRow]:
         """Read all attribute rows from the database."""
         async with self.execute(
             f"""
@@ -723,7 +733,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
     async def _populate_attribute_cache(
         self,
-        rows: list[AttributeRow],
+        rows: list[AttributeCacheRow],
         *,
         migrate: bool = False,
     ) -> None:

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -42,6 +42,7 @@ from zigpy.zdo import types as zdo_t
 
 if TYPE_CHECKING:
     from zigpy.application import ControllerApplication
+    from zigpy.zcl import Cluster
 
 LOGGER = logging.getLogger(__name__)
 
@@ -657,6 +658,19 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self.execute(q, (backup_time.isoformat(),))
         await self._db.commit()
 
+    async def _read_all_attributes(
+        self,
+    ) -> list[tuple[t.EUI64, int, int, int, int, int, int, bytes, float]]:
+        """Read all attribute rows from the database."""
+        async with self.execute(
+            f"""
+            SELECT ieee, endpoint_id, cluster_type, cluster_id, attr_id,
+                   manufacturer_code, status, value, last_updated
+            FROM attributes_cache{DB_V}
+            """
+        ) as cursor:
+            return await cursor.fetchall()
+
     async def load(self) -> None:
         LOGGER.debug("Loading application state")
         await self._load_devices()
@@ -664,19 +678,31 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._load_endpoints()
         await self._load_clusters()
 
-        # Load as many attributes as we can in the first pass
-        await self._load_attributes()
+        # Read all attribute rows from the database once
+        all_attributes = await self._read_all_attributes()
+
+        # First pass: populate cache on bare clusters for quirks
+        await self._populate_attribute_cache(all_attributes)
 
         for device in self._application.devices.values():
             # Populate the device signature before we apply any quirks, which can modify
             # the device structure (for now)
             device.original_signature = device.get_signature()
 
-            device = zigpy.quirks.get_device(device)
-            self._application.devices[device.ieee] = device
+            self._application.devices[device.ieee] = zigpy.quirks.get_device(device)
 
-        # Load them once more, to make sure virtual clusters get re-populated
-        await self._load_attributes()
+        # Clear the attribute cache to ensure the quirked state is correct
+        for device in self._application.devices.values():
+            for ep in device.non_zdo_endpoints:
+                for cluster in ep.in_clusters.values():
+                    cluster._attr_cache.clear()
+
+                for cluster in ep.out_clusters.values():
+                    cluster._attr_cache.clear()
+
+        # Second pass: populate the attribute cache for the final device state and
+        # migrate attributes with unknown manufacturer codes to the correct codes
+        await self._populate_attribute_cache(all_attributes, migrate=True)
 
         await self._load_groups()
         await self._load_group_members()
@@ -687,111 +713,192 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         await self._db.commit()
 
-        async with self._transaction():
-            await self._run_data_migrations()
-
         await self._register_device_listeners()
 
-    async def _load_attributes(self) -> None:
-        async with self.execute(
-            f"""
-            SELECT ieee, endpoint_id, cluster_type, cluster_id, attr_id,
-                   manufacturer_code, status, value, last_updated
-            FROM attributes_cache{DB_V}
-            """
-        ) as cursor:
-            async for (
-                ieee,
+    async def _populate_attribute_cache(
+        self,
+        rows: list[tuple[t.EUI64, int, int, int, int, int, int, bytes, float]],
+        *,
+        migrate: bool = False,
+    ) -> None:
+        """Populate cluster attribute cache from pre-loaded rows.
+
+        When `migrate` is True, unmigrated rows with ambiguous attribute IDs are
+        resolved using the (now-quirked) cluster definitions and the database is
+        updated to match.
+        """
+        for (
+            ieee,
+            endpoint_id,
+            cluster_type,
+            cluster_id,
+            attr_id,
+            manufacturer_code,
+            status,
+            value,
+            last_updated,
+        ) in rows:
+            dev = self._application.get_device(ieee)
+
+            LOGGER.debug(
+                "[0x%04x:%s:0x%04x] Loading attribute %s=%r status=%r mfg_code=%r",
+                dev.nwk,
                 endpoint_id,
-                cluster_type,
                 cluster_id,
-                attr_id,
-                manufacturer_code,
-                status,
+                (attr_id if isinstance(attr_id, str) else f"0x{attr_id:04x}"),
                 value,
-                last_updated,
-            ) in cursor:
-                dev = self._application.get_device(ieee)
+                status,
+                manufacturer_code,
+            )
 
-                LOGGER.debug(
-                    "[0x%04x:%s:0x%04x] Loading attribute %s=%r status=%r mfg_code=%r",
-                    dev.nwk,
-                    endpoint_id,
-                    cluster_id,
-                    (attr_id if isinstance(attr_id, str) else f"0x{attr_id:04x}"),
-                    value,
-                    status,
-                    manufacturer_code,
-                )
+            if endpoint_id not in dev.endpoints:
+                continue
 
-                # Some quirks create endpoints and clusters that do not exist
-                if endpoint_id not in dev.endpoints:
-                    continue
+            ep = dev.endpoints[endpoint_id]
+            clusters = (
+                ep.in_clusters
+                if cluster_type == ClusterType.Server
+                else ep.out_clusters
+            )
 
-                ep = dev.endpoints[endpoint_id]
-                clusters = (
-                    ep.in_clusters
-                    if cluster_type == ClusterType.Server
-                    else ep.out_clusters
-                )
+            if cluster_id not in clusters:
+                LOGGER.debug("Unknown ZCL cluster, skipping")
+                continue
 
-                if cluster_id not in clusters:
-                    LOGGER.debug("Unknown ZCL cluster, skipping")
-                    continue
+            cluster = clusters[cluster_id]
 
-                cluster = clusters[cluster_id]
-
-                # Handle unsupported attributes
-                if status != Status.SUCCESS:
-                    try:
-                        with suppress_events():
-                            cluster.add_unsupported_attribute(
-                                attr_id,
-                                manufacturer_code=(
-                                    UNDEFINED
-                                    if manufacturer_code == UNMIGRATED_MANUFACTURER_CODE
-                                    else manufacturer_code
-                                ),
-                            )
-                    except KeyError:
-                        LOGGER.debug("Unknown ZCL attribute, skipping")
-                    continue
-
+            # Handle unsupported attributes
+            if status != Status.SUCCESS:
                 try:
-                    attr_def = cluster.find_attribute(
-                        attr_id,
-                        manufacturer_code=(
-                            UNDEFINED
-                            if manufacturer_code == UNMIGRATED_MANUFACTURER_CODE
-                            else manufacturer_code
-                        ),
-                    )
+                    with suppress_events():
+                        cluster.add_unsupported_attribute(
+                            attr_id,
+                            manufacturer_code=(
+                                UNDEFINED
+                                if manufacturer_code == UNMIGRATED_MANUFACTURER_CODE
+                                else manufacturer_code
+                            ),
+                        )
                 except KeyError:
                     LOGGER.debug("Unknown ZCL attribute, skipping")
-                    cluster._attr_cache.set_legacy_value(
-                        attr_id,
-                        value,
-                        last_updated=datetime.fromtimestamp(last_updated, UTC),
-                    )
-                    continue
+                continue
 
-                cluster._attr_cache.set_value(
-                    attr_def,
+            # For unmigrated rows on the second pass, try to resolve the
+            # manufacturer code using the full quirk cluster definitions
+            if migrate and manufacturer_code == UNMIGRATED_MANUFACTURER_CODE:
+                resolved_manufacturer_code = self._resolve_unmigrated_attribute(
+                    cluster=cluster,
+                    attr_id=attr_id,
+                    value=value,
+                    dev=dev,
+                )
+
+                if resolved_manufacturer_code is not UNDEFINED:
+                    manufacturer_code = resolved_manufacturer_code
+
+                    await self.execute(
+                        f"""
+                        UPDATE attributes_cache{DB_V}
+                        SET manufacturer_code = :manufacturer_code
+                        WHERE
+                            ieee = :ieee
+                            AND endpoint_id = :endpoint_id
+                            AND cluster_type = :cluster_type
+                            AND cluster_id = :cluster_id
+                            AND attr_id = :attr_id
+                            AND manufacturer_code = :old_manufacturer_code
+                        """,
+                        {
+                            "manufacturer_code": manufacturer_code,
+                            "ieee": ieee,
+                            "endpoint_id": endpoint_id,
+                            "cluster_type": cluster_type,
+                            "cluster_id": cluster_id,
+                            "attr_id": attr_id,
+                            "old_manufacturer_code": UNMIGRATED_MANUFACTURER_CODE,
+                        },
+                    )
+
+            try:
+                attr_def = cluster.find_attribute(
+                    attr_id,
+                    manufacturer_code=(
+                        UNDEFINED
+                        if manufacturer_code == UNMIGRATED_MANUFACTURER_CODE
+                        else manufacturer_code
+                    ),
+                )
+            except KeyError:
+                LOGGER.debug("Unknown ZCL attribute, skipping")
+                cluster._attr_cache.set_legacy_value(
+                    attr_id,
                     value,
                     last_updated=datetime.fromtimestamp(last_updated, UTC),
                 )
+                continue
 
-                # Populate the device's manufacturer and model attributes
-                if (
-                    cluster_id == Basic.cluster_id
-                    and attr_def == Basic.AttributeDefs.manufacturer
-                ):
-                    dev.manufacturer = decode_str_attribute(value)
-                elif (
-                    cluster_id == Basic.cluster_id
-                    and attr_def == Basic.AttributeDefs.model
-                ):
-                    dev.model = decode_str_attribute(value)
+            cluster._attr_cache.set_value(
+                attr_def,
+                value,
+                last_updated=datetime.fromtimestamp(last_updated, UTC),
+            )
+
+            # Populate the device's manufacturer and model attributes
+            if (
+                cluster_id == Basic.cluster_id
+                and attr_def == Basic.AttributeDefs.manufacturer
+            ):
+                dev.manufacturer = decode_str_attribute(value)
+            elif (
+                cluster_id == Basic.cluster_id and attr_def == Basic.AttributeDefs.model
+            ):
+                dev.model = decode_str_attribute(value)
+
+    @staticmethod
+    def _resolve_unmigrated_attribute(
+        cluster: Cluster,
+        attr_id: int,
+        value: bytes,
+        dev: Device,
+    ) -> int | None | zigpy.typing.UndefinedType:
+        """Try to resolve the manufacturer code for an unmigrated attribute.
+
+        Returns the resolved manufacturer code, or UNDEFINED if unresolvable.
+        """
+        try:
+            attr_defs = cluster.find_attributes(attr_id)
+        except KeyError:
+            LOGGER.debug(
+                "Unable to find any attributes %r=%r on cluster %r for %r"
+                " for data migration, skipping",
+                attr_id,
+                value,
+                cluster,
+                dev,
+            )
+            return UNDEFINED
+
+        if len(attr_defs) == 1:
+            attr_def = attr_defs[0]
+        elif (
+            len(attr_defs) == 2
+            and attr_defs[0].is_manufacturer_specific
+            != attr_defs[1].is_manufacturer_specific
+        ):
+            attr_def = next(a for a in attr_defs if a.is_manufacturer_specific)
+        else:
+            LOGGER.debug(
+                "Unable to find unique attribute %r=%r on cluster %r for %r"
+                " for data migration, skipping (candidates: %r)",
+                attr_id,
+                value,
+                cluster,
+                dev,
+                attr_defs,
+            )
+            return UNDEFINED
+
+        return cluster._get_effective_manufacturer_code(attr_def)
 
     async def _load_devices(self) -> None:
         async with self.execute(f"SELECT * FROM devices{DB_V}") as cursor:
@@ -1414,109 +1521,4 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                         value,
                         last_updated,
                     ),
-                )
-
-    async def _run_data_migrations(self) -> None:
-        """Run any data migrations needed after loading the database."""
-        async with self.execute(
-            """
-            SELECT ieee, endpoint_id, cluster_type, cluster_id, attr_id,
-                   manufacturer_code, status, value, last_updated
-            FROM attributes_cache_v14
-            WHERE manufacturer_code = :unmigrated
-            """,
-            {"unmigrated": UNMIGRATED_MANUFACTURER_CODE},
-        ) as cursor:
-            async for (
-                ieee,
-                endpoint_id,
-                cluster_type,
-                cluster_id,
-                attr_id,
-                manufacturer_code,
-                status,
-                value,
-                last_updated,
-            ) in cursor:
-                dev = self._application.get_device(ieee)
-
-                try:
-                    ep = dev.endpoints[endpoint_id]
-                except KeyError:
-                    continue
-
-                clusters = (
-                    ep.in_clusters
-                    if cluster_type == ClusterType.Server
-                    else ep.out_clusters
-                )
-
-                try:
-                    cluster = clusters[cluster_id]
-                except KeyError:
-                    LOGGER.debug(
-                        "Unable to find cluster %r for attribute %r=%r on endpoint %r for %r for data migration, skipping",
-                        cluster_id,
-                        attr_id,
-                        value,
-                        ep,
-                        dev,
-                    )
-                    continue
-
-                try:
-                    attr_defs = cluster.find_attributes(attr_id)
-                except KeyError:
-                    LOGGER.debug(
-                        "Unable to find any attributes %r=%r on cluster %r for %r for data migration, skipping",
-                        attr_id,
-                        value,
-                        cluster,
-                        dev,
-                    )
-                    continue
-
-                if len(attr_defs) == 1:
-                    attr_def = attr_defs[0]
-                elif (
-                    len(attr_defs) == 2
-                    and attr_defs[0].is_manufacturer_specific
-                    != attr_defs[1].is_manufacturer_specific
-                ):
-                    # Prefer the manufacturer specific one
-                    attr_def = next(a for a in attr_defs if a.is_manufacturer_specific)
-                else:
-                    LOGGER.debug(
-                        "Unable to find unique attribute %r=%r on cluster %r for %r for data migration, skipping (candidates: %r)",
-                        attr_id,
-                        value,
-                        cluster,
-                        dev,
-                        attr_defs,
-                    )
-                    continue
-
-                manufacturer_code = cluster._get_effective_manufacturer_code(attr_def)
-
-                await self.execute(
-                    """
-                    UPDATE attributes_cache_v14
-                    SET manufacturer_code = :manufacturer_code
-                    WHERE
-                        ieee = :ieee
-                        AND endpoint_id = :endpoint_id
-                        AND cluster_type = :cluster_type
-                        AND cluster_id = :cluster_id
-                        AND attr_id = :attr_id
-                        AND manufacturer_code = :old_manufacturer_code
-                    """,
-                    {
-                        "manufacturer_code": manufacturer_code,
-                        "ieee": ieee,
-                        "endpoint_id": endpoint_id,
-                        "cluster_type": cluster_type,
-                        "cluster_id": cluster_id,
-                        "attr_id": attr_id,
-                        "old_manufacturer_code": UNMIGRATED_MANUFACTURER_CODE,
-                    },
                 )

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -705,8 +705,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     cluster._attr_cache.clear()
 
         # Second pass: populate the attribute cache for the final device state and
-        # migrate attributes with unknown manufacturer codes to the correct codes
-        await self._populate_attribute_cache(all_attributes, migrate=True)
+        # migrate attributes with unknown manufacturer codes to the correct codes. Only
+        # the migration pass modifies the database so we do it in a transaction.
+        async with self._transaction():
+            await self._populate_attribute_cache(all_attributes, migrate=True)
 
         await self._load_groups()
         await self._load_group_members()

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -498,6 +498,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     if UNDEFINED in manuf_specific:
                         results.append(manuf_specific[UNDEFINED])
 
+                if not results:
+                    raise KeyError(manufacturer_code)
+
                 return results
 
             # No manufacturer code filter: return all candidates
@@ -522,9 +525,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         all_candidates = cls.find_attributes(
             name_or_id, manufacturer_code=manufacturer_code
         )
-
-        if not all_candidates:
-            raise KeyError(manufacturer_code)
 
         # Non-integer lookups always return a single result
         if not isinstance(name_or_id, int):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -462,76 +462,101 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         return None
 
     @classmethod
+    def find_attributes(
+        cls,
+        name_or_id: int | str | foundation.ZCLAttributeDef,
+        *,
+        manufacturer_code: int | UndefinedType | None = UNDEFINED,
+    ) -> list[foundation.ZCLAttributeDef]:
+        if isinstance(name_or_id, foundation.ZCLAttributeDef):
+            return [cls.attributes_by_name[name_or_id.name]]
+        elif isinstance(name_or_id, str):
+            return [cls.attributes_by_name[name_or_id]]
+        elif isinstance(name_or_id, int):
+            candidates = cls._attributes_by_id[name_or_id]
+            manuf_specific = candidates[True]
+            non_manuf_specific = candidates[False]
+            maybe_manuf_specific = candidates[None]
+
+            if manufacturer_code is not UNDEFINED:
+                results = []
+
+                if manufacturer_code is None:
+                    # Explicitly no manufacturer code
+                    if None in non_manuf_specific:
+                        results.append(non_manuf_specific[None])
+                    if UNDEFINED in non_manuf_specific:
+                        results.append(non_manuf_specific[UNDEFINED])
+                    if UNDEFINED in maybe_manuf_specific:
+                        results.append(maybe_manuf_specific[UNDEFINED])
+                else:
+                    # Try exact manufacturer-specific match
+                    if manufacturer_code in manuf_specific:
+                        results.append(manuf_specific[manufacturer_code])
+
+                    # Try manufacturer-specific without explicit code (deprecation)
+                    if UNDEFINED in manuf_specific:
+                        results.append(manuf_specific[UNDEFINED])
+
+                if not results:
+                    raise KeyError(manufacturer_code)
+
+                return results
+
+            # No manufacturer code filter: return all candidates
+            return (
+                list(manuf_specific.values())
+                + list(non_manuf_specific.values())
+                + list(maybe_manuf_specific.values())
+            )
+        else:
+            raise TypeError(  # noqa: TRY004
+                f"Attribute must be a definition, string, or integer,"
+                f" not {name_or_id!r} ({type(name_or_id)!r})"
+            )
+
+    @classmethod
     def find_attribute(
         cls,
         name_or_id: int | str | foundation.ZCLAttributeDef,
         *,
         manufacturer_code: int | UndefinedType | None = UNDEFINED,
     ) -> foundation.ZCLAttributeDef:
-        if isinstance(name_or_id, foundation.ZCLAttributeDef):
-            return cls.attributes_by_name[name_or_id.name]
-        elif isinstance(name_or_id, str):
-            return cls.attributes_by_name[name_or_id]
-        elif isinstance(name_or_id, int):
-            # Integer lookups are the most complicated, since we know the ID of an
-            # attribute but there may be multiple candidates sharing it
-            candidates = cls._attributes_by_id[name_or_id]
-            manuf_specific = candidates[True]
-            non_manuf_specific = candidates[False]
-            maybe_manuf_specific = candidates[None]
+        all_candidates = cls.find_attributes(
+            name_or_id, manufacturer_code=manufacturer_code
+        )
 
-            # If a manufacturer code is explicitly provided, we can narrow things down
-            if manufacturer_code is not UNDEFINED:
-                if manufacturer_code is None:
-                    # Explicitly no manufacturer code
-                    if None in non_manuf_specific:
-                        return non_manuf_specific[None]
+        # Non-integer lookups always return a single result
+        if not isinstance(name_or_id, int):
+            return all_candidates[0]
 
-                    # Fall back to unspecified
-                    if UNDEFINED in non_manuf_specific:
-                        return non_manuf_specific[UNDEFINED]
-
-                    if UNDEFINED in maybe_manuf_specific:
-                        return maybe_manuf_specific[UNDEFINED]
-                else:
-                    # Try exact manufacturer-specific match
-                    if manufacturer_code in manuf_specific:
-                        return manuf_specific[manufacturer_code]
-
-                    # Try manufacturer-specific without explicit code (deprecation)
-                    if UNDEFINED in manuf_specific:
-                        attr_def = manuf_specific[UNDEFINED]
-                        warnings.warn(
-                            f"Attribute {attr_def.name!r} has `is_manufacturer_specific`"
-                            f" without an explicit `manufacturer_code`. Please set"
-                            f" `manufacturer_code=0x{manufacturer_code:04X}`.",
-                            DeprecationWarning,
-                            stacklevel=3,
-                        )
-                        return attr_def
-
-                raise KeyError(manufacturer_code)
-
-            # Otherwise, we pick the first one and hope there is only a single choice
-            all_candidates = (
-                list(manuf_specific.values())
-                + list(non_manuf_specific.values())
-                + list(maybe_manuf_specific.values())
-            )
-
-            if len(all_candidates) > 1:
-                raise KeyError(
-                    f"Multiple definitions exist for attribute ID {name_or_id:#06x},"
-                    f" please specify a manufacturer code: {candidates!r}"
+        if manufacturer_code is not UNDEFINED:
+            # Emit deprecation warning for manufacturer-specific attrs without
+            # an explicit manufacturer_code
+            if (
+                manufacturer_code is not None
+                and all_candidates[0].manufacturer_code is UNDEFINED
+                and all_candidates[0].is_manufacturer_specific is True
+            ):
+                warnings.warn(
+                    f"Attribute {all_candidates[0].name!r} has"
+                    f" `is_manufacturer_specific` without an explicit"
+                    f" `manufacturer_code`. Please set"
+                    f" `manufacturer_code=0x{manufacturer_code:04X}`.",
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
 
-            # Pick the only one
             return all_candidates[0]
-        else:
-            raise TypeError(  # noqa: TRY004
-                f"Attribute must be a definition, string, or integer,"
-                f" not {name_or_id!r} ({type(name_or_id)!r})"
+
+        if len(all_candidates) > 1:
+            candidates = cls._attributes_by_id[name_or_id]
+            raise KeyError(
+                f"Multiple definitions exist for attribute ID {name_or_id:#06x},"
+                f" please specify a manufacturer code: {candidates!r}"
             )
+
+        return all_candidates[0]
 
     def is_attribute_unsupported(
         self, attr: int | str | foundation.ZCLAttributeDef

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -498,9 +498,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     if UNDEFINED in manuf_specific:
                         results.append(manuf_specific[UNDEFINED])
 
-                if not results:
-                    raise KeyError(manufacturer_code)
-
                 return results
 
             # No manufacturer code filter: return all candidates
@@ -525,6 +522,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         all_candidates = cls.find_attributes(
             name_or_id, manufacturer_code=manufacturer_code
         )
+
+        if not all_candidates:
+            raise KeyError(manufacturer_code)
 
         # Non-integer lookups always return a single result
         if not isinstance(name_or_id, int):

--- a/zigpy/zcl/helpers.py
+++ b/zigpy/zcl/helpers.py
@@ -45,6 +45,11 @@ class AttributeCache:
             self._cluster._get_effective_manufacturer_code(attr_def),
         )
 
+    def clear(self) -> None:
+        self._cache.clear()
+        self._unsupported.clear()
+        self._legacy_cache.clear()
+
     def remove(self, attr_def: ZCLAttributeDef) -> None:
         key = self._cache_key(attr_def)
         self._cache.pop(key, None)


### PR DESCRIPTION
When a manufacturer-specific attribute is defined in a quirk, it most likely is in use. If the old ZCL cache without manufacturer codes contained a value but there is no unique attribute definition we can match it up against (due to two attributes sharing an ID), we should pick the manufacturer-specific one over the ZCL-defined one. Currently, we do nothing and ignore this, which breaks the cache.