### PR TITLE
Fix v14 startup when the database contains new rows with a manufacturer code

### DIFF
--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -699,7 +699,8 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
                 # Unmigrated row from v13->v14 (ambiguous cluster)
                 (str(dev.ieee), 1, 0, 0xFC02, 0x0020, -1, b"\x99", 0),
                 # Manually read through the UI after v13->v14, duplicating the above
-                (str(dev.ieee), 1, 0, 0xFC01, 0x0010, 0xABCD, b"\x42", 1.0),
+                # but with a newer value
+                (str(dev.ieee), 1, 0, 0xFC01, 0x0010, 0xABCD, b"\x43", 1.0),
             ],
         )
         conn.commit()
@@ -712,8 +713,9 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
     disambiguated = dev.endpoints[1].in_clusters[0xFC01]
     ambiguous = dev.endpoints[1].in_clusters[0xFC02]
 
-    # 2 candidates (1 manuf + 1 non-manuf): picked manuf-specific
-    assert disambiguated.get("manuf_attr") == b"\x42"
+    # 2 candidates (1 manuf + 1 non-manuf): picked manuf-specific.
+    # Uses the newer value from the already-resolved row, not stale/unmigrated value.
+    assert disambiguated.get("manuf_attr") == b"\x43"
     assert disambiguated.get("standard_attr") is None
 
     # 3 candidates: ambiguous, skipped

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -687,17 +687,21 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
     app.device_initialized(dev)
     await app.shutdown()
 
-    # Insert unmigrated attribute rows (manufacturer_code=-1)
     with sqlite3.connect(db_path) as conn:
-        insert_sql = (
+        conn.executemany(
             "INSERT INTO attributes_cache_v14"
             " (ieee, endpoint_id, cluster_type, cluster_id,"
             "  attr_id, manufacturer_code, status, value, last_updated)"
-            " VALUES (?, ?, ?, ?, ?, -1, 0, ?, ?)"
+            " VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)",
+            [
+                # Unmigrated row from v13->v14 (disambiguated cluster)
+                (str(dev.ieee), 1, 0, 0xFC01, 0x0010, -1, b"\x42", 0),
+                # Unmigrated row from v13->v14 (ambiguous cluster)
+                (str(dev.ieee), 1, 0, 0xFC02, 0x0020, -1, b"\x99", 0),
+                # Manually read through the UI after v13->v14, duplicating the above
+                (str(dev.ieee), 1, 0, 0xFC01, 0x0010, 0xABCD, b"\x42", 1.0),
+            ],
         )
-
-        conn.execute(insert_sql, (str(dev.ieee), 1, 0, 0xFC01, 0x0010, b"\x42", 0))
-        conn.execute(insert_sql, (str(dev.ieee), 1, 0, 0xFC02, 0x0020, b"\x99", 0))
         conn.commit()
 
     with patch("zigpy.quirks.DEVICE_REGISTRY", registry):

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -722,3 +722,20 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
     assert ambiguous.get("attr_c") is None
 
     await app.shutdown()
+
+    with sqlite3.connect(db_path) as conn:
+        # The disambiguated unmigrated row was deleted (a row with 0xABCD already existed)
+        rows = conn.execute(
+            "SELECT manufacturer_code FROM attributes_cache_v14"
+            " WHERE ieee = ? AND cluster_id = ? AND attr_id = ?",
+            (str(dev.ieee), 0xFC01, 0x0010),
+        ).fetchall()
+        assert rows == [(0xABCD,)]
+
+        # The ambiguous unmigrated row is still present
+        rows = conn.execute(
+            "SELECT manufacturer_code FROM attributes_cache_v14"
+            " WHERE ieee = ? AND cluster_id = ? AND attr_id = ?",
+            (str(dev.ieee), 0xFC02, 0x0020),
+        ).fetchall()
+        assert rows == [(-1,)]

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -824,7 +824,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                         },
                     )
 
-                    await self.execute(
+                    async with self.execute(
                         f"""
                         INSERT OR IGNORE INTO attributes_cache{DB_V}
                             (ieee, endpoint_id, cluster_type, cluster_id,
@@ -842,7 +842,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                             "value": row.value,
                             "last_updated": row.last_updated,
                         },
-                    )
+                    ) as cursor:
+                        # A resolved row already exists, it will populate the cache
+                        if cursor.rowcount == 0:
+                            continue
 
             try:
                 attr_def = cluster.find_attribute(

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -795,10 +795,21 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 if resolved_manufacturer_code is not UNDEFINED:
                     manufacturer_code = resolved_manufacturer_code
 
+                    row_params = {
+                        "ieee": row.ieee,
+                        "endpoint_id": row.endpoint_id,
+                        "cluster_type": row.cluster_type,
+                        "cluster_id": row.cluster_id,
+                        "attr_id": row.attr_id,
+                    }
+
+                    # Delete the unmigrated row and re-insert with the resolved
+                    # manufacturer code. INSERT OR IGNORE handles the case where a row
+                    # with the resolved code already exists (e.g. the user manually
+                    # read the attribute through the UI).
                     await self.execute(
                         f"""
-                        UPDATE attributes_cache{DB_V}
-                        SET manufacturer_code = :manufacturer_code
+                        DELETE FROM attributes_cache{DB_V}
                         WHERE
                             ieee = :ieee
                             AND endpoint_id = :endpoint_id
@@ -808,13 +819,28 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                             AND manufacturer_code = :old_manufacturer_code
                         """,
                         {
-                            "manufacturer_code": manufacturer_code,
-                            "ieee": row.ieee,
-                            "endpoint_id": row.endpoint_id,
-                            "cluster_type": row.cluster_type,
-                            "cluster_id": row.cluster_id,
-                            "attr_id": row.attr_id,
+                            **row_params,
                             "old_manufacturer_code": UNMIGRATED_MANUFACTURER_CODE,
+                        },
+                    )
+
+                    await self.execute(
+                        f"""
+                        INSERT OR IGNORE INTO attributes_cache{DB_V}
+                            (ieee, endpoint_id, cluster_type, cluster_id,
+                             attr_id, manufacturer_code, status, value,
+                             last_updated)
+                        VALUES
+                            (:ieee, :endpoint_id, :cluster_type, :cluster_id,
+                             :attr_id, :manufacturer_code, :status, :value,
+                             :last_updated)
+                        """,
+                        {
+                            **row_params,
+                            "manufacturer_code": manufacturer_code,
+                            "status": row.status,
+                            "value": row.value,
+                            "last_updated": row.last_updated,
                         },
                     )
 


### PR DESCRIPTION
Instead of catching the integrity error from the `UPDATE` statement, we can just delete the existing row and maybe insert a new one.