### PR TITLE
Implement structured attribute reading and writing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -415,7 +415,7 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = "zigpy.types.struct"
 disable_error_code = [
-    "arg-type",  # 2
+    "arg-type",  # 3
     "attr-defined",  # 19
     "misc",  # 2
 ]
@@ -431,8 +431,8 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = "zigpy.zcl"
 disable_error_code = [
-    "arg-type",  # 14
-    "assignment",  # 6
+    "arg-type",  # 13
+    "assignment",  # 7
     "attr-defined",  # 3
     "misc",  # 3
 ]
@@ -457,19 +457,19 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
-module = "zigpy.zcl.foundation"
-disable_error_code = [
-    "arg-type",  # 29
-    "assignment",  # 18
-    "attr-defined",  # 6
-]
-
-[[tool.mypy.overrides]]
 module = "zigpy.quirks.v2"
 disable_error_code = [
     "arg-type",  # 34
     "assignment",  # 20
     "attr-defined",  # 1
+]
+
+[[tool.mypy.overrides]]
+module = "zigpy.zcl.foundation"
+disable_error_code = [
+    "arg-type",  # 28
+    "assignment",  # 21
+    "attr-defined",  # 9
 ]
 
 [[tool.mypy.overrides]]

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1050,6 +1050,10 @@ def test_struct_field_length_computed():
         == b"\x00"
     )
 
+    # Zero length with incongruent items array is an error
+    with pytest.raises(ValueError):
+        TestStruct(raw_count=0, items=[0x0001]).serialize()
+
     # Deserialization will fail if the exact number of elements isn't available
     with pytest.raises(ValueError):
         TestStruct.deserialize(s.serialize()[:-1])

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1038,3 +1038,26 @@ def test_struct_field_length_computed():
     assert s2.raw_count == 2
     assert list(s2.items) == [0x0001, 0x0002, 0x0003, 0x0004]
     assert remaining == b"tail"
+
+
+def test_struct_field_default(expose_global):
+    """Test that StructField `default` provides a default value for omitted fields."""
+
+    @expose_global
+    class Op(t.enum8):
+        Read = 0x0
+        Write = 0x1
+
+    class TestStruct(t.Struct):
+        value: t.uint8_t
+        op: Op = t.StructField(default=Op.Read)
+
+    # Omit op, should get default
+    s1 = TestStruct(value=0x42)
+    assert s1.op == Op.Read
+    assert s1.serialize() == b"\x42\x00"
+
+    # Provide op explicitly
+    s2 = TestStruct(value=0x42, op=Op.Write)
+    assert s2.op == Op.Write
+    assert s2.serialize() == b"\x42\x01"

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -949,3 +949,92 @@ def test_frozen_struct():
         frozen,
         frozen.replace(a=2),
     }
