### PR TITLE
Fix manufacturer attribute report updating standard ZCL cache

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -29,6 +29,7 @@ from zigpy.zcl import (
 )
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota
 from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.helpers import ReportingConfig
 
 DEFAULT_TSN = 123
@@ -314,6 +315,52 @@ def test_attribute_report(cluster):
     cluster.handle_message(hdr, cmd)
 
     assert cluster._attr_cache[4] == "manufacturer"
+
+
+def test_attribute_report_manufacturer_specific_does_not_update_zcl_attribute(
+    cluster_by_id,
+):
+    """Manufacturer-specific attribute report must not update a standard ZCL attribute.
+
+    A device reports attribute 0x0302 with manufacturer code 0x1015 on the Metering
+    cluster (0x0702). Even though 0x0302 is the standard ZCL "divisor" attribute, the
+    report is manufacturer-specific and should NOT update the standard divisor cache.
+    """
+    metering = cluster_by_id(Metering.cluster_id)
+
+    # Ensure divisor is not in the cache
+    assert Metering.AttributeDefs.divisor.id not in metering._attr_cache
+
+    attr = zcl.foundation.Attribute()
+    attr.attrid = 0x0302
+    attr.value = zcl.foundation.TypeValue()
+    attr.value.value = 0x0200
+
+    hdr = foundation.ZCLHeader(
+        frame_control=foundation.FrameControl(
+            frame_type=foundation.FrameType.GLOBAL_COMMAND,
+            is_manufacturer_specific=True,
+            direction=foundation.Direction.Server_to_Client,
+            disable_default_response=True,
+            reserved=0,
+        ),
+        manufacturer=0x1015,
+        tsn=3,
+        command_id=foundation.GeneralCommand.Report_Attributes,
+    )
+
+    cmd = foundation.GENERAL_COMMANDS[
+        foundation.GeneralCommand.Report_Attributes
+    ].schema([attr])
+    metering.handle_message(hdr, cmd)
+
+    # The standard ZCL divisor attribute's typed cache must NOT be updated
+    with pytest.raises(KeyError):
+        metering._attr_cache.get_value(Metering.AttributeDefs.divisor)
+
+    # The value should only be stored in the legacy cache (keyed by raw attr ID)
+    assert 0x0302 in metering._attr_cache._legacy_cache
+    assert metering._attr_cache._legacy_cache[0x0302].value == 0x0200
 
 
 def test_handle_request_unknown(cluster):

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -883,7 +883,10 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
                 if attr_def is None:
                     # Unknown attribute, update and emit reported event
-                    with _suppress_attribute_update_event(self.cluster_id, attr.attrid):
+                    with (
+                        _suppress_attribute_update_event(self.cluster_id, attr.attrid),
+                        _set_attribute_update_context(attr.attrid, hdr.manufacturer),
+                    ):
                         self._update_attribute(attr.attrid, value)
 
                     self.emit(


### PR DESCRIPTION
## Proposed change

This fixes an issue where manufacturer-specific attribute reports can update the cache with `manufacturer=None`.


## Additional information

This happens if a manufacturer-specific attribute report with an attribute ID of a ZCL attribute comes in and there's no matching definition for the manufacturer-specific attribute. For example, this can be seen on the Frient EMI Norwegian HAN.


### Impact

Due to the discovery of events fired for "unknown-def attribute reports" always having `attribute_name=None` (more info [here](https://github.com/zigpy/zha-device-handlers/pull/4749#issuecomment-3893984648)), I think this shouldn't break anything? At least nothing more than what's already broken. So far, it was only the Aqara FP1E sensor ([fix PR](https://github.com/zigpy/zha-device-handlers/pull/4749)).

 `_update_attribute` will still be called as usual. It's just that the attribute now correctly ends up in the legacy cache at the end, instead of the typed cache.

As we've not merged https://github.com/zigpy/zigpy/pull/1774, this does mean `cluster.get` can't be used to access these values that were (before this PR; incorrectly) inserted into the typed cache. But if we had ZHA entities defined for these attributes, they would have already stopped updating in ZHA, even without this PR (and did, e.g. Aqara FP1E: https://github.com/zigpy/zha-device-handlers/pull/4749).

### Alternative

IF we wanted to make sure we haven't already caused any breakage somewhere else (with entities not updating at the moment) because attribute reports come in and have a manufacturer code that doesn't match the attribute definition, I think the most technically correct solution would be to merge both this PR and the `cluster.get` fix PR (https://github.com/zigpy/zigpy/pull/1774).

We can add logging for everything that `cluster.get` accesses from the legacy cache, collect reports, fix any quirks with invalid manufacturer code definitions, and remove it in a month or so. If we do merge both in the meantime, it does mean that (e.g.) the Frient EMI Norwegian HAN still requires the workaround to be kept.

But the advantage of having this PR merged is that we no longer (incorrectly) insert mf-specific attribute values with `manufacturer=None` (mostly for Frient and Ubisys devices that report values on their own).

### How this fix works

Attribute reports handled in `handle_cluster_general_request` always use `find_attribute` with the manufacturer code of the attribute report. For the Frient HAN device (mf-bit set), no definition would be found here, so only this "legacy case" [here](https://github.com/zigpy/zigpy/blob/0ceeb47a324f911fda830e23312fd47a4162d136/zigpy/zcl/__init__.py#L861-L880) is called. So, `_update_attribute` then calls `find_attribute` again, but always without a manufacturer code in this case. So, for the Frient HAN device, it'll find the ZCL `divisor` attribute and incorrectly update the cache for that.

With https://github.com/zigpy/zigpy/pull/1760, we can now just also provide the manufacturer code context for `_update_attribute`, so it can make a better decision where to insert the attribute value. Now, it'll use the legacy cache, instead of incorrectly using the typed cache, for this Frient HAN device (and similar cases).

### Related PRs

- https://github.com/zigpy/zha-device-handlers/pull/4396 (original workaround preventing `divisor` attribute reports`)
- https://github.com/zigpy/zha-device-handlers/pull/4750 (pending removal of that workaround, relying on this PR)
- https://github.com/zigpy/zigpy/pull/1760#discussion_r2800974172 (comment for context)
- https://github.com/zigpy/zha-device-handlers/pull/4749#issuecomment-3893984648 (other comment for context)