### PR TITLE
Match devices with missing models/manufacturers with quirks v2

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -215,9 +215,9 @@ async def test_quirks_v2_model_manufacturer(device_mock):
 @pytest.mark.parametrize(
     ("manufacturer", "model"),
     [
+        ("manufacturer", "model"),  # has both
         ("manufacturer", None),  # missing model
         (None, "model"),  # missing manufacturer
-        (None, None),  # missing both
     ],
 )
 async def test_quirks_v2_missing_model_manufacturer(

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -201,6 +201,16 @@ async def test_quirks_v2_model_manufacturer(device_mock):
             .add_to_registry()
         )
 
+    with pytest.raises(
+        ValueError,
+        match="At least one manufacturer and model must be specified for a v2 quirk.",
+    ):
+        (
+            QuirkBuilder(registry=registry)
+            # Fails early, before we even add it to the registry
+            .applies_to(manufacturer=None, model=None)
+        )
+
 
 @pytest.mark.parametrize(
     ("manufacturer", "model"),

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -185,38 +185,6 @@ async def test_quirks_v2_model_manufacturer(device_mock):
 
     with pytest.raises(
         ValueError,
-        match="manufacturer and model must be provided together or completely omitted.",
-    ):
-        (
-            QuirkBuilder(device_mock.manufacturer, model=None, registry=registry)
-            .adds(Basic.cluster_id)
-            .adds(OnOff.cluster_id)
-            .enum(
-                OnOff.AttributeDefs.start_up_on_off.name,
-                OnOff.StartUpOnOff,
-                OnOff.cluster_id,
-            )
-            .add_to_registry()
-        )
-
-    with pytest.raises(
-        ValueError,
-        match="manufacturer and model must be provided together or completely omitted.",
-    ):
-        (
-            QuirkBuilder(manufacturer=None, model=device_mock.model, registry=registry)
-            .adds(Basic.cluster_id)
-            .adds(OnOff.cluster_id)
-            .enum(
-                OnOff.AttributeDefs.start_up_on_off.name,
-                OnOff.StartUpOnOff,
-                OnOff.cluster_id,
-            )
-            .add_to_registry()
-        )
-
-    with pytest.raises(
-        ValueError,
         match="At least one manufacturer and model must be specified for a v2 quirk.",
     ):
         (
@@ -232,6 +200,49 @@ async def test_quirks_v2_model_manufacturer(device_mock):
             )
             .add_to_registry()
         )
