### PR TITLE
Fix time cluster DST handling

### DIFF
--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -137,23 +137,11 @@ async def test_basic_cluster():
     )
 
 
-async def test_time_cluster():
-    ep = MagicMock()
-    ep.reply = AsyncMock()
-
-    cluster = Time(ep)
-
-    Read_Attributes_rsp = foundation.GENERAL_COMMANDS[
-        foundation.GeneralCommand.Read_Attributes_rsp
-    ].schema
-
-    # Datetime objects need to be subclassed to be patched so we may as well implement
-    # the patches directly
+def _make_patched_datetime(fake_now):
+    """Create a PatchedDatetime class that returns `fake_now` as the current time."""
 
     class PatchedDatetime(datetime):
-        _fake_now = datetime(
-            2000, 1, 2, 0, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")
-        )
+        _fake_now = fake_now
 
         def astimezone(self):
             return self.replace(tzinfo=self._fake_now.tzinfo)
@@ -184,6 +172,48 @@ async def test_time_cluster():
                     - cls._fake_now.utcoffset()
                 )
 
+    return PatchedDatetime
+
+
+@pytest.mark.parametrize(
+    ("fake_now", "expected_utc", "expected_tz", "expected_local"),
+    [
+        pytest.param(
+            # January: PST (UTC-8), no DST
+            datetime(2000, 1, 2, 0, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            # UTC time: midnight Jan 2 PST = 08:00 Jan 2 UTC = 1 day + 8 hours
+            24 * 60 * 60 + 8 * 60 * 60,
+            # Standard timezone offset: UTC-8
+            -(8 * 60 * 60),
+            # Local time: midnight Jan 2 = 1 day from epoch
+            24 * 60 * 60,
+            id="winter_no_dst",
+        ),
+        pytest.param(
+            # July: PDT (UTC-7), DST active
+            datetime(2000, 7, 2, 0, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            # UTC time: midnight Jul 2 PDT = 07:00 Jul 2 UTC
+            183 * 24 * 60 * 60 + 7 * 60 * 60,
+            # Standard timezone offset: still UTC-8 (DST not included)
+            -(8 * 60 * 60),
+            # Local time: midnight Jul 2 local
+            183 * 24 * 60 * 60,
+            id="summer_with_dst",
+        ),
+    ],
+)
+async def test_time_cluster(fake_now, expected_utc, expected_tz, expected_local):
+    ep = MagicMock()
+    ep.reply = AsyncMock()
+
+    cluster = Time(ep)
+
+    Read_Attributes_rsp = foundation.GENERAL_COMMANDS[
+        foundation.GeneralCommand.Read_Attributes_rsp
+    ].schema
+
+    PatchedDatetime = _make_patched_datetime(fake_now)
+
     with patch("zigpy.zcl.clusters.general.datetime", PatchedDatetime):
         # Supported attributes
         rsp1 = await read_attributes(
@@ -201,8 +231,7 @@ async def test_time_cluster():
         status=foundation.Status.SUCCESS,
         value=foundation.TypeValue(
             type=foundation.DataTypeId.UTC,
-            # One day from the epoch, plus time zone offset
-            value=24 * 60 * 60 + 8 * 60 * 60,
+            value=expected_utc,
         ),
     )
 
@@ -220,8 +249,7 @@ async def test_time_cluster():
         status=foundation.Status.SUCCESS,
         value=foundation.TypeValue(
             type=foundation.DataTypeId.int32,
-            # Time zone offset
-            value=-(8 * 60 * 60),
+            value=expected_tz,
         ),
     )
 
@@ -230,8 +258,7 @@ async def test_time_cluster():
         status=foundation.Status.SUCCESS,
         value=foundation.TypeValue(
             type=foundation.DataTypeId.uint32,
-            # One day from the epoch, as on the clock
-            value=24 * 60 * 60,
+            value=expected_local,
         ),
     )
 

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -211,11 +211,7 @@ async def test_time_cluster():
         status=foundation.Status.SUCCESS,
         value=foundation.TypeValue(
             type=foundation.DataTypeId.map8,
-            value=(
-                Time.TimeStatus.Master
-                | Time.TimeStatus.Synchronized
-                | Time.TimeStatus.Master_for_Zone_and_DST
-            ),
+            value=(Time.TimeStatus.Master | Time.TimeStatus.Master_for_Zone_and_DST),
         ),
     )
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -1136,24 +1136,23 @@ class Time(Cluster):
         return t.UTCTime((now - ZIGBEE_EPOCH).total_seconds())
 
     def handle_read_attribute_time_status(self) -> TimeStatus:
-        return (
-            TimeStatus.Master
-            | TimeStatus.Synchronized
-            | TimeStatus.Master_for_Zone_and_DST
-        )
+        return TimeStatus.Master | TimeStatus.Master_for_Zone_and_DST
 
     def handle_read_attribute_time_zone(self) -> t.int32s:
-        tz_offset = datetime.now().astimezone().utcoffset()
-        assert tz_offset is not None
+        now_local = datetime.now().astimezone()
+        utc_offset = now_local.utcoffset()
+        dst = now_local.dst()
+        assert utc_offset is not None and dst is not None
 
-        return t.int32s(tz_offset.total_seconds())
+        return t.int32s((utc_offset - dst).total_seconds())
 
     def handle_read_attribute_local_time(self) -> t.LocalTime:
-        now = datetime.now(UTC)
-        tz_offset = datetime.now().astimezone().utcoffset()
-        assert tz_offset is not None
+        now_local = datetime.now().astimezone()
+        utc_offset = now_local.utcoffset()
+        assert utc_offset is not None
 
-        return t.LocalTime((now + tz_offset - ZIGBEE_EPOCH).total_seconds())
+        utc_seconds = (now_local - ZIGBEE_EPOCH).total_seconds()
+        return t.LocalTime(utc_seconds + utc_offset.total_seconds())
 
     # For backwards compatibility
     TimeStatus: Final = TimeStatus

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, Final, Self
 
 import zigpy.types as t
@@ -1140,16 +1140,14 @@ class Time(Cluster):
 
     def handle_read_attribute_time_zone(self) -> t.int32s:
         now_local = datetime.now().astimezone()
-        utc_offset = now_local.utcoffset()
-        dst = now_local.dst()
-        assert utc_offset is not None and dst is not None
+        utc_offset = now_local.utcoffset() or timedelta(0)
+        dst = now_local.dst() or timedelta(0)
 
         return t.int32s((utc_offset - dst).total_seconds())
 
     def handle_read_attribute_local_time(self) -> t.LocalTime:
         now_local = datetime.now().astimezone()
-        utc_offset = now_local.utcoffset()
-        assert utc_offset is not None
+        utc_offset = now_local.utcoffset() or timedelta(0)
 
         utc_seconds = (now_local - ZIGBEE_EPOCH).total_seconds()
         return t.LocalTime(utc_seconds + utc_offset.total_seconds())


### PR DESCRIPTION
## Proposed change

This PR improves zigpy's server `Time` cluster:
It fixes an issue where daylight saving time was not correctly accounted for.
The `Master` and `Synchronized` bit were both set before. This isn't allowed, as it doesn't make any sense.

## Additional information

- We may wanna check (Tuya) quirks that adjust time handling to see if they also need any adjustment. Hopefully not?
- HA has its own time utility that's preferred to be used. We (obviously) don't use that or values from it. I hope the time zone is still set correctly on a HAOS system?
- A future PR may add additional attributes to our `Time` cluster that can be read.

## AI summary

<details><summary>AI summary of the changes (CLICK TO EXPAND)</summary>
<p>

### Issues before this change

- **`time_zone` returned wrong values during DST.** It returned the full UTC offset (`utcoffset()`), which includes DST. So in summer for `America/Los_Angeles`, it would return `-7h` (PDT) instead of the correct `-8h` (PST). The spec defines `TimeZone` as the standard offset only — devices using `Standard Time = Time + TimeZone` would compute wrong standard times during DST.

- **`local_time` was wrong during DST.** The old code added a timezone-aware UTC `datetime` to a `timedelta` offset, producing a timezone-aware `datetime` that was then subtracted from the UTC-aware `ZIGBEE_EPOCH`. Python's timezone-aware subtraction computes the absolute difference between the two instants — so the offset effectively canceled out, and the result was just UTC seconds, not local seconds. Local time would always equal UTC time regardless of timezone.

- **`time_status` incorrectly claimed `Synchronized`.** The spec says: "If the Master bit is 1, the value of [Synchronized] is 0." Since we set `Master`, `Synchronized` should not have been set. This would cause devices to treat the clock as both an internal master and externally synchronized, which is contradictory.

- **The existing test only covered winter (PST, no DST)**, so the `time_zone` and `local_time` bugs were never caught — both happen to produce correct results when DST is inactive.

### Changes

#### `time_status`
- Removed `Synchronized` bit. Per the ZCL spec, if `Master` is 1 then `Synchronized` must be 0.

#### `time_zone`
- Now correctly subtracts the DST component to return only the standard timezone offset, matching the spec definition: `Standard Time = Time + TimeZone`.

#### `local_time`
- Now uses a single `datetime.now().astimezone()` call and timezone-aware subtraction from `ZIGBEE_EPOCH` to get UTC seconds, then adds the UTC offset. This also avoids a potential race from two separate `datetime.now()` calls straddling a second boundary.

#### Tests
- Removed `Synchronized` from the expected `time_status` value.
- Parameterized `test_time_cluster` with a winter (PST, no DST) and summer (PDT, DST active) case to verify that `time_zone` consistently returns the standard offset and `local_time` is correct regardless of DST.
- Extracted `_make_patched_datetime` helper for reuse across test parameters.



</p>
</details> 