+
+
+def test_struct_field_length():
+    """Test that StructField `length` reads exactly N items from a List field."""
+
+    class TestStruct(t.Struct):
+        count: t.uint8_t
+        items: t.List[t.uint16_t] = t.StructField(length=lambda s: s.count)
+
+    s = TestStruct(count=3, items=[0x0001, 0x0002, 0x0003])
+    serialized = s.serialize()
+    assert serialized == b"\x03\x01\x00\x02\x00\x03\x00"
+
+    s2, remaining = TestStruct.deserialize(serialized + b"extra")
+    assert s2.count == 3
+    assert list(s2.items) == [0x0001, 0x0002, 0x0003]
+    assert remaining == b"extra"
+
+
+def test_struct_field_length_zero():
+    """Test that length=0 produces an empty list and consumes no data."""
+
+    class TestStruct(t.Struct):
+        count: t.uint8_t
+        items: t.List[t.uint16_t] = t.StructField(length=lambda s: s.count)
+
+    s = TestStruct(count=0, items=[])
+    serialized = s.serialize()
+    assert serialized == b"\x00"
+
+    s2, remaining = TestStruct.deserialize(serialized + b"\xff\xff")
+    assert s2.count == 0
+    assert list(s2.items) == []
+    assert remaining == b"\xff\xff"
+
+
+def test_struct_field_length_with_trailing_field():
+    """Test that length-limited List doesn't consume data needed by later fields."""
+
+    class TestStruct(t.Struct):
+        count: t.uint8_t
+        items: t.List[t.uint16_t] = t.StructField(length=lambda s: s.count)
+        trailer: t.uint8_t
+
+    s = TestStruct(count=2, items=[0x000A, 0x000B], trailer=0xFF)
+    serialized = s.serialize()
+    assert serialized == b"\x02\x0a\x00\x0b\x00\xff"
+
+    s2, remaining = TestStruct.deserialize(serialized + b"tail")
+    assert s2.count == 2
+    assert list(s2.items) == [0x000A, 0x000B]
+    assert s2.trailer == 0xFF
+    assert remaining == b"tail"
+
+
+def test_struct_field_length_with_bitfields():
+    """Test that length works with a bitfield count field."""
+
+    class TestStruct(t.Struct):
+        count: t.uint4_t
+        flags: t.uint4_t
+        items: t.List[t.uint16_t] = t.StructField(length=lambda s: s.count)
+
+    s = TestStruct(count=2, flags=0x0F, items=[0x1234, 0x5678])
+    serialized = s.serialize()
+    # Bitfields: count=2 (low nibble), flags=0xF (high nibble) => 0xF2
+    assert serialized == b"\xf2\x34\x12\x78\x56"
+
+    s2, remaining = TestStruct.deserialize(serialized + b"rest")
+    assert s2.count == 2
+    assert s2.flags == 0x0F
+    assert list(s2.items) == [0x1234, 0x5678]
+    assert remaining == b"rest"
+
+
+def test_struct_field_length_computed():
+    """Test that length lambda can compute a value from other fields."""
+
+    class TestStruct(t.Struct):
+        raw_count: t.uint8_t
+        items: t.List[t.uint16_t] = t.StructField(length=lambda s: s.raw_count * 2)
+
+    s = TestStruct(raw_count=2, items=[0x0001, 0x0002, 0x0003, 0x0004])
+    serialized = s.serialize()
+
+    s2, remaining = TestStruct.deserialize(serialized + b"tail")
+    assert s2.raw_count == 2
+    assert list(s2.items) == [0x0001, 0x0002, 0x0003, 0x0004]
+    assert remaining == b"tail"

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1039,6 +1039,31 @@ def test_struct_field_length_computed():
     assert list(s2.items) == [0x0001, 0x0002, 0x0003, 0x0004]
     assert remaining == b"tail"
 
+    with pytest.raises(ValueError):
+        # Not enough items provided
+        TestStruct(raw_count=2, items=[0x0001]).serialize()
+
+    # Zero is a special case
+    assert (
+        TestStruct(raw_count=0).serialize()
+        == TestStruct(raw_count=0, items=[]).serialize()
+        == b"\x00"
+    )
+
+    # Deserialization will fail if the exact number of elements isn't available
+    with pytest.raises(ValueError):
+        TestStruct.deserialize(s.serialize()[:-1])
+
+
+def test_struct_field_bad_type_derived_length() -> None:
+    """Test that structs cannot be created with non-List fields with lengths."""
+
+    with pytest.raises(TypeError):
+
+        class TestStruct(t.Struct):
+            count: t.uint8_t
+            items: t.uint16_t = t.StructField(length=lambda s: s.count)
+
 
 def test_struct_field_default(expose_global):
     """Test that StructField `default` provides a default value for omitted fields."""

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2588,3 +2588,94 @@ async def test_quirk_manufacturer_code_context_isolation(app_mock) -> None:
         raw_value=42,
         value=42,
     )
+
+
+async def test_read_attributes_structured_raw(cluster):
+    """Test read_attributes_structured_raw sends the correct request."""
+    mock_response = [
+        [
+            foundation.ReadAttributeRecord(
+                attrid=0x0001, status=foundation.Status.SUCCESS
+            )
+        ]
+    ]
+
+    with patch.object(
+        cluster.endpoint, "request", new=AsyncMock(return_value=mock_response)
+    ):
+        result = await cluster.read_attributes_structured_raw(
+            [
+                foundation.ReadAttributeStructured(
+                    attrid=0x0001,
+                    selector=foundation.Selector(depth=0),
+                ),
+            ]
+        )
+
+        assert result == mock_response
+        assert cluster.endpoint.request.call_count == 1
+
+        # Verify the serialized payload contains attr_id + selector
+        data = cluster.endpoint.request.mock_calls[0].kwargs["data"]
+        assert data[3:] == b"\x01\x00\x00"  # attr_id=0x0001 + indicator=0x00
+
+
+async def test_write_attributes_structured_raw(cluster):
+    """Test write_attributes_structured_raw sends the correct request."""
+    mock_response = [
+        foundation.WriteAttributesStructuredResponse(
+            [
+                foundation.WriteAttributesStructuredStatusRecord(
+                    status=foundation.Status.SUCCESS,
+                )
+            ]
+        )
+    ]
+
+    with patch.object(
+        cluster.endpoint, "request", new=AsyncMock(return_value=mock_response)
+    ):
+        result = await cluster.write_attributes_structured_raw(
+            [
+                foundation.WriteAttributeStructured(
+                    attrid=0x0001,
+                    selector=foundation.Selector(depth=0),
+                    value=foundation.TypeValue(
+                        type=foundation.DataTypeId.uint8,
+                        value=t.uint8_t(0x42),
+                    ),
+                ),
+            ]
+        )
+
+        assert result == mock_response
+        assert cluster.endpoint.request.call_count == 1
+
+
+async def test_read_attributes_structured_raw_nested(cluster):
+    """Test read_attributes_structured_raw with nested index selector."""
+    mock_response = [
+        [
+            foundation.ReadAttributeRecord(
+                attrid=0x0005, status=foundation.Status.SUCCESS
+            )
+        ]
+    ]
+
+    with patch.object(
+        cluster.endpoint, "request", new=AsyncMock(return_value=mock_response)
+    ):
+        result = await cluster.read_attributes_structured_raw(
+            [
+                foundation.ReadAttributeStructured(
+                    attrid=0x0005,
+                    selector=foundation.Selector(depth=2, indexes=[5, 3]),
+                ),
+            ]
+        )
+
+        assert result == mock_response
+
+        data = cluster.endpoint.request.mock_calls[0].kwargs["data"]
+        # attr_id=0x0005 + indicator=0x02 + index1=5 + index2=3
+        assert data[3:] == b"\x05\x00\x02\x05\x00\x03\x00"

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -836,3 +836,97 @@ def test_array():
     ]
 
     assert orig_data == hdr.serialize() + rsp.serialize()
