### PR TITLE
Suppress expected warnings in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ enabled = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+filterwarnings = [
+    "ignore:Attribute .* has `is_manufacturer_specific` without an explicit `manufacturer_code`:DeprecationWarning",
+    "ignore:Increasing the TX power:UserWarning",
+]
 
 [tool.ruff]
 required-version = ">=0.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,6 @@ enabled = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-filterwarnings = [
-    "ignore:Attribute .* has `is_manufacturer_specific` without an explicit `manufacturer_code`:DeprecationWarning",
-    "ignore:Increasing the TX power:UserWarning",
-]
 
 [tool.ruff]
 required-version = ">=0.5.0"

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -548,7 +548,8 @@ async def test_unknown_manufacturer_code_migration(test_db, caplog):
 
 
 @pytest.mark.filterwarnings(
-    r"ignore:Attribute .* has `is_manufacturer_specific` without an explicit `manufacturer_code`:DeprecationWarning"
+    r"ignore:Attribute .* has `is_manufacturer_specific`"
+    r":DeprecationWarning"
 )
 async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     """Test that attributes on manufacturer-specific clusters get the device's manufacturer_id."""
@@ -631,7 +632,8 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
 
 
 @pytest.mark.filterwarnings(
-    r"ignore:Attribute .* has `is_manufacturer_specific` without an explicit `manufacturer_code`:DeprecationWarning"
+    r"ignore:Attribute .* has `is_manufacturer_specific`"
+    r":DeprecationWarning"
 )
 async def test_data_migration_ambiguous_attributes(tmp_path):
     """Test data migration disambiguation when find_attributes returns multiple."""

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -547,6 +547,9 @@ async def test_unknown_manufacturer_code_migration(test_db, caplog):
         assert after_total == before_total
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:Attribute .* has `is_manufacturer_specific` without an explicit `manufacturer_code`:DeprecationWarning"
+)
 async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     """Test that attributes on manufacturer-specific clusters get the device's manufacturer_id."""
 
@@ -627,6 +630,9 @@ async def test_manufacturer_code_migration_uses_device_manufacturer_id(test_db):
     await app.shutdown()
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:Attribute .* has `is_manufacturer_specific` without an explicit `manufacturer_code`:DeprecationWarning"
+)
 async def test_data_migration_ambiguous_attributes(tmp_path):
     """Test data migration disambiguation when find_attributes returns multiple."""
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -590,6 +590,7 @@ async def test_form_network_tx_power(
         (FeaturelessApp, {"network": {"tx_power": 15, "country_code": "NL"}}, 15),
     ],
 )
+@pytest.mark.filterwarnings("ignore:Increasing the TX power:UserWarning")
 async def test_startup_tx_power_config(
     app_cls: type[zigpy.application.ControllerApplication],
     config_override: dict,

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1691,6 +1691,9 @@ def test_find_attribute_colliding_manufacturer_codes() -> None:
     assert TestCluster.find_attribute(0x0002) is TestCluster.AttributeDefs.attribute4
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:Attribute .* has `is_manufacturer_specific` without an explicit `manufacturer_code`:DeprecationWarning"
+)
 def test_find_attribute_unspecified_manufacturer_code() -> None:
     """Test attribute finding when the manufacturer code is unspecified."""
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1692,7 +1692,8 @@ def test_find_attribute_colliding_manufacturer_codes() -> None:
 
 
 @pytest.mark.filterwarnings(
-    r"ignore:Attribute .* has `is_manufacturer_specific` without an explicit `manufacturer_code`:DeprecationWarning"
+    r"ignore:Attribute .* has `is_manufacturer_specific`"
+    r":DeprecationWarning"
 )
 def test_find_attribute_unspecified_manufacturer_code() -> None:
     """Test attribute finding when the manufacturer code is unspecified."""


### PR DESCRIPTION
This filters expected warnings triggered by various tests.
There are two approaches (commits) though the current one (filtering by test) makes more sense IMO.