### PR TITLE
Persist OTA `query_next_image` fields in appdb

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1607,3 +1607,209 @@ async def test_device_signature_ignores_quirks(tmp_path) -> None:
     assert dev2.original_signature == expected_signature
 
     await app2.shutdown()
+
+
+@patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))
+async def test_ota_query_cache_persistence(tmp_path):
+    """Test that OTA query cache is persisted and restored from the database."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+    ieee = make_ieee()
+    app.handle_join(99, ieee, 0)
+
+    dev = app.get_device(ieee)
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+    ep.add_input_cluster(0)  # Basic cluster, exercises non-OTA skip in load
+    ota_cluster = ep.add_output_cluster(Ota.cluster_id)
+    app.device_initialized(dev)
+
+    # Simulate a query_next_image command from the device
+    cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+        manufacturer_code=0x1234,
+        image_type=0x5678,
+        current_file_version=0x000A0001,
+    )
+    cmd.hardware_version = 3
+
+    ota_cluster.last_query_cmd = cmd
+
+    # Trigger a save
+    app.device_initialized(dev)
+    await app.shutdown()
+
+    # Reload and check the OTA query cache was restored
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(ieee)
+    ota2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
+
+    assert ota2.last_query_cmd is not None
+    assert ota2.last_query_cmd.manufacturer_code == 0x1234
+    assert ota2.last_query_cmd.image_type == 0x5678
+    assert ota2.last_query_cmd.current_file_version == 0x000A0001
+    assert ota2.last_query_cmd.hardware_version == 3
+
+    # Also test get_last_ota_query_cmd
+    assert dev2.get_last_ota_query_cmd() is not None
+    assert dev2.get_last_ota_query_cmd().manufacturer_code == 0x1234
+
+    await app2.shutdown()
+
+
+@patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))
+async def test_ota_query_cache_no_hardware_version(tmp_path):
+    """Test OTA query cache round-trip without hardware_version."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+    ieee = make_ieee()
+    app.handle_join(99, ieee, 0)
+
+    dev = app.get_device(ieee)
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+    ota_cluster = ep.add_output_cluster(Ota.cluster_id)
+    app.device_initialized(dev)
+
+    cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0xAAAA,
+        image_type=0xBBBB,
+        current_file_version=0x00000042,
+    )
+    ota_cluster.last_query_cmd = cmd
+    app.device_initialized(dev)
+    await app.shutdown()
+
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(ieee)
+    ota2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
+
+    assert ota2.last_query_cmd is not None
+    assert ota2.last_query_cmd.manufacturer_code == 0xAAAA
+    assert ota2.last_query_cmd.image_type == 0xBBBB
+    assert ota2.last_query_cmd.current_file_version == 0x00000042
+    assert not hasattr(ota2.last_query_cmd, "hardware_version") or (
+        ota2.last_query_cmd.hardware_version is None
+    )
+
+    await app2.shutdown()
+
+
+@patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))
+async def test_ota_query_cache_event_save(tmp_path):
+    """Test that the OtaQueryCacheUpdatedEvent triggers a DB save."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+    ieee = make_ieee()
+    app.handle_join(99, ieee, 0)
+
+    dev = app.get_device(ieee)
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+    ota_cluster = ep.add_output_cluster(Ota.cluster_id)
+    app.device_initialized(dev)
+
+    # Simulate the event that _handle_query_next_image would emit
+    from zigpy.zcl import OtaQueryCacheUpdatedEvent
+
+    event = OtaQueryCacheUpdatedEvent(
+        device_ieee=str(ieee),
+        endpoint_id=1,
+        cluster_type=ota_cluster.cluster_type,
+        cluster_id=ota_cluster.cluster_id,
+        manufacturer_code=0x1111,
+        image_type=0x2222,
+        current_file_version=0x00000099,
+        hardware_version=7,
+    )
+
+    ota_cluster.emit(OtaQueryCacheUpdatedEvent.event_type, event)
+    await asyncio.sleep(0.2)
+
+    await app.shutdown()
+
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(ieee)
+    ota2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
+
+    assert ota2.last_query_cmd is not None
+    assert ota2.last_query_cmd.manufacturer_code == 0x1111
+    assert ota2.last_query_cmd.image_type == 0x2222
+    assert ota2.last_query_cmd.current_file_version == 0x00000099
+    assert ota2.last_query_cmd.hardware_version == 7
+
+    await app2.shutdown()
+
+
+async def test_ota_query_cache_load_missing_device(tmp_path):
+    """Test that loading OTA cache skips entries for devices no longer in the app."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+    ieee = make_ieee()
+    app.handle_join(99, ieee, 0)
+
+    dev = app.get_device(ieee)
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+    ota_cluster = ep.add_output_cluster(Ota.cluster_id)
+    app.device_initialized(dev)
+
+    # Set a query cmd and save
+    ota_cluster.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x5678,
+        current_file_version=0x00000001,
+    )
+    await app._dblistener._save_device(dev)
+    await app.shutdown()
+
+    # Insert a row referencing a non-existent device directly in the DB
+    import sqlite3
+
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            f"INSERT INTO ota_query_cache{zigpy.appdb.DB_V}"
+            " (ieee, endpoint_id, manufacturer_code, image_type,"
+            "  current_file_version, hardware_version, last_updated)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ff:ff:ff:ff:ff:ff:ff:ff", 1, 0xAAAA, 0xBBBB, 0x00000002, None, 0),
+        )
+
+    # Reload — should not crash, just skip the unknown device row
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(ieee)
+    ota2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
+    assert ota2.last_query_cmd is not None
+    assert ota2.last_query_cmd.manufacturer_code == 0x1234
+
+    await app2.shutdown()
+
+
+async def test_get_last_ota_query_cmd_returns_none(tmp_path):
+    """Test that get_last_ota_query_cmd returns None when no query has been cached."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+    ieee = make_ieee()
+    app.handle_join(99, ieee, 0)
+
+    dev = app.get_device(ieee)
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+    ep.add_output_cluster(Ota.cluster_id)
+    app.device_initialized(dev)
+
+    assert dev.get_last_ota_query_cmd() is None
+
+    await app.shutdown()

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1747,6 +1747,59 @@ async def test_ota_query_cache_event_save(tmp_path):
     await app2.shutdown()
 
 
+@patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))
+async def test_ota_query_cache_restore_correct_cluster_type(tmp_path):
+    """Test that OTA query cache restores to the correct cluster type."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+    ieee = make_ieee()
+    app.handle_join(99, ieee, 0)
+
+    dev = app.get_device(ieee)
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+    ota_server = ep.add_input_cluster(Ota.cluster_id)
+    ota_client = ep.add_output_cluster(Ota.cluster_id)
+    app.device_initialized(dev)
+
+    # Set different query cmds on each cluster
+    ota_server.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1111,
+        image_type=0x2222,
+        current_file_version=0x00000001,
+    )
+    ota_client.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x3333,
+        image_type=0x4444,
+        current_file_version=0x00000002,
+    )
+
+    app.device_initialized(dev)
+    await app.shutdown()
+
+    # Reload and verify each cluster got its own query cmd back
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(ieee)
+    server2 = dev2.endpoints[1].in_clusters[Ota.cluster_id]
+    client2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
+
+    assert server2.last_query_cmd is not None
+    assert server2.last_query_cmd.manufacturer_code == 0x1111
+    assert server2.last_query_cmd.image_type == 0x2222
+    assert server2.last_query_cmd.current_file_version == 0x00000001
+
+    assert client2.last_query_cmd is not None
+    assert client2.last_query_cmd.manufacturer_code == 0x3333
+    assert client2.last_query_cmd.image_type == 0x4444
+    assert client2.last_query_cmd.current_file_version == 0x00000002
+
+    await app2.shutdown()
+
+
 async def test_ota_query_cache_load_missing_device(tmp_path):
     """Test that loading OTA cache skips entries for devices no longer in the app."""
     db = tmp_path / "test.db"

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1611,7 +1611,7 @@ async def test_device_signature_ignores_quirks(tmp_path) -> None:
 
 @patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))
 async def test_ota_query_cache_persistence(tmp_path):
-    """Test that OTA query cache is persisted per cluster type and restored."""
+    """Test that OTA query cache is persisted and restored from the database."""
     db = tmp_path / "test.db"
     app = await make_app_with_db(db)
     ieee = make_ieee()
@@ -1623,55 +1623,55 @@ async def test_ota_query_cache_persistence(tmp_path):
     ep.profile_id = 260
     ep.device_type = profiles.zha.DeviceType.PUMP
     ep.add_input_cluster(0)  # Basic cluster, exercises non-OTA skip in load
-    ota_server = ep.add_input_cluster(Ota.cluster_id)
-    ota_client = ep.add_output_cluster(Ota.cluster_id)
+    ota_cluster = ep.add_output_cluster(Ota.cluster_id)
     app.device_initialized(dev)
 