+
+
+@pytest.mark.parametrize(
+    ("data", "depth", "op", "indexes"),
+    [
+        (b"\x00", 0, foundation.SelectorOperation.Write, []),
+        (b"\x02\x05\x00\x03\x00", 2, foundation.SelectorOperation.Write, [5, 3]),
+        (b"\x11\xab\xcd", 1, foundation.SelectorOperation.Add, [0xCDAB]),
+        (b"\x21\xab\xcd", 1, foundation.SelectorOperation.Remove, [0xCDAB]),
+    ],
+)
+def test_selector_deserialize(data, depth, op, indexes):
+    selector, rest = foundation.Selector.deserialize(data)
+    assert rest == b""
+    assert selector.depth == depth
+    assert selector.op == op
+    assert list(selector.indexes) == indexes
+    assert selector.serialize() == data
+
+
+def test_write_attrs_structured_response_deserialize():
+    """Test WriteAttributesStructuredResponse deserialization."""
+
+    # All success: single status byte
+    extra = b"\xaa\x55"
+    r, rest = foundation.WriteAttributesStructuredResponse.deserialize(b"\x00" + extra)
+    assert len(r) == 1
+    assert r[0].status == foundation.Status.SUCCESS
+    assert rest == extra
+
+    # Multiple failures: status(1) + attrid(2) + selector indicator(1) = 4 bytes each
+    data = (
+        b"\x86"  # UNSUPPORTED_ATTRIBUTE
+        b"\x34\x12"  # attrid=0x1234
+        b"\x00"  # selector: depth=0, op=Write
+        b"\x87"  # INVALID_VALUE
+        b"\x35\x12"  # attrid=0x1235
+        b"\x01\xab\xcd"  # selector: depth=1, op=Write, index=0xCDAB
+    )
+    r, rest = foundation.WriteAttributesStructuredResponse.deserialize(data + extra)
+    assert len(r) == 2
+    assert rest == extra
+    assert r[0].status == foundation.Status.UNSUPPORTED_ATTRIBUTE
+    assert r[0].attrid == 0x1234
+    assert r[0].selector.depth == 0
+    assert r[1].status == foundation.Status.INVALID_VALUE
+    assert r[1].attrid == 0x1235
+    assert r[1].selector.depth == 1
+    assert list(r[1].selector.indexes) == [0xCDAB]
+
+
+@pytest.mark.parametrize(
+    ("records", "data"),
+    [
+        # All success → single 0x00 byte
+        (
+            [
+                foundation.WriteAttributesStructuredStatusRecord(
+                    status=foundation.Status.SUCCESS,
+                ),
+            ],
+            b"\x00",
+        ),
+        # Single failure
+        (
+            [
+                foundation.WriteAttributesStructuredStatusRecord(
+                    status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
+                    attrid=0x1234,
+                    selector=foundation.Selector(depth=0),
+                ),
+            ],
+            b"\x86\x34\x12\x00",
+        ),
+        # Mixed: only failures serialized
+        (
+            [
+                foundation.WriteAttributesStructuredStatusRecord(
+                    status=foundation.Status.SUCCESS,
+                ),
+                foundation.WriteAttributesStructuredStatusRecord(
+                    status=foundation.Status.INVALID_VALUE,
+                    attrid=0x0001,
+                    selector=foundation.Selector(depth=1, indexes=[0x0002]),
+                ),
+            ],
+            b"\x87\x01\x00\x01\x02\x00",
+        ),
+    ],
+)
+def test_write_attrs_structured_response_serialize(records, data):
+    """Test WriteAttributesStructuredResponse serialization."""
+    r = foundation.WriteAttributesStructuredResponse(records)
+    assert r.serialize() == data