+
+
+@pytest.mark.parametrize(
+    ("manufacturer", "model"),
+    [
+        ("manufacturer", None),  # missing model
+        (None, "model"),  # missing manufacturer
+        (None, None),  # missing both
+    ],
+)
+async def test_quirks_v2_missing_model_manufacturer(
+    app_mock, manufacturer: str | None, model: str | None
+):
+    """Test that v2 quirks can match devices with missing model/manufacturer."""
+    registry = DeviceRegistry()
+
+    quirk = (
+        QuirkBuilder(manufacturer, model, registry=registry)
+        .adds(Basic.cluster_id)
+        .adds(OnOff.cluster_id)
+        .add_to_registry()
+    )
+
+    device = Device(app_mock, sentinel.ieee, 0x2233)
+    device.add_endpoint(1)
+    device[1].profile_id = 255
+    device[1].device_type = 255
+    device[1].add_input_cluster(3)
+    device[1].add_output_cluster(6)
+
+    if manufacturer is not None:
+        device.manufacturer = manufacturer
+
+    if model is not None:
+        device.model = model
+
+    quirked = registry.get_device(device)
+    assert isinstance(quirked, CustomDeviceV2)
+    assert quirked.quirk_metadata is quirk
+
+    assert quirked in registry
+    registry.remove(quirked)
+    assert quirked not in registry
 
 
 async def test_quirks_v2_quirk_builder_cloning(device_mock):

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -203,7 +203,7 @@ async def test_quirks_v2_model_manufacturer(device_mock):
 
     with pytest.raises(
         ValueError,
-        match="At least one manufacturer and model must be specified for a v2 quirk.",
+        match="A manufacturer and/or model must be specified for a v2 quirk.",
     ):
         (
             QuirkBuilder(registry=registry)

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -78,7 +78,7 @@ class DeviceRegistry:
                 self.registry_v1[manufacturer][model].appendleft(custom_device)
 
     def add_to_registry_v2(
-        self, manufacturer: str, model: str, entry: QuirksV2RegistryEntry
+        self, manufacturer: str | None, model: str | None, entry: QuirksV2RegistryEntry
     ) -> None:
         """Add an entry to the registry."""
         self._registry_v2[(manufacturer, model)].appendleft(entry)

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -682,7 +682,7 @@ class QuirkBuilder:
         """Register this quirks v2 entry for the specified manufacturer and model."""
         if manufacturer is None and model is None:
             raise ValueError(
-                "At least one manufacturer and model must be specified for a v2 quirk."
+                "A manufacturer and/or model must be specified for a v2 quirk."
             )
 
         self.manufacturer_model_metadata.append(

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -11,7 +11,7 @@ import inspect
 import logging
 import pathlib
 from types import FrameType
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Self, overload
 
 import attrs
 from frozendict import frozendict
@@ -669,8 +669,22 @@ class QuirkBuilder:
         self.entity_metadata.append(entity_metadata)
         return self
 
+    @overload
+    def applies_to(self, manufacturer: str, model: str) -> Self: ...
+
+    @overload
+    def applies_to(self, manufacturer: str, model: str | None) -> Self: ...
+
+    @overload
+    def applies_to(self, manufacturer: None, model: str) -> Self: ...
+
     def applies_to(self, manufacturer: str | None, model: str | None) -> Self:
         """Register this quirks v2 entry for the specified manufacturer and model."""
+        if manufacturer is None and model is None:
+            raise ValueError(
+                "At least one manufacturer and model must be specified for a v2 quirk."
+            )
+
         self.manufacturer_model_metadata.append(
             ManufacturerModelMetadata(manufacturer=manufacturer, model=model)
         )

--- a/zigpy/quirks/v2/__init__.py
+++ b/zigpy/quirks/v2/__init__.py
@@ -33,6 +33,7 @@ from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
+from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import Ota
 from zigpy.zdo import ZDO
@@ -421,8 +422,8 @@ class ZCLCommandButtonMetadata(EntityMetadata):
 class ManufacturerModelMetadata:
     """Metadata for manufacturers and models to apply this quirk to."""
 
-    manufacturer: str = attrs.field(default=None)
-    model: str = attrs.field(default=None)
+    manufacturer: str | None = attrs.field(default=None)
+    model: str | None = attrs.field(default=None)
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
@@ -604,16 +605,11 @@ class QuirkBuilder:
 
     def __init__(
         self,
-        manufacturer: str | None = None,
-        model: str | None = None,
+        manufacturer: str | None | UndefinedType = UNDEFINED,
+        model: str | None | UndefinedType = UNDEFINED,
         registry: DeviceRegistry | None = None,
     ) -> None:
         """Initialize the quirk builder."""
-        if manufacturer and not model or model and not manufacturer:
-            raise ValueError(
-                "manufacturer and model must be provided together or completely omitted."
-            )
-
         self.registry: DeviceRegistry = (
             registry if registry is not None else DEVICE_REGISTRY
         )
@@ -655,8 +651,11 @@ class QuirkBuilder:
         self.quirk_file = pathlib.Path(caller.f_code.co_filename)
         self.quirk_file_line = caller.f_lineno
 
-        if manufacturer and model:
-            self.applies_to(manufacturer, model)
+        if manufacturer is not UNDEFINED or model is not UNDEFINED:
+            self.applies_to(
+                manufacturer=manufacturer if manufacturer is not UNDEFINED else None,
+                model=model if model is not UNDEFINED else None,
+            )
 
         UNBUILT_QUIRK_BUILDERS.append(self)
 
@@ -670,7 +669,7 @@ class QuirkBuilder:
         self.entity_metadata.append(entity_metadata)
         return self
 
-    def applies_to(self, manufacturer: str, model: str) -> Self:
+    def applies_to(self, manufacturer: str | None, model: str | None) -> Self:
         """Register this quirks v2 entry for the specified manufacturer and model."""
         self.manufacturer_model_metadata.append(
             ManufacturerModelMetadata(manufacturer=manufacturer, model=model)
@@ -1369,7 +1368,9 @@ class QuirkBuilder:
 
 
 def add_to_registry_v2(
-    manufacturer: str, model: str, registry: DeviceRegistry = DEVICE_REGISTRY
+    manufacturer: str | None,
+    model: str | None,
+    registry: DeviceRegistry = DEVICE_REGISTRY,
 ) -> QuirkBuilder:
     """Add an entry to the registry."""
     _LOGGER.error(


### PR DESCRIPTION
A few devices do not have a valid model or manufacturer name but we should still match them with quirks v2.

Should help with https://github.com/zigpy/zha/issues/705.