-    # Server cluster: with hardware_version
-    server_cmd = Ota.QueryNextImageCommand(
+    # With hardware_version
+    cmd = Ota.QueryNextImageCommand(
         field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
         manufacturer_code=0x1234,
         image_type=0x5678,
         current_file_version=0x000A0001,
     )
-    server_cmd.hardware_version = 3
-    ota_server.last_query_cmd = server_cmd
+    cmd.hardware_version = 3
+    ota_cluster.last_query_cmd = cmd
 
-    # Client cluster: without hardware_version
-    ota_client.last_query_cmd = Ota.QueryNextImageCommand(
+    app.device_initialized(dev)
+    await app.shutdown()
+
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(ieee)
+    ota2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
+
+    assert ota2.last_query_cmd is not None
+    assert ota2.last_query_cmd.manufacturer_code == 0x1234
+    assert ota2.last_query_cmd.image_type == 0x5678
+    assert ota2.last_query_cmd.current_file_version == 0x000A0001
+    assert ota2.last_query_cmd.hardware_version == 3
+    assert dev2.get_last_ota_query_cmd() is ota2.last_query_cmd
+
+    # Update to a command without hardware_version
+    ota2.last_query_cmd = Ota.QueryNextImageCommand(
         field_control=Ota.QueryNextImageCommand.FieldControl(0),
         manufacturer_code=0xAAAA,
         image_type=0xBBBB,
         current_file_version=0x00000042,
     )
+    app2.device_initialized(dev2)
+    await app2.shutdown()
 
-    app.device_initialized(dev)
-    await app.shutdown()
+    app3 = await make_app_with_db(db)
+    dev3 = app3.get_device(ieee)
+    ota3 = dev3.endpoints[1].out_clusters[Ota.cluster_id]
 
-    # Reload and verify each cluster got its own query cmd back
-    app2 = await make_app_with_db(db)
-    dev2 = app2.get_device(ieee)
-    server2 = dev2.endpoints[1].in_clusters[Ota.cluster_id]
-    client2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
-
-    assert server2.last_query_cmd is not None
-    assert server2.last_query_cmd.manufacturer_code == 0x1234
-    assert server2.last_query_cmd.image_type == 0x5678
-    assert server2.last_query_cmd.current_file_version == 0x000A0001
-    assert server2.last_query_cmd.hardware_version == 3
-
-    assert client2.last_query_cmd is not None
-    assert client2.last_query_cmd.manufacturer_code == 0xAAAA
-    assert client2.last_query_cmd.image_type == 0xBBBB
-    assert client2.last_query_cmd.current_file_version == 0x00000042
-    assert not hasattr(client2.last_query_cmd, "hardware_version") or (
-        client2.last_query_cmd.hardware_version is None
+    assert ota3.last_query_cmd is not None
+    assert ota3.last_query_cmd.manufacturer_code == 0xAAAA
+    assert ota3.last_query_cmd.current_file_version == 0x00000042
+    assert not hasattr(ota3.last_query_cmd, "hardware_version") or (
+        ota3.last_query_cmd.hardware_version is None
     )
 
-    # get_last_ota_query_cmd returns the first match (server, since in_clusters first)
-    assert dev2.get_last_ota_query_cmd() is server2.last_query_cmd
-
-    await app2.shutdown()
+    await app3.shutdown()
 
 
 @patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -40,7 +40,12 @@ from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 import zigpy.zcl
-from zigpy.zcl import ClusterType, OtaQueryCacheUpdatedEvent, UnsupportedAttribute
+from zigpy.zcl import (
+    ClusterType,
+    OtaQueryCacheClearedEvent,
+    OtaQueryCacheUpdatedEvent,
+    UnsupportedAttribute,
+)
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota
 from zigpy.zcl.foundation import Status as ZCLStatus, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
@@ -1694,6 +1699,52 @@ async def test_ota_query_cache_event_save(tmp_path):
     assert ota2.last_query_cmd.image_type == 0x2222
     assert ota2.last_query_cmd.current_file_version == 0x00000099
     assert ota2.last_query_cmd.hardware_version == 7
+
+    await app2.shutdown()
+
+
+@patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))
+async def test_ota_query_cache_cleared_after_update(tmp_path):
+    """Test that OTA query cache is deleted from DB when cleared after an update."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+    ieee = make_ieee()
+    app.handle_join(99, ieee, 0)
+
+    dev = app.get_device(ieee)
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+    ota_cluster = ep.add_output_cluster(Ota.cluster_id)
+    app.device_initialized(dev)
+
+    # Save a query cmd
+    ota_cluster.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x5678,
+        current_file_version=0x00000001,
+    )
+    app.device_initialized(dev)
+
+    # Clear the cache (as update_firmware does after a successful OTA)
+    ota_cluster.last_query_cmd = None
+    ota_cluster.emit(
+        OtaQueryCacheClearedEvent.event_type,
+        OtaQueryCacheClearedEvent(
+            device_ieee=str(ieee),
+            endpoint_id=1,
+        ),
+    )
+    await app.shutdown()
+
+    # Reload: the cleared cache should not be restored
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(ieee)
+    ota2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
+    assert ota2.last_query_cmd is None
+    assert dev2.get_last_ota_query_cmd() is None
 
     await app2.shutdown()
 

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1720,6 +1720,59 @@ async def test_ota_query_cache_event_save(tmp_path):
     await app2.shutdown()
 
 
+@patch("zigpy.quirks.DEVICE_REGISTRY", new=DeviceRegistry())
+async def test_ota_query_cache_skips_quirk_removed_endpoint(tmp_path):
+    """Test that OTA cache load skips entries for endpoints removed by quirks."""
+    # Register a quirk that removes endpoint 2
+    (
+        QuirkBuilder(
+            "ota manufacturer", "ota model", registry=zigpy.quirks.DEVICE_REGISTRY
+        )
+        .removes_endpoint(2)
+        .add_to_registry()
+    )
+
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+    dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+    dev.model = "ota model"
+    dev.manufacturer = "ota manufacturer"
+
+    ep1 = dev.add_endpoint(1)
+    ep1.status = zigpy.endpoint.Status.ZDO_INIT
+    ep1.profile_id = 260
+    ep1.device_type = profiles.zha.DeviceType.PUMP
+    basic = ep1.add_input_cluster(Basic.cluster_id)
+    basic.update_attribute(Basic.AttributeDefs.model, "ota model")
+    basic.update_attribute(Basic.AttributeDefs.manufacturer, "ota manufacturer")
+
+    ep2 = dev.add_endpoint(2)
+    ep2.status = zigpy.endpoint.Status.ZDO_INIT
+    ep2.profile_id = 260
+    ep2.device_type = profiles.zha.DeviceType.PUMP
+    ota_cluster = ep2.add_output_cluster(Ota.cluster_id)
+
+    ota_cluster.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x5678,
+        current_file_version=0x00000001,
+    )
+
+    app.device_initialized(dev)
+    await app.shutdown()
+
+    # Reload — quirk removes endpoint 2, OTA cache load should skip it
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+    assert 2 not in dev2.endpoints
+    assert dev2.get_last_ota_query_cmd() is None
+
+    await app2.shutdown()
+
+
 async def test_get_last_ota_query_cmd_returns_none(tmp_path):
     """Test that get_last_ota_query_cmd returns None when no query has been cached."""
     db = tmp_path / "test.db"

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1776,10 +1776,11 @@ async def test_ota_query_cache_load_missing_device(tmp_path):
     with sqlite3.connect(db) as conn:
         conn.execute(
             f"INSERT INTO ota_query_cache{zigpy.appdb.DB_V}"
-            " (ieee, endpoint_id, manufacturer_code, image_type,"
-            "  current_file_version, hardware_version, last_updated)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?)",
-            ("ff:ff:ff:ff:ff:ff:ff:ff", 1, 0xAAAA, 0xBBBB, 0x00000002, None, 0),
+            " (ieee, endpoint_id, cluster_type, manufacturer_code,"
+            "  image_type, current_file_version, hardware_version,"
+            "  last_updated)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("ff:ff:ff:ff:ff:ff:ff:ff", 1, 1, 0xAAAA, 0xBBBB, 0x00000002, None, 0),
         )
 
     # Reload — should not crash, just skip the unknown device row

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1703,8 +1703,6 @@ async def test_ota_query_cache_event_save(tmp_path):
     )
 
     ota_cluster.emit(OtaQueryCacheUpdatedEvent.event_type, event)
-    await asyncio.sleep(0.2)
-
     await app.shutdown()
 
     app2 = await make_app_with_db(db)

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -2,7 +2,6 @@ import asyncio
 import contextlib
 from datetime import UTC, datetime, timedelta
 import pathlib
-import sqlite3
 import threading
 import time
 
@@ -1612,7 +1611,7 @@ async def test_device_signature_ignores_quirks(tmp_path) -> None:
 
 @patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))
 async def test_ota_query_cache_persistence(tmp_path):
-    """Test that OTA query cache is persisted and restored from the database."""
+    """Test that OTA query cache is persisted per cluster type and restored."""
     db = tmp_path / "test.db"
     app = await make_app_with_db(db)
     ieee = make_ieee()
@@ -1624,79 +1623,53 @@ async def test_ota_query_cache_persistence(tmp_path):
     ep.profile_id = 260
     ep.device_type = profiles.zha.DeviceType.PUMP
     ep.add_input_cluster(0)  # Basic cluster, exercises non-OTA skip in load
-    ota_cluster = ep.add_output_cluster(Ota.cluster_id)
+    ota_server = ep.add_input_cluster(Ota.cluster_id)
+    ota_client = ep.add_output_cluster(Ota.cluster_id)
     app.device_initialized(dev)
 
-    # Simulate a query_next_image command from the device
-    cmd = Ota.QueryNextImageCommand(
+    # Server cluster: with hardware_version
+    server_cmd = Ota.QueryNextImageCommand(
         field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
         manufacturer_code=0x1234,
         image_type=0x5678,
         current_file_version=0x000A0001,
     )
-    cmd.hardware_version = 3
+    server_cmd.hardware_version = 3
+    ota_server.last_query_cmd = server_cmd
 
-    ota_cluster.last_query_cmd = cmd
-
-    # Trigger a save
-    app.device_initialized(dev)
-    await app.shutdown()
-
-    # Reload and check the OTA query cache was restored
-    app2 = await make_app_with_db(db)
-    dev2 = app2.get_device(ieee)
-    ota2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
-
-    assert ota2.last_query_cmd is not None
-    assert ota2.last_query_cmd.manufacturer_code == 0x1234
-    assert ota2.last_query_cmd.image_type == 0x5678
-    assert ota2.last_query_cmd.current_file_version == 0x000A0001
-    assert ota2.last_query_cmd.hardware_version == 3
-
-    # Also test get_last_ota_query_cmd
-    assert dev2.get_last_ota_query_cmd() is not None
-    assert dev2.get_last_ota_query_cmd().manufacturer_code == 0x1234
-
-    await app2.shutdown()
-
-
-@patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))
-async def test_ota_query_cache_no_hardware_version(tmp_path):
-    """Test OTA query cache round-trip without hardware_version."""
-    db = tmp_path / "test.db"
-    app = await make_app_with_db(db)
-    ieee = make_ieee()
-    app.handle_join(99, ieee, 0)
-
-    dev = app.get_device(ieee)
-    ep = dev.add_endpoint(1)
-    ep.status = zigpy.endpoint.Status.ZDO_INIT
-    ep.profile_id = 260
-    ep.device_type = profiles.zha.DeviceType.PUMP
-    ota_cluster = ep.add_output_cluster(Ota.cluster_id)
-    app.device_initialized(dev)
-
-    cmd = Ota.QueryNextImageCommand(
+    # Client cluster: without hardware_version
+    ota_client.last_query_cmd = Ota.QueryNextImageCommand(
         field_control=Ota.QueryNextImageCommand.FieldControl(0),
         manufacturer_code=0xAAAA,
         image_type=0xBBBB,
         current_file_version=0x00000042,
     )
-    ota_cluster.last_query_cmd = cmd
+
     app.device_initialized(dev)
     await app.shutdown()
 
+    # Reload and verify each cluster got its own query cmd back
     app2 = await make_app_with_db(db)
     dev2 = app2.get_device(ieee)
-    ota2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
+    server2 = dev2.endpoints[1].in_clusters[Ota.cluster_id]
+    client2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
 
-    assert ota2.last_query_cmd is not None
-    assert ota2.last_query_cmd.manufacturer_code == 0xAAAA
-    assert ota2.last_query_cmd.image_type == 0xBBBB
-    assert ota2.last_query_cmd.current_file_version == 0x00000042
-    assert not hasattr(ota2.last_query_cmd, "hardware_version") or (
-        ota2.last_query_cmd.hardware_version is None
+    assert server2.last_query_cmd is not None
+    assert server2.last_query_cmd.manufacturer_code == 0x1234
+    assert server2.last_query_cmd.image_type == 0x5678
+    assert server2.last_query_cmd.current_file_version == 0x000A0001
+    assert server2.last_query_cmd.hardware_version == 3
+
+    assert client2.last_query_cmd is not None
+    assert client2.last_query_cmd.manufacturer_code == 0xAAAA
+    assert client2.last_query_cmd.image_type == 0xBBBB
+    assert client2.last_query_cmd.current_file_version == 0x00000042
+    assert not hasattr(client2.last_query_cmd, "hardware_version") or (
+        client2.last_query_cmd.hardware_version is None
     )
+
+    # get_last_ota_query_cmd returns the first match (server, since in_clusters first)
+    assert dev2.get_last_ota_query_cmd() is server2.last_query_cmd
 
     await app2.shutdown()
 
@@ -1743,105 +1716,6 @@ async def test_ota_query_cache_event_save(tmp_path):
     assert ota2.last_query_cmd.image_type == 0x2222
     assert ota2.last_query_cmd.current_file_version == 0x00000099
     assert ota2.last_query_cmd.hardware_version == 7
-
-    await app2.shutdown()
-
-
-@patch("zigpy.device.Device.schedule_initialize", new=mock_dev_init(True))
-async def test_ota_query_cache_restore_correct_cluster_type(tmp_path):
-    """Test that OTA query cache restores to the correct cluster type."""
-    db = tmp_path / "test.db"
-    app = await make_app_with_db(db)
-    ieee = make_ieee()
-    app.handle_join(99, ieee, 0)
-
-    dev = app.get_device(ieee)
-    ep = dev.add_endpoint(1)
-    ep.status = zigpy.endpoint.Status.ZDO_INIT
-    ep.profile_id = 260
-    ep.device_type = profiles.zha.DeviceType.PUMP
-    ota_server = ep.add_input_cluster(Ota.cluster_id)
-    ota_client = ep.add_output_cluster(Ota.cluster_id)
-    app.device_initialized(dev)
-
-    # Set different query cmds on each cluster
-    ota_server.last_query_cmd = Ota.QueryNextImageCommand(
-        field_control=Ota.QueryNextImageCommand.FieldControl(0),
-        manufacturer_code=0x1111,
-        image_type=0x2222,
-        current_file_version=0x00000001,
-    )
-    ota_client.last_query_cmd = Ota.QueryNextImageCommand(
-        field_control=Ota.QueryNextImageCommand.FieldControl(0),
-        manufacturer_code=0x3333,
-        image_type=0x4444,
-        current_file_version=0x00000002,
-    )
-
-    app.device_initialized(dev)
-    await app.shutdown()
-
-    # Reload and verify each cluster got its own query cmd back
-    app2 = await make_app_with_db(db)
-    dev2 = app2.get_device(ieee)
-    server2 = dev2.endpoints[1].in_clusters[Ota.cluster_id]
-    client2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
-
-    assert server2.last_query_cmd is not None
-    assert server2.last_query_cmd.manufacturer_code == 0x1111
-    assert server2.last_query_cmd.image_type == 0x2222
-    assert server2.last_query_cmd.current_file_version == 0x00000001
-
-    assert client2.last_query_cmd is not None
-    assert client2.last_query_cmd.manufacturer_code == 0x3333
-    assert client2.last_query_cmd.image_type == 0x4444
-    assert client2.last_query_cmd.current_file_version == 0x00000002
-
-    await app2.shutdown()
-
-
-async def test_ota_query_cache_load_missing_device(tmp_path):
-    """Test that loading OTA cache skips entries for devices no longer in the app."""
-    db = tmp_path / "test.db"
-    app = await make_app_with_db(db)
-    ieee = make_ieee()
-    app.handle_join(99, ieee, 0)
-
-    dev = app.get_device(ieee)
-    ep = dev.add_endpoint(1)
-    ep.status = zigpy.endpoint.Status.ZDO_INIT
-    ep.profile_id = 260
-    ep.device_type = profiles.zha.DeviceType.PUMP
-    ota_cluster = ep.add_output_cluster(Ota.cluster_id)
-    app.device_initialized(dev)
-
-    # Set a query cmd and save
-    ota_cluster.last_query_cmd = Ota.QueryNextImageCommand(
-        field_control=Ota.QueryNextImageCommand.FieldControl(0),
-        manufacturer_code=0x1234,
-        image_type=0x5678,
-        current_file_version=0x00000001,
-    )
-    await app._dblistener._save_device(dev)
-    await app.shutdown()
-
-    # Insert a row referencing a non-existent device directly in the DB
-    with sqlite3.connect(db) as conn:
-        conn.execute(
-            f"INSERT INTO ota_query_cache{zigpy.appdb.DB_V}"
-            " (ieee, endpoint_id, cluster_type, manufacturer_code,"
-            "  image_type, current_file_version, hardware_version,"
-            "  last_updated)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ("ff:ff:ff:ff:ff:ff:ff:ff", 1, 1, 0xAAAA, 0xBBBB, 0x00000002, None, 0),
-        )
-
-    # Reload — should not crash, just skip the unknown device row
-    app2 = await make_app_with_db(db)
-    dev2 = app2.get_device(ieee)
-    ota2 = dev2.endpoints[1].out_clusters[Ota.cluster_id]
-    assert ota2.last_query_cmd is not None
-    assert ota2.last_query_cmd.manufacturer_code == 0x1234
 
     await app2.shutdown()
 

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1764,7 +1764,7 @@ async def test_ota_query_cache_skips_quirk_removed_endpoint(tmp_path):
     app.device_initialized(dev)
     await app.shutdown()
 
-    # Reload — quirk removes endpoint 2, OTA cache load should skip it
+    # Reload: quirk removes endpoint 2, OTA cache load should skip it
     app2 = await make_app_with_db(db)
     dev2 = app2.get_device(t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
     assert 2 not in dev2.endpoints

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 from datetime import UTC, datetime, timedelta
 import pathlib
+import sqlite3
 import threading
 import time
 
@@ -42,7 +43,7 @@ from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 import zigpy.zcl
-from zigpy.zcl import ClusterType, UnsupportedAttribute
+from zigpy.zcl import ClusterType, OtaQueryCacheUpdatedEvent, UnsupportedAttribute
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota
 from zigpy.zcl.foundation import Status as ZCLStatus, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
@@ -1717,8 +1718,6 @@ async def test_ota_query_cache_event_save(tmp_path):
     app.device_initialized(dev)
 
     # Simulate the event that _handle_query_next_image would emit
-    from zigpy.zcl import OtaQueryCacheUpdatedEvent
-
     event = OtaQueryCacheUpdatedEvent(
         device_ieee=str(ieee),
         endpoint_id=1,
@@ -1774,8 +1773,6 @@ async def test_ota_query_cache_load_missing_device(tmp_path):
     await app.shutdown()
 
     # Insert a row referencing a non-existent device directly in the DB
-    import sqlite3
-
     with sqlite3.connect(db) as conn:
         conn.execute(
             f"INSERT INTO ota_query_cache{zigpy.appdb.DB_V}"

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -276,8 +276,13 @@ async def test_migration_missing_node_descriptor(test_db, caplog):
     [
         ("INSERT INTO node_descriptors_v4 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", 0),
         ("INSERT INTO neighbors_v4 VALUES (?,?,?,?,?,?,?,?,?,?,?,?)", 5),
-        ("SELECT * FROM output_clusters", 0),
-        ("INSERT INTO neighbors_v5 VALUES (?,?,?,?,?,?,?,?,?,?,?,?)", 5),
+        ("SELECT ieee, endpoint_id, cluster FROM output_clusters", 0),
+        (
+            "INSERT INTO neighbors_v5 (device_ieee, extended_pan_id, ieee, nwk,"
+            " device_type, rx_on_when_idle, relationship, reserved1, permit_joining,"
+            " reserved2, depth, lqi) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            5,
+        ),
     ],
 )
 async def test_migration_failure(fail_on_sql, fail_on_count, test_db):
@@ -476,12 +481,34 @@ async def test_migration_missing_tables(app):
     # The untouched table will never be queried
     await appdb._migrate_tables({"table1_v1": "table1_v2", "table2_v1": None})
 
-    mock_execute.assert_called_once_with("SELECT * FROM table1_v1")
-
-    with pytest.raises(AssertionError):
-        mock_execute.assert_called_once_with("SELECT * FROM table2_v1")
+    # table1_v1 is queried (pragma + select), table2_v1 is not
+    assert any("table1_v1" in call.args[0] for call in mock_execute.call_args_list)
+    assert not any("table2_v1" in call.args[0] for call in mock_execute.call_args_list)
 
     await appdb.shutdown()
+
+
+async def test_migrate_tables_integrity_error_raises(tmp_path):
+    """Test that _migrate_tables re-raises IntegrityError with errors='raise'."""
+    db_path = tmp_path / "test.db"
+    app = await make_app_with_db(db_path)
+
+    # Create two simple tables, pre-populate the destination with a conflicting row
+    await app._dblistener.execute(
+        "CREATE TABLE src_v1 (id INTEGER PRIMARY KEY, val TEXT)"
+    )
+    await app._dblistener.execute(
+        "CREATE TABLE dst_v2 (id INTEGER PRIMARY KEY, val TEXT)"
+    )
+    await app._dblistener.execute("INSERT INTO src_v1 VALUES (1, 'hello')")
+    await app._dblistener.execute("INSERT INTO dst_v2 VALUES (1, 'conflict')")
+
+    app._dblistener._get_table_versions = AsyncMock(return_value={"src_v1": "1"})
+
+    with pytest.raises(sqlite3.IntegrityError):
+        await app._dblistener._migrate_tables({"src_v1": "dst_v2"})
+
+    await app.shutdown()
 
 
 async def test_last_seen_initial_migration(test_db):
@@ -541,7 +568,7 @@ async def test_unknown_manufacturer_code_migration(test_db, caplog):
     # Count rows after migration
     with sqlite3.connect(test_db_prod) as conn:
         cur = conn.cursor()
-        cur.execute("SELECT COUNT(*) FROM attributes_cache_v14")
+        cur.execute(f"SELECT COUNT(*) FROM attributes_cache{zigpy.appdb.DB_V}")
         after_total = cur.fetchone()[0]
 
         assert after_total == before_total
@@ -586,9 +613,9 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     with sqlite3.connect(test_db_path) as conn:
         cur = conn.cursor()
         cur.execute(
-            """
+            f"""
             SELECT manufacturer_code
-            FROM attributes_cache_v14
+            FROM attributes_cache{zigpy.appdb.DB_V}
             WHERE cluster_id = 0xFC00 AND attr_id = 0x0002
             """,
         )