--- a/zigpy/types/basic.py
+++ b/zigpy/types/basic.py
@@ -1050,13 +1050,18 @@ class List(list, Generic[_T], metaclass=KwargTypeMeta):
         return b"".join([self._item_type(i).serialize() for i in self])
 
     @classmethod
-    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
+    def deserialize(
+        cls, data: bytes, *, count: int | None = None
+    ) -> tuple[Self, bytes]:
         assert cls._item_type is not None
         lst = cls()
 
-        while data:
+        while data and (len(lst) < count if count is not None else True):
             item, data = cls._item_type.deserialize(data)
             lst.append(item)
+
+        if count is not None and len(lst) != count:
+            raise ValueError(f"Expected {count} items, got {len(lst)}")
 
         return lst, data
 

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -40,6 +40,7 @@ class StructField:
     length: typing.Callable[[Struct], int] | None = dataclasses.field(
         default=None, repr=False
     )
+    default: Any = dataclasses.field(default=None, repr=False)
 
     repr: typing.Callable[[typing.Any], str] | None = dataclasses.field(
         default=repr, repr=False
@@ -91,7 +92,7 @@ class Struct:
                 inspect.Parameter(
                     name=f.name,
                     kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    default=None,
+                    default=f.default,
                     annotation=f.type,
                 )
                 for f in cls.fields

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -283,6 +283,12 @@ class Struct:
                 expected_length = field.length(self)
 
                 if expected_length == 0:
+                    if value:
+                        raise ValueError(
+                            f"Field {field.name!r} expected an empty array,"
+                            f" got: {value!r}"
+                        )
+
                     # Special case for a list with no elements
                     value = field._convert_type([])
                 elif value is None or len(value) != expected_length:

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -37,6 +37,9 @@ class StructField:
         default=None, repr=False
     )
     optional: bool | None = False
+    length: typing.Callable[[Struct], int] | None = dataclasses.field(
+        default=None, repr=False
+    )
 
     repr: typing.Callable[[typing.Any], str] | None = dataclasses.field(
         default=repr, repr=False
@@ -338,7 +341,18 @@ class Struct:
                     f" {bitfields}"
                 )
 
-            value, data = field.type.deserialize(data)
+            if field.length is not None:
+                count = field.length(temp_instance)
+                items = []
+
+                for _ in range(count):
+                    item, data = field.type._item_type.deserialize(data)
+                    items.append(item)
+
+                value = field.type(items)
+            else:
+                value, data = field.type.deserialize(data)
+
             result[field.name] = value
             setattr(temp_instance, field.name, value)
 

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -200,7 +200,10 @@ class Struct:
 
             # Missing fields cause an error if strict
             if value is None and not field.optional:
-                if strict:
+                if field.length is not None:
+                    value = field.type()
+                    setattr(self, field.name, value)
+                elif strict:
                     raise ValueError(
                         f"Value for field {field.name!r} is required: {self!r}"
                     )

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -69,8 +69,15 @@ if TYPE_CHECKING:
 
         name: str
         type: type[Any]
+
+    class ResolvedArrayStructField(ResolvedStructField):
+        """`StructField` instance with name, type, and length resolved."""
+
+        type: type[t.List[Any]]
+        length: typing.Callable[[Struct], int]
 else:
     ResolvedStructField = StructField
+    ResolvedArrayStructField = StructField
 
 
 class Struct:
@@ -181,8 +188,18 @@ class Struct:
             elif field.type is None:
                 raise TypeError(f"Field {name!r} has no type")
 
-            fields.append(cast(ResolvedStructField, field))
-            setattr(fields, field.name, field)
+            resolved_field = cast(ResolvedStructField, field)
+
+            if resolved_field.length is not None and not issubclass(
+                resolved_field.type, t.List
+            ):
+                raise TypeError(
+                    f"Field {name!r} has a length function but is not a list type: "
+                    f"{resolved_field.type}"
+                )
+
+            fields.append(resolved_field)
+            setattr(fields, field.name, resolved_field)
 
         return fields
 
