### PR TITLE
Add device re-interview support

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1862,3 +1862,90 @@ async def test_callback_wrapping_async(
             ),
         ),
     ]
+
+
+async def test_device_reinterviewed(app):
+    """Test _device_reinterviewed swaps the old device for the shadow."""
+    import zigpy.device
+    import zigpy.endpoint
+
+    ieee = make_ieee()
+    nwk = t.NWK(0x1234)
+
+    old_dev = app.add_device(ieee=ieee, nwk=nwk)
+    old_dev.node_desc = make_node_desc()
+    old_dev.model = "OldModel"
+    old_dev.manufacturer = "OldManufacturer"
+    assert app.devices[ieee] is old_dev
+
+    # Create a shadow device (as reinterview would)
+    shadow = zigpy.device.Device(app, ieee, nwk)
+    shadow.node_desc = make_node_desc()
+    shadow.model = "NewModel"
+    shadow.manufacturer = "NewManufacturer"
+    shadow.status = zigpy.device.Status.ENDPOINTS_INIT
+    ep = shadow.add_endpoint(1)
+    ep.profile_id = 260
+    ep.device_type = 0x0100
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+
+    await app._device_reinterviewed(old_dev, shadow)
+
+    # The device in app.devices should now be the shadow (or quirked version)
+    new_dev = app.devices[ieee]
+    assert new_dev is not old_dev
+    assert new_dev.model == "NewModel"
+    assert new_dev.manufacturer == "NewManufacturer"
+
+    # device_initialized and device_reinterviewed events should have been fired
+    app.listener_event.assert_any_call("device_initialized", new_dev)
+    app.listener_event.assert_any_call("device_reinterviewed", new_dev)
+
+
+async def test_device_reinterviewed_with_db(app):
+    """Test _device_reinterviewed removes old device from DB before saving new one."""
+    import zigpy.device
+    import zigpy.endpoint
+
+    ieee = make_ieee()
+    nwk = t.NWK(0x1234)
+
+    old_dev = app.add_device(ieee=ieee, nwk=nwk)
+    old_dev.node_desc = make_node_desc()
+
+    # Set up a mock DB listener
+    db_listener = MagicMock()
+    db_listener._remove_device = AsyncMock()
+    app._dblistener = db_listener
+    old_dev.add_context_listener(db_listener)
+
+    shadow = zigpy.device.Device(app, ieee, nwk)
+    shadow.node_desc = make_node_desc()
+    shadow.status = zigpy.device.Status.ENDPOINTS_INIT
+    ep = shadow.add_endpoint(1)
+    ep.profile_id = 260
+    ep.device_type = 0x0100
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+
+    await app._device_reinterviewed(old_dev, shadow)
+
+    # DB removal should have been called for the old device
+    db_listener._remove_device.assert_awaited_once_with(old_dev)
+
+
+async def test_reinterview_device_public_api(app):
+    """Test reinterview_device delegates to dev.reinterview()."""
+    ieee = make_ieee()
+    nwk = t.NWK(0x1234)
+    dev = app.add_device(ieee=ieee, nwk=nwk)
+    dev.reinterview = AsyncMock()
+
+    await app.reinterview_device(ieee)
+
+    dev.reinterview.assert_awaited_once()
+
+
+async def test_reinterview_device_not_found(app):
+    """Test reinterview_device raises KeyError for unknown device."""
+    with pytest.raises(KeyError):
+        await app.reinterview_device(make_ieee(99))

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1889,6 +1889,7 @@ async def test_device_reinterviewed(app):
     shadow.model = "NewModel"
     shadow.manufacturer = "NewManufacturer"
     shadow.status = zigpy.device.Status.ENDPOINTS_INIT
+    shadow._reinterview_in_progress = True  # set by reinterview() before discovery
     ep = shadow.add_endpoint(1)
     ep.profile_id = 260
     ep.device_type = 0x0100
@@ -1907,6 +1908,9 @@ async def test_device_reinterviewed(app):
     assert new_dev._relays == t.Relays([t.NWK(0x1111), t.NWK(0x2222)])
     assert new_dev.lqi == 200
     assert new_dev.rssi == -40
+
+    # New device should not be stuck in reinterviewing state
+    assert not new_dev.reinterviewing
 
     # device_reinterviewed should be fired, but NOT device_initialized
     app.listener_event.assert_any_call("device_reinterviewed", new_dev)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1866,60 +1866,6 @@ async def test_callback_wrapping_async(
     ]
 
 
-async def test_device_reinterviewed(app):
-    """Test _device_reinterviewed swaps the old device for the shadow."""
-    from datetime import UTC, datetime
-
-    ieee = make_ieee()
-    nwk = t.NWK(0x1234)
-
-    old_dev = app.add_device(ieee=ieee, nwk=nwk)
-    old_dev.node_desc = make_node_desc()
-    old_dev.model = "OldModel"
-    old_dev.manufacturer = "OldManufacturer"
-    old_dev._last_seen = datetime(2026, 1, 1, tzinfo=UTC)
-    old_dev._relays = t.Relays([t.NWK(0x1111), t.NWK(0x2222)])
-    old_dev.lqi = 200
-    old_dev.rssi = -40
-    assert app.devices[ieee] is old_dev
-
-    # Create a shadow device (as reinterview would)
-    shadow = zigpy.device.Device(app, ieee, nwk)
-    shadow.node_desc = make_node_desc()
-    shadow.model = "NewModel"
-    shadow.manufacturer = "NewManufacturer"
-    shadow.status = zigpy.device.Status.ENDPOINTS_INIT
-    shadow._reinterview_in_progress = True  # set by reinterview() before discovery
-    ep = shadow.add_endpoint(1)
-    ep.profile_id = 260
-    ep.device_type = 0x0100
-    ep.status = zigpy.endpoint.Status.ZDO_INIT
-
-    await app._device_reinterviewed(old_dev, shadow)
-
-    # The device in app.devices should now be the shadow (or quirked version)
-    new_dev = app.devices[ieee]
-    assert new_dev is not old_dev
-    assert new_dev.model == "NewModel"
-    assert new_dev.manufacturer == "NewManufacturer"
-
-    # Non-discovery state should have been preserved
-    assert new_dev._last_seen == datetime(2026, 1, 1, tzinfo=UTC)
-    assert new_dev._relays == t.Relays([t.NWK(0x1111), t.NWK(0x2222)])
-    assert new_dev.lqi == 200
-    assert new_dev.rssi == -40
-
-    # New device should not be stuck in reinterviewing state
-    assert not new_dev.reinterviewing
-
-    # device_reinterviewed should be fired, but NOT device_initialized
-    app.listener_event.assert_any_call("device_reinterviewed", new_dev)
-    device_initialized_calls = [
-        c for c in app.listener_event.call_args_list if c[0][0] == "device_initialized"
-    ]
-    assert len(device_initialized_calls) == 0
-
-
 async def test_device_reinterviewed_with_db(app):
     """Test _device_reinterviewed removes old device from DB before saving new one."""
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -2012,21 +2012,13 @@ async def test_device_reinterviewed_preserves_groups(app):
 
 
 async def test_device_reinterviewed_finalization_failure_restores_old(app):
-    """Test that if finalization fails after DB delete, old device is restored."""
+    """Test that _device_reinterviewed lets exceptions propagate."""
     ieee = make_ieee()
     nwk = t.NWK(0x1234)
 
     old_dev = app.add_device(ieee=ieee, nwk=nwk)
     old_dev.node_desc = make_node_desc()
     old_dev.model = "OldModel"
-    old_ep = old_dev.add_endpoint(1)
-    old_ep.profile_id = 260
-    old_ep.device_type = 0x0100
-    old_ep.status = zigpy.endpoint.Status.ZDO_INIT
-
-    # Add to a group
-    group = app.groups.add_group(42, "TestGroup")
-    group.add_member(old_ep, suppress_event=True)
 
     shadow = zigpy.device.Device(app, ieee, nwk)
     shadow.node_desc = make_node_desc()
@@ -2035,16 +2027,9 @@ async def test_device_reinterviewed_finalization_failure_restores_old(app):
     # Make _finalize_device fail
     app._finalize_device = Mock(side_effect=RuntimeError("finalization boom"))
 
+    # Exception should propagate — reinterview() is responsible for restoration
     with pytest.raises(RuntimeError, match="finalization boom"):
         await app._device_reinterviewed(old_dev, shadow)
-
-    # Old device should be restored in app.devices
-    assert app.devices[ieee] is old_dev
-    assert old_dev.model == "OldModel"
-
-    # Group membership should be restored on old endpoint
-    assert old_ep.unique_id in group
-    assert 42 in old_ep.member_of
 
 
 async def test_device_reinterviewed_persists_relays(app):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1961,8 +1961,8 @@ async def test_device_reinterviewed_preserves_groups(app):
     assert not old_ep.member_of
 
 
