### PR TITLE
Return `ZCLAttributeDef` and status for reporting configuration

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -907,7 +907,7 @@ async def test_configure_reporting_multiple(cluster):
     )
     assert cluster.endpoint.request.call_count == 2
     assert len(results) == 1
-    assert results[0].status == zcl.foundation.Status.SUCCESS
+    assert results[Basic.AttributeDefs.hw_version] == zcl.foundation.Status.SUCCESS
     # Both methods should produce equivalent requests
     assert (
         cluster.endpoint.request.mock_calls[0] == cluster.endpoint.request.mock_calls[1]
@@ -932,7 +932,9 @@ async def test_configure_reporting_multiple_def_rsp(cluster):
     )
     assert cluster.endpoint.request.await_count == 1
     assert len(results) == 2
-    assert all(r.status == zcl.foundation.Status.UNSUP_GENERAL_COMMAND for r in results)
+    assert all(
+        s == zcl.foundation.Status.UNSUP_GENERAL_COMMAND for s in results.values()
+    )
 
 
 def _mk_cfg_rsp(responses: dict[int, zcl.foundation.Status]):
@@ -968,7 +970,7 @@ async def test_configure_reporting_multiple_single_success(cluster):
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
     assert len(results) == 2
-    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
+    assert all(s == zcl.foundation.Status.SUCCESS for s in results.values())
 
 
 async def test_configure_reporting_multiple_single_fail(cluster):
@@ -995,15 +997,11 @@ async def test_configure_reporting_multiple_single_fail(cluster):
     assert cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
     assert len(results) == 2
-    results_by_attrid = {r.attrid: r for r in results}
     assert (
-        results_by_attrid[Basic.AttributeDefs.hw_version.id].status
+        results[Basic.AttributeDefs.hw_version]
         == zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE
     )