@@ -600,9 +627,9 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     with sqlite3.connect(test_db_path) as conn:
         cur = conn.cursor()
         cur.execute(
-            """
+            f"""
             SELECT manufacturer_code, status
-            FROM attributes_cache_v14
+            FROM attributes_cache{zigpy.appdb.DB_V}
             WHERE ieee = ? AND cluster_id = 0xFC00 AND attr_id = 0x0004
             """,
             (third_reality_ieee,),
@@ -689,7 +716,7 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
 
     with sqlite3.connect(db_path) as conn:
         conn.executemany(
-            "INSERT INTO attributes_cache_v14"
+            f"INSERT INTO attributes_cache{zigpy.appdb.DB_V}"
             " (ieee, endpoint_id, cluster_type, cluster_id,"
             "  attr_id, manufacturer_code, status, value, last_updated)"
             " VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)",
@@ -728,7 +755,7 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
     with sqlite3.connect(db_path) as conn:
         # The disambiguated unmigrated row was deleted (a row with 0xABCD already existed)
         rows = conn.execute(
-            "SELECT manufacturer_code FROM attributes_cache_v14"
+            f"SELECT manufacturer_code FROM attributes_cache{zigpy.appdb.DB_V}"
             " WHERE ieee = ? AND cluster_id = ? AND attr_id = ?",
             (str(dev.ieee), 0xFC01, 0x0010),
         ).fetchall()
@@ -736,7 +763,7 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
 
         # The ambiguous unmigrated row is still present
         rows = conn.execute(
-            "SELECT manufacturer_code FROM attributes_cache_v14"
+            f"SELECT manufacturer_code FROM attributes_cache{zigpy.appdb.DB_V}"
             " WHERE ieee = ? AND cluster_id = ? AND attr_id = ?",
             (str(dev.ieee), 0xFC02, 0x0020),
         ).fetchall()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -18,7 +18,7 @@ from zigpy.profiles import zha
 import zigpy.state
 import zigpy.types as t
 import zigpy.util
-from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl import ClusterType, OtaQueryCacheClearedEvent, foundation
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PollControl
 from zigpy.zdo import types as zdo_t
 
@@ -713,6 +713,10 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
 
     dev.application.send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
+
+    cleared_events = []
+    cluster.on_event(OtaQueryCacheClearedEvent.event_type, cleared_events.append)
+
     result = await dev.update_firmware(fw_image, progress_callback)
     assert (
         dev.endpoints[1]
@@ -726,6 +730,8 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     assert progress_callback.call_args_list[0] == call(40, 70, 57.142857142857146)
     assert progress_callback.call_args_list[1] == call(70, 70, 100.0)
     assert result == foundation.Status.SUCCESS
+    assert len(cleared_events) == 1
+    assert isinstance(cleared_events[0], OtaQueryCacheClearedEvent)
 
     progress_callback.reset_mock()
     dev.application.send_packet.reset_mock()

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -11,7 +11,7 @@ import pytest
 from zigpy import device, types, zcl
 import zigpy.endpoint
 from zigpy.ota import OtaImagesResult
-from zigpy.zcl import foundation
+from zigpy.zcl import OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import Basic, Ota, Time
 import zigpy.zcl.clusters.security as sec
 from zigpy.zdo import types as zdo_t
@@ -349,6 +349,9 @@ async def test_ota_handle_query_next_image(ota_cluster):
     )
     cmd = MagicMock()
 
+    cache_events = []
+    ota_cluster.on_event(OtaQueryCacheUpdatedEvent.event_type, cache_events.append)
+
     # No image is available
     dev.application.ota.get_ota_images = AsyncMock(
         return_value=OtaImagesResult(upgrades=(), downgrades=())
@@ -363,6 +366,8 @@ async def test_ota_handle_query_next_image(ota_cluster):
         call(OtaImagesResult(upgrades=(), downgrades=()), cmd)
     ]
     assert ota_cluster.last_query_cmd is cmd
+    assert len(cache_events) == 1
+    assert isinstance(cache_events[0], OtaQueryCacheUpdatedEvent)
 
     ota_cluster.query_next_image_response.reset_mock()
     listener.device_ota_image_query_result.reset_mock()

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -323,6 +323,7 @@ async def test_ota_handle_query_next_image(ota_cluster):
     assert listener.device_ota_image_query_result.mock_calls == [
         call(OtaImagesResult(upgrades=(), downgrades=()), cmd)
     ]
+    assert ota_cluster.last_query_cmd is cmd
 
     ota_cluster.query_next_image_response.reset_mock()
     listener.device_ota_image_query_result.reset_mock()

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -34,8 +34,9 @@ from zigpy.zcl import (
     AttributeUpdatedEvent,
     AttributeWrittenEvent,
     ClusterType,
+    OtaQueryCacheUpdatedEvent,
 )
-from zigpy.zcl.clusters.general import Basic
+from zigpy.zcl.clusters.general import Basic, Ota
 from zigpy.zcl.foundation import Status
 from zigpy.zdo import types as zdo_t
 
@@ -54,7 +55,7 @@ if sqlite3.sqlite_version_info < MIN_SQLITE_VERSION:
 
 LOGGER = logging.getLogger(__name__)
 
-DB_VERSION = 14
+DB_VERSION = 15
 DB_V = f"_v{DB_VERSION}"
 
 UNIX_EPOCH = datetime.fromtimestamp(0, tz=UTC)
@@ -228,6 +229,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             AttributeUnsupportedEvent.event_type, self.on_attribute_unsupported
         )
         cluster.on_event(AttributeClearedEvent.event_type, self.on_attribute_cleared)
+        cluster.on_event(
+            OtaQueryCacheUpdatedEvent.event_type,
+            self.on_ota_query_cache_updated,
+        )
 
     def enqueue(self, cb_name: str, *args) -> None:
         """Enqueue an async callback handler action."""
@@ -417,6 +422,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             await self._save_clusters(ep)
             await self._save_attribute_cache(ep)
             await self._save_unsupported_attributes(ep)
+        await self._save_ota_query_cache(device)
         await self._db.commit()
 
     async def _save_endpoints(self, device: Device) -> None:
@@ -526,6 +532,36 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     DO NOTHING"""
         await self._db.executemany(q, clusters)
 
+    async def _save_ota_query_cache(self, device: Device) -> None:
+        rows = []
+        for ep in device.non_zdo_endpoints:
+            for cluster in ep.clusters:
+                if isinstance(cluster, Ota) and cluster.last_query_cmd is not None:
+                    cmd = cluster.last_query_cmd
+                    rows.append(
+                        (
+                            device.ieee,
+                            ep.endpoint_id,
+                            cmd.manufacturer_code,
+                            cmd.image_type,
+                            cmd.current_file_version,
+                            getattr(cmd, "hardware_version", None),
+                            datetime.now(UTC).timestamp(),
+                        )
+                    )
+        if rows:
+            q = f"""INSERT INTO ota_query_cache{DB_V}
+                        (ieee, endpoint_id, manufacturer_code, image_type,
+                         current_file_version, hardware_version, last_updated)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT (ieee, endpoint_id) DO UPDATE SET
+                        manufacturer_code=excluded.manufacturer_code,
+                        image_type=excluded.image_type,
+                        current_file_version=excluded.current_file_version,
+                        hardware_version=excluded.hardware_version,
+                        last_updated=excluded.last_updated"""
+            await self._db.executemany(q, rows)
+
     def on_attribute_read(self, event: AttributeReadEvent) -> None:
         self.enqueue("_save_attribute", event)
 
@@ -631,6 +667,37 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         )
         await self._db.commit()
 
