### PR TITLE
Make `_cache_key` aware of the effective manufacturer code

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1113,6 +1113,70 @@ def test_unsupported_attr_add_unknown_attribute(cluster):
         cluster.add_unsupported_attribute(0xDEED)
 
 
+def test_attr_cache_key_uses_effective_manufacturer_code():
+    """Test that the attribute cache distinguishes attributes by effective manuf code."""
+
+    class TestCluster(zcl.Cluster):
+        cluster_id = 0xFC01
+        ep_attribute = "test_cluster"
+
+        class AttributeDefs(zcl.BaseAttributeDefs):
+            standard_attr = foundation.ZCLAttributeDef(
+                id=0x0010, type=t.uint8_t, is_manufacturer_specific=False
+            )
+            manuf_attr = foundation.ZCLAttributeDef(
+                id=0x0010, type=t.uint8_t, is_manufacturer_specific=True
+            )
+
+    app = make_app({})
+    dev = add_initialized_device(app, nwk=0x1234, ieee=make_ieee(1))
+
+    ep = dev.endpoints[1]
+    ep.add_input_cluster(TestCluster.cluster_id)
+    cluster = ep.in_clusters[TestCluster.cluster_id]
+    cache = cluster._attr_cache
+
+    standard = TestCluster.AttributeDefs.standard_attr
+    manuf = TestCluster.AttributeDefs.manuf_attr
+
+    # Both start empty
+    with pytest.raises(KeyError):
+        cache.get_value(standard)
+    with pytest.raises(KeyError):
+        cache.get_value(manuf)
+
+    # Setting one does not affect the other
+    cache.set_value(standard, 100)
+    assert cache.get_value(standard) == 100
+    with pytest.raises(KeyError):
+        cache.get_value(manuf)
+
+    cache.set_value(manuf, 200)
+    assert cache.get_value(manuf) == 200
+    assert cache.get_value(standard) == 100
+
+    # Overwriting one does not affect the other
+    cache.set_value(standard, 111)
+    assert cache.get_value(standard) == 111
+    assert cache.get_value(manuf) == 200
+
+    # Marking one unsupported does not affect the other
+    cache.mark_unsupported(standard)
+    assert cache.is_unsupported(standard)
+    assert not cache.is_unsupported(manuf)
+    assert cache.get_value(manuf) == 200
+
+    # Setting a value clears the unsupported flag only for that attribute
+    cache.mark_unsupported(manuf)
+    assert cache.is_unsupported(standard)
+    assert cache.is_unsupported(manuf)
+
+    cache.set_value(manuf, 300)
+    assert not cache.is_unsupported(manuf)
+    assert cache.is_unsupported(standard)
+    assert cache.get_value(manuf) == 300
+
+
 def test_attr_cache_deprecated_setter(cluster, caplog):
     """Test deprecated _attr_cache setter logs warning and updates values."""
     cluster._attr_cache = {0x0004: "test_manufacturer", 0x0005: "test_model"}

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1119,6 +1119,7 @@ def test_attr_cache_key_uses_effective_manufacturer_code():
     class TestCluster(zcl.Cluster):
         cluster_id = 0xFC01
         ep_attribute = "test_cluster"