-    assert (
-        results_by_attrid[Basic.AttributeDefs.manufacturer.id].status
-        == zcl.foundation.Status.SUCCESS
-    )
+    assert results[Basic.AttributeDefs.manufacturer] == zcl.foundation.Status.SUCCESS
 
     cluster.endpoint.request.return_value = _mk_cfg_rsp(
         {3: zcl.foundation.Status.SUCCESS}
@@ -1021,7 +1019,7 @@ async def test_configure_reporting_multiple_single_fail(cluster):
     assert cluster.endpoint.request.await_count == 2
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
     assert len(results) == 2
-    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
+    assert all(s == zcl.foundation.Status.SUCCESS for s in results.values())
 
 
 async def test_configure_reporting_multiple_single_unreportable(cluster):
@@ -1044,15 +1042,11 @@ async def test_configure_reporting_multiple_single_unreportable(cluster):
     # UNREPORTABLE_ATTRIBUTE doesn't mark the attribute as unsupported
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
     assert len(results) == 2
-    results_by_attrid = {r.attrid: r for r in results}
     assert (
-        results_by_attrid[Basic.AttributeDefs.manufacturer.id].status
+        results[Basic.AttributeDefs.manufacturer]
         == zcl.foundation.Status.UNREPORTABLE_ATTRIBUTE
     )
-    assert (
-        results_by_attrid[Basic.AttributeDefs.hw_version.id].status
-        == zcl.foundation.Status.SUCCESS
-    )
+    assert results[Basic.AttributeDefs.hw_version] == zcl.foundation.Status.SUCCESS
 
 
 async def test_configure_reporting_multiple_both_unsupp(cluster):
@@ -1078,7 +1072,9 @@ async def test_configure_reporting_multiple_both_unsupp(cluster):
     assert cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
     assert cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
     assert len(results) == 2
-    assert all(r.status == zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE for r in results)
+    assert all(
+        s == zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE for s in results.values()
+    )
 
     cluster.endpoint.request.return_value = _mk_cfg_rsp(
         {
@@ -1101,7 +1097,7 @@ async def test_configure_reporting_multiple_both_unsupp(cluster):
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
     assert len(results) == 2
-    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
+    assert all(s == zcl.foundation.Status.SUCCESS for s in results.values())
 
 
 async def test_configure_reporting_multiple_partial_failure(cluster):
@@ -1124,15 +1120,11 @@ async def test_configure_reporting_multiple_partial_failure(cluster):
     # Only the failed attribute is in the device response; SUCCESS is synthesized
     # for hw_version which was omitted (implicitly succeeded per ZCL spec)
     assert len(results) == 2
-    results_by_attrid = {r.attrid: r for r in results}
     assert (
-        results_by_attrid[Basic.AttributeDefs.manufacturer.id].status
+        results[Basic.AttributeDefs.manufacturer]
         == zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE
     )
-    assert (
-        results_by_attrid[Basic.AttributeDefs.hw_version.id].status
-        == zcl.foundation.Status.SUCCESS
-    )
+    assert results[Basic.AttributeDefs.hw_version] == zcl.foundation.Status.SUCCESS
 
     assert not cluster._attr_cache.is_unsupported(Basic.AttributeDefs.hw_version)
     assert cluster._attr_cache.is_unsupported(Basic.AttributeDefs.manufacturer)
@@ -2367,7 +2359,7 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
         )
 
     assert len(results) == 2
-    assert all(r.status == zcl.foundation.Status.SUCCESS for r in results)
+    assert all(s == zcl.foundation.Status.SUCCESS for s in results.values())
 
     # Two separate requests should have been made (one per manufacturer group)
     assert mock_configure.await_count == 2

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2317,16 +2317,17 @@ async def test_write_attributes_multiple_manufacturer_groups(app_mock) -> None:
 
 
 async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> None:
-    """Test configure_reporting_multiple with attributes spanning
-    multiple manufacturer groups.
+    """Test configure_reporting_multiple with attributes spanning multiple manufacturer
+    groups, including colliding attribute IDs that differ only by manufacturer code.
     """
 
     class TestCluster(Basic):
         _skip_registry = True
 
         class AttributeDefs(Basic.AttributeDefs):
-            manuf_attr = foundation.ZCLAttributeDef(
-                id=0xB001,
+            # Same numeric ID as hw_version (0x0003) but manufacturer-specific
+            manuf_hw_version = foundation.ZCLAttributeDef(
+                id=0x0003,
                 type=t.uint8_t,
                 manufacturer_code=0x5678,
             )
@@ -2337,29 +2338,46 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
     cluster = TestCluster(dev.endpoints[1])
     dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
 
-    cfg_response = zcl.foundation.ConfigureReportingResponse(
+    cfg_success = zcl.foundation.ConfigureReportingResponse(
         [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
     )
+    cfg_fail = zcl.foundation.ConfigureReportingResponse(
+        [
+            zcl.foundation.ConfigureReportingResponseRecord(
+                zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE,
+                zcl.foundation.ReportingDirection.ReceiveReports,
+                0x0003,
+            )
+        ]
+    )
 
+    # Standard fails, manufacturer-specific succeeds
     with patch.object(
         cluster,
         "_configure_reporting",
         new_callable=AsyncMock,
-        return_value=[cfg_response],
+        side_effect=[[cfg_fail], [cfg_success]],
     ) as mock_configure:
         results = await cluster.configure_reporting_multiple(
             {
                 Basic.AttributeDefs.hw_version: ReportingConfig(
                     min_interval=5, max_interval=15, reportable_change=20
                 ),
-                TestCluster.AttributeDefs.manuf_attr: ReportingConfig(
+                TestCluster.AttributeDefs.manuf_hw_version: ReportingConfig(
                     min_interval=10, max_interval=30, reportable_change=5
                 ),
             }
         )
 
     assert len(results) == 2
-    assert all(s == zcl.foundation.Status.SUCCESS for s in results.values())
+    assert (
+        results[Basic.AttributeDefs.hw_version]
+        == zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE
+    )
+    assert (
+        results[TestCluster.AttributeDefs.manuf_hw_version]
+        == zcl.foundation.Status.SUCCESS
+    )
 
     # Two separate requests should have been made (one per manufacturer group)
     assert mock_configure.await_count == 2
@@ -2373,11 +2391,11 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
     assert std_call.args[0][0].max_interval == 15
     assert std_call.args[0][0].reportable_change == 20
 
-    # Second call: manufacturer-specific attribute
+    # Second call: manufacturer-specific attribute (same attrid, different manuf code)
     manuf_call = mock_configure.call_args_list[1]
     assert manuf_call.kwargs["manufacturer"] == 0x5678
     assert len(manuf_call.args[0]) == 1
-    assert manuf_call.args[0][0].attrid == TestCluster.AttributeDefs.manuf_attr.id
+    assert manuf_call.args[0][0].attrid == TestCluster.AttributeDefs.manuf_hw_version.id
     assert manuf_call.args[0][0].min_interval == 10
     assert manuf_call.args[0][0].max_interval == 30
     assert manuf_call.args[0][0].reportable_change == 5

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1416,7 +1416,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         min_interval: int,
         max_interval: int,
         reportable_change: int,
-    ) -> list[foundation.ConfigureReportingResponseRecord]:
+    ) -> dict[foundation.ZCLAttributeDef, foundation.Status]:
         """Configure attribute reporting for a single attribute."""
         attr_def = self.find_attribute(attribute)
         return await self.configure_reporting_multiple(
@@ -1431,7 +1431,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
     async def configure_reporting_multiple(
         self, config: dict[foundation.ZCLAttributeDef, ReportingConfig]
-    ) -> list[foundation.ConfigureReportingResponseRecord]:
+    ) -> dict[foundation.ZCLAttributeDef, foundation.Status]:
         """Configure attribute reporting for multiple attributes in the same request."""
 
         # Group attributes by effective manufacturer code
@@ -1458,19 +1458,16 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             effective_manuf = self._get_effective_manufacturer_code(attr_def)
             reporting_by_manuf_code[effective_manuf].append((attr_def, cfg))
 
-        results: list[foundation.ConfigureReportingResponseRecord] = []
+        results: dict[foundation.ZCLAttributeDef, foundation.Status] = {}
 
         for manufacturer_code, reporting_configs in reporting_by_manuf_code.items():
             configs = [cfg for _attr_def, cfg in reporting_configs]
-            attr_defs_by_id = {
-                attr_def.id: attr_def for attr_def, _cfg in reporting_configs
-            }
 
             rsp = await self._configure_reporting(
                 configs, manufacturer=manufacturer_code
             )
 
-            reporting_results = []
+            group_results: dict[foundation.ZCLAttributeDef, foundation.Status] = {}
 
             if isinstance(rsp[0], list):
                 records = rsp[0]
@@ -1483,43 +1480,24 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 ):
                     # Global success: all attributes succeeded
                     for attr_def, _cfg in reporting_configs:
-                        reporting_results.append(
-                            foundation.ConfigureReportingResponseRecord(
-                                status=foundation.Status.SUCCESS,
-                                attrid=attr_def.id,
-                            )
-                        )
+                        group_results[attr_def] = foundation.Status.SUCCESS
                 else:
                     # Only failed reports are in the response. Attributes not
                     # present implicitly succeeded.
-                    failed_attrids = {r.attrid for r in records}
+                    failed_attrids = {r.attrid: r.status for r in records}
                     for attr_def, _cfg in reporting_configs:
                         if attr_def.id in failed_attrids:
-                            reporting_results.extend(
-                                r for r in records if r.attrid == attr_def.id
-                            )
+                            group_results[attr_def] = failed_attrids[attr_def.id]
                         else:
-                            reporting_results.append(
-                                foundation.ConfigureReportingResponseRecord(
-                                    status=foundation.Status.SUCCESS,
-                                    attrid=attr_def.id,
-                                )
-                            )
+                            group_results[attr_def] = foundation.Status.SUCCESS
             else:
                 # Default response: apply status to all attributes in this group
                 status = rsp[1]
-                reporting_results.extend(
-                    foundation.ConfigureReportingResponseRecord(
-                        status=status,
-                        attrid=attr_def.id,
-                    )
-                    for attr_def, _cfg in reporting_configs
-                )
+                for attr_def, _cfg in reporting_configs:
+                    group_results[attr_def] = status
 
-            for result in reporting_results:
-                attr_def = attr_defs_by_id[result.attrid]
-
-                if result.status == foundation.Status.SUCCESS:
+            for attr_def, status in group_results.items():
+                if status == foundation.Status.SUCCESS:
                     self._attr_cache.remove_unsupported(attr_def)
                     self.emit(
                         AttributeReportingConfiguredEvent.event_type,
@@ -1536,7 +1514,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                             reportable_change=config[attr_def].reportable_change,
                         ),
                     )
-                elif result.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
+                elif status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
                     self._attr_cache.mark_unsupported(attr_def)
                     self.emit(
                         AttributeUnsupportedEvent.event_type,
@@ -1550,11 +1528,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                             manufacturer_code=manufacturer_code,
                         ),
                     )
-                else:
-                    # Is this even possible?
-                    pass
 
-            results.extend(reporting_results)
+            results.update(group_results)
 
         return results
 


### PR DESCRIPTION
## Proposed change

This changes `configure_reporting_multiple` and `configure_reporting` to return `dict[ZCLAttributeDef, foundation.Status]`, instead of a list with `ConfigureReportingResponseRecord`, as those only contain the attribute ID and status, not the manufacturer code.

Without these changes, reporting results are unclear if you try to set up reporting for an attribute ID with a manufacturer code and without one in the same call.

## Additional information

Discovered whilst working on:
- https://github.com/zigpy/zha-device-handlers/pull/4595/

This will need ZHA changes:
- https://github.com/zigpy/zha/pull/710

### Future

A similar issue also exist for `write_attributes` results.