+    def on_ota_query_cache_updated(self, event: OtaQueryCacheUpdatedEvent) -> None:
+        self.enqueue("_save_ota_query_cache_entry", event)
+
+    async def _save_ota_query_cache_entry(
+        self, event: OtaQueryCacheUpdatedEvent
+    ) -> None:
+        q = f"""INSERT INTO ota_query_cache{DB_V}
+                    (ieee, endpoint_id, manufacturer_code, image_type,
+                     current_file_version, hardware_version, last_updated)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (ieee, endpoint_id) DO UPDATE SET
+                    manufacturer_code=excluded.manufacturer_code,
+                    image_type=excluded.image_type,
+                    current_file_version=excluded.current_file_version,
+                    hardware_version=excluded.hardware_version,
+                    last_updated=excluded.last_updated"""
+
+        await self.execute(
+            q,
+            (
+                event.device_ieee,
+                event.endpoint_id,
+                event.manufacturer_code,
+                event.image_type,
+                event.current_file_version,
+                event.hardware_version,
+                datetime.now(UTC).timestamp(),
+            ),
+        )
+        await self._db.commit()
+
     def network_backup_created(self, backup: zigpy.backups.NetworkBackup) -> None:
         self.enqueue("_network_backup_created", json.dumps(backup.as_dict()))
 