@@ -199,11 +216,8 @@ class Struct:
                 continue
 
             # Missing fields cause an error if strict
-            if value is None and not field.optional:
-                if field.length is not None:
-                    value = field.type()
-                    setattr(self, field.name, value)
-                elif strict:
+            if value is None and not field.optional and field.length is None:
+                if strict:
                     raise ValueError(
                         f"Value for field {field.name!r} is required: {self!r}"
                     )
@@ -263,6 +277,19 @@ class Struct:
                 continue
 
             value = field._convert_type(value)
+
+            # Fields with lengths dependent on other fields need to be validated
+            if field.length is not None:
+                expected_length = field.length(self)
+
+                if expected_length == 0:
+                    # Special case for a list with no elements
+                    value = field._convert_type([])
+                elif value is None or len(value) != expected_length:
+                    raise ValueError(
+                        f"Field {field.name!r} expected an array with length"
+                        f" {expected_length}, got: {value!r}"
+                    )
 
             # All integral types are compacted into one chunk, unless they start and end
             # on a byte boundary.
@@ -346,13 +373,10 @@ class Struct:
                 )
 
             if field.length is not None:
+                field = cast(ResolvedArrayStructField, field)
+
                 count = field.length(temp_instance)
-                items = []
-
-                for _ in range(count):
-                    item, data = field.type._item_type.deserialize(data)
-                    items.append(item)
-
+                items, data = field.type.deserialize(data, count=count)
                 value = field.type(items)
             else:
                 value, data = field.type.deserialize(data)

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1242,7 +1242,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         attributes: list[foundation.Attribute],
         manufacturer_code: int | None = None,
         **kwargs,
-    ) -> list[foundation.WriteAttributesResponse]:
+    ) -> foundation.WriteAttributesResponseSchema | foundation.DefaultResponse:
         """Write attributes to the device without any validation or caching."""
         return await self._write_attributes(
             attributes, manufacturer=manufacturer_code, **kwargs
@@ -1382,7 +1382,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         attributes: list[foundation.ReadAttributeStructured],
         manufacturer_code: int | None = None,
         **kwargs,
-    ) -> list[foundation.ReadAttributeRecord]:
+    ) -> foundation.ReadAttributesResponse | foundation.DefaultResponse:
         """Read attributes (structured) from the device."""
         return await self._read_attributes_structured(
             attributes, manufacturer=manufacturer_code, **kwargs
@@ -1393,7 +1393,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         attributes: list[foundation.WriteAttributeStructured],
         manufacturer_code: int | None = None,
         **kwargs,
-    ) -> foundation.WriteAttributesStructuredResponse:
+    ) -> (
+        foundation.WriteAttributesStructuredResponseSchema | foundation.DefaultResponse
+    ):
         """Write attributes (structured) to the device."""
         return await self._write_attributes_structured(
             attributes, manufacturer=manufacturer_code, **kwargs

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1237,6 +1237,17 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     "attribute_updated", attrid, value, datetime.now(UTC)
                 )
 