-async def test_device_reinterviewed_finalization_failure_restores_old(app):
-    """Test that _device_reinterviewed lets exceptions propagate."""
+async def test_device_reinterviewed_finalization_failure_propagates(app):
+    """Test that _device_reinterviewed lets exceptions propagate to reinterview()."""
     ieee = make_ieee()
     nwk = t.NWK(0x1234)
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1868,6 +1868,7 @@ async def test_callback_wrapping_async(
 
 async def test_device_reinterviewed(app):
     """Test _device_reinterviewed swaps the old device for the shadow."""
+    from datetime import UTC, datetime
 
     ieee = make_ieee()
     nwk = t.NWK(0x1234)
@@ -1876,6 +1877,10 @@ async def test_device_reinterviewed(app):
     old_dev.node_desc = make_node_desc()
     old_dev.model = "OldModel"
     old_dev.manufacturer = "OldManufacturer"
+    old_dev._last_seen = datetime(2026, 1, 1, tzinfo=UTC)
+    old_dev._relays = t.Relays([t.NWK(0x1111), t.NWK(0x2222)])
+    old_dev.lqi = 200
+    old_dev.rssi = -40
     assert app.devices[ieee] is old_dev
 
     # Create a shadow device (as reinterview would)
@@ -1896,6 +1901,12 @@ async def test_device_reinterviewed(app):
     assert new_dev is not old_dev
     assert new_dev.model == "NewModel"
     assert new_dev.manufacturer == "NewManufacturer"
+
+    # Non-discovery state should have been preserved
+    assert new_dev._last_seen == datetime(2026, 1, 1, tzinfo=UTC)
+    assert new_dev._relays == t.Relays([t.NWK(0x1111), t.NWK(0x2222)])
+    assert new_dev.lqi == 200
+    assert new_dev.rssi == -40
 
     # device_initialized and device_reinterviewed events should have been fired
     app.listener_event.assert_any_call("device_initialized", new_dev)
@@ -1947,3 +1958,120 @@ async def test_reinterview_device_not_found(app):
     """Test reinterview_device raises KeyError for unknown device."""
     with pytest.raises(KeyError):
         await app.reinterview_device(make_ieee(99))
+
+
+async def test_device_reinterviewed_preserves_groups(app):
+    """Test _device_reinterviewed migrates group memberships to the new device."""
+    ieee = make_ieee()
+    nwk = t.NWK(0x1234)
+
+    old_dev = app.add_device(ieee=ieee, nwk=nwk)
+    old_dev.node_desc = make_node_desc()
+    old_ep = old_dev.add_endpoint(1)
+    old_ep.profile_id = 260
+    old_ep.device_type = 0x0100
+    old_ep.status = zigpy.endpoint.Status.ZDO_INIT
+
+    # Add old endpoint to groups
+    group_10 = app.groups.add_group(10, "Group 10")
+    group_20 = app.groups.add_group(20, "Group 20")
+    group_10.add_member(old_ep, suppress_event=True)
+    group_20.add_member(old_ep, suppress_event=True)
+    assert old_ep.unique_id in group_10
+    assert old_ep.unique_id in group_20
+
+    # Create shadow with matching endpoint
+    shadow = zigpy.device.Device(app, ieee, nwk)
+    shadow.node_desc = make_node_desc()
+    shadow.status = zigpy.device.Status.ENDPOINTS_INIT
+    new_ep = shadow.add_endpoint(1)
+    new_ep.profile_id = 260
+    new_ep.device_type = 0x0100
+    new_ep.status = zigpy.endpoint.Status.ZDO_INIT
+
+    await app._device_reinterviewed(old_dev, shadow)
+
+    new_dev = app.devices[ieee]
+    new_ep = new_dev.endpoints[1]
+
+    # Group members should point to new endpoint objects, not old ones
+    assert group_10[new_ep.unique_id] is new_ep
+    assert group_10[new_ep.unique_id] is not old_ep
+    assert group_20[new_ep.unique_id] is new_ep
+    assert group_20[new_ep.unique_id] is not old_ep
+
+    # New endpoint should know about its group memberships
+    assert 10 in new_ep.member_of
+    assert 20 in new_ep.member_of
+
+    # Old endpoint should no longer be a member
+    assert not old_ep.member_of
+
+
+async def test_device_reinterviewed_finalization_failure_restores_old(app):
+    """Test that if finalization fails after DB delete, old device is restored."""
+    ieee = make_ieee()
+    nwk = t.NWK(0x1234)
+
+    old_dev = app.add_device(ieee=ieee, nwk=nwk)
+    old_dev.node_desc = make_node_desc()
+    old_dev.model = "OldModel"
+    old_ep = old_dev.add_endpoint(1)
+    old_ep.profile_id = 260
+    old_ep.device_type = 0x0100
+    old_ep.status = zigpy.endpoint.Status.ZDO_INIT
+
+    # Add to a group
+    group = app.groups.add_group(42, "TestGroup")
+    group.add_member(old_ep, suppress_event=True)
+
+    shadow = zigpy.device.Device(app, ieee, nwk)
+    shadow.node_desc = make_node_desc()
+    shadow.status = zigpy.device.Status.ENDPOINTS_INIT
+
+    # Make device_initialized fail
+    app.device_initialized = Mock(side_effect=RuntimeError("finalization boom"))
+
+    with pytest.raises(RuntimeError, match="finalization boom"):
+        await app._device_reinterviewed(old_dev, shadow)
+
+    # Old device should be restored in app.devices
+    assert app.devices[ieee] is old_dev
+    assert old_dev.model == "OldModel"
+
+    # Group membership should be restored on old endpoint
+    assert old_ep.unique_id in group
+    assert 42 in old_ep.member_of
+
+
+async def test_device_reinterviewed_persists_relays(app):
+    """Test that relays are re-persisted after reinterview."""
+    ieee = make_ieee()
+    nwk = t.NWK(0x1234)
+
+    old_dev = app.add_device(ieee=ieee, nwk=nwk)
+    old_dev.node_desc = make_node_desc()
+    old_dev._relays = t.Relays([t.NWK(0xAAAA)])
+
+    db_listener = MagicMock()
+    db_listener._remove_device = AsyncMock()
+    app._dblistener = db_listener
+    old_dev.add_context_listener(db_listener)
+
+    shadow = zigpy.device.Device(app, ieee, nwk)
+    shadow.node_desc = make_node_desc()
+    shadow.status = zigpy.device.Status.ENDPOINTS_INIT
+    ep = shadow.add_endpoint(1)
+    ep.profile_id = 260
+    ep.device_type = 0x0100
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+
+    await app._device_reinterviewed(old_dev, shadow)
+
+    new_dev = app.devices[ieee]
+
+    # Relays should have been copied and re-persisted
+    assert new_dev._relays == t.Relays([t.NWK(0xAAAA)])
+    db_listener.device_relays_updated.assert_called_once_with(
+        new_dev, t.Relays([t.NWK(0xAAAA)])
+    )

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -12,6 +12,8 @@ import pytest
 import zigpy.application
 import zigpy.config as conf
 from zigpy.datastructures import RequestLimiter
+import zigpy.device
+import zigpy.endpoint
 from zigpy.exceptions import (
     DeliveryError,
     NetworkNotFormed,
@@ -1866,8 +1868,6 @@ async def test_callback_wrapping_async(
 
 async def test_device_reinterviewed(app):
     """Test _device_reinterviewed swaps the old device for the shadow."""
-    import zigpy.device
-    import zigpy.endpoint
 
     ieee = make_ieee()
     nwk = t.NWK(0x1234)
@@ -1904,8 +1904,6 @@ async def test_device_reinterviewed(app):
 
 async def test_device_reinterviewed_with_db(app):
     """Test _device_reinterviewed removes old device from DB before saving new one."""
-    import zigpy.device
-    import zigpy.endpoint
 
     ieee = make_ieee()
     nwk = t.NWK(0x1234)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1908,9 +1908,12 @@ async def test_device_reinterviewed(app):
     assert new_dev.lqi == 200
     assert new_dev.rssi == -40
 
-    # device_initialized and device_reinterviewed events should have been fired
-    app.listener_event.assert_any_call("device_initialized", new_dev)
+    # device_reinterviewed should be fired, but NOT device_initialized
     app.listener_event.assert_any_call("device_reinterviewed", new_dev)
+    device_initialized_calls = [
+        c for c in app.listener_event.call_args_list if c[0][0] == "device_initialized"
+    ]
+    assert len(device_initialized_calls) == 0
 
 
 async def test_device_reinterviewed_with_db(app):
@@ -2029,8 +2032,8 @@ async def test_device_reinterviewed_finalization_failure_restores_old(app):
     shadow.node_desc = make_node_desc()
     shadow.status = zigpy.device.Status.ENDPOINTS_INIT
 
-    # Make device_initialized fail
-    app.device_initialized = Mock(side_effect=RuntimeError("finalization boom"))
+    # Make _finalize_device fail
+    app._finalize_device = Mock(side_effect=RuntimeError("finalization boom"))
 
     with pytest.raises(RuntimeError, match="finalization boom"):
         await app._device_reinterviewed(old_dev, shadow)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1961,6 +1961,56 @@ async def test_device_reinterviewed_preserves_groups(app):
     assert not old_ep.member_of
 
 
+async def test_device_reinterviewed_skips_group_removed_during_swap(app):
+    """If a group is removed while `_remove_device` is awaiting, restoration skips it
+    instead of raising and aborting the reinterview.
+    """
+    ieee = make_ieee()
+    nwk = t.NWK(0x1234)
+
+    old_dev = app.add_device(ieee=ieee, nwk=nwk)
+    old_dev.node_desc = make_node_desc()
+    old_ep = old_dev.add_endpoint(1)
+    old_ep.profile_id = 260
+    old_ep.device_type = 0x0100
+    old_ep.status = zigpy.endpoint.Status.ZDO_INIT
+
+    surviving = app.groups.add_group(10, "Group 10")
+    doomed = app.groups.add_group(20, "Group 20")
+    surviving.add_member(old_ep, suppress_event=True)
+    doomed.add_member(old_ep, suppress_event=True)
+
+    # Simulate the race: between `_remove_device` returning and group restoration
+    # running, group 20 is removed. We trigger this by patching the dblistener's
+    # `_remove_device` to drop the group as a side effect.
+    db_listener = MagicMock()
+
+    async def fake_remove(_dev):
+        app.groups.pop(20, None)
+
+    db_listener._remove_device = AsyncMock(side_effect=fake_remove)
+    app._dblistener = db_listener
+    old_dev.add_context_listener(db_listener)
+
+    shadow = zigpy.device.Device(app, ieee, nwk)
+    shadow.node_desc = make_node_desc()
+    shadow.status = zigpy.device.Status.ENDPOINTS_INIT
+    new_ep = shadow.add_endpoint(1)
+    new_ep.profile_id = 260
+    new_ep.device_type = 0x0100
+    new_ep.status = zigpy.endpoint.Status.ZDO_INIT
+
+    await app._device_reinterviewed(old_dev, shadow)
+
+    new_dev = app.devices[ieee]
+    new_ep = new_dev.endpoints[1]
+
+    # Surviving group has the new endpoint; doomed group is gone, no KeyError raised.
+    assert new_ep.unique_id in surviving
+    assert 20 not in app.groups
+    app.listener_event.assert_any_call("device_reinterviewed", new_dev)
+
+
 async def test_device_reinterviewed_finalization_failure_propagates(app):
     """Test that _device_reinterviewed lets exceptions propagate to reinterview()."""
     ieee = make_ieee()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2177,6 +2177,16 @@ async def test_reinterview_during_initialization(dev):
     dev._initialize_task.cancel()
 
 
+async def test_reinterview_during_ota(dev):
+    """Test that reinterview is skipped while an OTA is in progress."""
+    dev.ota_in_progress = True
+    dev._application._device_reinterviewed = AsyncMock()
+
+    await dev.reinterview()
+
+    dev._application._device_reinterviewed.assert_not_called()
+
+
 async def test_update_firmware_triggers_reinterview(monkeypatch, dev):
     """Test that successful OTA triggers reinterview."""
     ep = dev.add_endpoint(1)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -494,6 +494,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
     monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
     dev.zdo.Active_EP_req = mockrequest
+    dev.reinterview = AsyncMock()
 
     with mock_attribute_reads(cluster, {"current_file_version": 0x00000001}):
         await dev.initialize()
@@ -877,6 +878,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
     monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
     dev.zdo.Active_EP_req = mockrequest
+    dev.reinterview = AsyncMock()
 
     with mock_attribute_reads(cluster, {"current_file_version": 0x00000001}):
         await dev.initialize()
@@ -1899,3 +1901,179 @@ async def test_attribute_report_not_matched_with_request(dev):
     result = await request_task
 
     assert result == default_rsp_cmd
+
+
+async def test_reinterview_success(monkeypatch, dev):
+    """Test successful re-interview creates a shadow device and swaps it in."""
+    node_desc = zdo_t.NodeDescriptor(1, 1, 1, 4, 5, 6, 7, 8)
+
+    async def mockrequest(*args, **kwargs):
+        return [0, None, [0, 1, 2]]
+
+    async def mock_get_node_descriptor(self):
+        self.node_desc = node_desc
+        return node_desc
+
+    async def mockepinit(self, *args, **kwargs):
+        self.status = endpoint.Status.ZDO_INIT
+        self.add_input_cluster(Basic.cluster_id)
+
+    async def mock_ep_get_model_info(self):
+        return "NewModel", "NewManufacturer"
+
+    monkeypatch.setattr(device.Device, "get_node_descriptor", mock_get_node_descriptor)
+    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
+    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
+
+    # First initialize the device normally
+    dev.zdo.Active_EP_req = mockrequest
+    await dev.initialize()
+    assert dev.is_initialized
+
+    # Set up the application mock for _device_reinterviewed
+    dev._application._device_reinterviewed = AsyncMock()
+
+    # Patch Device.__init__ to set up Active_EP_req mock on any new Device instance
+    original_init = device.Device.__init__
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.zdo.Active_EP_req = mockrequest
+
+    monkeypatch.setattr(device.Device, "__init__", patched_init)
+
+    # Run reinterview
+    await dev.reinterview()
+
+    # Verify _device_reinterviewed was called with the old device and a shadow
+    dev._application._device_reinterviewed.assert_called_once()
+    call_args = dev._application._device_reinterviewed.call_args
+    old_dev, shadow = call_args[0]
+    assert old_dev is dev
+    assert isinstance(shadow, device.Device)
+    assert shadow.ieee == dev.ieee
+    assert shadow.nwk == dev.nwk
+    assert shadow.is_initialized
+    assert 1 in shadow.endpoints
+    assert 2 in shadow.endpoints
+    assert shadow.model == "NewModel"
+    assert shadow.manufacturer == "NewManufacturer"
+
+
+async def test_reinterview_failure_preserves_device(monkeypatch, dev):
+    """Test that failed re-interview preserves the old device."""
+
+    async def mockrequest_success(*args, **kwargs):
+        return [0, None, [0, 1]]
+
+    async def mockepinit(self, *args, **kwargs):
+        self.status = endpoint.Status.ZDO_INIT
+        self.add_input_cluster(Basic.cluster_id)
+
+    async def mock_ep_get_model_info(self):
+        return "OldModel", "OldManufacturer"
+
+    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
+    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
+
+    # First initialize normally
+    dev.zdo.Active_EP_req = mockrequest_success
+    await dev.initialize()
+    assert dev.model == "OldModel"
+
+    # Now make the shadow's discovery fail (sleepy device)
+    async def mockrequest_fail(*args, **kwargs):
+        raise TimeoutError("Device asleep")
+
+    monkeypatch.setattr(
+        device.Device, "get_node_descriptor", AsyncMock(side_effect=TimeoutError)
+    )
+
+    dev._application._device_reinterviewed = AsyncMock()
+
+    await dev.reinterview()
+
+    # _device_reinterviewed should NOT have been called
+    dev._application._device_reinterviewed.assert_not_called()
+
+    # Old device is completely untouched
+    assert dev.model == "OldModel"
+    assert dev.manufacturer == "OldManufacturer"
+    assert 1 in dev.endpoints
+    assert dev.is_initialized
+
+    # Failure event was fired
+    dev._application.listener_event.assert_called_with(
+        "device_reinterview_failure", dev
+    )
+
+
+async def test_reinterview_already_in_progress(dev):
+    """Test that concurrent reinterview calls are prevented."""
+    dev._reinterview_in_progress = True
+    dev._application._device_reinterviewed = AsyncMock()
+
+    await dev.reinterview()
+
+    dev._application._device_reinterviewed.assert_not_called()
+
+
+async def test_reinterview_during_initialization(dev):
+    """Test that reinterview is skipped if initialization is in progress."""
+    dev._initialize_task = asyncio.Future()  # simulate in-progress init
+    dev._application._device_reinterviewed = AsyncMock()
+
+    await dev.reinterview()
+
+    dev._application._device_reinterviewed.assert_not_called()
+    dev._initialize_task.cancel()
+
+
+async def test_reinterview_poll_control_checkin(dev):
+    """Test that poll control checkin enables fast polling during reinterview."""
+    dev._reinterview_in_progress = True
+
+    # Verify the condition in poll_control_checkin_callback would trigger fast polling
+    assert dev.reinterviewing is True
+
+
+async def test_update_firmware_triggers_reinterview(monkeypatch, dev):
+    """Test that successful OTA triggers reinterview."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    async def mockrequest(nwk, tries=None, delay=None):
+        return [0, None, [0, 1]]
+
+    async def mockepinit(self, *args, **kwargs):
+        self.status = endpoint.Status.ZDO_INIT
+        self.add_input_cluster(Basic.cluster_id)
+
+    async def mock_ep_get_model_info(self):
+        return "Model", "Manufacturer"
+
+    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
+    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
+    dev.zdo.Active_EP_req = mockrequest
+
+    with mock_attribute_reads(cluster, {"current_file_version": 0x00000001}):
+        await dev.initialize()
+
+    # Mock the OTA process to return success
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+
+    dev.reinterview = AsyncMock()
+
+    with mock_attribute_reads(cluster, {"current_file_version": 0x00000002}):
+        result = await dev.update_firmware(
+            MagicMock(),
+            progress_callback=MagicMock(),
+        )
+
+    assert result == foundation.Status.SUCCESS
+    dev.reinterview.assert_awaited_once()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2066,6 +2066,16 @@ async def test_reinterview_unexpected_failure_preserves_device(monkeypatch, dev)
     assert not dev.reinterviewing
 
 
+async def test_reinterview_shadow_blocks_auto_init(dev):
+    """Test that schedule_initialize is a no-op on a reinterview shadow device."""
+    dev._reinterview_in_progress = True
+
+    result = dev.schedule_initialize()
+
+    assert result is None
+    assert not dev.initializing
+
+
 async def test_reinterview_already_in_progress(dev):
     """Test that concurrent reinterview calls are prevented."""
     dev._reinterview_in_progress = True

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1985,8 +1985,13 @@ async def test_reinterview_end_to_end(
     assert len(device_initialized_calls) == 0
 
 
-async def test_reinterview_failure_preserves_device(monkeypatch, dev):
-    """Test that failed re-interview preserves the old device."""
+@pytest.mark.parametrize(
+    "exception",
+    [TimeoutError, RuntimeError("unexpected")],
+    ids=["timeout", "unexpected"],
+)
+async def test_reinterview_failure_preserves_device(monkeypatch, dev, exception):
+    """Test that failed re-interview preserves the old device regardless of exception type."""
 
     async def mockrequest_success(*args, **kwargs):
         return [0, None, [0, 1]]
@@ -2009,9 +2014,9 @@ async def test_reinterview_failure_preserves_device(monkeypatch, dev):
     # Use a real dict for devices so we can verify restoration
     dev._application.devices = {dev.ieee: dev}
 
-    # Now make the shadow's discovery fail (sleepy device)
+    # Make the shadow's discovery fail
     monkeypatch.setattr(
-        device.Device, "get_node_descriptor", AsyncMock(side_effect=TimeoutError)
+        device.Device, "get_node_descriptor", AsyncMock(side_effect=exception)
     )
 
     dev._application._device_reinterviewed = AsyncMock()
@@ -2029,70 +2034,16 @@ async def test_reinterview_failure_preserves_device(monkeypatch, dev):
     assert dev.manufacturer == "OldManufacturer"
     assert 1 in dev.endpoints
     assert dev.is_initialized
-
-    # Failure event was fired
-    dev._application.listener_event.assert_called_with(
-        "device_reinterview_failure", dev
-    )
-
-
-async def test_reinterview_unexpected_failure_preserves_device(monkeypatch, dev):
-    """Test that an unexpected exception during re-interview preserves the old device."""
-
-    async def mockrequest_success(*args, **kwargs):
-        return [0, None, [0, 1]]
-
-    async def mockepinit(self, *args, **kwargs):
-        self.status = endpoint.Status.ZDO_INIT
-        self.add_input_cluster(Basic.cluster_id)
-
-    async def mock_ep_get_model_info(self):
-        return "OldModel", "OldManufacturer"
-
-    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
-    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
-
-    # First initialize normally
-    dev.zdo.Active_EP_req = mockrequest_success
-    await dev.initialize()
-    assert dev.model == "OldModel"
-
-    # Use a real dict for devices so we can verify restoration
-    dev._application.devices = {dev.ieee: dev}
-
-    # Make discovery raise an unexpected (non-Zigbee) exception
-    monkeypatch.setattr(
-        device.Device,
-        "get_node_descriptor",
-        AsyncMock(side_effect=RuntimeError("unexpected")),
-    )
-
-    dev._application._device_reinterviewed = AsyncMock()
-
-    await dev.reinterview()
-
-    # _device_reinterviewed should NOT have been called
-    dev._application._device_reinterviewed.assert_not_called()
-
-    # Old device should be restored in app.devices
-    assert dev._application.devices[dev.ieee] is dev
-
-    # Old device is completely untouched
-    assert dev.model == "OldModel"
-    assert dev.manufacturer == "OldManufacturer"
-    assert dev.is_initialized
-
-    # Failure event was fired
-    dev._application.listener_event.assert_called_with(
-        "device_reinterview_failure", dev
-    )
-
-    # Guard flag was cleared
     assert not dev.reinterviewing
 
+    # Failure event was fired
+    dev._application.listener_event.assert_called_with(
+        "device_reinterview_failure", dev
+    )
 
-async def test_reinterview_shadow_blocks_auto_init(dev):
-    """Test that schedule_initialize is a no-op on a reinterview shadow device."""
+
+async def test_reinterview_blocks_auto_init(dev):
+    """Test that schedule_initialize is a no-op while reinterviewing."""
     dev._reinterview_in_progress = True
 
     result = dev.schedule_initialize()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1959,6 +1959,9 @@ async def test_reinterview_success(monkeypatch, dev):
     assert shadow.model == "NewModel"
     assert shadow.manufacturer == "NewManufacturer"
 
+    # Guard flag should be cleared on old device after reinterview
+    assert not dev.reinterviewing
+
 
 async def test_reinterview_failure_preserves_device(monkeypatch, dev):
     """Test that failed re-interview preserves the old device."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2008,6 +2008,55 @@ async def test_reinterview_failure_preserves_device(monkeypatch, dev):
     )
 
 
+async def test_reinterview_unexpected_failure_preserves_device(monkeypatch, dev):
+    """Test that an unexpected exception during re-interview preserves the old device."""
+
+    async def mockrequest_success(*args, **kwargs):
+        return [0, None, [0, 1]]
+
+    async def mockepinit(self, *args, **kwargs):
+        self.status = endpoint.Status.ZDO_INIT
+        self.add_input_cluster(Basic.cluster_id)
+
+    async def mock_ep_get_model_info(self):
+        return "OldModel", "OldManufacturer"
+
+    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
+    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
+
+    # First initialize normally
+    dev.zdo.Active_EP_req = mockrequest_success
+    await dev.initialize()
+    assert dev.model == "OldModel"
+
+    # Make discovery raise an unexpected (non-Zigbee) exception
+    monkeypatch.setattr(
+        device.Device,
+        "get_node_descriptor",
+        AsyncMock(side_effect=RuntimeError("unexpected")),
+    )
+
+    dev._application._device_reinterviewed = AsyncMock()
+
+    await dev.reinterview()
+
+    # _device_reinterviewed should NOT have been called
+    dev._application._device_reinterviewed.assert_not_called()
+
+    # Old device is completely untouched
+    assert dev.model == "OldModel"
+    assert dev.manufacturer == "OldManufacturer"
+    assert dev.is_initialized
+
+    # Failure event was fired
+    dev._application.listener_event.assert_called_with(
+        "device_reinterview_failure", dev
+    )
+
+    # Guard flag was cleared
+    assert not dev.reinterviewing
+
+
 async def test_reinterview_already_in_progress(dev):
     """Test that concurrent reinterview calls are prevented."""
     dev._reinterview_in_progress = True

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1903,6 +1903,71 @@ async def test_attribute_report_not_matched_with_request(dev):
     assert result == default_rsp_cmd
 
 
+async def test_reinterview_end_to_end(
+    monkeypatch,
+    app: zigpy.application.ControllerApplication,
+):
+    """End-to-end reinterview: real app, full flow from reinterview() through swap."""
+    ieee = t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11")
+    node_desc = zdo_t.NodeDescriptor(1, 1, 1, 4, 5, 6, 7, 8)
+
+    async def mock_get_node_descriptor(self):
+        self.node_desc = node_desc
+        return node_desc
+
+    async def mockrequest(*args, **kwargs):
+        return [0, None, [0, 1]]
+
+    async def mockepinit(self, *args, **kwargs):
+        self.status = endpoint.Status.ZDO_INIT
+        self.add_input_cluster(Basic.cluster_id)
+
+    async def mock_ep_get_model_info(self):
+        return "Model", "Manufacturer"
+
+    monkeypatch.setattr(device.Device, "get_node_descriptor", mock_get_node_descriptor)
+    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
+    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
+
+    # Initial join and initialization
+    dev = app.add_device(ieee=ieee, nwk=t.NWK(0x1234))
+    dev.zdo.Active_EP_req = mockrequest
+    await dev.initialize()
+    assert dev.is_initialized
+    old_dev = app.devices[ieee]
+
+    # Patch Device.__init__ so the shadow also gets Active_EP_req mocked
+    original_init = device.Device.__init__
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.zdo.Active_EP_req = mockrequest
+
+    monkeypatch.setattr(device.Device, "__init__", patched_init)
+
+    # Change what model info returns for the reinterview
+    async def mock_ep_get_model_info_v2(self):
+        return "ModelV2", "ManufacturerV2"
+
+    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info_v2)
+
+    # Run the full reinterview flow
+    await old_dev.reinterview()
+
+    # The device in app.devices should be a new object
+    new_dev = app.devices[ieee]
+    assert new_dev is not old_dev
+    assert new_dev.model == "ModelV2"
+    assert new_dev.manufacturer == "ManufacturerV2"
+    assert new_dev.is_initialized
+    assert 1 in new_dev.endpoints
+    assert not new_dev.reinterviewing
+    assert not old_dev.reinterviewing
+
+    # device_reinterviewed event should have been fired
+    app.listener_event.assert_any_call("device_reinterviewed", new_dev)
+
+
 async def test_reinterview_success(monkeypatch, dev):
     """Test successful re-interview creates a shadow device and swaps it in."""
     node_desc = zdo_t.NodeDescriptor(1, 1, 1, 4, 5, 6, 7, 8)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1936,6 +1936,11 @@ async def test_reinterview_end_to_end(
     assert dev.is_initialized
     old_dev = app.devices[ieee]
 
+    # Set non-discovery state on the old device
+    old_dev._last_seen = datetime(2026, 1, 1, tzinfo=UTC)
+    old_dev.lqi = 200
+    old_dev.rssi = -40
+
     # Patch Device.__init__ so the shadow also gets Active_EP_req mocked
     original_init = device.Device.__init__
 
@@ -1951,6 +1956,9 @@ async def test_reinterview_end_to_end(
 
     monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info_v2)
 
+    # Reset listener_event mock so we only see events from the reinterview
+    app.listener_event.reset_mock()
+
     # Run the full reinterview flow
     await old_dev.reinterview()
 
@@ -1964,68 +1972,17 @@ async def test_reinterview_end_to_end(
     assert not new_dev.reinterviewing
     assert not old_dev.reinterviewing
 
-    # device_reinterviewed event should have been fired
+    # Non-discovery state should have been preserved
+    assert new_dev._last_seen == datetime(2026, 1, 1, tzinfo=UTC)
+    assert new_dev.lqi == 200
+    assert new_dev.rssi == -40
+
+    # device_reinterviewed event should have been fired, but NOT device_initialized
     app.listener_event.assert_any_call("device_reinterviewed", new_dev)
-
-
-async def test_reinterview_success(monkeypatch, dev):
-    """Test successful re-interview creates a shadow device and swaps it in."""
-    node_desc = zdo_t.NodeDescriptor(1, 1, 1, 4, 5, 6, 7, 8)
-
-    async def mockrequest(*args, **kwargs):
-        return [0, None, [0, 1, 2]]
-
-    async def mock_get_node_descriptor(self):
-        self.node_desc = node_desc
-        return node_desc
-
-    async def mockepinit(self, *args, **kwargs):
-        self.status = endpoint.Status.ZDO_INIT
-        self.add_input_cluster(Basic.cluster_id)
-
-    async def mock_ep_get_model_info(self):
-        return "NewModel", "NewManufacturer"
-
-    monkeypatch.setattr(device.Device, "get_node_descriptor", mock_get_node_descriptor)
-    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
-    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
-
-    # First initialize the device normally
-    dev.zdo.Active_EP_req = mockrequest
-    await dev.initialize()
-    assert dev.is_initialized
-
-    # Set up the application mock for _device_reinterviewed
-    dev._application._device_reinterviewed = AsyncMock()
-
-    # Patch Device.__init__ to set up Active_EP_req mock on any new Device instance
-    original_init = device.Device.__init__
-
-    def patched_init(self, *args, **kwargs):
-        original_init(self, *args, **kwargs)
-        self.zdo.Active_EP_req = mockrequest
-
-    monkeypatch.setattr(device.Device, "__init__", patched_init)
-
-    # Run reinterview
-    await dev.reinterview()
-
-    # Verify _device_reinterviewed was called with the old device and a shadow
-    dev._application._device_reinterviewed.assert_called_once()
-    call_args = dev._application._device_reinterviewed.call_args
-    old_dev, shadow = call_args[0]
-    assert old_dev is dev
-    assert isinstance(shadow, device.Device)
-    assert shadow.ieee == dev.ieee
-    assert shadow.nwk == dev.nwk
-    assert shadow.is_initialized
-    assert 1 in shadow.endpoints
-    assert 2 in shadow.endpoints
-    assert shadow.model == "NewModel"
-    assert shadow.manufacturer == "NewManufacturer"
-
-    # Guard flag should be cleared on old device after reinterview
-    assert not dev.reinterviewing
+    device_initialized_calls = [
+        c for c in app.listener_event.call_args_list if c[0][0] == "device_initialized"
+    ]
+    assert len(device_initialized_calls) == 0
 
 
 async def test_reinterview_failure_preserves_device(monkeypatch, dev):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1981,10 +1981,10 @@ async def test_reinterview_failure_preserves_device(monkeypatch, dev):
     await dev.initialize()
     assert dev.model == "OldModel"
 
-    # Now make the shadow's discovery fail (sleepy device)
-    async def mockrequest_fail(*args, **kwargs):
-        raise TimeoutError("Device asleep")
+    # Use a real dict for devices so we can verify restoration
+    dev._application.devices = {dev.ieee: dev}
 
+    # Now make the shadow's discovery fail (sleepy device)
     monkeypatch.setattr(
         device.Device, "get_node_descriptor", AsyncMock(side_effect=TimeoutError)
     )
@@ -1995,6 +1995,9 @@ async def test_reinterview_failure_preserves_device(monkeypatch, dev):
 
     # _device_reinterviewed should NOT have been called
     dev._application._device_reinterviewed.assert_not_called()
+
+    # Old device should be restored in app.devices
+    assert dev._application.devices[dev.ieee] is dev
 
     # Old device is completely untouched
     assert dev.model == "OldModel"
@@ -2029,6 +2032,9 @@ async def test_reinterview_unexpected_failure_preserves_device(monkeypatch, dev)
     await dev.initialize()
     assert dev.model == "OldModel"
 
+    # Use a real dict for devices so we can verify restoration
+    dev._application.devices = {dev.ieee: dev}
+
     # Make discovery raise an unexpected (non-Zigbee) exception
     monkeypatch.setattr(
         device.Device,
@@ -2042,6 +2048,9 @@ async def test_reinterview_unexpected_failure_preserves_device(monkeypatch, dev)
 
     # _device_reinterviewed should NOT have been called
     dev._application._device_reinterviewed.assert_not_called()
+
+    # Old device should be restored in app.devices
+    assert dev._application.devices[dev.ieee] is dev
 
     # Old device is completely untouched
     assert dev.model == "OldModel"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -494,7 +494,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
     monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
     dev.zdo.Active_EP_req = mockrequest
-    dev.reinterview = AsyncMock()
+    dev.reinterview = AsyncMock()  # prevent post-OTA reinterview side effects
 
     with mock_attribute_reads(cluster, {"current_file_version": 0x00000001}):
         await dev.initialize()
@@ -878,7 +878,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
     monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
     dev.zdo.Active_EP_req = mockrequest
-    dev.reinterview = AsyncMock()
+    dev.reinterview = AsyncMock()  # prevent post-OTA reinterview side effects
 
     with mock_attribute_reads(cluster, {"current_file_version": 0x00000001}):
         await dev.initialize()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2122,14 +2122,6 @@ async def test_reinterview_during_initialization(dev):
     dev._initialize_task.cancel()
 
 
-async def test_reinterview_poll_control_checkin(dev):
-    """Test that poll control checkin enables fast polling during reinterview."""
-    dev._reinterview_in_progress = True
-
-    # Verify the condition in poll_control_checkin_callback would trigger fast polling
-    assert dev.reinterviewing is True
-
-
 async def test_update_firmware_triggers_reinterview(monkeypatch, dev):
     """Test that successful OTA triggers reinterview."""
     ep = dev.add_endpoint(1)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -663,6 +663,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         new_device = self.devices[shadow.ieee]
 
+        # Clear the reinterview flag so the new device isn't permanently stuck
+        # (relevant when no quirk is applied and new_device is the shadow itself)
+        new_device._reinterview_in_progress = False
+
         # Restore group memberships on the new device's matching endpoints
         for ep_id, group_ids in old_group_memberships.items():
             if ep_id in new_device.endpoints:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -613,20 +613,81 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         old_device: zigpy.device.Device,
         shadow: zigpy.device.Device,
     ) -> None:
-        """Atomically swap an old device with a successfully re-interviewed shadow."""
-        # Remove old device data from DB (cascade deletes endpoints, clusters, cache)
+        """Swap an old device with a successfully re-interviewed shadow.
+
+        Preserves non-discovery state (last_seen, relays, lqi, rssi) and group
+        memberships.  If anything goes wrong after the DB delete, the old device
+        is restored so the system stays functional.
+        """
+        # Copy non-discovery state from old device to shadow
+        shadow._last_seen = old_device._last_seen
+        shadow._relays = old_device._relays
+        shadow.lqi = old_device.lqi
+        shadow.rssi = old_device.rssi
+
+        # Collect group memberships from old endpoints before teardown
+        # Maps endpoint_id -> set of group_ids
+        old_group_memberships: dict[int, set[int]] = {}
+        for ep in old_device.non_zdo_endpoints:
+            if ep.member_of:
+                old_group_memberships[ep.endpoint_id] = set(ep.member_of)
+
+        # Remove old device from in-memory groups (prevents stale endpoint refs)
+        for ep in old_device.non_zdo_endpoints:
+            for group in list(ep.member_of.values()):
+                group.remove_member(ep, suppress_event=True)
+
+        # Remove old device data from DB (cascade deletes endpoints, clusters,
+        # attribute cache, group members, and relays)
         if self._dblistener is not None:
             old_device.remove_listener(self._dblistener)
             await self._dblistener._remove_device(old_device)
 
-        # Clean up old device's callbacks and tasks
-        old_device.on_remove()
+        try:
+            # Clean up old device's callbacks and tasks
+            old_device.on_remove()
 
-        # Finalize the shadow via the existing device_initialized path:
-        # sets original_signature, applies quirks, saves to DB, fires events
-        self.device_initialized(shadow)
+            # Finalize the shadow via the existing device_initialized path:
+            # sets original_signature, applies quirks, saves to DB, fires events
+            self.device_initialized(shadow)
+        except Exception:
+            # Finalization failed — restore the old device so the system stays
+            # functional.  DB data is gone but will be re-persisted on next save.
+            LOGGER.warning(
+                "Re-interview finalization failed for %s, restoring old device",
+                old_device.ieee,
+                exc_info=True,
+            )
+            self.devices[old_device.ieee] = old_device
+            if self._dblistener is not None:
+                old_device.add_context_listener(self._dblistener)
 
-        self.listener_event("device_reinterviewed", self.devices[shadow.ieee])
+            # Restore group memberships on the old device
+            for ep_id, group_ids in old_group_memberships.items():
+                if ep_id in old_device.endpoints:
+                    old_ep = old_device.endpoints[ep_id]
+                    for group_id in group_ids:
+                        self.groups[group_id].add_member(
+                            old_ep, suppress_event=True
+                        )
+
+            raise
+
+        new_device = self.devices[shadow.ieee]
+
+        # Restore group memberships on the new device's matching endpoints
+        for ep_id, group_ids in old_group_memberships.items():
+            if ep_id in new_device.endpoints:
+                new_ep = new_device.endpoints[ep_id]
+                for group_id in group_ids:
+                    group = self.groups[group_id]
+                    group.add_member(new_ep)
+
+        # Persist relays for the new device (cascade deleted the old row)
+        if self._dblistener is not None and new_device._relays is not None:
+            self._dblistener.device_relays_updated(new_device, new_device._relays)
+
+        self.listener_event("device_reinterviewed", new_device)
 
     async def reinterview_device(self, ieee: t.EUI64) -> None:
         """Re-interview a device. Safe for sleepy end-devices.

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -661,9 +661,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # Apply quirks, persist to DB, and register the device — but do NOT
         # fire the device_initialized listener event.  Callers (and ZHA)
         # should listen for device_reinterviewed instead.
-        self._finalize_device(shadow)
-
-        new_device = self.devices[shadow.ieee]
+        new_device = self._finalize_device(shadow)
 
         # Clear the reinterview flag so the new device isn't permanently stuck
         # (relevant when no quirk is applied and new_device is the shadow itself)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -608,6 +608,34 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             device.add_context_listener(self._dblistener)
         self.listener_event("device_initialized", device)
 
+    async def _device_reinterviewed(
+        self,
+        old_device: zigpy.device.Device,
+        shadow: zigpy.device.Device,
+    ) -> None:
+        """Atomically swap an old device with a successfully re-interviewed shadow."""
+        # Remove old device data from DB (cascade deletes endpoints, clusters, cache)
+        if self._dblistener is not None:
+            old_device.remove_listener(self._dblistener)
+            await self._dblistener._remove_device(old_device)
+
+        # Clean up old device's callbacks and tasks
+        old_device.on_remove()
+
+        # Finalize the shadow via the existing device_initialized path:
+        # sets original_signature, applies quirks, saves to DB, fires events
+        self.device_initialized(shadow)
+
+        self.listener_event("device_reinterviewed", self.devices[shadow.ieee])
+
+    async def reinterview_device(self, ieee: t.EUI64) -> None:
+        """Re-interview a device. Safe for sleepy end-devices.
+
+        If the device does not respond, existing state is preserved.
+        """
+        dev = self.get_device(ieee=ieee)
+        await dev.reinterview()
+
     async def remove(
         self, ieee: t.EUI64, remove_children: bool = True, rejoin: bool = False
     ) -> None:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -627,8 +627,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Swap an old device with a successfully re-interviewed shadow.
 
         Preserves non-discovery state (last_seen, relays, lqi, rssi) and group
-        memberships.  On any exception, ``reinterview()`` restores the old
-        device in ``app.devices``.
+        memberships.  Exceptions propagate to ``reinterview()`` which logs them
+        and fires the ``device_reinterview_failure`` event.
         """
         # Copy non-discovery state from old device to shadow
         shadow._last_seen = old_device._last_seen

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -596,9 +596,13 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.devices[ieee] = dev
         return dev
 
-    def device_initialized(self, device: zigpy.device.Device) -> None:
-        """Used by a device to signal that it is initialized"""
-        LOGGER.debug("Device is initialized %s", device)
+    def _finalize_device(self, device: zigpy.device.Device) -> zigpy.device.Device:
+        """Apply quirks, persist to DB, and register the device.
+
+        Returns the (possibly quirked) device stored in ``self.devices``.
+        Does **not** fire any listener events beyond ``raw_device_initialized``
+        (which triggers the DB save).
+        """
         device.original_signature = device.get_signature()
 
         self.listener_event("raw_device_initialized", device)
@@ -606,6 +610,13 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.devices[device.ieee] = device
         if self._dblistener is not None:
             device.add_context_listener(self._dblistener)
+
+        return device
+
+    def device_initialized(self, device: zigpy.device.Device) -> None:
+        """Used by a device to signal that it is initialized"""
+        LOGGER.debug("Device is initialized %s", device)
+        device = self._finalize_device(device)
         self.listener_event("device_initialized", device)
 
     async def _device_reinterviewed(
@@ -647,9 +658,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             # Clean up old device's callbacks and tasks
             old_device.on_remove()
 
-            # Finalize the shadow via the existing device_initialized path:
-            # sets original_signature, applies quirks, saves to DB, fires events
-            self.device_initialized(shadow)
+            # Apply quirks, persist to DB, and register the device — but do NOT
+            # fire the device_initialized listener event.  Callers (and ZHA)
+            # should listen for device_reinterviewed instead.
+            self._finalize_device(shadow)
         except Exception:
             # Finalization failed — restore the old device so the system stays
             # functional.  DB data is gone but will be re-persisted on next save.
@@ -667,9 +679,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 if ep_id in old_device.endpoints:
                     old_ep = old_device.endpoints[ep_id]
                     for group_id in group_ids:
-                        self.groups[group_id].add_member(
-                            old_ep, suppress_event=True
-                        )
+                        self.groups[group_id].add_member(old_ep, suppress_event=True)
 
             raise
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -664,12 +664,16 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # (relevant when no quirk is applied and new_device is the shadow itself)
         new_device._reinterview_in_progress = False
 
-        # Restore group memberships on the new device's matching endpoints
+        # Restore group memberships on the new device's matching endpoints.
+        # A group may have been removed while we were awaiting `_remove_device`,
+        # so guard against missing entries rather than aborting the reinterview.
         for ep_id, group_ids in old_group_memberships.items():
             if ep_id in new_device.endpoints:
                 new_ep = new_device.endpoints[ep_id]
                 for group_id in group_ids:
-                    self.groups[group_id].add_member(new_ep)
+                    group = self.groups.get(group_id)
+                    if group is not None:
+                        group.add_member(new_ep)
 
         # Persist relays for the new device (cascade deleted the old row)
         if self._dblistener is not None and new_device._relays is not None:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -627,8 +627,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Swap an old device with a successfully re-interviewed shadow.
 
         Preserves non-discovery state (last_seen, relays, lqi, rssi) and group
-        memberships.  If anything goes wrong after the DB delete, the old device
-        is restored so the system stays functional.
+        memberships.  On any exception, ``reinterview()`` restores the old
+        device in ``app.devices``.
         """
         # Copy non-discovery state from old device to shadow
         shadow._last_seen = old_device._last_seen
@@ -637,7 +637,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         shadow.rssi = old_device.rssi
 
         # Collect group memberships from old endpoints before teardown
-        # Maps endpoint_id -> set of group_ids
         old_group_memberships: dict[int, set[int]] = {}
         for ep in old_device.non_zdo_endpoints:
             if ep.member_of:
@@ -654,34 +653,13 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             old_device.remove_listener(self._dblistener)
             await self._dblistener._remove_device(old_device)
 
-        try:
-            # Clean up old device's callbacks and tasks
-            old_device.on_remove()
+        # Clean up old device's callbacks and tasks
+        old_device.on_remove()
 
-            # Apply quirks, persist to DB, and register the device — but do NOT
-            # fire the device_initialized listener event.  Callers (and ZHA)
-            # should listen for device_reinterviewed instead.
-            self._finalize_device(shadow)
-        except Exception:
-            # Finalization failed — restore the old device so the system stays
-            # functional.  DB data is gone but will be re-persisted on next save.
-            LOGGER.warning(
-                "Re-interview finalization failed for %s, restoring old device",
-                old_device.ieee,
-                exc_info=True,
-            )
-            self.devices[old_device.ieee] = old_device
-            if self._dblistener is not None:
-                old_device.add_context_listener(self._dblistener)
-
-            # Restore group memberships on the old device
-            for ep_id, group_ids in old_group_memberships.items():
-                if ep_id in old_device.endpoints:
-                    old_ep = old_device.endpoints[ep_id]
-                    for group_id in group_ids:
-                        self.groups[group_id].add_member(old_ep, suppress_event=True)
-
-            raise
+        # Apply quirks, persist to DB, and register the device — but do NOT
+        # fire the device_initialized listener event.  Callers (and ZHA)
+        # should listen for device_reinterviewed instead.
+        self._finalize_device(shadow)
 
         new_device = self.devices[shadow.ieee]
 
@@ -690,8 +668,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             if ep_id in new_device.endpoints:
                 new_ep = new_device.endpoints[ep_id]
                 for group_id in group_ids:
-                    group = self.groups[group_id]
-                    group.add_member(new_ep)
+                    self.groups[group_id].add_member(new_ep)
 
         # Persist relays for the new device (cascade deleted the old row)
         if self._dblistener is not None and new_device._relays is not None:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -648,7 +648,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 group.remove_member(ep, suppress_event=True)
 
         # Remove old device data from DB (cascade deletes endpoints, clusters,
-        # attribute cache, group members, and relays)
+        # attribute cache, group members, and relays).  We call _remove_device
+        # directly instead of the public device_removed() because we need the
+        # delete to complete before _finalize_device enqueues the save.
         if self._dblistener is not None:
             old_device.remove_listener(self._dblistener)
             await self._dblistener._remove_device(old_device)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -636,16 +636,13 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         shadow.lqi = old_device.lqi
         shadow.rssi = old_device.rssi
 
-        # Collect group memberships from old endpoints before teardown
+        # Collect group memberships and remove old endpoints from groups
         old_group_memberships: dict[int, set[int]] = {}
         for ep in old_device.non_zdo_endpoints:
             if ep.member_of:
                 old_group_memberships[ep.endpoint_id] = set(ep.member_of)
-
-        # Remove old device from in-memory groups (prevents stale endpoint refs)
-        for ep in old_device.non_zdo_endpoints:
-            for group in list(ep.member_of.values()):
-                group.remove_member(ep, suppress_event=True)
+                for group in list(ep.member_of.values()):
+                    group.remove_member(ep, suppress_event=True)
 
         # Remove old device data from DB (cascade deletes endpoints, clusters,
         # attribute cache, group members, and relays).  We call _remove_device

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -339,8 +339,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             except Exception:
                 # Ensure old device is restored in app.devices on any failure
                 self._application.devices[self._ieee] = self
-                # Re-register DB listener if it was removed during the swap
+                # Ensure exactly one DB listener registration on the restored
+                # device (it may or may not have been removed before the failure)
                 if self._application._dblistener is not None:
+                    self.remove_listener(self._application._dblistener)
                     self.add_context_listener(self._application._dblistener)
                 # Clean up shadow's callbacks/tasks (e.g. PollControl listener)
                 shadow.on_remove()

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -317,10 +317,21 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         try:
             shadow = Device(self._application, self._ieee, self.nwk)
 
-            async with self._application.request_priority(t.PacketPriority.CRITICAL):
-                await zigpy.util.retryable_request(tries=5, delay=0.5)(
-                    shadow._discover
-                )()
+            # Temporarily register the shadow in app.devices so it receives
+            # ZDO responses routed by packet_received().
+            self._application.devices[self._ieee] = shadow
+
+            try:
+                async with self._application.request_priority(
+                    t.PacketPriority.CRITICAL
+                ):
+                    await zigpy.util.retryable_request(tries=5, delay=0.5)(
+                        shadow._discover
+                    )()
+            except Exception:
+                # Discovery failed — restore the old device so it keeps working
+                self._application.devices[self._ieee] = self
+                raise
 
             # Discovery succeeded — swap the old device for the new one
             await self._application._device_reinterviewed(self, shadow)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -102,6 +102,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._last_seen: datetime | None = None
 
         self._initialize_task: asyncio.Task | None = None
+        self._reinterview_in_progress: bool = False
         self._group_scan_task: asyncio.Task | None = None
         self._fast_polling_reset_task: asyncio.Task | None = None
 
@@ -271,6 +272,11 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         """Return True if device is being initialized."""
         return self._initialize_task is not None and not self._initialize_task.done()
 
+    @property
+    def reinterviewing(self) -> bool:
+        """Return True if device is being re-interviewed."""
+        return self._reinterview_in_progress
+
     def cancel_initialization(self) -> None:
         """Cancel initialization call."""
         if self.initializing:
@@ -290,6 +296,49 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._initialize_task = self.create_task(self.initialize(), name="initialize")
 
         return self._initialize_task
+
+    async def reinterview(self) -> None:
+        """Re-interview this device using a shadow device for safety.
+
+        Creates a fresh Device, discovers its endpoints/clusters/model info,
+        and on success swaps the old device out. On failure, the old device
+        and its DB state are preserved.
+        """
+        if self.reinterviewing:
+            self.debug("Re-interview already in progress, skipping")
+            return
+
+        if self.initializing:
+            self.debug("Initialization in progress, skipping re-interview")
+            return
+
+        self._reinterview_in_progress = True
+
+        try:
+            shadow = Device(self._application, self._ieee, self.nwk)
+
+            async with self._application.request_priority(t.PacketPriority.CRITICAL):
+                await zigpy.util.retryable_request(tries=5, delay=0.5)(
+                    shadow._discover
+                )()
+
+            # Discovery succeeded — swap the old device for the new one
+            await self._application._device_reinterviewed(self, shadow)
+        except (TimeoutError, zigpy.exceptions.ZigbeeException):
+            self.warning(
+                "Re-interview failed, keeping existing device",
+                exc_info=True,
+            )
+            self._application.listener_event("device_reinterview_failure", self)
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                "Device %r re-interview failed due to unexpected error",
+                self,
+                exc_info=True,
+            )
+            self._application.listener_event("device_reinterview_failure", self)
+        finally:
+            self._reinterview_in_progress = False
 
     async def get_node_descriptor(self) -> zdo_t.NodeDescriptor:
         self.info("Requesting 'Node Descriptor'")
@@ -348,6 +397,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             # to be sent
             if (
                 self.initializing
+                or self.reinterviewing
                 or self._concurrent_requests_semaphore.active_requests > 0
                 or self._fast_polling
             ):
@@ -421,11 +471,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             LOGGER.debug("Stopping fast polling on next device check-in")
             self._fast_polling = False
 
-    @zigpy.util.retryable_request(tries=5, delay=0.5)
-    async def _initialize(self) -> None:
-        """Attempts multiple times to discover all basic information about a device: namely
-        its node descriptor, all endpoints and clusters, and the model and manufacturer
-        attributes from any Basic cluster exposing those attributes.
+    async def _discover(self) -> None:
+        """Discover all basic information about a device: its node descriptor, all
+        endpoints and clusters, and the model and manufacturer attributes from any
+        Basic cluster exposing those attributes. Does not signal completion.
         """
 
         # Some devices are improperly initialized and are missing a node descriptor
@@ -512,6 +561,11 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.status = Status.ENDPOINTS_INIT
 
         self.info("Discovered basic device information for %s", self)
+
+    @zigpy.util.retryable_request(tries=5, delay=0.5)
+    async def _initialize(self) -> None:
+        """Discover device information and signal to the application."""
+        await self._discover()
 
         # Signal to the application that the device is ready
         self._application.device_initialized(self)
@@ -933,6 +987,18 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         await OTA_RETRY_DECORATOR(ota.read_attributes)(
             [Ota.AttributeDefs.current_file_version.name]
         )
+
+        # Re-interview the device after successful OTA to pick up
+        # any changes in clusters/endpoints/model and re-apply quirks
+        try:
+            await self.reinterview()
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                "Post-OTA re-interview failed for %r,"
+                " device may need manual re-interview",
+                self,
+                exc_info=True,
+            )
 
         return result
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -333,20 +333,16 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     await zigpy.util.retryable_request(tries=2, delay=0.5)(
                         shadow._discover
                     )()
-
-                # Discovery succeeded — swap the old device for the new one
-                await self._application._device_reinterviewed(self, shadow)
             except Exception:
-                # Ensure old device is restored in app.devices on any failure
+                # Discovery failed — restore old device, clean up shadow
                 self._application.devices[self._ieee] = self
-                # Ensure exactly one DB listener registration on the restored
-                # device (it may or may not have been removed before the failure)
-                if self._application._dblistener is not None:
-                    self.remove_listener(self._application._dblistener)
-                    self.add_context_listener(self._application._dblistener)
-                # Clean up shadow's callbacks/tasks (e.g. PollControl listener)
                 shadow.on_remove()
                 raise
+
+            # Discovery succeeded — swap the old device for the new one.
+            # If this somehow fails, the state may be partially swapped; attempting
+            # to undo would likely make things worse.
+            await self._application._device_reinterviewed(self, shadow)
         except Exception:  # noqa: BLE001
             self.warning(
                 "Re-interview failed, keeping existing device",

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -339,6 +339,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             except Exception:
                 # Ensure old device is restored in app.devices on any failure
                 self._application.devices[self._ieee] = self
+                # Re-register DB listener if it was removed during the swap
+                if self._application._dblistener is not None:
+                    self.add_context_listener(self._application._dblistener)
                 # Clean up shadow's callbacks/tasks (e.g. PollControl listener)
                 shadow.on_remove()
                 raise

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -339,6 +339,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             except Exception:
                 # Ensure old device is restored in app.devices on any failure
                 self._application.devices[self._ieee] = self
+                # Clean up shadow's callbacks/tasks (e.g. PollControl listener)
+                shadow.on_remove()
                 raise
         except Exception:  # noqa: BLE001
             self.warning(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -338,8 +338,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 await self._application._device_reinterviewed(self, shadow)
             except Exception:
                 # Ensure old device is restored in app.devices on any failure
-                # (_device_reinterviewed may have already done this for
-                # finalization failures, but the assignment is idempotent)
                 self._application.devices[self._ieee] = self
                 raise
         except Exception:  # noqa: BLE001

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -1000,16 +1000,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         )
 
         # Re-interview the device after successful OTA to pick up
-        # any changes in clusters/endpoints/model and re-apply quirks
-        try:
-            await self.reinterview()
-        except Exception:  # noqa: BLE001
-            LOGGER.warning(
-                "Post-OTA re-interview failed for %r,"
-                " device may need manual re-interview",
-                self,
-                exc_info=True,
-            )
+        # any changes in clusters/endpoints/model and re-apply quirks.
+        # reinterview() handles its own errors internally.
+        await self.reinterview()
 
         return result
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -330,7 +330,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 async with self._application.request_priority(
                     t.PacketPriority.CRITICAL
                 ):
-                    await zigpy.util.retryable_request(tries=5, delay=0.5)(
+                    await zigpy.util.retryable_request(tries=2, delay=0.5)(
                         shadow._discover
                     )()
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -316,6 +316,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self.debug("Initialization in progress, skipping re-interview")
             return
 
+        if self.ota_in_progress:
+            self.debug("OTA in progress, skipping re-interview")
+            return
+
         self._reinterview_in_progress = True
 
         try:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -328,23 +328,18 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     await zigpy.util.retryable_request(tries=5, delay=0.5)(
                         shadow._discover
                     )()
+
+                # Discovery succeeded — swap the old device for the new one
+                await self._application._device_reinterviewed(self, shadow)
             except Exception:
-                # Discovery failed — restore the old device so it keeps working
+                # Ensure old device is restored in app.devices on any failure
+                # (_device_reinterviewed may have already done this for
+                # finalization failures, but the assignment is idempotent)
                 self._application.devices[self._ieee] = self
                 raise
-
-            # Discovery succeeded — swap the old device for the new one
-            await self._application._device_reinterviewed(self, shadow)
-        except (TimeoutError, zigpy.exceptions.ZigbeeException):
+        except Exception:  # noqa: BLE001
             self.warning(
                 "Re-interview failed, keeping existing device",
-                exc_info=True,
-            )
-            self._application.listener_event("device_reinterview_failure", self)
-        except Exception:  # noqa: BLE001
-            LOGGER.warning(
-                "Device %r re-interview failed due to unexpected error",
-                self,
                 exc_info=True,
             )
             self._application.listener_event("device_reinterview_failure", self)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -290,6 +290,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             self._application.device_initialized(self)
             return None
 
+        if self.reinterviewing:
+            self.debug("Skipping initialization, re-interview in progress")
+            return None
+
         self.debug("Scheduling initialization")
 
         self.cancel_initialization()
@@ -316,6 +320,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         try:
             shadow = Device(self._application, self._ieee, self.nwk)
+            shadow._reinterview_in_progress = True  # prevent auto-initialization
 
             # Temporarily register the shadow in app.devices so it receives
             # ZDO responses routed by packet_received().


### PR DESCRIPTION
Tested and working.

## Note

This is somewhat similar to the approach of quirk matching, where we also create a new `Device` object.
With how both zigpy and zha-quirks currently work, I don't see any other way than basically how it's done in this PR.

IMO, re-interview support is something we really need, especially for OTA updates. I think this solution is "good enough". If quirks ever drastically change in the future, we can re-evaluate this.

### Related changes

This is already working with these changes to ZHA and Core (they include the dynamic entity rediscovery):
- https://github.com/zigpy/zha/compare/dev...TheJulianJES:tjj/reinterviewing
- https://github.com/home-assistant/core/compare/dev...TheJulianJES:tjj/reinterviewing

## Proposed change

This is an experimental PR to allow zigpy to re-interview a device at runtime, without needing to fully remove it, and re-join it.

This works by creating a temporary "shadow device" for which the initialization is started. Only if it's successful is the existing data wiped from the DB and the existing runtime `Device` object replaced with the "shadow device" and hooked up for DB events.


### Possible advantages of this approach

I think the approach of this might actually be nicer than a lot of other ideas that came up:
- We don't need to modify the DB until after we're done with a successful reinterview
- We don't need to remove the (working) device until after we're done with a successful reinterview
  - ~~During the reinterview process, the device would still work as is~~
  - EDIT: We (obviously) need to forward any messages to the new shadow device, only reverting them if we time out. This does work nicely.
- We don't need to selectively modify existing attributes in the cache and just replace all of them
- We don't need to change ZHA attribute reading logic to re-read existing attributes already in cache
  - We can likely just hook up the reconfiguration to `Device.reinterview()`
- It's also a relatively small approach and works with existing logic
- We have a "completely fresh device" at the end
- This works with the [quirks registry's `get_device` method](https://github.com/zigpy/zigpy/blob/190043d14476b190a77345c37248f87bd60a65c9/zigpy/quirks/registry.py#L104-L166), which essentially requires a new `Device` object if we want to redo quirk matching

### TODO:
- Test
- See if we even want to do this
  - Would there be any advantages if we completely remove and re-add the `Device`?
  - Could we re-interview on an existing `Device` object but revert all runtime (+ DB?) changes if unsuccessful?
  - Or is this approach fine?
- Make some parts slightly less hacky
- Investigate if this even works nicely with ZHA and HA
  - ZHA holds references to the zigpy device, HA to the ZHA device
  - Can we have ZHA devices "re-initialize" from the zigpy `Device`? Similar to `recompute_capabilities` (kind of...)?
- Copy over parts from old `Device`: `_last_seen` + `_relays` + `lqi` + `rssi` + group membership + ...?

The ZHA part of this also somewhat depends on:
- https://github.com/zigpy/zha/pull/517

---

## AI summary

Adds the ability to re-interview a device after an OTA firmware update (or on demand from upstream applications like ZHA). Re-interviewing re-discovers the device's node descriptor, endpoints, clusters, model/manufacturer info, and OTA firmware version, then re-applies quirks.

This is needed because a firmware update can change a device's exposed endpoints, clusters, or model string, which may require a different quirk to be applied.

## Approach: Shadow Device

A fresh "shadow" `Device` object is created with the same IEEE/NWK and fully initialized via ZDO requests. The old device continues to handle messages normally throughout the entire process.

- **On success**: the old device is removed from the DB (cascading to endpoints, clusters, and attribute cache), cleaned up, and replaced by the shadow. Quirks are re-applied and the new device is persisted.
- **On failure** (e.g. sleepy end-device doesn't respond): the shadow is discarded. The old device and its DB state are completely untouched and it keeps working.

## More details

<details><summary>Other (unnecessary) AI information (CLICK TO EXPAND)</summary>
<p>

## Changes

### `zigpy/device.py`
- Extract `_discover()` from `_initialize()` — pure discovery logic without side effects, enabling reuse by the reinterview flow.
- Add `Device.reinterview()` — creates a shadow device, runs discovery, swaps on success.
- Add `reinterviewing` property and `_reinterview_in_progress` guard flag.
- Trigger `reinterview()` automatically after a successful OTA update in `update_firmware()`.
- Enable fast polling during reinterview in `poll_control_checkin_callback` so sleepy devices are more likely to respond.

### `zigpy/application.py`
- Add `_device_reinterviewed(old_device, shadow)` — handles the atomic swap: DB removal, cleanup, quirk re-application, and event firing.
- Add `reinterview_device(ieee)` — public API for upstream applications (e.g. ZHA) to trigger a re-interview.

### Events
- `device_reinterviewed` — fired after a successful re-interview, with the new (possibly quirked) device.
- `device_reinterview_failure` — fired when re-interview fails, with the old device (still functional).

## Test plan

- [x] Successful re-interview creates shadow, calls `_device_reinterviewed`
- [x] Failed re-interview (sleepy device timeout) preserves old device and DB
- [x] Concurrent reinterview calls are prevented (`_reinterview_in_progress` guard)
- [x] Reinterview is skipped while initialization is in progress
- [x] Poll control checkin enables fast polling during reinterview
- [x] Successful OTA triggers `reinterview()`
- [x] `_device_reinterviewed` swaps device in `app.devices` and fires events
- [x] `_device_reinterviewed` removes old device from DB before saving new one
- [x] `reinterview_device()` public API delegates correctly
- [x] `reinterview_device()` raises `KeyError` for unknown IEEE
- [x] Existing OTA and initialization tests still pass (267 tests, 0 failures)


</p>
</details> 


### Thought with `_save_device` not really doing anything for quirked devices

<details><summary>_save_device behavior for quirked devices (CLICK TO EXPAND)</summary>
<p>

This doesn't seem to be an issue here, but `_save_device` being called after for quirked devices doesn't really save anything to the DB. It completely skips even saving attribute cache (and unsupported ones). This isn't ideal and we should look at this at some point, though we do not want to save endpoints or clusters added or removed by quirks to the DB.
https://github.com/zigpy/zigpy/blob/7d1ea41f37fb7f78c7202ccd21ee5df22c092a89/zigpy/appdb.py#L411-L420

Why it's not an issue below (AI-generated):

## How attributes are saved

The `_save_device` method in `appdb.py` has an early return for `BaseCustomDevice` instances (quirked devices), skipping endpoint, cluster, and attribute cache persistence. This is intentional — quirk-added clusters/endpoints should not be persisted to the DB, which serves as the source of truth for quirk matching.

This is **not** an issue for the reinterview flow. In `device_initialized()`:

```python
self.listener_event("raw_device_initialized", device)   # fires with raw shadow
device = zigpy.quirks.get_device(device)                 # quirk applied AFTER
```

`raw_device_initialized` fires with the **raw shadow** (a plain `Device`, not a `BaseCustomDevice`) before quirks are applied. So `_save_device` receives the raw device, the `isinstance` check is `False`, and the full save path runs:

1. **`_save_device(shadow)`** — shadow is a raw `Device` → saves original endpoints, clusters, and attribute cache (from `read_attributes` calls during `_discover()`)
2. **`get_device(shadow)`** — returns quirked device with potentially modified clusters/endpoints
3. **`register_cluster_events`** — quirked device's clusters get event handlers hooked up, so future attribute reads/reports persist individually via `on_attribute_read`, `on_attribute_updated`, etc.

The DB ends up with the original (pre-quirk) endpoints and clusters as source of truth, plus the attribute cache populated during discovery. This matches how initial device join already works.


</p>
</details> 