@@ -707,6 +774,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._load_neighbors()
         await self._load_routes()
         await self._load_network_backups()
+        await self._load_ota_query_cache()
 
         await self._db.commit()
 
@@ -1014,6 +1082,42 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         for backup in backups:
             self._application.backups.add_backup(backup, suppress_event=True)
 
+    async def _load_ota_query_cache(self) -> None:
+        async with self.execute(f"SELECT * FROM ota_query_cache{DB_V}") as cursor:
+            async for (
+                ieee,
+                endpoint_id,
+                manufacturer_code,
+                image_type,
+                current_file_version,
+                hardware_version,
+                _last_updated,
+            ) in cursor:
+                try:
+                    dev = self._application.get_device(ieee)
+                    ep = dev.endpoints[endpoint_id]
+                except (KeyError, AttributeError):
+                    continue
+
+                for cluster in ep.clusters:
+                    if not isinstance(cluster, Ota):
+                        continue
+
+                    field_control = (
+                        Ota.QueryNextImageCommand.FieldControl(0)
+                        if hardware_version is None
+                        else Ota.QueryNextImageCommand.FieldControl.HardwareVersion
+                    )
+                    cmd = Ota.QueryNextImageCommand(
+                        field_control=field_control,
+                        manufacturer_code=manufacturer_code,
+                        image_type=image_type,
+                        current_file_version=current_file_version,
+                    )
+                    if hardware_version is not None:
+                        cmd.hardware_version = hardware_version
+                    cluster.last_query_cmd = cmd
+
     async def _register_device_listeners(self) -> None:
         for dev in self._application.devices.values():
             dev.add_context_listener(self)
@@ -1105,6 +1209,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 (self._migrate_to_v12, 12),
                 (self._migrate_to_v13, 13),
                 (self._migrate_to_v14, 14),
+                (self._migrate_to_v15, 15),
             ]:
                 if db_version >= min(to_db_version, DB_VERSION):
                     continue
@@ -1145,14 +1250,19 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             if new_table is None:
                 continue
 
-            async with self.execute(f"SELECT * FROM {old_table}") as cursor:
-                async for row in cursor:
-                    placeholders = ",".join("?" * len(row))
+            # Use explicit column names to skip generated columns automatically
+            async with self.execute(f"PRAGMA table_info({old_table})") as cursor:
+                columns = [row[1] async for row in cursor]
 
+            col_list = ", ".join(columns)
+            placeholders = ", ".join("?" * len(columns))
+            select_sql = f"SELECT {col_list} FROM {old_table}"
+            insert_sql = f"INSERT INTO {new_table} ({col_list}) VALUES ({placeholders})"
+
+            async with self.execute(select_sql) as cursor:
+                async for row in cursor:
                     try:
-                        await self.execute(
-                            f"INSERT INTO {new_table} VALUES ({placeholders})", row
-                        )
+                        await self.execute(insert_sql, row)
                     except sqlite3.IntegrityError as e:
                         if errors == "raise":
                             raise
@@ -1546,3 +1656,22 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                         last_updated,
                     ),
                 )
+
+    async def _migrate_to_v15(self) -> None:
+        """Schema v15 adds `ota_query_cache` table for persisting OTA query fields."""
+        await self._migrate_tables(
+            {
+                "devices_v14": "devices_v15",
+                "endpoints_v14": "endpoints_v15",
+                "neighbors_v14": "neighbors_v15",
+                "routes_v14": "routes_v15",
+                "node_descriptors_v14": "node_descriptors_v15",
+                "groups_v14": "groups_v15",
+                "group_members_v14": "group_members_v15",
+                "relays_v14": "relays_v15",
+                "network_backups_v14": "network_backups_v15",
+                "clusters_v14": "clusters_v15",
+                "attributes_cache_v14": "attributes_cache_v15",
+            }
+        )
+        # ota_query_cache_v15 is new and starts empty

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -1096,7 +1096,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 try:
                     dev = self._application.get_device(ieee)
                     ep = dev.endpoints[endpoint_id]
-                except (KeyError, AttributeError):
+                except KeyError:
                     # Quirks or firmware updates can remove endpoints/clusters
                     continue
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -1102,6 +1102,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     dev = self._application.get_device(ieee)
                     ep = dev.endpoints[endpoint_id]
                 except (KeyError, AttributeError):