+    async def write_attributes_raw(
+        self,
+        attributes: list[foundation.Attribute],
+        manufacturer_code: int | None = None,
+        **kwargs,
+    ) -> list[foundation.WriteAttributesResponse]:
+        """Write attributes to the device without any validation or caching."""
+        return await self._write_attributes(
+            attributes, manufacturer=manufacturer_code, **kwargs
+        )
+
     async def write_attributes(
         self,
         attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
@@ -1274,7 +1285,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 zcl_attr.value.value = attr_def.type(value)
                 zcl_attrs.append(zcl_attr)
 
-            result = await self._write_attributes(
+            result = await self.write_attributes_raw(
                 zcl_attrs, manufacturer=manufacturer_code, **kwargs
             )
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1286,7 +1286,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 zcl_attrs.append(zcl_attr)
 
             result = await self.write_attributes_raw(
-                zcl_attrs, manufacturer=manufacturer_code, **kwargs
+                zcl_attrs, manufacturer_code=manufacturer_code, **kwargs
             )
 
             records_group: list[foundation.WriteAttributesStatusRecord] = []

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1377,6 +1377,28 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         # TODO: ditch the low-level return type
         return [results]
 
+    async def read_attributes_structured_raw(
+        self,
+        attributes: list[foundation.ReadAttributeStructured],
+        manufacturer_code: int | None = None,
+        **kwargs,
+    ) -> list[foundation.ReadAttributeRecord]:
+        """Read attributes (structured) from the device."""
+        return await self._read_attributes_structured(
+            attributes, manufacturer=manufacturer_code, **kwargs
+        )
+
+    async def write_attributes_structured_raw(
+        self,
+        attributes: list[foundation.WriteAttributeStructured],
+        manufacturer_code: int | None = None,
+        **kwargs,
+    ) -> foundation.WriteAttributesStructuredResponse:
+        """Write attributes (structured) to the device."""
+        return await self._write_attributes_structured(
+            attributes, manufacturer=manufacturer_code, **kwargs
+        )
+
     async def bind(self, **kwargs):
         return await self._endpoint.device.zdo.bind(cluster=self, **kwargs)
 
@@ -1692,6 +1714,12 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
     )
     _write_attributes = functools.partialmethod(
         general_command, foundation.GeneralCommand.Write_Attributes
+    )
+    _read_attributes_structured = functools.partialmethod(
+        general_command, foundation.GeneralCommand.Read_Attributes_Structured
+    )
+    _write_attributes_structured = functools.partialmethod(
+        general_command, foundation.GeneralCommand.Write_Attributes_Structured
     )
     discover_attributes = functools.partialmethod(
         general_command, foundation.GeneralCommand.Discover_Attributes

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -972,8 +972,7 @@ class ReadAttributeStructured(t.Struct):
 class WriteAttributeStructured(t.Struct):
     attrid: t.uint16_t
     selector: Selector
-    datatype: DataTypeId
-    value: typing.Any
+    value: TypeValue
 
 
 class WriteAttributesStructuredStatusRecord(t.Struct):

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -950,16 +950,28 @@ class DiscoverAttributesExtendedResponseRecord(t.Struct):
     acl: AttributeAccessControl
 
 
+class SelectorOperation(t.enum4):
+    Write = 0x0
+    Add = 0x1
+    Remove = 0x2
+
+
+class Selector(t.Struct):
+    """ZCL attribute selector for structured read/write commands."""
+
+    depth: t.uint4_t
+    op: SelectorOperation = t.StructField(default=SelectorOperation.Write)
+    indexes: t.List[t.uint16_t] = t.StructField(length=lambda s: s.depth)
+
+
 class ReadAttributeStructured(t.Struct):
     attrid: t.uint16_t
-    # `selector` combines "indicator" + "index"
-    selector: t.LVList[t.uint16_t, t.uint8_t]
+    selector: Selector
 
 
 class WriteAttributeStructured(t.Struct):
     attrid: t.uint16_t
-    # `selector` combines "indicator" + "index"
-    selector: t.LVList[t.uint16_t, t.uint8_t]
+    selector: Selector
     datatype: DataTypeId
     value: typing.Any
 
@@ -969,9 +981,7 @@ class WriteAttributesStructuredStatusRecord(t.Struct):
     attrid: t.uint16_t = t.StructField(
         requires=lambda s: s.status != Status.SUCCESS, repr=_hex_uint16_repr
     )
-    selector: t.LVList[t.uint16_t, t.uint8_t] = t.StructField(
-        requires=lambda s: s.status != Status.SUCCESS
-    )
+    selector: Selector = t.StructField(requires=lambda s: s.status != Status.SUCCESS)
 
 
 class WriteAttributesStructuredResponse(list):

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -964,6 +964,45 @@ class StructuredAttributeWrite(t.Struct):
     value: typing.Any
 
 
+class WriteAttributesStructuredStatusRecord(t.Struct):
+    status: Status
+    attrid: t.uint16_t = t.StructField(
+        requires=lambda s: s.status != Status.SUCCESS, repr=_hex_uint16_repr
+    )
+    selector: t.LVList[t.uint16_t, t.uint8_t] = t.StructField(
+        requires=lambda s: s.status != Status.SUCCESS
+    )
+
+
+class StructuredAttributesWriteResponse(list):
+    """Write Attributes Structured response list.
+
+    Response to Write Attributes Structured request should contain only success status,
+    in case when all attributes were successfully written or list of status + attr_id
+    records for all failed writes.
+    """
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
+        record, data = WriteAttributesStructuredStatusRecord.deserialize(data)
+        r = cls([record])
+        if record.status == Status.SUCCESS:
+            return r, data
+
+        while len(data) >= 3:
+            record, data = WriteAttributesStructuredStatusRecord.deserialize(data)
+            r.append(record)
+        return r, data
+
+    def serialize(self) -> bytes:
+        failed = [record for record in self if record.status != Status.SUCCESS]
+        if failed:
+            return b"".join(
+                [WriteAttributesStructuredStatusRecord(i).serialize() for i in failed]
+            )
+        return Status.SUCCESS.serialize()
+
+
 class FrameType(t.enum2):
     """ZCL Frame Type."""
 
@@ -1356,7 +1395,7 @@ class GeneralCommand(t.enum8):
     Discover_Attributes_rsp = 0x0D
     Read_Attributes_Structured = 0x0E
     Write_Attributes_Structured = 0x0F
-    # Write_Attributes_Structured_rsp = 0x10
+    Write_Attributes_Structured_rsp = 0x10
     Discover_Commands_Received = 0x11
     Discover_Commands_Received_rsp = 0x12
     Discover_Commands_Generated = 0x13
@@ -1430,7 +1469,10 @@ GENERAL_COMMANDS = COMMANDS = {
         schema={"attributes": t.List[StructuredAttributeWrite]},
         direction=Direction.Client_to_Server,
     ),
-    # Command.Write_Attributes_Structured_rsp: ZCLCommandDef(schema=(, ), direction=Direction.Server_to_Client),
+    GeneralCommand.Write_Attributes_Structured_rsp: ZCLCommandDef(
+        schema={"status_records": StructuredAttributesWriteResponse},
+        direction=Direction.Server_to_Client,
+    ),
     GeneralCommand.Discover_Commands_Received: ZCLCommandDef(
         schema={"start_command_id": t.uint8_t, "max_command_ids": t.uint8_t},
         direction=Direction.Client_to_Server,

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -950,6 +950,12 @@ class DiscoverAttributesExtendedResponseRecord(t.Struct):
     acl: AttributeAccessControl
 
 
+class StructuredAttributeRead(t.Struct):
+    attrid: t.uint16_t
+    # `selector` combines "indicator" + "index"
+    selector: t.LVList[t.uint16_t, t.uint8_t]
+
+
 class FrameType(t.enum2):
     """ZCL Frame Type."""
 
@@ -1340,7 +1346,7 @@ class GeneralCommand(t.enum8):
     Default_Response = 0x0B
     Discover_Attributes = 0x0C
     Discover_Attributes_rsp = 0x0D
-    # Read_Attributes_Structured = 0x0e
+    Read_Attributes_Structured = 0x0E
     # Write_Attributes_Structured = 0x0f
     # Write_Attributes_Structured_rsp = 0x10
     Discover_Commands_Received = 0x11
@@ -1408,7 +1414,10 @@ GENERAL_COMMANDS = COMMANDS = {
         },
         direction=Direction.Server_to_Client,
     ),
-    # Command.Read_Attributes_Structured: ZCLCommandDef(schema=(, ), direction=Direction.Client_to_Server),
+    GeneralCommand.Read_Attributes_Structured: ZCLCommandDef(
+        schema={"attributes": t.List[StructuredAttributeRead]},
+        direction=Direction.Client_to_Server,
+    ),
     # Command.Write_Attributes_Structured: ZCLCommandDef(schema=(, ), direction=Direction.Client_to_Server),
     # Command.Write_Attributes_Structured_rsp: ZCLCommandDef(schema=(, ), direction=Direction.Server_to_Client),
     GeneralCommand.Discover_Commands_Received: ZCLCommandDef(

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -950,13 +950,13 @@ class DiscoverAttributesExtendedResponseRecord(t.Struct):
     acl: AttributeAccessControl
 
 
-class StructuredAttributeRead(t.Struct):
+class ReadAttributeStructured(t.Struct):
     attrid: t.uint16_t
     # `selector` combines "indicator" + "index"
     selector: t.LVList[t.uint16_t, t.uint8_t]
 
 
-class StructuredAttributeWrite(t.Struct):
+class WriteAttributeStructured(t.Struct):
     attrid: t.uint16_t
     # `selector` combines "indicator" + "index"
     selector: t.LVList[t.uint16_t, t.uint8_t]
@@ -974,7 +974,7 @@ class WriteAttributesStructuredStatusRecord(t.Struct):
     )
 
 
-class StructuredAttributesWriteResponse(list):
+class WriteAttributesStructuredResponse(list):
     """Write Attributes Structured response list.
 
     Response to Write Attributes Structured request should contain only success status,
@@ -1462,15 +1462,15 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Read_Attributes_Structured: ZCLCommandDef(
-        schema={"attributes": t.List[StructuredAttributeRead]},
+        schema={"attributes": t.List[ReadAttributeStructured]},
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Write_Attributes_Structured: ZCLCommandDef(
-        schema={"attributes": t.List[StructuredAttributeWrite]},
+        schema={"attributes": t.List[WriteAttributeStructured]},
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Write_Attributes_Structured_rsp: ZCLCommandDef(
-        schema={"status_records": StructuredAttributesWriteResponse},
+        schema={"status_records": WriteAttributesStructuredResponse},
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Discover_Commands_Received: ZCLCommandDef(

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -989,7 +989,7 @@ class WriteAttributesStructuredResponse(list):
         if record.status == Status.SUCCESS:
             return r, data
 
-        while len(data) >= 3:
+        while len(data) >= 4:
             record, data = WriteAttributesStructuredStatusRecord.deserialize(data)
             r.append(record)
         return r, data

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1273,6 +1273,23 @@ class CommandSchema(t.Struct, tuple):  # noqa: SLOT001, PLW1641
         return super().__eq__(other)
 
 
+class ReadAttributesResponse(CommandSchema):
+    status_records: t.List[ReadAttributeRecord]
+
+
+class WriteAttributesResponseSchema(CommandSchema):
+    status_records: WriteAttributesResponse
+
+
+class WriteAttributesStructuredResponseSchema(CommandSchema):
+    status_records: WriteAttributesStructuredResponse
+
+
+class DefaultResponse(CommandSchema):
+    command_id: t.uint8_t
+    status: Status
+
+
 class ZCLAttributeAccess(enum.Flag):
     NONE = 0
     Read = 1
@@ -1419,7 +1436,7 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Read_Attributes_rsp: ZCLCommandDef(
-        schema={"status_records": t.List[ReadAttributeRecord]},
+        schema=ReadAttributesResponse,
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Write_Attributes: ZCLCommandDef(
@@ -1429,7 +1446,7 @@ GENERAL_COMMANDS = COMMANDS = {
         schema={"attributes": t.List[Attribute]}, direction=Direction.Client_to_Server
     ),
     GeneralCommand.Write_Attributes_rsp: ZCLCommandDef(
-        schema={"status_records": WriteAttributesResponse},
+        schema=WriteAttributesResponseSchema,
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Write_Attributes_No_Response: ZCLCommandDef(
@@ -1456,7 +1473,7 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Default_Response: ZCLCommandDef(
-        schema={"command_id": t.uint8_t, "status": Status},
+        schema=DefaultResponse,
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Discover_Attributes: ZCLCommandDef(
@@ -1479,7 +1496,7 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Write_Attributes_Structured_rsp: ZCLCommandDef(
-        schema={"status_records": WriteAttributesStructuredResponse},
+        schema=WriteAttributesStructuredResponseSchema,
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Discover_Commands_Received: ZCLCommandDef(

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -956,6 +956,14 @@ class StructuredAttributeRead(t.Struct):
     selector: t.LVList[t.uint16_t, t.uint8_t]
 
 
+class StructuredAttributeWrite(t.Struct):
+    attrid: t.uint16_t
+    # `selector` combines "indicator" + "index"
+    selector: t.LVList[t.uint16_t, t.uint8_t]
+    datatype: DataTypeId
+    value: typing.Any
+
+
 class FrameType(t.enum2):
     """ZCL Frame Type."""
 
@@ -1347,7 +1355,7 @@ class GeneralCommand(t.enum8):
     Discover_Attributes = 0x0C
     Discover_Attributes_rsp = 0x0D
     Read_Attributes_Structured = 0x0E
-    # Write_Attributes_Structured = 0x0f
+    Write_Attributes_Structured = 0x0F
     # Write_Attributes_Structured_rsp = 0x10
     Discover_Commands_Received = 0x11
     Discover_Commands_Received_rsp = 0x12
@@ -1418,7 +1426,10 @@ GENERAL_COMMANDS = COMMANDS = {
         schema={"attributes": t.List[StructuredAttributeRead]},
         direction=Direction.Client_to_Server,
     ),
-    # Command.Write_Attributes_Structured: ZCLCommandDef(schema=(, ), direction=Direction.Client_to_Server),
+    GeneralCommand.Write_Attributes_Structured: ZCLCommandDef(
+        schema={"attributes": t.List[StructuredAttributeWrite]},
+        direction=Direction.Client_to_Server,
+    ),
     # Command.Write_Attributes_Structured_rsp: ZCLCommandDef(schema=(, ), direction=Direction.Server_to_Client),
     GeneralCommand.Discover_Commands_Received: ZCLCommandDef(
         schema={"start_command_id": t.uint8_t, "max_command_ids": t.uint8_t},


### PR DESCRIPTION
We've finally run across a device that requires this functionality!

I've extended `t.Struct` with a few new features:
- `StructField(length=lambda s: s.other_field)`, which allows array fields to have a length depend on earlier fields.
- `StructField(default=123)`, giving default values to fields.

This allows the complex operations encoded in the `Selector` object be relatively straightforward to use. These operations are rarely used so they are exposed as low-level `_raw` cluster methods:

- `read_attributes_structured_raw`
- `write_attributes_structured_raw`
- `write_attributes_raw` (this should have existed already)