### PR TITLE
Bump zigpy-ota schema to v2

### DIFF
--- a/tests/ota/files/zigpy_ota_version_dev.json
+++ b/tests/ota/files/zigpy_ota_version_dev.json
@@ -2,7 +2,7 @@
   "schemas": {
     "zigpy_v2": {
       "version": "dev",
-      "url": "https://raw.githubusercontent.com/zigpy/zigpy-ota/release/files/dev/zigpy_v1_ota.json"
+      "url": "https://raw.githubusercontent.com/zigpy/zigpy-ota/release/files/dev/zigpy_v2_ota.json"
     },
     "z2m_v1": {
       "version": "dev",

--- a/tests/ota/files/zigpy_ota_version_dev.json
+++ b/tests/ota/files/zigpy_ota_version_dev.json
@@ -1,6 +1,6 @@
 {
   "schemas": {
-    "zigpy_v1": {
+    "zigpy_v2": {
       "version": "dev",
       "url": "https://raw.githubusercontent.com/zigpy/zigpy-ota/release/files/dev/zigpy_v1_ota.json"
     },

--- a/tests/ota/files/zigpy_ota_version_stable.json
+++ b/tests/ota/files/zigpy_ota_version_stable.json
@@ -1,6 +1,6 @@
 {
   "schemas": {
-    "zigpy_v1": {
+    "zigpy_v2": {
       "version": "0.0.20",
       "url": "https://github.com/zigpy/zigpy-ota/releases/download/0.0.20/zigpy_v1_ota.json"
     },

--- a/tests/ota/files/zigpy_ota_version_stable.json
+++ b/tests/ota/files/zigpy_ota_version_stable.json
@@ -2,7 +2,7 @@
   "schemas": {
     "zigpy_v2": {
       "version": "0.0.20",
-      "url": "https://github.com/zigpy/zigpy-ota/releases/download/0.0.20/zigpy_v1_ota.json"
+      "url": "https://github.com/zigpy/zigpy-ota/releases/download/0.0.20/zigpy_v2_ota.json"
     },
     "z2m_v1": {
       "version": "0.0.20",

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -672,7 +672,7 @@ async def test_ota_fetch_size_and_checksum_validation(
 
 async def test_zigpy_ota_provider():
     version_json = (FILES_DIR / "zigpy_ota_version_stable.json").read_text()
-    version_obj = json.loads(version_json)  # {"schemas": {"zigpy_v1": {...}}} format
+    version_obj = json.loads(version_json)  # {"schemas": {"zigpy_v2": {...}}} format
     index_json = (FILES_DIR / "zigpy_ota_index.json").read_text()
     index_obj = json.loads(index_json)  # {"firmwares": [...]} format
 
@@ -687,7 +687,7 @@ async def test_zigpy_ota_provider():
     version_url = (
         "https://raw.githubusercontent.com/zigpy/zigpy-ota/release/version/stable.json"
     )
-    index_url = version_obj["schemas"]["zigpy_v1"]["url"]
+    index_url = version_obj["schemas"]["zigpy_v2"]["url"]
 
     with aioresponses() as mock_http:
         mock_http.get(version_url, body=version_json, content_type="application/json")
@@ -758,7 +758,7 @@ async def test_zigpy_ota_provider_channel(
         url
         or f"https://raw.githubusercontent.com/zigpy/zigpy-ota/release/version/{channel}.json"
     )
-    index_url = version_obj["schemas"]["zigpy_v1"]["url"]
+    index_url = version_obj["schemas"]["zigpy_v2"]["url"]
 
     with aioresponses() as mock_http:
         mock_http.get(version_url, body=version_json, content_type="application/json")

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -725,8 +725,8 @@ class ZigpyOtaProvider(BaseZigpyProvider):
             version_data = await rsp.json(content_type=None)
 
         # Extract the index URL from the version file
-        # Format: {"schemas": {"zigpy_v1": {"version": "...", "url": "..."}}}
-        index_url = version_data["schemas"]["zigpy_v1"]["url"]
+        # Format: {"schemas": {"zigpy_v2": {"version": "...", "url": "..."}}}
+        index_url = version_data["schemas"]["zigpy_v2"]["url"]
 
         # Now fetch the actual OTA index
         async with session.get(index_url) as rsp:


### PR DESCRIPTION
## Proposed change

This bumps the schema version for the zigpy-ota provider to `v2` to align with the latest zigpy-ota release.

Corresponding zigpy-ota PR + release:
- https://github.com/zigpy/zigpy-ota/pull/29
- https://github.com/zigpy/zigpy-ota/releases/tag/2026.2.0

## Additional information

https://github.com/zigpy/zigpy/pull/1781 changed OTA behavior by increasing the OTA block size limit. This is to work around an issue with Sonoff/Telink devices that require OTA block sizes of 48 bytes, rejecting any images with our previous limit of 40.

As (some) new images pushed to the zigpy-ota will be incompatible with older zigpy versions, we bump the schema of zigpy-ota from v1 to v2. Older zigpy versions will still be available to install all updates that were available up to this point, so Aeotec and Innr images (https://github.com/zigpy/zigpy-ota/releases/tag/2026.1.1, which includes [these images](https://github.com/zigpy/zigpy-ota/blob/f2b66c2f14d9c9e4825ab1e0407e059cd33f8dd3/stable/markdown_v1.md)).

### Future

In the future, we'll consider implementing a min/max application version field in the OTA metadata, so we can individually limit specific images to certain ZHA versions. When doing that, we'll likely want to bump the schema to v3.