+                    # Quirks or firmware updates can remove endpoints/clusters
                     continue
 
                 cluster_type = ClusterType(cluster_type)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -542,6 +542,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                         (
                             device.ieee,
                             ep.endpoint_id,
+                            cluster.cluster_type,
                             cmd.manufacturer_code,
                             cmd.image_type,
                             cmd.current_file_version,
@@ -551,10 +552,11 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     )
         if rows:
             q = f"""INSERT INTO ota_query_cache{DB_V}
-                        (ieee, endpoint_id, manufacturer_code, image_type,
-                         current_file_version, hardware_version, last_updated)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT (ieee, endpoint_id) DO UPDATE SET
+                        (ieee, endpoint_id, cluster_type, manufacturer_code,
+                         image_type, current_file_version, hardware_version,
+                         last_updated)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT (ieee, endpoint_id, cluster_type) DO UPDATE SET
                         manufacturer_code=excluded.manufacturer_code,
                         image_type=excluded.image_type,
                         current_file_version=excluded.current_file_version,
@@ -674,10 +676,11 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         self, event: OtaQueryCacheUpdatedEvent
     ) -> None:
         q = f"""INSERT INTO ota_query_cache{DB_V}
-                    (ieee, endpoint_id, manufacturer_code, image_type,
-                     current_file_version, hardware_version, last_updated)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT (ieee, endpoint_id) DO UPDATE SET
+                    (ieee, endpoint_id, cluster_type, manufacturer_code,
+                     image_type, current_file_version, hardware_version,
+                     last_updated)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (ieee, endpoint_id, cluster_type) DO UPDATE SET
                     manufacturer_code=excluded.manufacturer_code,
                     image_type=excluded.image_type,
                     current_file_version=excluded.current_file_version,
