### PR TITLE
Raise `InvalidDefaultResponse` on unsuccessful default response

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -435,7 +435,6 @@ disable_error_code = [
     "arg-type",  # 13
     "assignment",  # 7
     "attr-defined",  # 3
-    "misc",  # 3
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -414,19 +414,19 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
-module = "zigpy.zcl"
-disable_error_code = [
-    "arg-type",  # 13
-    "assignment",  # 7
-    "attr-defined",  # 3
-]
-
-[[tool.mypy.overrides]]
 module = "zigpy.types.struct"
 disable_error_code = [
     "arg-type",  # 3
     "attr-defined",  # 19
     "misc",  # 2
+]
+
+[[tool.mypy.overrides]]
+module = "zigpy.zcl"
+disable_error_code = [
+    "arg-type",  # 13
+    "assignment",  # 7
+    "attr-defined",  # 4
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,7 +321,7 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = "zigpy.quirks"
 disable_error_code = [
-    "arg-type",  # 2
+    "arg-type",  # 3
     "attr-defined",  # 2
 ]
 
@@ -414,6 +414,14 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
+module = "zigpy.zcl"
+disable_error_code = [
+    "arg-type",  # 13
+    "assignment",  # 7
+    "attr-defined",  # 3
+]
+
+[[tool.mypy.overrides]]
 module = "zigpy.types.struct"
 disable_error_code = [
     "arg-type",  # 3
@@ -427,14 +435,6 @@ disable_error_code = [
     "assignment",  # 18
     "attr-defined",  # 6
     "misc",  # 1
-]
-
-[[tool.mypy.overrides]]
-module = "zigpy.zcl"
-disable_error_code = [
-    "arg-type",  # 13
-    "assignment",  # 7
-    "attr-defined",  # 3
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,7 +321,7 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = "zigpy.quirks"
 disable_error_code = [
-    "arg-type",  # 3
+    "arg-type",  # 2
     "attr-defined",  # 2
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -414,19 +414,19 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
+module = "zigpy.zcl"
+disable_error_code = [
+    "arg-type",  # 13
+    "assignment",  # 7
+    "attr-defined",  # 3
+]
+
+[[tool.mypy.overrides]]
 module = "zigpy.types.struct"
 disable_error_code = [
     "arg-type",  # 3
     "attr-defined",  # 19
     "misc",  # 2
-]
-
-[[tool.mypy.overrides]]
-module = "zigpy.zcl"
-disable_error_code = [
-    "arg-type",  # 13
-    "assignment",  # 7
-    "attr-defined",  # 4
 ]
 
 [[tool.mypy.overrides]]
@@ -457,19 +457,19 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
+module = "zigpy.zcl.foundation"
+disable_error_code = [
+    "arg-type",  # 22
+    "assignment",  # 21
+    "attr-defined",  # 9
+]
+
+[[tool.mypy.overrides]]
 module = "zigpy.quirks.v2"
 disable_error_code = [
     "arg-type",  # 34
     "assignment",  # 20
     "attr-defined",  # 1
-]
-
-[[tool.mypy.overrides]]
-module = "zigpy.zcl.foundation"
-disable_error_code = [
-    "arg-type",  # 28
-    "assignment",  # 21
-    "attr-defined",  # 9
 ]
 
 [[tool.mypy.overrides]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -395,6 +395,8 @@ def verify_cleanup() -> typing.Generator[None, None, None]:
 def mock_attribute_reads(
     cluster: Cluster,
     mock_attributes: dict[str | int | foundation.ZCLAttributeDef, typing.Any],
+    *,
+    rsp: foundation.CommandSchema | None = None,
 ) -> typing.Generator[
     tuple[AsyncMock, dict[str | int | foundation.ZCLAttributeDef, AsyncMock]],
     None,
@@ -415,6 +417,9 @@ def mock_attribute_reads(
         manufacturer: int | UndefinedType | None = UNDEFINED,
         **kwargs,
     ):
+        if rsp is not None:
+            return rsp
+
         status_records = []
 
         for attrid in attributes:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2475,3 +2475,58 @@ async def test_request_retry_delay_releases_concurrency(app) -> None:
         # Tear down the still-pending requests so the task group can exit
         for task in tasks:
             task.cancel()
+
+
+async def test_request_error_default_response(app) -> None:
+    """An unsuccessful default response is raised to the caller."""
+    tsn = 0x12
+
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
+    dev.node_desc = make_node_desc()
+
+    ep = dev.add_endpoint(1)
+    ep.status = endpoint.Status.ZDO_INIT
+    ep.add_input_cluster(Basic.cluster_id)
+
+    def send_packet(*args, **kwargs) -> None:
+        asyncio.get_running_loop().call_soon(
+            dev.packet_received,
+            t.ZigbeePacket(
+                profile_id=260,
+                cluster_id=Basic.cluster_id,
+                src_ep=1,
+                dst_ep=1,
+                data=t.SerializableBytes(
+                    foundation.ZCLHeader(
+                        frame_control=foundation.FrameControl(
+                            frame_type=foundation.FrameType.GLOBAL_COMMAND,
+                            is_manufacturer_specific=False,
+                            direction=foundation.Direction.Server_to_Client,
+                            disable_default_response=True,
+                            reserved=0,
+                        ),
+                        tsn=tsn,
+                        command_id=foundation.GeneralCommand.Default_Response,
+                        manufacturer=None,
+                    ).serialize()
+                    + foundation.DefaultResponse(
+                        command_id=Basic.ServerCommandDefs.reset_fact_default.id,
+                        status=foundation.Status.UNSUP_GENERAL_COMMAND,
+                    ).serialize()
+                ),
+                src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+                dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+            ),
+        )
+
+    app.send_packet.side_effect = send_packet
+    dev.get_sequence = MagicMock(return_value=tsn)
+
+    with pytest.raises(zigpy.exceptions.InvalidDefaultResponse) as exc_info:
+        await dev.endpoints[1].basic.reset_fact_default()
+
+    assert exc_info.value.status == foundation.Status.UNSUP_GENERAL_COMMAND
+    assert exc_info.value.command_id == Basic.ServerCommandDefs.reset_fact_default.id
+
+    # A definitive error response from the device must not be retried
+    assert len(app.send_packet.mock_calls) == 1

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -261,51 +261,6 @@ async def test_get_model_info_missing_basic_cluster(ep):
     assert manuf is None
 
 
-async def test_init_endpoint_info_null_padded_manuf(ep):
-    basic = ep.add_input_cluster(0)
-    with mock_attribute_reads(
-        basic,
-        {
-            "manufacturer": b"Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07",
-            "model": b"Mock Model",
-        },
-    ):
-        mod, man = await ep.get_model_info()
-
-    assert man == "Mock Manufacturer"
-    assert mod == "Mock Model"
-
-
-async def test_init_endpoint_info_null_padded_model(ep):
-    basic = ep.add_input_cluster(0)
-    with mock_attribute_reads(
-        basic,
-        {
-            "manufacturer": b"Mock Manufacturer",
-            "model": b"Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-        },
-    ):
-        mod, man = await ep.get_model_info()
-
-    assert man == "Mock Manufacturer"
-    assert mod == "Mock Model"
-
-
-async def test_init_endpoint_info_null_padded_manuf_model(ep):
-    basic = ep.add_input_cluster(0)
-    with mock_attribute_reads(
-        basic,
-        {
-            "manufacturer": b"Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07",
-            "model": b"Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-        },
-    ):
-        mod, man = await ep.get_model_info()
-
-    assert man == "Mock Manufacturer"
-    assert mod == "Mock Model"
-
-
 async def test_get_model_info_delivery_error(ep):
     basic = ep.add_input_cluster(0)
     with pytest.raises(zigpy.exceptions.ZigbeeException):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -3,10 +3,10 @@ from unittest.mock import AsyncMock, MagicMock, call, patch, sentinel
 
 import pytest
 
+from tests.conftest import mock_attribute_reads
 from zigpy import endpoint, group, zcl
 import zigpy.device
 import zigpy.exceptions
-import zigpy.types as t
 from zigpy.zcl.foundation import GENERAL_COMMANDS, GeneralCommand, Status as ZCLStatus
 from zigpy.zdo import types
 
@@ -222,68 +222,31 @@ async def test_reply_change_profile_id(ep):
     ]
 
 
-def _get_model_info(ep, attributes={}):
-    clus = ep.add_input_cluster(0)
-    assert 0 in ep.in_clusters
-    assert ep.in_clusters[0] is clus
-
-    async def mockrequest(
-        foundation, command, schema, args, manufacturer=None, **kwargs
-    ):
-        assert foundation is True
-        assert command == 0
-
-        result = []
-
-        for attr_id, value in zip(args, attributes[tuple(args)], strict=True):
-            if isinstance(value, BaseException):
-                raise value
-
-            if value is None:
-                rar = zcl.foundation.ReadAttributeRecord(
-                    attrid=attr_id,
-                    status=zcl.foundation.Status.FAILURE,
-                )
-            else:
-                rar = zcl.foundation.ReadAttributeRecord(
-                    attrid=attr_id,
-                    status=zcl.foundation.Status.SUCCESS,
-                    value=zcl.foundation.TypeValue(
-                        type=zcl.foundation.DataTypeId.string,
-                        value=t.CharacterString(value),
-                    ),
-                )
-
-            result.append(rar)
-
-        return zcl.foundation.ReadAttributesResponse(status_records=result)
-
-    clus.request = mockrequest
-
-    return ep.get_model_info()
-
-
 async def test_get_model_info(ep):
-    mod, man = await _get_model_info(
-        ep,
-        attributes={
-            (0x0004, 0x0005): (b"Mock Manufacturer", b"Mock Model"),
+    basic = ep.add_input_cluster(0)
+    with mock_attribute_reads(
+        basic,
+        {
+            "manufacturer": "Mock Manufacturer",
+            "model": "Mock Model",
         },
-    )
+    ):
+        mod, man = await ep.get_model_info()
 
     assert man == "Mock Manufacturer"
     assert mod == "Mock Model"
 
 
 async def test_init_endpoint_info_none(ep):
-    mod, man = await _get_model_info(
-        ep,
-        attributes={
-            (0x0004, 0x0005): (None, None),
-            (0x0004,): (None,),
-            (0x0005,): (None,),
+    basic = ep.add_input_cluster(0)
+    with mock_attribute_reads(
+        basic,
+        {
+            "manufacturer": None,
+            "model": None,
         },
-    )
+    ):
+        mod, man = await ep.get_model_info()
 
     assert man is None
     assert mod is None
@@ -299,86 +262,91 @@ async def test_get_model_info_missing_basic_cluster(ep):
 
 
 async def test_init_endpoint_info_null_padded_manuf(ep):
-    mod, man = await _get_model_info(
-        ep,
-        attributes={
-            (0x0004, 0x0005): (
-                b"Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07",
-                b"Mock Model",
-            ),
+    basic = ep.add_input_cluster(0)
+    with mock_attribute_reads(
+        basic,
+        {
+            "manufacturer": b"Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07",
+            "model": b"Mock Model",
         },
-    )
+    ):
+        mod, man = await ep.get_model_info()
 
     assert man == "Mock Manufacturer"
     assert mod == "Mock Model"
 
 
 async def test_init_endpoint_info_null_padded_model(ep):
-    mod, man = await _get_model_info(
-        ep,
-        attributes={
-            (0x0004, 0x0005): (
-                b"Mock Manufacturer",
-                b"Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-            ),
+    basic = ep.add_input_cluster(0)
+    with mock_attribute_reads(
+        basic,
+        {
+            "manufacturer": b"Mock Manufacturer",
+            "model": b"Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
         },
-    )
+    ):
+        mod, man = await ep.get_model_info()
 
     assert man == "Mock Manufacturer"
     assert mod == "Mock Model"
 
 
 async def test_init_endpoint_info_null_padded_manuf_model(ep):
-    mod, man = await _get_model_info(
-        ep,
-        attributes={
-            (0x0004, 0x0005): (
-                b"Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07",
-                b"Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-            ),
+    basic = ep.add_input_cluster(0)
+    with mock_attribute_reads(
+        basic,
+        {
+            "manufacturer": b"Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07",
+            "model": b"Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
         },
-    )
+    ):
+        mod, man = await ep.get_model_info()
 
     assert man == "Mock Manufacturer"
     assert mod == "Mock Model"
 
 
 async def test_get_model_info_delivery_error(ep):
+    basic = ep.add_input_cluster(0)
     with pytest.raises(zigpy.exceptions.ZigbeeException):
-        await _get_model_info(
-            ep,
-            attributes={
-                (0x0004, 0x0005): (
-                    zigpy.exceptions.ZigbeeException(),
-                    zigpy.exceptions.ZigbeeException(),
-                )
+        with mock_attribute_reads(
+            basic,
+            {
+                "manufacturer": MagicMock(
+                    side_effect=zigpy.exceptions.ZigbeeException()
+                ),
+                "model": "Mock Model",
             },
-        )
+        ):
+            await ep.get_model_info()
 
 
 async def test_get_model_info_timeout(ep):
+    basic = ep.add_input_cluster(0)
     with pytest.raises(asyncio.TimeoutError):
-        await _get_model_info(
-            ep,
-            attributes={
-                (0x0004, 0x0005): (TimeoutError(), TimeoutError()),
-                (0x0004,): (TimeoutError(),),
-                (0x0005,): (TimeoutError(),),
+        with mock_attribute_reads(
+            basic,
+            {
+                "manufacturer": MagicMock(side_effect=[TimeoutError(), TimeoutError()]),
+                "model": "Mock Model",
             },
-        )
+        ):
+            await ep.get_model_info()
 
 
 async def test_get_model_info_double_read_timeout(ep):
-    mod, man = await _get_model_info(
-        ep,
-        attributes={
-            # The double read fails
-            (0x0004, 0x0005): (TimeoutError(), TimeoutError()),
-            # But individually the attributes can be read
-            (0x0004,): (b"Mock Manufacturer",),
-            (0x0005,): (b"Mock Model",),
+    basic = ep.add_input_cluster(0)
+    with mock_attribute_reads(
+        basic,
+        {
+            # The double read fails, but the single manufacturer read succeeds
+            "manufacturer": MagicMock(
+                side_effect=[TimeoutError(), "Mock Manufacturer"]
+            ),
+            "model": "Mock Model",
         },
-    )
+    ):
+        mod, man = await ep.get_model_info()
 
     assert man == "Mock Manufacturer"
     assert mod == "Mock Model"

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -222,15 +222,6 @@ async def test_reply_change_profile_id(ep):
     ]
 
 
-def _mk_rar(attrid, value, status=0):
-    r = zcl.foundation.ReadAttributeRecord()
-    r.attrid = attrid
-    r.status = status
-    r.value = zcl.foundation.TypeValue()
-    r.value.value = value
-    return r
-
-
 def _get_model_info(ep, attributes={}):
     clus = ep.add_input_cluster(0)
     assert 0 in ep.in_clusters
@@ -247,15 +238,25 @@ def _get_model_info(ep, attributes={}):
         for attr_id, value in zip(args, attributes[tuple(args)], strict=True):
             if isinstance(value, BaseException):
                 raise value
-            elif value is None:
-                rar = _mk_rar(attr_id, None, status=1)
+
+            if value is None:
+                rar = zcl.foundation.ReadAttributeRecord(
+                    attrid=attr_id,
+                    status=zcl.foundation.Status.FAILURE,
+                )
             else:
-                raw_attr_value = t.uint8_t(len(value)).serialize() + value
-                rar = _mk_rar(attr_id, t.CharacterString.deserialize(raw_attr_value)[0])
+                rar = zcl.foundation.ReadAttributeRecord(
+                    attrid=attr_id,
+                    status=zcl.foundation.Status.SUCCESS,
+                    value=zcl.foundation.TypeValue(
+                        type=zcl.foundation.DataTypeId.string,
+                        value=t.CharacterString(value),
+                    ),
+                )
 
             result.append(rar)
 
-        return [result]
+        return zcl.foundation.ReadAttributesResponse(status_records=result)
 
     clus.request = mockrequest
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -485,6 +485,25 @@ async def test_group_membership_scan_fail_default_response(ep, caplog):
     assert ep.device.application.groups.update_group_membership.call_count == 0
 
 
+async def test_group_membership_scan_invalid_default_response(ep, caplog):
+    """Test group membership scan when the device rejects the command outright."""
+
+    ep.device.application.groups.update_group_membership = MagicMock()
+    ep.add_input_cluster(4)
+
+    with patch.object(ep.groups, "get_membership", new=AsyncMock()) as get_membership:
+        get_membership.side_effect = zigpy.exceptions.InvalidDefaultResponse(
+            "invalid default response",
+            command_id=2,
+            status=ZCLStatus.UNSUP_CLUSTER_COMMAND,
+        )
+        await ep.group_membership_scan()
+
+    assert "Device does not support group commands" in caplog.text
+
+    assert ep.device.application.groups.update_group_membership.call_count == 0
+
+
 def test_endpoint_manufacturer_id(ep):
     """Test manufacturer id."""
     ep.device.manufacturer_id = sentinel.manufacturer_id

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -349,6 +349,29 @@ def test_character_string():
     assert d == "abc"
 
 
+@pytest.mark.parametrize(
+    ("raw_payload", "expected"),
+    [
+        (
+            b"Mock Manufacturer\x00\x04\\\x00\\\x00\x00\x00\x00\x00\x07",
+            "Mock Manufacturer",
+        ),
+        (
+            b"Mock Model\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+            "Mock Model",
+        ),
+    ],
+)
+def test_character_string_null_padded_wire_payload(raw_payload, expected):
+    serialized = len(raw_payload).to_bytes(1, "little") + raw_payload + b"tail"
+
+    decoded, rest = t.CharacterString.deserialize(serialized)
+
+    assert decoded == expected
+    assert decoded.raw == raw_payload
+    assert rest == b"tail"
+
+
 def test_character_string_decode_failure():
     d, _ = t.CharacterString.deserialize(b"\x04\xf9123\xff\xff45")
     assert d == "�123"

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2629,7 +2629,10 @@ async def test_configure_reporting_multiple_chunked_by_size(app_mock) -> None:
         cluster,
         "_configure_reporting",
         new_callable=AsyncMock,
-        side_effect=[[cfg_success], [cfg_success]],
+        side_effect=[
+            zcl.foundation.ConfigureReportingResponseSchema(status_records=cfg_success),
+            zcl.foundation.ConfigureReportingResponseSchema(status_records=cfg_success),
+        ],
     ) as mock_configure:
         results = await cluster.configure_reporting_multiple(dict.fromkeys(attrs, cfg))
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -19,6 +19,7 @@ from tests.conftest import (
 from zigpy import zcl
 import zigpy.device
 import zigpy.endpoint
+from zigpy.exceptions import InvalidDefaultResponse
 import zigpy.profiles.zha
 import zigpy.types as t
 from zigpy.zcl import (
@@ -423,7 +424,9 @@ async def test_read_attributes_uncached(cluster):
         rar1 = _mk_rar(1, None, foundation.Status.HARDWARE_FAILURE)
         rar5 = _mk_rar(5, "Model")
         rar16 = _mk_rar(0x0010, None, zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE)
-        return [[rar0, rar4, rar1, rar5, rar16]]
+        return foundation.ReadAttributesResponse(
+            status_records=[rar0, rar4, rar1, rar5, rar16]
+        )
 
     cluster.request = mockrequest
     success, failure = await cluster.read_attributes(
@@ -454,7 +457,11 @@ async def test_read_attributes_cached(cluster):
 async def test_read_attributes_mixed_cached(cluster):
     """Reading cached and uncached attributes."""
 
-    cluster.request = AsyncMock(return_value=[[_mk_rar(5, "Model")]])
+    cluster.request = AsyncMock(
+        return_value=foundation.ReadAttributesResponse(
+            status_records=[_mk_rar(5, "Model")]
+        )
+    )
     cluster._attr_cache.set_value(Basic.AttributeDefs.zcl_version, 99)
     cluster._attr_cache.set_value(Basic.AttributeDefs.manufacturer, "Manufacturer")
     cluster.add_unsupported_attribute("location_desc")
@@ -475,14 +482,22 @@ async def test_read_attributes_default_response(cluster):
     ):
         assert foundation is True
         assert command == 0
-        return [0xC1]
+        raise InvalidDefaultResponse(
+            "invalid default response",
+            command_id=command,
+            status=zcl.foundation.Status.SOFTWARE_FAILURE,
+        )
 
     cluster.request = mockrequest
     success, failure = await cluster.read_attributes(
         ["zcl_version", "model", "hw_version"], allow_cache=False
     )
     assert success == {}
-    assert failure == {"zcl_version": 0xC1, "model": 0xC1, "hw_version": 0xC1}
+    assert failure == {
+        "zcl_version": zcl.foundation.Status.SOFTWARE_FAILURE,
+        "model": zcl.foundation.Status.SOFTWARE_FAILURE,
+        "hw_version": zcl.foundation.Status.SOFTWARE_FAILURE,
+    }
 
 
 async def test_item_access_attributes(cluster):
@@ -522,9 +537,11 @@ async def test_item_access_attributes(cluster):
 
 
 async def test_write_attributes(cluster):
-    success_response = [
-        [foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]
-    ]
+    success_response = foundation.WriteAttributesResponseSchema(
+        status_records=[
+            foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)
+        ]
+    )
     with patch.object(
         cluster, "_write_attributes", new=AsyncMock(return_value=success_response)
     ):
@@ -562,9 +579,11 @@ async def test_write_attribute_types(
     cluster_id: int, attr: str, value: Any, serialized: bytes, cluster_by_id
 ):
     cluster = cluster_by_id(cluster_id)
-    success_response = [
-        [foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]
-    ]
+    success_response = foundation.WriteAttributesResponseSchema(
+        status_records=[
+            foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)
+        ]
+    )
     with patch.object(
         cluster.endpoint, "request", new=AsyncMock(return_value=success_response)
     ):
@@ -575,16 +594,39 @@ async def test_write_attribute_types(
 
 
 @pytest.mark.parametrize(
-    "status", [foundation.Status.SUCCESS, foundation.Status.UNSUPPORTED_ATTRIBUTE]
+    ("status", "expected_status"),
+    [
+        (foundation.Status.SUCCESS, foundation.Status.FAILURE),
+        (
+            foundation.Status.UNSUPPORTED_ATTRIBUTE,
+            foundation.Status.UNSUPPORTED_ATTRIBUTE,
+        ),
+    ],
 )
-async def test_write_attributes_cache_default_response(cluster, status):
-    write_mock = AsyncMock(
-        return_value=[foundation.GeneralCommand.Write_Attributes, status]
-    )
+async def test_write_attributes_cache_default_response(
+    cluster, status, expected_status
+):
+    if status == foundation.Status.SUCCESS:
+        write_mock = AsyncMock(
+            return_value=foundation.DefaultResponse(
+                command_id=foundation.GeneralCommand.Write_Attributes,
+                status=status,
+            )
+        )
+    else:
+        write_mock = AsyncMock(
+            side_effect=InvalidDefaultResponse(
+                "invalid default response",
+                command_id=foundation.GeneralCommand.Write_Attributes,
+                status=status,
+            )
+        )
+
     with patch.object(cluster, "_write_attributes", write_mock):
         attributes = {4: "manufacturer", 5: "model", 12: 12}
-        await cluster.write_attributes(attributes)
+        records = (await cluster.write_attributes(attributes))[0]
         assert cluster._write_attributes.call_count == 1
+        assert {record.status for record in records} == {expected_status}
         for attr_id in attributes:
             assert attr_id not in cluster._attr_cache
 
@@ -601,8 +643,8 @@ async def test_write_attributes_cache_success(cluster, attributes, result):
     event_listener = MagicMock()
     cluster.on_event(AttributeWrittenEvent.event_type, event_listener)
 
-    rsp_type = t.List[foundation.WriteAttributesStatusRecord]
-    write_mock = AsyncMock(return_value=[rsp_type.deserialize(result)[0]])
+    rsp_type = foundation.WriteAttributesResponseSchema
+    write_mock = AsyncMock(return_value=rsp_type.deserialize(result)[0])
     with patch.object(cluster, "_write_attributes", write_mock):
         await cluster.write_attributes(attributes)
         assert cluster._write_attributes.call_count == 1
@@ -643,8 +685,8 @@ async def test_write_attributes_cache_failure(cluster, attributes, result, faile
     event_listener = MagicMock()
     cluster.on_event(AttributeWrittenEvent.event_type, event_listener)
 
-    rsp_type = foundation.WriteAttributesResponse
-    write_mock = AsyncMock(return_value=[rsp_type.deserialize(result)[0]])
+    rsp_type = foundation.WriteAttributesResponseSchema
+    write_mock = AsyncMock(return_value=rsp_type.deserialize(result)[0])
 
     with patch.object(cluster, "_write_attributes", write_mock):
         await cluster.write_attributes(attributes)
@@ -707,9 +749,15 @@ async def test_configure_reporting_wrong_attrid(cluster):
 async def test_configure_reporting_manuf():
     ep = MagicMock()
     cluster = zcl.Cluster.from_id(ep, 6)
-    success_response = [
-        [foundation.ConfigureReportingResponseRecord(status=foundation.Status.SUCCESS)]
-    ]
+    success_response = foundation.ConfigureReportingResponseSchema(
+        status_records=foundation.ConfigureReportingResponse(
+            [
+                foundation.ConfigureReportingResponseRecord(
+                    status=foundation.Status.SUCCESS
+                )
+            ]
+        )
+    )
     cluster.request = AsyncMock(name="request", return_value=success_response)
     await cluster.configure_reporting(0, 10, 20, 1)
     assert cluster.request.mock_calls == [
@@ -893,7 +941,9 @@ async def test_configure_reporting_multiple(cluster):
     cfg_response = zcl.foundation.ConfigureReportingResponse(
         [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
     )
-    cluster.endpoint.request.return_value = [cfg_response]
+    cluster.endpoint.request.return_value = (
+        zcl.foundation.ConfigureReportingResponseSchema(status_records=cfg_response)
+    )
 
     await cluster.configure_reporting(
         attribute=3,
@@ -919,9 +969,10 @@ async def test_configure_reporting_multiple(cluster):
 
 async def test_configure_reporting_multiple_def_rsp(cluster):
     """Configure reporting returned a default response. May happen."""
-    cluster.endpoint.request.return_value = (
-        zcl.foundation.GeneralCommand.Configure_Reporting,
-        zcl.foundation.Status.UNSUP_GENERAL_COMMAND,
+    cluster.endpoint.request.side_effect = InvalidDefaultResponse(
+        "invalid default response",
+        command_id=zcl.foundation.GeneralCommand.Configure_Reporting,
+        status=zcl.foundation.Status.UNSUP_GENERAL_COMMAND,
     )
     results = await cluster.configure_reporting_multiple(
         {
@@ -949,7 +1000,7 @@ def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status]):
                 status, zcl.foundation.ReportingDirection.ReceiveReports, attrid
             )
         )
-    return [cfg_response]
+    return zcl.foundation.ConfigureReportingResponseSchema(status_records=cfg_response)
 
 
 async def test_configure_reporting_multiple_single_success(cluster):
@@ -957,7 +1008,9 @@ async def test_configure_reporting_multiple_single_success(cluster):
     cfg_response = zcl.foundation.ConfigureReportingResponse(
         [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
     )
-    cluster.endpoint.request.return_value = [cfg_response]
+    cluster.endpoint.request.return_value = (
+        zcl.foundation.ConfigureReportingResponseSchema(status_records=cfg_response)
+    )
 
     results = await cluster.configure_reporting_multiple(
         {
@@ -2487,7 +2540,10 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
         cluster,
         "_configure_reporting",
         new_callable=AsyncMock,
-        side_effect=[[cfg_fail], [cfg_success]],
+        side_effect=[
+            zcl.foundation.ConfigureReportingResponseSchema(status_records=cfg_fail),
+            zcl.foundation.ConfigureReportingResponseSchema(status_records=cfg_success),
+        ],
     ) as mock_configure:
         results = await cluster.configure_reporting_multiple(
             {

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -26,6 +26,7 @@ from zigpy.zcl import (
     MAX_ATTRIBUTE_RECORDS_BYTES,
     AttributeReadEvent,
     AttributeReportedEvent,
+    AttributeReportingConfiguredEvent,
     AttributeUpdatedEvent,
     AttributeWrittenEvent,
     _chunk_records_by_size,
@@ -497,6 +498,27 @@ async def test_read_attributes_default_response(cluster):
         "zcl_version": zcl.foundation.Status.SOFTWARE_FAILURE,
         "model": zcl.foundation.Status.SOFTWARE_FAILURE,
         "hw_version": zcl.foundation.Status.SOFTWARE_FAILURE,
+    }
+
+
+async def test_read_attributes_success_default_response(cluster):
+    """A successful default response carries no attribute values, so nothing was read."""
+    with mock_attribute_reads(
+        cluster,
+        {},
+        rsp=zcl.foundation.DefaultResponse(
+            command_id=zcl.foundation.GeneralCommand.Read_Attributes,
+            status=zcl.foundation.Status.SUCCESS,
+        ),
+    ):
+        success, failure = await cluster.read_attributes(
+            ["zcl_version", "model"], allow_cache=False
+        )
+
+    assert success == {}
+    assert failure == {
+        "zcl_version": zcl.foundation.Status.FAILURE,
+        "model": zcl.foundation.Status.FAILURE,
     }
 
 
@@ -989,6 +1011,37 @@ async def test_configure_reporting_multiple_def_rsp(cluster):
     assert all(
         s == zcl.foundation.Status.UNSUP_GENERAL_COMMAND for s in results.values()
     )
+
+
+async def test_configure_reporting_multiple_success_default_response(cluster):
+    """Some devices confirm reporting with a bare default response. Trust it."""
+    cluster.endpoint.request.return_value = zcl.foundation.DefaultResponse(
+        command_id=zcl.foundation.GeneralCommand.Configure_Reporting,
+        status=zcl.foundation.Status.SUCCESS,
+    )
+
+    events = []
+    cluster.on_event(AttributeReportingConfiguredEvent.event_type, events.append)
+
+    results = await cluster.configure_reporting_multiple(
+        {
+            Basic.AttributeDefs.hw_version: ReportingConfig(
+                min_interval=5, max_interval=15, reportable_change=20
+            ),
+            Basic.AttributeDefs.manufacturer: ReportingConfig(
+                min_interval=6, max_interval=16, reportable_change=26
+            ),
+        }
+    )
+
+    assert results == {
+        Basic.AttributeDefs.hw_version: zcl.foundation.Status.SUCCESS,
+        Basic.AttributeDefs.manufacturer: zcl.foundation.Status.SUCCESS,
+    }
+    assert [event.attribute_name for event in events] == [
+        Basic.AttributeDefs.hw_version.name,
+        Basic.AttributeDefs.manufacturer.name,
+    ]
 
 
 def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status]):
@@ -2785,6 +2838,36 @@ async def test_read_attributes_insufficient_space_retry_success(app_mock) -> Non
             value=20,
         ),
     ]
+
+
+async def test_read_attributes_insufficient_space_retry_default_response(cluster):
+    """A solo re-read of an attribute that did not fit can itself fail."""
+    with mock_attribute_reads(
+        cluster,
+        {
+            "zcl_version": 1,
+            "model": mock.Mock(
+                side_effect=[
+                    zcl.foundation.Status.INSUFFICIENT_SPACE,
+                    InvalidDefaultResponse(
+                        "invalid default response",
+                        command_id=zcl.foundation.GeneralCommand.Read_Attributes,
+                        status=zcl.foundation.Status.SOFTWARE_FAILURE,
+                    ),
+                ]
+            ),
+        },
+    ) as (mock_read, _):
+        success, failure = await cluster.read_attributes(
+            ["zcl_version", "model"], allow_cache=False
+        )
+
+    assert success == {"zcl_version": 1}
+    assert failure == {"model": zcl.foundation.Status.SOFTWARE_FAILURE}
+
+    # The batched read, then a solo re-read of the attribute that did not fit
+    chunks = [call_obj.args[0] for call_obj in mock_read.call_args_list]
+    assert chunks == [[0x0000, 0x0005], [0x0005]]
 
 
 async def test_read_attributes_insufficient_space_retry_persistent(app_mock) -> None:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -30,8 +30,15 @@ from zigpy.const import (
 )
 import zigpy.datastructures
 import zigpy.endpoint
-import zigpy.exceptions
-from zigpy.exceptions import DeliveryError, InvalidDefaultResponse
+from zigpy.exceptions import (
+    ControllerException,
+    DeliveryError,
+    InvalidDefaultResponse,
+    InvalidResponse,
+    ParsingError,
+    ResponseError,
+    ZigbeeException,
+)
 import zigpy.listeners
 from zigpy.ota.manager import update_firmware
 from zigpy.profiles import zha, zll
@@ -359,9 +366,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         status, _, node_desc = await self.zdo.Node_Desc_req(self.nwk)
 
         if status != zdo_t.Status.SUCCESS:
-            raise zigpy.exceptions.InvalidResponse(
-                f"Requesting Node Descriptor failed: {status}"
-            )
+            raise InvalidResponse(f"Requesting Node Descriptor failed: {status}")
 
         self.node_desc = node_desc
         self.info("Got Node Descriptor: %s", node_desc)
@@ -373,7 +378,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             # Perform initialization with critical priority
             async with self._application.request_priority(t.PacketPriority.CRITICAL):
                 await self._initialize()
-        except (TimeoutError, zigpy.exceptions.ZigbeeException):
+        except (TimeoutError, ZigbeeException):
             self.application.listener_event("device_init_failure", self)
         except Exception:  # noqa: BLE001
             LOGGER.warning(
@@ -503,9 +508,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             status, _, endpoints = await self.zdo.Active_EP_req(self.nwk)
 
             if status != zdo_t.Status.SUCCESS:
-                raise zigpy.exceptions.InvalidResponse(
-                    f"Endpoint request failed: {status}"
-                )
+                raise InvalidResponse(f"Endpoint request failed: {status}")
 
             self.info("Discovered endpoints: %s", endpoints)
 
@@ -660,9 +663,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     rsp_key,
                     self._requests,
                 )
-                raise zigpy.exceptions.ControllerException(
-                    f"Duplicate request key: {rsp_key}"
-                )
+                raise ControllerException(f"Duplicate request key: {rsp_key}")
         else:
             rsp_key = None
 
@@ -708,7 +709,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                         if not future.done():
                             future.cancel()
                         self._requests.pop(rsp_key, None)
-            except zigpy.exceptions.ResponseError:
+            except ResponseError:
                 # The device responded, it was just not with something we can use.
                 # Retrying will only repeat the same exchange.
                 raise
@@ -922,7 +923,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             # `error` and `cmd` cannot both be provided so this can never shadow `error`
             assert error is None
             error = InvalidDefaultResponse(
-                f"Invalid default response {cmd.status} for command 0x{cmd.command_id:#02x}",
+                f"Invalid default response {cmd.status} for command {cmd.command_id:#04x}",
                 command_id=cmd.command_id,
                 status=cmd.status,
             )
@@ -971,7 +972,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             cmd = self._parse_packet_command(packet, endpoint, zcl_cluster)
         except Exception as exc:  # noqa: BLE001
             cmd = None
-            error = zigpy.exceptions.ParsingError()
+            error = ParsingError()
             error.__cause__ = exc
             self.debug("Failed to parse packet %r", packet, exc_info=error)
         else:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -708,7 +708,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                         if not future.done():
                             future.cancel()
                         self._requests.pop(rsp_key, None)
-            except zigpy.exceptions.ParsingError:
+            except zigpy.exceptions.ResponseError:
+                # The device responded, it was just not with something we can use.
+                # Retrying will only repeat the same exchange.
                 raise
             except Exception:
                 LOGGER.debug(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -917,7 +917,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             isinstance(cmd, foundation.DefaultResponse)
             and cmd.status != foundation.Status.SUCCESS
         ):
-            raise InvalidDefaultResponse(
+            # `error` and `cmd` cannot both be provided so this can never shadow `error`
+            assert error is None
+            error = InvalidDefaultResponse(
                 f"Invalid default response {cmd.status} for command 0x{cmd.command_id:#02x}",
                 command_id=cmd.command_id,
                 status=cmd.status,

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -31,7 +31,7 @@ from zigpy.const import (
 import zigpy.datastructures
 import zigpy.endpoint
 import zigpy.exceptions
-from zigpy.exceptions import DeliveryError
+from zigpy.exceptions import DeliveryError, InvalidDefaultResponse
 import zigpy.listeners
 from zigpy.ota.manager import update_firmware
 from zigpy.profiles import zha, zll
@@ -901,6 +901,17 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             ].schema,
         ):
             return False
+
+        # Default responses with non-success status should be treated as errors
+        if (
+            isinstance(cmd, foundation.DefaultResponse)
+            and cmd.status != foundation.Status.SUCCESS
+        ):
+            raise InvalidDefaultResponse(
+                f"Invalid default response {cmd.status} for command 0x{cmd.command_id:#02x}",
+                command_id=cmd.command_id,
+                status=cmd.status,
+            )
 
         try:
             if error is not None:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -12,7 +12,7 @@ import logging
 import math
 import time
 import typing
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 import warnings
 
 from zigpy import zdo
@@ -883,6 +883,16 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             _, cmd = zcl_cluster.deserialize(data)
 
         return cmd
+
+    @overload
+    def _maybe_match_response(
+        self, rsp_key: ResponseKey, cmd: typing.Any, error: None
+    ) -> bool: ...
+
+    @overload
+    def _maybe_match_response(
+        self, rsp_key: ResponseKey, cmd: None, error: Exception
+    ) -> bool: ...
 
     def _maybe_match_response(
         self, rsp_key: ResponseKey, cmd: typing.Any | None, error: Exception | None

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -10,7 +10,7 @@ import zigpy.profiles
 import zigpy.types as t
 import zigpy.util
 import zigpy.zcl
-from zigpy.zcl.foundation import GeneralCommand, Status as ZCLStatus
+from zigpy.zcl.foundation import DefaultResponse, GeneralCommand, Status as ZCLStatus
 from zigpy.zdo.types import Status as ZDOStatus
 
 if TYPE_CHECKING:
@@ -170,10 +170,16 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             res = await self.groups.get_membership(groups=[])
         except AttributeError:
             return
-        except zigpy.exceptions.InvalidDefaultResponse:
-            self.debug("Device does not support group commands: %s", res)
+        except zigpy.exceptions.InvalidDefaultResponse as exc:
+            self.debug("Device does not support group commands: %s", exc)
+            return
         except (TimeoutError, zigpy.exceptions.ZigbeeException):
             self.debug("Failed to sync-up group membership")
+            return
+
+        # TODO: can a device send a successful default response here?
+        if isinstance(res, DefaultResponse):
+            self.debug("Device does not support group commands: %s", res)
             return
 
         groups = set(res[1])

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -10,7 +10,7 @@ import zigpy.profiles
 import zigpy.types as t
 import zigpy.util
 import zigpy.zcl
-from zigpy.zcl.foundation import GENERAL_COMMANDS, GeneralCommand, Status as ZCLStatus
+from zigpy.zcl.foundation import GeneralCommand, Status as ZCLStatus
 from zigpy.zdo.types import Status as ZDOStatus
 
 if TYPE_CHECKING:
@@ -170,12 +170,10 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             res = await self.groups.get_membership(groups=[])
         except AttributeError:
             return
+        except zigpy.exceptions.InvalidDefaultResponse:
+            self.debug("Device does not support group commands: %s", res)
         except (TimeoutError, zigpy.exceptions.ZigbeeException):
             self.debug("Failed to sync-up group membership")
-            return
-
-        if isinstance(res, GENERAL_COMMANDS[GeneralCommand.Default_Response].schema):
-            self.debug("Device does not support group commands: %s", res)
             return
 
         groups = set(res[1])

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -11,7 +11,11 @@ class ZigbeeException(Exception):
     """Base exception class"""
 
 
-class ParsingError(ZigbeeException):
+class ResponseError(ZigbeeException):
+    """A response was received but cannot be used"""
+
+
+class ParsingError(ResponseError):
     """Failed to parse a frame"""
 
 
@@ -43,7 +47,7 @@ class SendError(DeliveryError):
     """Message could not be enqueued."""
 
 
-class InvalidResponse(ZigbeeException):
+class InvalidResponse(ResponseError):
     """A ZDO or ZCL response has an unsuccessful status code"""
 
 

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -4,6 +4,7 @@ import typing
 
 if typing.TYPE_CHECKING:
     import zigpy.backups
+    from zigpy.zcl import foundation
 
 
 class ZigbeeException(Exception):
@@ -44,6 +45,17 @@ class SendError(DeliveryError):
 
 class InvalidResponse(ZigbeeException):
     """A ZDO or ZCL response has an unsuccessful status code"""
+
+
+class InvalidDefaultResponse(InvalidResponse):
+    """A ZCL default response has an unsuccessful status code"""
+
+    def __init__(
+        self, message: str, command_id: int, status: foundation.Status
+    ) -> None:
+        super().__init__(message)
+        self.command_id = command_id
+        self.status = status
 
 
 class RadioException(Exception):

--- a/zigpy/group.py
+++ b/zigpy/group.py
@@ -77,9 +77,7 @@ class Group(ListenableMixin, dict):
             )
         )
 
-        return foundation.GENERAL_COMMANDS[
-            foundation.GeneralCommand.Default_Response
-        ].schema(
+        return foundation.DefaultResponse(
             status=foundation.Status.SUCCESS,
             command_id=data[2],
         )

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1724,10 +1724,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
                     continue
 
-                # A device should never send back a successful default response
+                # If a device replies with a successful default response, assume the
+                # whole chunk has been configured correctly.
                 if isinstance(rsp, foundation.DefaultResponse):
                     for attr_def, _cfg in chunk:
-                        group_results[attr_def] = foundation.Status.FAILURE
+                        group_results[attr_def] = rsp.status
 
                     continue
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1658,6 +1658,20 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             }
         )
 
+    async def configure_reporting_raw(
+        self,
+        config_records: list[foundation.AttributeReportingConfig],
+        manufacturer_code: int | None = None,
+        **kwargs,
+    ) -> foundation.CommandSchema | foundation.DefaultResponse:
+        result = await self._configure_reporting(
+            config_records,
+            manufacturer=manufacturer_code,
+            **kwargs,
+        )
+
+        return cast(foundation.CommandSchema | foundation.DefaultResponse, result)
+
     async def configure_reporting_multiple(
         self, config: dict[foundation.ZCLAttributeDef, ReportingConfig]
     ) -> dict[foundation.ZCLAttributeDef, foundation.Status]:
@@ -1695,37 +1709,45 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             for chunk in _chunk_records_by_size(
                 reporting_configs, lambda pair: len(pair[1].serialize())
             ):
-                rsp = await self._configure_reporting(
-                    [cfg for _attr_def, cfg in chunk],
-                    manufacturer=manufacturer_code,
-                )
-
-                if isinstance(rsp[0], list):
-                    records = rsp[0]
-
-                    # Check for global success (status=SUCCESS, attrid=None)
-                    if (
-                        len(records) == 1
-                        and records[0].status == foundation.Status.SUCCESS
-                        and records[0].attrid is None
-                    ):
-                        # Global success: all attributes succeeded
-                        for attr_def, _cfg in chunk:
-                            group_results[attr_def] = foundation.Status.SUCCESS
-                    else:
-                        # Only failed reports are in the response. Attributes not
-                        # present implicitly succeeded.
-                        failed_attrids = {r.attrid: r.status for r in records}
-                        for attr_def, _cfg in chunk:
-                            if attr_def.id in failed_attrids:
-                                group_results[attr_def] = failed_attrids[attr_def.id]
-                            else:
-                                group_results[attr_def] = foundation.Status.SUCCESS
-                else:
-                    # Default response: apply status to all attributes in this group
-                    status = rsp[1]
+                try:
+                    rsp = await self.configure_reporting_raw(
+                        [cfg for _attr_def, cfg in chunk],
+                        manufacturer_code=manufacturer_code,
+                    )
+                except InvalidDefaultResponse as exc:
+                    # If we get back a default response, all reports failed
                     for attr_def, _cfg in chunk:
-                        group_results[attr_def] = status
+                        group_results[attr_def] = exc.status
+
+                    continue
+
+                # A device should never send back a successful default response
+                if isinstance(rsp, foundation.DefaultResponse):
+                    for attr_def, _cfg in chunk:
+                        group_results[attr_def] = foundation.Status.FAILURE
+
+                    continue
+
+                records = rsp.status_records
+
+                # Check for global success (status=SUCCESS, attrid=None)
+                if (
+                    len(records) == 1
+                    and records[0].status == foundation.Status.SUCCESS
+                    and records[0].attrid is None
+                ):
+                    # Global success: all attributes succeeded
+                    for attr_def, _cfg in chunk:
+                        group_results[attr_def] = foundation.Status.SUCCESS
+                else:
+                    # Only failed reports are in the response. Attributes not
+                    # present implicitly succeeded.
+                    failed_attrids = {r.attrid: r.status for r in records}
+                    for attr_def, _cfg in chunk:
+                        if attr_def.id in failed_attrids:
+                            group_results[attr_def] = failed_attrids[attr_def.id]
+                        else:
+                            group_results[attr_def] = foundation.Status.SUCCESS
 
             for attr_def, status in group_results.items():
                 if status == foundation.Status.SUCCESS:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1663,14 +1663,17 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         config_records: list[foundation.AttributeReportingConfig],
         manufacturer_code: int | None = None,
         **kwargs,
-    ) -> foundation.CommandSchema | foundation.DefaultResponse:
+    ) -> foundation.ConfigureReportingResponseSchema | foundation.DefaultResponse:
         result = await self._configure_reporting(
             config_records,
             manufacturer=manufacturer_code,
             **kwargs,
         )
 
-        return cast(foundation.CommandSchema | foundation.DefaultResponse, result)
+        return cast(
+            foundation.ConfigureReportingResponseSchema | foundation.DefaultResponse,
+            result,
+        )
 
     async def configure_reporting_multiple(
         self, config: dict[foundation.ZCLAttributeDef, ReportingConfig]

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1459,8 +1459,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         **kwargs,
     ) -> foundation.WriteAttributesResponseSchema | foundation.DefaultResponse:
         """Write attributes to the device without any validation or caching."""
-        return await self._write_attributes(
+        result = await self._write_attributes(
             attributes, manufacturer=manufacturer_code, **kwargs
+        )
+
+        return cast(
+            foundation.WriteAttributesResponseSchema | foundation.DefaultResponse,
+            result,
         )
 
     async def write_attributes(
@@ -1505,16 +1510,32 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             for chunk in _chunk_records_by_size(
                 zcl_attrs, lambda a: len(a.serialize())
             ):
-                result = await self.write_attributes_raw(
-                    chunk, manufacturer_code=manufacturer_code, **kwargs
-                )
-
-                if isinstance(result[0], list):
+                try:
+                    result = await self.write_attributes_raw(
+                        chunk, manufacturer_code=manufacturer_code, **kwargs
+                    )
+                except InvalidDefaultResponse as exc:
+                    # If we get back a default response, all writes failed
+                    records_group.extend(
+                        foundation.WriteAttributesStatusRecord(
+                            status=exc.status, attrid=zcl_attr.attrid
+                        )
+                        for zcl_attr in chunk
+                    )
+                else:
+                    # A device should never send back a successful default response
+                    if isinstance(result, foundation.DefaultResponse):
+                        records_group.extend(
+                            foundation.WriteAttributesStatusRecord(
+                                status=foundation.Status.FAILURE, attrid=zcl_attr.attrid
+                            )
+                            for zcl_attr in chunk
+                        )
                     # Check for global success (status=SUCCESS, attrid=None)
-                    if (
-                        len(result[0]) == 1
-                        and result[0][0].status == foundation.Status.SUCCESS
-                        and result[0][0].attrid is None
+                    elif (
+                        len(result.status_records) == 1
+                        and result.status_records[0].status == foundation.Status.SUCCESS
+                        and result.status_records[0].attrid is None
                     ):
                         # Global success: all attributes succeeded
                         records_group.extend(
@@ -1527,11 +1548,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     else:
                         # Only failed writes are in the response. Attributes not
                         # present implicitly succeeded.
-                        failed_attrids = {r.attrid for r in result[0]}
+                        failed_attrids = {r.attrid for r in result.status_records}
                         for zcl_attr in chunk:
                             if zcl_attr.attrid in failed_attrids:
                                 records_group.extend(
-                                    r for r in result[0] if r.attrid == zcl_attr.attrid
+                                    r
+                                    for r in result.status_records
+                                    if r.attrid == zcl_attr.attrid
                                 )
                             else:
                                 records_group.append(
@@ -1540,15 +1563,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                                         attrid=zcl_attr.attrid,
                                     )
                                 )
-                else:
-                    # Default response: apply status to all attributes in this group
-                    status = result[0]
-                    records_group.extend(
-                        foundation.WriteAttributesStatusRecord(
-                            status=status, attrid=zcl_attr.attrid
-                        )
-                        for zcl_attr in chunk
-                    )
 
             results.extend(records_group)
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -12,12 +12,13 @@ import functools
 import itertools
 import logging
 import types
-from typing import TYPE_CHECKING, Any, Final, TypeVar
+from typing import TYPE_CHECKING, Any, Final, TypeVar, cast
 import warnings
 
 from zigpy import util
 from zigpy.const import APS_REPLY_TIMEOUT
 from zigpy.event import EventBase
+from zigpy.exceptions import InvalidDefaultResponse
 import zigpy.types as t
 from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import foundation
@@ -413,7 +414,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         # and cannot represent two same-ID attributes (e.g. a standard and a
         # manufacturer-specific one), so rebuilding from it would drop one of them
         if cls.__dict__.get("attributes") and "AttributeDefs" not in cls.__dict__:
-            cls.AttributeDefs = types.new_class(
+            cls.AttributeDefs = types.new_class(  # type: ignore[misc]
                 name="AttributeDefs",
                 bases=(BaseAttributeDefs,),
             )
@@ -425,7 +426,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             cls.__dict__.get("server_commands")
             and "ServerCommandDefs" not in cls.__dict__
         ):
-            cls.ServerCommandDefs = types.new_class(
+            cls.ServerCommandDefs = types.new_class(  # type: ignore[misc]
                 name="ServerCommandDefs",
                 bases=(BaseCommandDefs,),
             )
@@ -437,7 +438,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             cls.__dict__.get("client_commands")
             and "ClientCommandDefs" not in cls.__dict__
         ):
-            cls.ClientCommandDefs = types.new_class(
+            cls.ClientCommandDefs = types.new_class(  # type: ignore[misc]
                 name="ClientCommandDefs",
                 bases=(BaseCommandDefs,),
             )
@@ -1066,11 +1067,15 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 foundation.Status.SUCCESS,
             )
 
-    def read_attributes_raw(
+    async def read_attributes_raw(
         self, attributes: list[int], manufacturer: int | None = None, **kwargs
-    ):
-        return self._read_attributes(
+    ) -> foundation.ReadAttributesResponse | foundation.DefaultResponse:
+        result = await self._read_attributes(
             [t.uint16_t(a) for a in attributes], manufacturer=manufacturer, **kwargs
+        )
+
+        return cast(
+            foundation.ReadAttributesResponse | foundation.DefaultResponse, result
         )
 
     def _get_effective_manufacturer_code(
@@ -1181,11 +1186,19 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
             for i in range(0, len(attribute_group), MAX_READ_ATTRIBUTES_PER_REQ):
                 chunk = attribute_group[i : i + MAX_READ_ATTRIBUTES_PER_REQ]
-                result = await self.read_attributes_raw(
-                    [attr_def.id for attr_def in chunk],
-                    manufacturer=manufacturer_code,
-                    **kwargs,
-                )
+
+                try:
+                    result = await self.read_attributes_raw(
+                        [attr_def.id for attr_def in chunk],
+                        manufacturer=manufacturer_code,
+                        **kwargs,
+                    )
+                except InvalidDefaultResponse as exc:
+                    # If we get back a default response, all reads in the chunk failed
+                    for attr_def in chunk:
+                        failure[attribute_map[attr_def]] = exc.status
+
+                    continue
 
                 retry_attrs.extend(
                     self._process_read_attributes_response(
@@ -1206,11 +1219,15 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             # at a time, giving each value the whole frame (ZCL R8 §2.5.2.3). An
             # attribute that still does not fit when read alone is a terminal failure.
             for attr_def in retry_attrs:
-                result = await self.read_attributes_raw(
-                    [attr_def.id],
-                    manufacturer=manufacturer_code,
-                    **kwargs,
-                )
+                try:
+                    result = await self.read_attributes_raw(
+                        [attr_def.id],
+                        manufacturer=manufacturer_code,
+                        **kwargs,
+                    )
+                except InvalidDefaultResponse as exc:
+                    failure[attribute_map[attr_def]] = exc.status
+                    continue
 
                 self._process_read_attributes_response(
                     result,
@@ -1226,7 +1243,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
     def _process_read_attributes_response(
         self,
-        result: Any,
+        result: foundation.ReadAttributesResponse | foundation.DefaultResponse,
         chunk: list[foundation.ZCLAttributeDef],
         attribute_map: dict[
             foundation.ZCLAttributeDef, int | str | foundation.ZCLAttributeDef
@@ -1239,10 +1256,10 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
     ) -> list[foundation.ZCLAttributeDef]:
         """Process a Read Attributes Response, updating `success`/`failure` in place."""
 
-        # If we get back a single response status, all reads failed
-        if not isinstance(result[0], list):
+        # A device should never send back a successful default response
+        if isinstance(result, foundation.DefaultResponse):
             for attr_def in chunk:
-                failure[attribute_map[attr_def]] = result[0]
+                failure[attribute_map[attr_def]] = foundation.Status.FAILURE
 
             return []
 
@@ -1253,7 +1270,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         potential_attributes = {attr_def.id: attr_def for attr_def in chunk}
         insufficient_space_attrs: list[foundation.ZCLAttributeDef] = []
 
-        for record in result[0]:
+        for record in result.status_records:
             attr_def = potential_attributes[record.attrid]
             seen_attr_ids.add(record.attrid)
 

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -1285,6 +1285,34 @@ class WriteAttributesStructuredResponseSchema(CommandSchema):
     status_records: WriteAttributesStructuredResponse
 
 
+class ConfigureReportingResponseSchema(CommandSchema):
+    status_records: ConfigureReportingResponse
+
+
+class ReadReportingConfigurationResponseSchema(CommandSchema):
+    attribute_configs: t.List[AttributeReportingConfigWithStatus]
+
+
+class DiscoverAttributesResponseSchema(CommandSchema):
+    discovery_complete: t.Bool
+    attribute_info: t.List[DiscoverAttributesResponseRecord]
+
+
+class DiscoverCommandsReceivedResponseSchema(CommandSchema):
+    discovery_complete: t.Bool
+    command_ids: t.List[t.uint8_t]
+
+
+class DiscoverCommandsGeneratedResponseSchema(CommandSchema):
+    discovery_complete: t.Bool
+    command_ids: t.List[t.uint8_t]
+
+
+class DiscoverAttributeExtendedResponseSchema(CommandSchema):
+    discovery_complete: t.Bool
+    extended_attr_info: t.List[DiscoverAttributesExtendedResponseRecord]
+
+
 class DefaultResponse(CommandSchema):
     command_id: t.uint8_t
     status: Status
@@ -1457,7 +1485,7 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Configure_Reporting_rsp: ZCLCommandDef(
-        schema={"status_records": ConfigureReportingResponse},
+        schema=ConfigureReportingResponseSchema,
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Read_Reporting_Configuration: ZCLCommandDef(
@@ -1465,7 +1493,7 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Read_Reporting_Configuration_rsp: ZCLCommandDef(
-        schema={"attribute_configs": t.List[AttributeReportingConfigWithStatus]},
+        schema=ReadReportingConfigurationResponseSchema,
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Report_Attributes: ZCLCommandDef(
@@ -1481,10 +1509,7 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Discover_Attributes_rsp: ZCLCommandDef(
-        schema={
-            "discovery_complete": t.Bool,
-            "attribute_info": t.List[DiscoverAttributesResponseRecord],
-        },
+        schema=DiscoverAttributesResponseSchema,
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Read_Attributes_Structured: ZCLCommandDef(
@@ -1504,7 +1529,7 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Discover_Commands_Received_rsp: ZCLCommandDef(
-        schema={"discovery_complete": t.Bool, "command_ids": t.List[t.uint8_t]},
+        schema=DiscoverCommandsReceivedResponseSchema,
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Discover_Commands_Generated: ZCLCommandDef(
@@ -1512,7 +1537,7 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Discover_Commands_Generated_rsp: ZCLCommandDef(
-        schema={"discovery_complete": t.Bool, "command_ids": t.List[t.uint8_t]},
+        schema=DiscoverCommandsGeneratedResponseSchema,
         direction=Direction.Server_to_Client,
     ),
     GeneralCommand.Discover_Attribute_Extended: ZCLCommandDef(
@@ -1520,10 +1545,7 @@ GENERAL_COMMANDS = COMMANDS = {
         direction=Direction.Client_to_Server,
     ),
     GeneralCommand.Discover_Attribute_Extended_rsp: ZCLCommandDef(
-        schema={
-            "discovery_complete": t.Bool,
-            "extended_attr_info": t.List[DiscoverAttributesExtendedResponseRecord],
-        },
+        schema=DiscoverAttributeExtendedResponseSchema,
         direction=Direction.Server_to_Client,
     ),
 }


### PR DESCRIPTION
This PR changes zigpy's behavior with default responses: any default response with a status code other than `SUCCESS` will turn into an exception. This is still a bit annoying to deal with typing-wise because practically any request can be responded to with a default response with a `SUCCESS` status code. We should perhaps modify our request sending to explicitly opt into _accepting_ a default response, with the default being not to?

Most general commands have been moved to exact types: for example, `foundation.DefaultResponse`. The same has been done for the attribute reading and writing commands. This allows us to more precisely pass around these response types and to fully restrict the types of `read_attributes_raw`, `write_attributes_raw`, and `configure_reporting_raw`. (This unfortunately brings up an issue with zigpy that has no simple fix: our easy-to-define `schema={"param": type}` is utterly unusable by type checkers).

---

Related: https://github.com/zigpy/zha/pull/678