### PR TITLE
Allow quirk loading to fail

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib.util
 import itertools
+import logging
 import pathlib
 import pkgutil
 import sys
@@ -1075,3 +1076,41 @@ QuirkBuilder("manufacturer2", "model2").adds(
 
     assert registry.get_device(dev1) is dev1
     assert registry.get_device(dev2) is dev2
+
+
+def test_quirk_v1_loading_failure(real_device, caplog) -> None:
+    class TestQuirk(zigpy.quirks.CustomDevice):
+        signature = {
+            SIG_MODELS_INFO: (("manufacturer", "model"),),
+            SIG_ENDPOINTS: {
+                1: {
+                    SIG_EP_PROFILE: 255,
+                    SIG_EP_TYPE: 255,
+                    SIG_EP_INPUT: [3],
+                    SIG_EP_OUTPUT: [6],
+                }
+            },
+        }
+
+        replacement = {
+            SIG_ENDPOINTS: {
+                1: {
+                    SIG_EP_PROFILE: 255,
+                    SIG_EP_TYPE: 255,
+                    SIG_EP_INPUT: [3],
+                    SIG_EP_OUTPUT: [6],
+                }
+            },
+        }
+
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("Failed to initialize quirk")
+
+    registry = DeviceRegistry()
+    registry.add_to_registry(TestQuirk)
+
+    with caplog.at_level(logging.ERROR, logger="zigpy.quirks"):
+        quirked = zigpy.quirks.get_device(real_device, registry=registry)
+
+    assert quirked is real_device
+    assert "Failed to initialize quirk" in caplog.text

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -1079,6 +1079,8 @@ QuirkBuilder("manufacturer2", "model2").adds(
 
 
 def test_quirk_v1_loading_failure(real_device, caplog) -> None:
+    """Test that v1 quirks can fail to load without crashing zigpy."""
+
     class TestQuirk(zigpy.quirks.CustomDevice):
         signature = {
             SIG_MODELS_INFO: (("manufacturer", "model"),),

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1634,7 +1634,7 @@ def test_quirk_v2_loading_failure(
         def __init__(self, *args, **kwargs) -> None:
             raise RuntimeError("This device failed to initialize")
 
-    entry = (
+    _entry = (
         QuirkBuilder(registry=registry)
         .applies_to(
             manufacturer=device_mock.manufacturer,
@@ -1647,5 +1647,5 @@ def test_quirk_v2_loading_failure(
     with caplog.at_level(logging.ERROR):
         quirked = registry.get_device(device_mock)
 
-    assert quirked is entry
+    assert quirked is device_mock
     assert "Failed to load quirk for" in caplog.text

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1635,11 +1635,10 @@ def test_quirk_v2_loading_failure(
             raise RuntimeError("This device failed to initialize")
 
     entry = (
-        QuirkBuilder()
+        QuirkBuilder(registry=registry)
         .applies_to(
             manufacturer=device_mock.manufacturer,
             model=device_mock.model,
-            registry=registry,
         )
         .device_class(BadCustomDevice)
         .add_to_registry()

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -1,5 +1,6 @@
 """Tests for the quirks v2 module."""
 
+import logging
 import pathlib
 from typing import Any, Final
 from unittest.mock import AsyncMock
@@ -1618,3 +1619,34 @@ def test_recursive_freeze(obj, expected):
     result = recursive_freeze(obj)
     assert strict_eq(result, expected)
     hash(result)
+
+
+def test_quirk_v2_loading_failure(
+    device_mock: Device, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that v2 quirks can fail to load without crashing zigpy."""
+
+    registry = DeviceRegistry()
+
+    class BadCustomDevice(CustomDeviceV2):
+        """Custom device with bad quirk definition."""
+
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("This device failed to initialize")
+
+    entry = (
+        QuirkBuilder()
+        .applies_to(
+            manufacturer=device_mock.manufacturer,
+            model=device_mock.model,
+            registry=registry,
+        )
+        .device_class(BadCustomDevice)
+        .add_to_registry()
+    )
+
+    with caplog.at_level(logging.ERROR):
+        quirked = registry.get_device(device_mock)
+
+    assert quirked is entry
+    assert "Failed to load quirk for" in caplog.text

--- a/zigpy/const.py
+++ b/zigpy/const.py
@@ -22,3 +22,5 @@ INTERFERENCE_MESSAGE = (
 
 APS_REPLY_TIMEOUT = 5
 APS_REPLY_TIMEOUT_EXTENDED = 28
+
+QUIRKS_REPO_URL = "https://github.com/zigpy/zha-device-handlers"

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -35,15 +35,13 @@ _uninitialized_device_message_handlers = []
 
 
 def get_device(
-    device: zigpy.device.Device, registry: DeviceRegistry = DEVICE_REGISTRY
+    device: zigpy.device.Device, registry: DeviceRegistry | None = None
 ) -> zigpy.device.Device:
     """Get a CustomDevice object, if one is available"""
+    if registry is None:
+        return DEVICE_REGISTRY.get_device(device)
 
-    try:
-        return registry.get_device(device)
-    except Exception:
-        _LOGGER.exception("Error setting up quirk for device %r", device)
-        return device
+    return registry.get_device(device)
 
 
 def get_quirk_list(

--- a/zigpy/quirks/__init__.py
+++ b/zigpy/quirks/__init__.py
@@ -35,13 +35,15 @@ _uninitialized_device_message_handlers = []
 
 
 def get_device(
-    device: zigpy.device.Device, registry: DeviceRegistry | None = None
+    device: zigpy.device.Device, registry: DeviceRegistry = DEVICE_REGISTRY
 ) -> zigpy.device.Device:
     """Get a CustomDevice object, if one is available"""
-    if registry is None:
-        return DEVICE_REGISTRY.get_device(device)
 
-    return registry.get_device(device)
+    try:
+        return registry.get_device(device)
+    except Exception:
+        _LOGGER.exception("Error setting up quirk for device %r", device)
+        return device
 
 
 def get_quirk_list(

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -140,7 +140,7 @@ class DeviceRegistry:
             try:
                 return candidate(device._application, device.ieee, device.nwk, device)
             except Exception:
-                _LOGGER.exception("Error creating quirk for %r: %r", device, candidate)
+                _LOGGER.exception("Failed to load quirk for %r: %r", device, candidate)
                 return device
 
         # If none match, return the original device

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -118,7 +118,13 @@ class DeviceRegistry:
         if key in self._registry_v2:
             for entry in self._registry_v2[key]:
                 if entry.matches_device(device):
-                    return entry.create_device(device)
+                    try:
+                        return entry.create_device(device)
+                    except Exception:
+                        _LOGGER.exception(
+                            "Failed to load quirk for %r: %r", device, entry
+                        )
+                        return device
 
         # Then, fall back to v1 quirks
         for candidate in itertools.chain(

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -136,7 +136,12 @@ class DeviceRegistry:
             _LOGGER.debug(
                 "Found custom device replacement for %s: %s", device.ieee, candidate
             )
-            return candidate(device._application, device.ieee, device.nwk, device)
+
+            try:
+                return candidate(device._application, device.ieee, device.nwk, device)
+            except Exception:
+                _LOGGER.exception("Error creating quirk for %r: %r", device, candidate)
+                return device
 
         # If none match, return the original device
         return device

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -123,11 +123,10 @@ class DeviceRegistry:
                     except Exception:  # noqa: BLE001
                         _LOGGER.exception(
                             (
-                                "Failed to load quirk for %r: %r\n"
+                                "Failed to load quirk for %r.\n"
                                 "This is a bug. Please report it here: %s"
                             ),
                             device,
-                            entry,
                             QUIRKS_REPO_URL,
                         )
                         return device

--- a/zigpy/quirks/registry.py
+++ b/zigpy/quirks/registry.py
@@ -9,7 +9,7 @@ import logging
 import pathlib
 from typing import TYPE_CHECKING, cast
 
-from zigpy.const import SIG_MANUFACTURER, SIG_MODEL, SIG_MODELS_INFO
+from zigpy.const import QUIRKS_REPO_URL, SIG_MANUFACTURER, SIG_MODEL, SIG_MODELS_INFO
 import zigpy.quirks
 from zigpy.util import deprecated
 
@@ -120,9 +120,15 @@ class DeviceRegistry:
                 if entry.matches_device(device):
                     try:
                         return entry.create_device(device)
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         _LOGGER.exception(
-                            "Failed to load quirk for %r: %r", device, entry
+                            (
+                                "Failed to load quirk for %r: %r\n"
+                                "This is a bug. Please report it here: %s"
+                            ),
+                            device,
+                            entry,
+                            QUIRKS_REPO_URL,
                         )
                         return device
 
@@ -145,8 +151,16 @@ class DeviceRegistry:
 
             try:
                 return candidate(device._application, device.ieee, device.nwk, device)
-            except Exception:
-                _LOGGER.exception("Failed to load quirk for %r: %r", device, candidate)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception(
+                    (
+                        "Failed to load quirk for %r: %r\n"
+                        "This is a bug. Please report it here: %s"
+                    ),
+                    device,
+                    candidate,
+                    QUIRKS_REPO_URL,
+                )
                 return device
 
         # If none match, return the original device


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/165380 exposed a bug with quirk loading: if a quirk fails to load, it takes down zigpy and the rest of ZHA in the process. This should not happen.

Independently, should `.removes()` hard crash when the cluster isn't present? Or should it silently succeed?