@@ -689,6 +692,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             (
                 event.device_ieee,
                 event.endpoint_id,
+                event.cluster_type,
                 event.manufacturer_code,
                 event.image_type,
                 event.current_file_version,
@@ -1087,6 +1091,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             async for (
                 ieee,
                 endpoint_id,
+                cluster_type,
                 manufacturer_code,
                 image_type,
                 current_file_version,
@@ -1099,24 +1104,31 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 except (KeyError, AttributeError):
                     continue
 
-                for cluster in ep.clusters:
-                    if not isinstance(cluster, Ota):
-                        continue
+                cluster_type = ClusterType(cluster_type)
 
-                    field_control = (
-                        Ota.QueryNextImageCommand.FieldControl(0)
-                        if hardware_version is None
-                        else Ota.QueryNextImageCommand.FieldControl.HardwareVersion
-                    )
-                    cmd = Ota.QueryNextImageCommand(
-                        field_control=field_control,
-                        manufacturer_code=manufacturer_code,
-                        image_type=image_type,
-                        current_file_version=current_file_version,
-                    )
-                    if hardware_version is not None:
-                        cmd.hardware_version = hardware_version
-                    cluster.last_query_cmd = cmd
+                if cluster_type == ClusterType.Server:
+                    clusters = ep.in_clusters
+                else:
+                    clusters = ep.out_clusters
+
+                cluster = clusters.get(Ota.cluster_id)
+                if not isinstance(cluster, Ota):
+                    continue
+
+                field_control = (
+                    Ota.QueryNextImageCommand.FieldControl(0)
+                    if hardware_version is None
+                    else Ota.QueryNextImageCommand.FieldControl.HardwareVersion
+                )
+                cmd = Ota.QueryNextImageCommand(
+                    field_control=field_control,
+                    manufacturer_code=manufacturer_code,
+                    image_type=image_type,
+                    current_file_version=current_file_version,
+                )
+                if hardware_version is not None:
+                    cmd.hardware_version = hardware_version
+                cluster.last_query_cmd = cmd
 
     async def _register_device_listeners(self) -> None:
         for dev in self._application.devices.values():

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -542,7 +542,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                         (
                             device.ieee,
                             ep.endpoint_id,
-                            cluster.cluster_type,
                             cmd.manufacturer_code,
                             cmd.image_type,
                             cmd.current_file_version,
@@ -552,11 +551,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     )
         if rows:
             q = f"""INSERT INTO ota_query_cache{DB_V}
-                        (ieee, endpoint_id, cluster_type, manufacturer_code,
-                         image_type, current_file_version, hardware_version,
-                         last_updated)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT (ieee, endpoint_id, cluster_type) DO UPDATE SET
+                        (ieee, endpoint_id, manufacturer_code, image_type,
+                         current_file_version, hardware_version, last_updated)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT (ieee, endpoint_id) DO UPDATE SET
                         manufacturer_code=excluded.manufacturer_code,
                         image_type=excluded.image_type,
                         current_file_version=excluded.current_file_version,
@@ -676,11 +674,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         self, event: OtaQueryCacheUpdatedEvent
     ) -> None:
         q = f"""INSERT INTO ota_query_cache{DB_V}
-                    (ieee, endpoint_id, cluster_type, manufacturer_code,
-                     image_type, current_file_version, hardware_version,
-                     last_updated)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT (ieee, endpoint_id, cluster_type) DO UPDATE SET
+                    (ieee, endpoint_id, manufacturer_code, image_type,
+                     current_file_version, hardware_version, last_updated)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (ieee, endpoint_id) DO UPDATE SET
                     manufacturer_code=excluded.manufacturer_code,
                     image_type=excluded.image_type,
                     current_file_version=excluded.current_file_version,
@@ -692,7 +689,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             (
                 event.device_ieee,
                 event.endpoint_id,
-                event.cluster_type,
                 event.manufacturer_code,
                 event.image_type,
                 event.current_file_version,
@@ -1091,7 +1087,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             async for (
                 ieee,
                 endpoint_id,
-                cluster_type,
                 manufacturer_code,
                 image_type,
                 current_file_version,
@@ -1103,17 +1098,6 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                     ep = dev.endpoints[endpoint_id]
                 except (KeyError, AttributeError):
                     # Quirks or firmware updates can remove endpoints/clusters
-                    continue
-
-                cluster_type = ClusterType(cluster_type)
-
-                if cluster_type == ClusterType.Server:
-                    clusters = ep.in_clusters
-                else:
-                    clusters = ep.out_clusters
-
-                cluster = clusters.get(Ota.cluster_id)
-                if not isinstance(cluster, Ota):
                     continue
 
                 field_control = (
@@ -1129,7 +1113,15 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 )
                 if hardware_version is not None:
                     cmd.hardware_version = hardware_version
-                cluster.last_query_cmd = cmd
+
+                # Restore to the first OTA cluster found; prefer client
+                # (out_clusters) since that's where runtime routing places it
+                # when both cluster types exist.
+                for clusters in (ep.out_clusters, ep.in_clusters):
+                    cluster = clusters.get(Ota.cluster_id)
+                    if isinstance(cluster, Ota):
+                        cluster.last_query_cmd = cmd
+                        break
 
     async def _register_device_listeners(self) -> None:
         for dev in self._application.devices.values():

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -34,6 +34,7 @@ from zigpy.zcl import (
     AttributeUpdatedEvent,
     AttributeWrittenEvent,
     ClusterType,
+    OtaQueryCacheClearedEvent,
     OtaQueryCacheUpdatedEvent,
 )
 from zigpy.zcl.clusters.general import Basic, Ota
@@ -232,6 +233,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         cluster.on_event(
             OtaQueryCacheUpdatedEvent.event_type,
             self.on_ota_query_cache_updated,
+        )
+        cluster.on_event(
+            OtaQueryCacheClearedEvent.event_type,
+            self.on_ota_query_cache_cleared,
         )
 
     def enqueue(self, cb_name: str, *args) -> None:
@@ -695,6 +700,18 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 event.hardware_version,
                 datetime.now(UTC).timestamp(),
             ),
+        )
+        await self._db.commit()
+
+    def on_ota_query_cache_cleared(self, event: OtaQueryCacheClearedEvent) -> None:
+        self.enqueue("_delete_ota_query_cache_entry", event)
+
+    async def _delete_ota_query_cache_entry(
+        self, event: OtaQueryCacheClearedEvent
+    ) -> None:
+        await self.execute(
+            f"DELETE FROM ota_query_cache{DB_V} WHERE ieee = ? AND endpoint_id = ?",
+            (event.device_ieee, event.endpoint_id),
         )
         await self._db.commit()
 

--- a/zigpy/appdb_schemas/schema_v15.sql
+++ b/zigpy/appdb_schemas/schema_v15.sql
@@ -1,0 +1,218 @@
+PRAGMA user_version = 15;
+
+-- devices
+DROP TABLE IF EXISTS devices_v15;
+CREATE TABLE devices_v15 (
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+    last_seen REAL NOT NULL
+);
+
+CREATE UNIQUE INDEX devices_idx_v15
+    ON devices_v15(ieee);
+
+
+-- endpoints
+DROP TABLE IF EXISTS endpoints_v15;
+CREATE TABLE endpoints_v15 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    profile_id INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v15(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX endpoint_idx_v15
+    ON endpoints_v15(ieee, endpoint_id);
+
+
+-- clusters
+DROP TABLE IF EXISTS clusters_v15;
+CREATE TABLE clusters_v15 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v15(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX clusters_idx_v15
+    ON clusters_v15(ieee, endpoint_id, cluster_type, cluster_id);
+
+
+-- attributes
+DROP TABLE IF EXISTS attributes_cache_v15;
+CREATE TABLE attributes_cache_v15 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+    attr_id INTEGER NOT NULL,
+    manufacturer_code INTEGER,
+    -- NULL is not considered equal to itself in unique indexes, so we need a non-NULL
+    -- column to use in the unique index
+    manufacturer_code_idx INTEGER NOT NULL GENERATED ALWAYS AS (IFNULL(manufacturer_code, -2)) STORED,
+    status INTEGER,
+    value BLOB,
+    last_updated REAL NOT NULL,
+
+    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
+    -- DB but whose values still need to be cached
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v15(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX attributes_cache_idx_v15
+    ON attributes_cache_v15(ieee, endpoint_id, cluster_type, cluster_id, attr_id, manufacturer_code_idx);
+
+
+-- neighbors
+DROP TABLE IF EXISTS neighbors_v15;
+CREATE TABLE neighbors_v15 (
+    device_ieee ieee NOT NULL,
+    extended_pan_id ieee NOT NULL,
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    rx_on_when_idle INTEGER NOT NULL,
+    relationship INTEGER NOT NULL,
+    reserved1 INTEGER NOT NULL,
+    permit_joining INTEGER NOT NULL,
+    reserved2 INTEGER NOT NULL,
+    depth INTEGER NOT NULL,
+    lqi INTEGER NOT NULL,
+
+    FOREIGN KEY(device_ieee)
+        REFERENCES devices_v15(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX neighbors_idx_v15
+    ON neighbors_v15(device_ieee);
+
+
+-- routes
+DROP TABLE IF EXISTS routes_v15;
+CREATE TABLE routes_v15 (
+    device_ieee ieee NOT NULL,
+    dst_nwk INTEGER NOT NULL,
+    route_status INTEGER NOT NULL,
+    memory_constrained INTEGER NOT NULL,
+    many_to_one INTEGER NOT NULL,
+    route_record_required INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    next_hop INTEGER NOT NULL
+);
+
+CREATE INDEX routes_idx_v15
+    ON routes_v15(device_ieee);
+
+
+-- node descriptors
+DROP TABLE IF EXISTS node_descriptors_v15;
+CREATE TABLE node_descriptors_v15 (
+    ieee ieee NOT NULL,
+
+    logical_type INTEGER NOT NULL,
+    complex_descriptor_available INTEGER NOT NULL,
+    user_descriptor_available INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    aps_flags INTEGER NOT NULL,
+    frequency_band INTEGER NOT NULL,
+    mac_capability_flags INTEGER NOT NULL,
+    manufacturer_code INTEGER NOT NULL,
+    maximum_buffer_size INTEGER NOT NULL,
+    maximum_incoming_transfer_size INTEGER NOT NULL,
+    server_mask INTEGER NOT NULL,
+    maximum_outgoing_transfer_size INTEGER NOT NULL,
+    descriptor_capability_field INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v15(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX node_descriptors_idx_v15
+    ON node_descriptors_v15(ieee);
+
+
+-- groups
+DROP TABLE IF EXISTS groups_v15;
+CREATE TABLE groups_v15 (
+    group_id INTEGER NOT NULL,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX groups_idx_v15
+    ON groups_v15(group_id);
+
+
+-- group members
+DROP TABLE IF EXISTS group_members_v15;
+CREATE TABLE group_members_v15 (
+    group_id INTEGER NOT NULL,
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+
+    FOREIGN KEY(group_id)
+        REFERENCES groups_v15(group_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v15(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX group_members_idx_v15
+    ON group_members_v15(group_id, ieee, endpoint_id);
+
+
+-- relays
+DROP TABLE IF EXISTS relays_v15;
+CREATE TABLE relays_v15 (
+    ieee ieee NOT NULL,
+    relays BLOB NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v15(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX relays_idx_v15
+    ON relays_v15(ieee);
+
+
+-- network backups
+DROP TABLE IF EXISTS network_backups_v15;
+CREATE TABLE network_backups_v15 (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    backup_json TEXT NOT NULL
+);
+
+
+-- OTA query cache: stores fields from the last query_next_image command per device
+DROP TABLE IF EXISTS ota_query_cache_v15;
+CREATE TABLE ota_query_cache_v15 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    manufacturer_code INTEGER NOT NULL,
+    image_type INTEGER NOT NULL,
+    current_file_version INTEGER NOT NULL,
+    hardware_version INTEGER,
+    last_updated REAL NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v15(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX ota_query_cache_idx_v15
+    ON ota_query_cache_v15(ieee, endpoint_id);

--- a/zigpy/appdb_schemas/schema_v15.sql
+++ b/zigpy/appdb_schemas/schema_v15.sql
@@ -209,8 +209,8 @@ CREATE TABLE ota_query_cache_v15 (
     hardware_version INTEGER,
     last_updated REAL NOT NULL,
 
-    FOREIGN KEY(ieee)
-        REFERENCES devices_v15(ieee)
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v15(ieee, endpoint_id)
         ON DELETE CASCADE
 );
 

--- a/zigpy/appdb_schemas/schema_v15.sql
+++ b/zigpy/appdb_schemas/schema_v15.sql
@@ -203,6 +203,7 @@ DROP TABLE IF EXISTS ota_query_cache_v15;
 CREATE TABLE ota_query_cache_v15 (
     ieee ieee NOT NULL,
     endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
     manufacturer_code INTEGER NOT NULL,
     image_type INTEGER NOT NULL,
     current_file_version INTEGER NOT NULL,
@@ -215,4 +216,4 @@ CREATE TABLE ota_query_cache_v15 (
 );
 
 CREATE UNIQUE INDEX ota_query_cache_idx_v15
-    ON ota_query_cache_v15(ieee, endpoint_id);
+    ON ota_query_cache_v15(ieee, endpoint_id, cluster_type);

--- a/zigpy/appdb_schemas/schema_v15.sql
+++ b/zigpy/appdb_schemas/schema_v15.sql
@@ -203,7 +203,6 @@ DROP TABLE IF EXISTS ota_query_cache_v15;
 CREATE TABLE ota_query_cache_v15 (
     ieee ieee NOT NULL,
     endpoint_id INTEGER NOT NULL,
-    cluster_type INTEGER NOT NULL,
     manufacturer_code INTEGER NOT NULL,
     image_type INTEGER NOT NULL,
     current_file_version INTEGER NOT NULL,
@@ -216,4 +215,4 @@ CREATE TABLE ota_query_cache_v15 (
 );
 
 CREATE UNIQUE INDEX ota_query_cache_idx_v15
-    ON ota_query_cache_v15(ieee, endpoint_id, cluster_type);
+    ON ota_query_cache_v15(ieee, endpoint_id);

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -38,7 +38,7 @@ from zigpy.profiles import zha, zll
 import zigpy.types as t
 import zigpy.util
 from zigpy.zcl import Cluster, ClusterType, foundation
-from zigpy.zcl.clusters.general import Ota, PollControl
+from zigpy.zcl.clusters.general import Ota, PollControl, QueryNextImageCommand
 import zigpy.zdo.types as zdo_t
 
 if typing.TYPE_CHECKING:
@@ -928,6 +928,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             cluster_id=Ota.cluster_id, cluster_type=ClusterType.Client
         )
         ota.update_attribute(Ota.AttributeDefs.current_file_version.id, None)
+        ota.last_query_cmd = None
 
         await asyncio.sleep(AFTER_OTA_ATTR_READ_DELAY)
         await OTA_RETRY_DECORATOR(ota.read_attributes)(
@@ -935,6 +936,14 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         )
 
         return result
+
+    def get_last_ota_query_cmd(self) -> QueryNextImageCommand | None:
+        """Return the last cached QueryNextImageCommand from any OTA cluster."""
+        for ep in self.non_zdo_endpoints:
+            for cluster in ep.clusters:
+                if isinstance(cluster, Ota) and cluster.last_query_cmd is not None:
+                    return cluster.last_query_cmd
+        return None
 
     def radio_details(self, lqi=None, rssi=None) -> None:
         if lqi is not None:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -37,7 +37,7 @@ from zigpy.ota.manager import update_firmware
 from zigpy.profiles import zha, zll
 import zigpy.types as t
 import zigpy.util
-from zigpy.zcl import Cluster, ClusterType, foundation
+from zigpy.zcl import Cluster, ClusterType, OtaQueryCacheClearedEvent, foundation
 from zigpy.zcl.clusters.general import Ota, PollControl, QueryNextImageCommand
 import zigpy.zdo.types as zdo_t
 
@@ -929,6 +929,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         )
         ota.update_attribute(Ota.AttributeDefs.current_file_version.id, None)
         ota.last_query_cmd = None
+        ota.emit(
+            OtaQueryCacheClearedEvent.event_type,
+            OtaQueryCacheClearedEvent(
+                device_ieee=str(self.ieee),
+                endpoint_id=ota.endpoint.endpoint_id,
+            ),
+        )
 
         await asyncio.sleep(AFTER_OTA_ATTR_READ_DELAY)
         await OTA_RETRY_DECORATOR(ota.read_attributes)(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -938,9 +938,12 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         return result
 
     def get_last_ota_query_cmd(self) -> QueryNextImageCommand | None:
-        """Return the last cached QueryNextImageCommand from any OTA cluster."""
+        """Return the last cached QueryNextImageCommand, preferring client clusters."""
         for ep in self.non_zdo_endpoints:
-            for cluster in ep.clusters:
+            # Prefer client (out) clusters since runtime routing places
+            # query_next_image there when both cluster types exist.
+            for clusters in (ep.out_clusters, ep.in_clusters):
+                cluster = clusters.get(Ota.cluster_id)
                 if isinstance(cluster, Ota) and cluster.last_query_cmd is not None:
                     return cluster.last_query_cmd
         return None

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -216,6 +216,16 @@ class OtaQueryCacheUpdatedEvent:
     hardware_version: int | None
 
 
+@dataclass(kw_only=True, frozen=True)
+class OtaQueryCacheClearedEvent:
+    """Event generated when OTA query cache is cleared after a successful update."""
+
+    event_type: Final[str] = "ota_query_cache_cleared"
+
+    device_ieee: str
+    endpoint_id: int
+
+
 def convert_list_schema(
     schema: Sequence[type], command_id: int, direction: foundation.Direction
 ) -> type[t.Struct]:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -200,6 +200,22 @@ class AttributeClearedEvent:
     manufacturer_code: int | None
 
 
+@dataclass(kw_only=True, frozen=True)
+class OtaQueryCacheUpdatedEvent:
+    """Event generated when OTA query_next_image fields are cached on a cluster."""
+
+    event_type: Final[str] = "ota_query_cache_updated"
+
+    device_ieee: str
+    endpoint_id: int
+    cluster_type: ClusterType
+    cluster_id: int
+    manufacturer_code: int
+    image_type: int
+    current_file_version: int
+    hardware_version: int | None
+
+
 def convert_list_schema(
     schema: Sequence[type], command_id: int, direction: foundation.Direction
 ) -> type[t.Struct]:

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from typing import Any, Final, Self
 
 import zigpy.types as t
-from zigpy.zcl import Cluster, foundation
+from zigpy.zcl import Cluster, OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
@@ -2024,6 +2024,10 @@ class Ota(Cluster):
     cluster_id: Final[t.uint16_t] = 0x0019
     ep_attribute: Final = "ota"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.last_query_cmd: QueryNextImageCommand | None = None
+
     class AttributeDefs(BaseAttributeDefs):
         upgrade_server_id: Final = ZCLAttributeDef(
             id=0x0000, type=t.EUI64, access="r", mandatory=True
@@ -2153,6 +2157,22 @@ class Ota(Cluster):
         # Always send no image available response so that the device stops asking
         await self.query_next_image_response(
             foundation.Status.NO_IMAGE_AVAILABLE, tsn=hdr.tsn
+        )
+
+        # Cache the query command fields for proactive OTA lookups
+        self.last_query_cmd = cmd
+        self.emit(
+            OtaQueryCacheUpdatedEvent.event_type,
+            OtaQueryCacheUpdatedEvent(
+                device_ieee=str(self.endpoint.device.ieee),
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_type=self.cluster_type,
+                cluster_id=self.cluster_id,
+                manufacturer_code=cmd.manufacturer_code,
+                image_type=cmd.image_type,
+                current_file_version=cmd.current_file_version,
+                hardware_version=getattr(cmd, "hardware_version", None),
+            ),
         )
 
         device = self.endpoint.device

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2159,11 +2159,6 @@ class Ota(Cluster):
             )
 
     async def _handle_query_next_image(self, hdr, cmd):
-        # Always send no image available response so that the device stops asking
-        await self.query_next_image_response(
-            foundation.Status.NO_IMAGE_AVAILABLE, tsn=hdr.tsn
-        )
-
         # Cache the query command fields for proactive OTA lookups
         self.last_query_cmd = cmd
         self.emit(
@@ -2178,6 +2173,11 @@ class Ota(Cluster):
                 current_file_version=cmd.current_file_version,
                 hardware_version=getattr(cmd, "hardware_version", None),
             ),
+        )
+
+        # Always send no image available response so that the device stops asking
+        await self.query_next_image_response(
+            foundation.Status.NO_IMAGE_AVAILABLE, tsn=hdr.tsn
         )
 
         device = self.endpoint.device


### PR DESCRIPTION
## Note

An AI summary is below but it's adjusted to be accurate. 😄 

The main problem this tries to solve is the issue of all ZHA entities being "Unknown" after HA is restarted, with devices needing to send a `query_img_command` before zigpy fetches all possible OTA images, finally causing a proper state to be shown in HA. This can take hours, e.g. when zigpy sends its first OTA notify broadcast, where not even all devices check-in.

Do note that, if we like to change this behavior in the future, we can always drop the table and don't really need to care about migrating. The only issue is that it'll take some time before all the updates show again.
This is just a (very) nice to have feature. Nothing critical, like the attribute cache.

## Problem

To proactively fetch all possible OTA images for a device, zigpy needs the fields from the device's `QueryNextImageCommand`: `manufacturer_code`, `image_type`, `current_file_version`, and `hardware_version`. Currently, these values are only used transiently when a device checks in, and are not stored anywhere.

While the OTA cluster does define ZCL attributes for some of these fields (`manufacturer_id`, `image_type_id`, `current_file_version`), they **cannot** be reliably used:

- **Some devices return incorrect values** when these attributes are read directly, differing from what they report in the `query_next_image` command.
- **No ZCL attribute exists for `hardware_version`**, which is needed by `check_compatibility` to match images with hardware version constraints.

## Solution

Store the last received `QueryNextImageCommand` fields in a **new dedicated `ota_query_cache` table** in the application database, keyed by `(ieee, endpoint_id)`.

### How it works

1. When a device sends a `query_next_image` command (in response to `image_notify`), the `Ota` cluster now caches the command on `self.last_query_cmd` and emits an `OtaQueryCacheUpdatedEvent`.
2. The `PersistingListener` in `appdb.py` handles this event and upserts the fields into the `ota_query_cache` table.
3. On database load, stored query commands are reconstructed and placed back on the appropriate `Ota` cluster instances.
4. Callers can use `device.get_last_ota_query_cmd()` to retrieve the cached command for proactive OTA image lookups via `ota.get_ota_images(device, query_cmd)`.
5. After a successful firmware update, `last_query_cmd` is cleared so stale version info is not reused.

### Impact on ZHA

The existing `device_ota_image_query_result` listener event flow is unchanged. ZHA continues to work as-is.
(`OtaQueryCacheUpdatedEvent` is emitted immediately when the cache is updated. `get_ota_images` is called by zigpy afterwards, so we can't replace it with the listener event. But we could introduce another event or something, possibly in another PR.)

This PR enables ZHA to **proactively check for OTA images on startup** instead of waiting for each device to check in. Currently, after a ZHA restart, the update entity has no firmware availability information until the device sends a `query_next_image` (spontaneously or in response to `image_notify`). With the persisted query cache, ZHA could populate this immediately by reusing the existing `device_ota_image_query_result` handler:

```python
# In FirmwareUpdateEntity.on_add or similar:
query_cmd = self.device.device.get_last_ota_query_cmd()
if query_cmd is not None:
    images_result = await self.device.device.application.ota.get_ota_images(
        self.device.device, query_cmd
    )
    # Reuse the existing handler with cached data
    self.device_ota_image_query_result(images_result, query_cmd)
```

### Further thoughts for ZHA/HA

Above code would fetch info from providers on startup but not download any new images for trusted providers (zigpy-ota)  with pending PR https://github.com/zigpy/zigpy/pull/1749.
The Matter integration has a different implementation where the [update entity restores](https://github.com/home-assistant/core/blob/e8a35ea69de70f2d98f1996ac6eef0242314b635/homeassistant/components/matter/update.py#L179-L184) a [lot of data](https://github.com/matter-js/python-matter-server/blob/9637a985ed5946efc698abb5901f22d6436f91cf/matter_server/common/models.py#L228-L273). The Matter server itself must fetch DCL data later.

So alternatively, I'm wondering if we should also immediately restore old data in Home Assistant. I guess the update entities would have the correct state maybe a second or two sooner but that likely doesn't matter (no need to fetch the index).
Then, ZHA or zigpy could be modified to also call `get_ota_images` in `update_firmware` (which ZHA can call with the last known latest firmware version) to make sure the image can be installed.

We could delay any global `get_ota_images` checks by 10 to 60 minutes, so HA doesn't immediately re-fetch the latest index upon startup and just reuses previous update information until we re-fetch it.
Either way, this is something that's mostly done in ZHA/HA and nothing that would impact this first PR.

Related backlog issue:
- https://github.com/zigpy/backlog/issues/15