+        _skip_registry = True
 
         class AttributeDefs(zcl.BaseAttributeDefs):
             standard_attr = foundation.ZCLAttributeDef(
@@ -1226,6 +1227,7 @@ def test_zcl_command_duplicate_name_prevention():
         class TestCluster(zcl.Cluster):
             cluster_id = 0x1234
             ep_attribute = "test_cluster"
+            _skip_registry = True
             server_commands = {
                 0x00: foundation.ZCLCommandDef(name="command1", schema={}),
                 0x01: foundation.ZCLCommandDef(name="command1", schema={}),
@@ -1336,6 +1338,7 @@ async def test_zcl_cluster_definition_backwards_compatibility():
     class TestCluster(zcl.Cluster):
         cluster_id = 0xABCD
         ep_attribute = "test_cluster"
+        _skip_registry = True
 
         attributes = {
             0x1234: ("attribute", t.uint8_t),
@@ -1384,6 +1387,7 @@ async def test_zcl_cluster_definition_invalid_name():
     class TestCluster(zcl.Cluster):
         cluster_id = 0xABCD
         ep_attribute = "test_cluster"
+        _skip_registry = True
 
         class AttributeDefs(zcl.BaseAttributeDefs):
             upgrade_server_id = foundation.ZCLAttributeDef(
@@ -1412,6 +1416,7 @@ async def test_zcl_cluster_definition_invalid_name():
         class TestCluster(zcl.Cluster):
             cluster_id = 0xABCD
             ep_attribute = "test_cluster"
+            _skip_registry = True
 
             class AttributeDefs(zcl.BaseAttributeDefs):
                 upgrade_server_id = foundation.ZCLAttributeDef(
@@ -1428,6 +1433,7 @@ async def test_zcl_cluster_definition_invalid_name():
         class TestCluster(zcl.Cluster):
             cluster_id = 0xABCD
             ep_attribute = "test_cluster"
+            _skip_registry = True
 
             class ServerCommandDefs(zcl.BaseCommandDefs):
                 upgrade_end = foundation.ZCLCommandDef(
@@ -1452,6 +1458,7 @@ async def test_cluster_definition_invalid_direction():
         class TestCluster(zcl.Cluster):
             cluster_id = 0xABCD
             ep_attribute = "test_cluster"
+            _skip_registry = True
 
             class ServerCommandDefs(zcl.BaseCommandDefs):
                 server_command = foundation.ZCLCommandDef(
@@ -1575,6 +1582,7 @@ def test_find_attribute_simple() -> None:
     class TestCluster(zcl.Cluster):
         cluster_id = 0xABCD
         ep_attribute = "test_cluster"
+        _skip_registry = True
 
         class AttributeDefs(zcl.BaseAttributeDefs):
             attribute1 = foundation.ZCLAttributeDef(id=0x0001, type=t.EUI64)
@@ -1605,6 +1613,7 @@ def test_find_attribute_colliding_manufacturer_codes() -> None:
     class TestCluster(zcl.Cluster):
         cluster_id = 0xABCD
         ep_attribute = "test_cluster"
+        _skip_registry = True
 
         class AttributeDefs(zcl.BaseAttributeDefs):
             attribute1 = foundation.ZCLAttributeDef(id=0x0001, type=t.EUI64)
@@ -1640,6 +1649,7 @@ def test_find_attribute_unspecified_manufacturer_code() -> None:
     class TestCluster(zcl.Cluster):
         cluster_id = 0xABCD
         ep_attribute = "test_cluster"
+        _skip_registry = True
 
         class AttributeDefs(zcl.BaseAttributeDefs):
             attribute1 = foundation.ZCLAttributeDef(id=0x0001, type=t.EUI64)
@@ -1672,6 +1682,7 @@ async def test_read_attributes_complex() -> None:
     class TestCluster(zcl.Cluster):
         cluster_id = 0xABCD
         ep_attribute = "test_cluster"
+        _skip_registry = True
 
         class AttributeDefs(zcl.BaseAttributeDefs):
             attribute1 = foundation.ZCLAttributeDef(id=0x0001, type=t.uint8_t)
@@ -1793,6 +1804,7 @@ async def test_command_explicit_manufacturer():
     class TestCluster(zcl.Cluster):
         cluster_id = 0xABCD
         ep_attribute = "test_cluster"
+        _skip_registry = True
 
         class ServerCommandDefs(zcl.foundation.BaseCommandDefs):
             test_cmd = foundation.ZCLCommandDef(id=0x00, schema={})

--- a/zigpy/zcl/helpers.py
+++ b/zigpy/zcl/helpers.py
@@ -6,22 +6,12 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from zigpy.typing import UNDEFINED
-
 from .foundation import ZCLAttributeDef
 
 if TYPE_CHECKING:
     from . import Cluster
 
 CacheKey = tuple[int, int | None]  # attribute id, manufacturer code
-
-
-def _cache_key(attr_def: ZCLAttributeDef) -> CacheKey:
-    """Create a cache key, resolving UNDEFINED to None."""
-    manuf_code = attr_def.manufacturer_code
-    if manuf_code is UNDEFINED:
-        manuf_code = None
-    return (attr_def.id, manuf_code)
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -48,31 +38,43 @@ class AttributeCache:
         # cache as generic data storage. Keyed by attr_id only.
         self._legacy_cache: dict[int, CacheItem] = {}
 
+    def _cache_key(self, attr_def: ZCLAttributeDef) -> CacheKey:
+        """Create a cache key using the effective manufacturer code."""
+        return (
+            attr_def.id,
+            self._cluster._get_effective_manufacturer_code(attr_def),
+        )
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._unsupported.clear()
+        self._legacy_cache.clear()
+
     def remove(self, attr_def: ZCLAttributeDef) -> None:
-        key = _cache_key(attr_def)
+        key = self._cache_key(attr_def)
         self._cache.pop(key, None)
         self._unsupported.discard(key)
 
     def _raise_if_unsupported(self, attr_def: ZCLAttributeDef) -> None:
-        if _cache_key(attr_def) in self._unsupported:
+        if self._cache_key(attr_def) in self._unsupported:
             raise UnsupportedAttribute(attr_def)
 
     def remove_unsupported(self, attr_def: ZCLAttributeDef) -> None:
-        self._unsupported.discard(_cache_key(attr_def))
+        self._unsupported.discard(self._cache_key(attr_def))
 
     def mark_unsupported(self, attr_def: ZCLAttributeDef) -> None:
-        self._unsupported.add(_cache_key(attr_def))
+        self._unsupported.add(self._cache_key(attr_def))
 
     def is_unsupported(self, attr_def: ZCLAttributeDef) -> bool:
-        return _cache_key(attr_def) in self._unsupported
+        return self._cache_key(attr_def) in self._unsupported
 
     def get_value(self, attr_def: ZCLAttributeDef) -> Any:
         self._raise_if_unsupported(attr_def)
-        return self._cache[_cache_key(attr_def)].value
+        return self._cache[self._cache_key(attr_def)].value
 
     def get_last_updated(self, attr_def: ZCLAttributeDef) -> datetime:
         self._raise_if_unsupported(attr_def)
-        return self._cache[_cache_key(attr_def)].last_updated
+        return self._cache[self._cache_key(attr_def)].last_updated
 
     def set_value(
         self,
@@ -82,7 +84,7 @@ class AttributeCache:
         last_updated: datetime | None = None,
     ) -> None:
         self.remove_unsupported(attr_def)
-        self._cache[_cache_key(attr_def)] = CacheItem(
+        self._cache[self._cache_key(attr_def)] = CacheItem(
             value=value,
             last_updated=datetime.now(UTC) if last_updated is None else last_updated,
         )

--- a/zigpy/zcl/helpers.py
+++ b/zigpy/zcl/helpers.py
@@ -45,11 +45,6 @@ class AttributeCache:
             self._cluster._get_effective_manufacturer_code(attr_def),
         )
 
-    def clear(self) -> None:
-        self._cache.clear()
-        self._unsupported.clear()
-        self._legacy_cache.clear()
-
     def remove(self, attr_def: ZCLAttributeDef) -> None:
         key = self._cache_key(attr_def)
         self._cache.pop(key, None)


### PR DESCRIPTION
For colliding attributes that use `is_manufacturer_specific=True` (not an explicit `manufacturer_code`!), the cache key is incorrectly computed. We need to compute the effective manufacturer code with more context.