### PR TITLE
Allow accessing legacy cache attributes via `cluster.get`

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -405,10 +405,8 @@ async def test_read_attributes_uncached():
 
         return [[responses[attr_id] for attr_id in args]]
 
-    # Unknown attribute read passes through
-    with pytest.raises(KeyError):
-        cluster.get("unknown_attribute", 123)
-
+    # Unknown attribute name returns the default
+    assert cluster.get("unknown_attribute", 123) == 123
     assert "unknown_attribute" not in cluster._attr_cache
 
     # Constant attribute can be read with `get`

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -466,9 +466,45 @@ async def test_item_access_attributes(cluster):
         # wrong key type
         cluster.get(None)
 
-    # Test access to cached attribute via wrong attr name
+    # Unknown attribute names return the default via `.get`
+    assert cluster.get("no_such_attribute") is None
+
+
+async def test_legacy_cache_access_via_get(cluster):
+    """Test that legacy cache values (unknown attribute IDs) are accessible via get."""
+
+    # Accessible via attribute ID
+    cluster._update_attribute(0x1234, "legacy_value")
+    assert cluster._attr_cache[0x1234] == "legacy_value"
+    assert cluster._attr_cache.get(0x1234) == "legacy_value"
+    assert cluster.get(0x1234) == "legacy_value"
+
+    # String keys do not fall back to legacy cache
     with pytest.raises(KeyError):
-        cluster.get("no_such_attribute")
+        cluster._attr_cache["no_such_attribute"]
+
+    assert cluster._attr_cache.get("no_such_attribute") is None
+    assert cluster.get("no_such_attribute") is None
+
+    # Missing legacy values still raise/return default
+    with pytest.raises(KeyError):
+        cluster._attr_cache[0xABCD]
+
+    assert cluster.get(0xABCD) is None
+    assert cluster._attr_cache.get(0xABCD, "fallback") == "fallback"
+
+
+async def test_cache_access_via_attr_def(cluster):
+    """Test that cache can be accessed via ZCLAttributeDef objects."""
+    cluster._attr_cache[Basic.AttributeDefs.model.id] = "model"
+
+    assert cluster.get(Basic.AttributeDefs.model) == "model"
+    assert cluster._attr_cache[Basic.AttributeDefs.model] == "model"
+    assert cluster._attr_cache.get(Basic.AttributeDefs.model) == "model"
+
+    # Missing attribute def returns default
+    assert cluster.get(Basic.AttributeDefs.manufacturer) is None
+    assert cluster._attr_cache.get(Basic.AttributeDefs.manufacturer, "x") == "x"
 
 
 async def test_write_attributes(cluster):

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -260,7 +260,11 @@ class CustomCluster(zigpy.zcl.Cluster):
             succeeded.extend(results[0])
         return [succeeded]
 
-    def get(self, key: int | str, default: typing.Any | None = None) -> typing.Any:
+    def get(
+        self,
+        key: int | str | foundation.ZCLAttributeDef,
+        default: typing.Any | None = None,
+    ) -> typing.Any:
         """Get cached attribute."""
 
         try:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1588,16 +1588,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
     def get_cached_value(self, key: int | str | foundation.ZCLAttributeDef) -> Any:
         """Get cached attribute."""
-        attr_def = self.find_attribute(key)
-        return self._attr_cache.get_value(attr_def)
+        return self._attr_cache[key]
 
-    def get(self, key: int | str, default: Any | None = None) -> Any:
+    def get(
+        self, key: int | str | foundation.ZCLAttributeDef, default: Any | None = None
+    ) -> Any:
         """Get cached attribute."""
-        attr_def = self.find_attribute(key)
-        try:
-            return self._attr_cache.get_value(attr_def)
-        except (KeyError, UnsupportedAttribute):
-            return default
+        return self._attr_cache.get(key, default=default)
 
     def __getitem__(self, key: int | str) -> Any:
         """Return cached value of the attr."""

--- a/zigpy/zcl/helpers.py
+++ b/zigpy/zcl/helpers.py
@@ -98,20 +98,23 @@ class AttributeCache:
             last_updated=datetime.now(UTC) if last_updated is None else last_updated,
         )
 
-    def get(self, key: int, default: Any | None = None) -> Any:
+    def get(self, key: int | str | ZCLAttributeDef, default: Any | None = None) -> Any:
         try:
             return self[key]
         except (KeyError, UnsupportedAttribute):
             return default
 
-    def __getitem__(self, key: int) -> Any:
+    def __getitem__(self, key: int | str | ZCLAttributeDef) -> Any:
         try:
-            return self.get_value(self._cluster.find_attribute(key))
+            attr_def = self._cluster.find_attribute(key)
         except KeyError:
             # Fall back to legacy cache for unknown attributes
-            if key in self._legacy_cache:
-                return self._legacy_cache[key].value
-            raise
+            if not isinstance(key, int):
+                raise
+
+            return self._legacy_cache[key].value
+        else:
+            return self.get_value(attr_def)
 
     def __setitem__(self, key: int, value: Any) -> None:
         attr_def = self._cluster.find_attribute(key)


### PR DESCRIPTION
The recent attribute cache consolidation/rewrite introduced [a regression](https://github.com/zigpy/zigpy/pull/1760#discussion_r2800974172): undefined attributes no longer could be accessed via `cluster.get`.

This PR fixes the behavior and aligns `.get()` with other methods that accept `int | str | ZCLAttributeDef` and updates it to correctly interface with the underlying attribute cache for the cluster.