### PR TITLE
Serialize complex ZCL attribute types for database persistence

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1638,6 +1638,56 @@ def test_serialize_for_db_serializable_types():
     assert result == lv_list.serialize()
 
 
+async def test_save_attribute_cache_serializes_complex_types(tmp_path) -> None:
+    """Test that _save_attribute_cache serializes complex ZCL types to bytes."""
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"))
+    dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = profiles.zha.DeviceType.PUMP
+
+    basic = ep.add_input_cluster(Basic.cluster_id)
+    basic.update_attribute(Basic.AttributeDefs.model, "some model")
+    basic.update_attribute(Basic.AttributeDefs.manufacturer, "some manufacturer")
+
+    # Let the device be fully saved so parent rows exist
+    app.device_initialized(dev)
+    await app._dblistener._callback_handlers.join()
+
+    # Now inject a complex type (LVList) directly into the cache
+    lv_list = t.LVList[t.LVBytes, t.uint16_t](
+        [b"\x13\x47\x06\xb1\xef\x4e", b"\x14\xa0\x39\x1d\x82\xd3"]
+    )
+    basic._attr_cache._cache[(Basic.AttributeDefs.product_label.id, None)] = (
+        zigpy.zcl.helpers.CacheItem(
+            value=lv_list,
+            last_updated=datetime.now(UTC),
+        )
+    )
+
+    await app._dblistener._save_attribute_cache(ep)
+    await app._dblistener._db.commit()
+
+    # Verify it was stored as serialized bytes
+    async with app._dblistener.execute(
+        f"SELECT value FROM attributes_cache{zigpy.appdb.DB_V}"
+        " WHERE ieee = :ieee AND attr_id = :attr_id",
+        {"ieee": str(dev.ieee), "attr_id": Basic.AttributeDefs.product_label.id},
+    ) as cursor:
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert isinstance(row[0], bytes)
+    assert row[0] == lv_list.serialize()
+
+    await app.shutdown()
+
+
 @patch("zigpy.quirks.DEVICE_REGISTRY", new=DeviceRegistry())
 async def test_attribute_read_complex_type_persists(tmp_path) -> None:
     """Test that complex ZCL types (e.g. LVList) are serialized to bytes for storage."""

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 import pathlib
 import threading
 import time
+from typing import Final
 
 import aiosqlite
 import freezegun
@@ -44,7 +45,7 @@ import zigpy.types as t
 import zigpy.zcl
 from zigpy.zcl import ClusterType, UnsupportedAttribute
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota
-from zigpy.zcl.foundation import Status as ZCLStatus, ZCLAttributeDef
+from zigpy.zcl.foundation import BaseAttributeDefs, Status as ZCLStatus, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
 
 
@@ -1607,3 +1608,132 @@ async def test_device_signature_ignores_quirks(tmp_path) -> None:
     assert dev2.original_signature == expected_signature
 
     await app2.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        (42, 42),
+        (3.14, 3.14),
+        ("hello", "hello"),
+        (b"\x01\x02\x03", b"\x01\x02\x03"),
+        # ZCL integer types are int subclasses, pass through as-is
+        (t.uint16_t(0x1234), 0x1234),
+        (t.uint8_t(0xFF), 0xFF),
+    ],
+)
+def test_serialize_for_db_native_types(value, expected):
+    """Test that native SQLite types pass through _serialize_for_db unchanged."""
+    assert zigpy.appdb._serialize_for_db(value) == expected
+
+
+def test_serialize_for_db_serializable_types():
+    """Test that types with a serialize() method are converted to bytes."""
+    lv_list = t.LVList[t.LVBytes, t.uint16_t](
+        [b"\x13\x47\x06\xb1\xef\x4e", b"\x14\xa0\x39\x1d\x82\xd3"]
+    )
+    result = zigpy.appdb._serialize_for_db(lv_list)
+    assert isinstance(result, bytes)
+    assert result == lv_list.serialize()
+
+
+def test_serialize_for_db_unsupported_type():
+    """Test that unsupported types raise ValueError."""
+    with pytest.raises(ValueError, match="Cannot persist attribute value"):
+        zigpy.appdb._serialize_for_db(object())
+
+
+@patch("zigpy.quirks.DEVICE_REGISTRY", new=DeviceRegistry())
+async def test_attribute_read_complex_type_persists(tmp_path) -> None:
+    """Test that complex ZCL types (e.g. LVList) are serialized to bytes for storage."""
+
+    class UbisysCluster(CustomCluster):
+        cluster_id = 0xFC00
+        name = "Ubisys Cluster"
+        ep_attribute = "ubisys_cluster"
+
+        class AttributeDefs(BaseAttributeDefs):
+            output_configurations: Final = ZCLAttributeDef(
+                id=0x0010,
+                type=t.LVList[t.LVBytes, t.uint16_t],
+                manufacturer_code=None,
+            )
+
+    (
+        QuirkBuilder("ubisys", "J1", registry=zigpy.quirks.DEVICE_REGISTRY)
+        .adds_endpoint(232)
+        .replaces(UbisysCluster, endpoint_id=232)
+        .add_to_registry()
+    )
+
+    db = tmp_path / "test.db"
+    app = await make_app_with_db(db)
+
+    dev = app.add_device(nwk=0x3459, ieee=t.EUI64.convert("00:1f:ee:00:00:00:96:f5"))
+    dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+
+    ep1 = dev.add_endpoint(1)
+    ep1.status = zigpy.endpoint.Status.ZDO_INIT
+    ep1.profile_id = 260
+    ep1.device_type = profiles.zha.DeviceType.PUMP
+
+    basic = ep1.add_input_cluster(Basic.cluster_id)
+    basic.update_attribute(Basic.AttributeDefs.model, "J1")
+    basic.update_attribute(Basic.AttributeDefs.manufacturer, "ubisys")
+
+    ep232 = dev.add_endpoint(232)
+    ep232.status = zigpy.endpoint.Status.ZDO_INIT
+    ep232.profile_id = 260
+    ep232.device_type = profiles.zha.DeviceType.PUMP
+    ep232.add_input_cluster(UbisysCluster.cluster_id)
+
+    await dev.initialize()
+
+    dev = app.get_device(ieee=dev.ieee)
+    ubisys = dev.endpoints[232].in_clusters[0xFC00]
+    assert isinstance(ubisys, UbisysCluster)
+
+    test_value = t.LVList[t.LVBytes, t.uint16_t](
+        [b"\x13\x47\x06\xb1\xef\x4e", b"\x14\xa0\x39\x1d\x82\xd3"]
+    )
+
+    with mock_attribute_reads(
+        ubisys,
+        {UbisysCluster.AttributeDefs.output_configurations: test_value},
+    ):
+        await ubisys.read_attributes(
+            [UbisysCluster.AttributeDefs.output_configurations]
+        )
+
+    await app.shutdown()
+
+    # Verify the value was stored as bytes in the database
+    async with aiosqlite.connect(db) as conn:
+        cursor = await conn.execute(
+            f"SELECT value FROM attributes_cache{zigpy.appdb.DB_V}"
+            " WHERE cluster_id = :cluster_id AND attr_id = :attr_id",
+            {"cluster_id": 0xFC00, "attr_id": 0x0010},
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+        assert isinstance(row[0], bytes)
+        assert row[0] == test_value.serialize()
+
+
+def test_save_attribute_cache_skips_unserializable() -> None:
+    """Test that _serialize_for_db raises ValueError for unserializable types,
+    which _save_attribute_cache handles by skipping the value.
+    """
+
+    # Verify that unserializable types raise ValueError
+    with pytest.raises(ValueError, match="Cannot persist attribute value"):
+        zigpy.appdb._serialize_for_db(object())
+
+    # Verify that list types without serialize() also raise
+    with pytest.raises(ValueError, match="Cannot persist attribute value"):
+        zigpy.appdb._serialize_for_db([1, 2, 3])
+
+    # Verify that dict types raise
+    with pytest.raises(ValueError, match="Cannot persist attribute value"):
+        zigpy.appdb._serialize_for_db({"key": "value"})

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1638,6 +1638,37 @@ def test_serialize_for_db_serializable_types():
     assert result == lv_list.serialize()
 
 
+@pytest.mark.parametrize(
+    ("value", "attr_type", "expected"),
+    [
+        # Non-bytes values are returned as-is regardless of attr_type
+        (42, t.uint16_t, 42),
+        ("hello", t.CharacterString, "hello"),
+        (None, t.uint8_t, None),
+        # Bytes value with a bytes-subclass attr_type is returned as-is
+        (b"\x01\x02", t.LVBytes, b"\x01\x02"),
+        # Bytes value with no attr_type is returned as-is
+        (b"\x01\x02", None, b"\x01\x02"),
+    ],
+)
+def test_deserialize_from_db_passthrough(value, attr_type, expected):
+    """Test that _deserialize_from_db does not alter values that should stay as-is."""
+    assert zigpy.appdb._deserialize_from_db(value, attr_type) == expected
+
+
+def test_deserialize_from_db_complex_type():
+    """Test that _deserialize_from_db restores serialized complex types."""
+    original = t.LVList[t.LVBytes, t.uint16_t](
+        [b"\x13\x47\x06\xb1\xef\x4e", b"\x14\xa0\x39\x1d\x82\xd3"]
+    )
+    serialized = original.serialize()
+
+    result = zigpy.appdb._deserialize_from_db(
+        serialized, t.LVList[t.LVBytes, t.uint16_t]
+    )
+    assert list(result) == list(original)
+
+
 async def test_save_attribute_cache_serializes_complex_types(tmp_path) -> None:
     """Test that _save_attribute_cache serializes complex ZCL types to bytes."""
     db = tmp_path / "test.db"

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1638,12 +1638,6 @@ def test_serialize_for_db_serializable_types():
     assert result == lv_list.serialize()
 
 
-def test_serialize_for_db_unsupported_type():
-    """Test that unsupported types raise ValueError."""
-    with pytest.raises(ValueError, match="Cannot persist attribute value"):
-        zigpy.appdb._serialize_for_db(object())
-
-
 @patch("zigpy.quirks.DEVICE_REGISTRY", new=DeviceRegistry())
 async def test_attribute_read_complex_type_persists(tmp_path) -> None:
     """Test that complex ZCL types (e.g. LVList) are serialized to bytes for storage."""
@@ -1733,19 +1727,12 @@ async def test_attribute_read_complex_type_persists(tmp_path) -> None:
     await app2.shutdown()
 
 
-def test_save_attribute_cache_skips_unserializable() -> None:
-    """Test that _serialize_for_db raises ValueError for unserializable types,
-    which _save_attribute_cache handles by skipping the value.
-    """
-
-    # Verify that unserializable types raise ValueError
+@pytest.mark.parametrize(
+    "value",
+    [object(), [1, 2, 3], {"key": "value"}],
+    ids=["object", "list", "dict"],
+)
+def test_serialize_for_db_unsupported_types(value) -> None:
+    """Test that _serialize_for_db raises ValueError for non-SQLite, non-serializable types."""
     with pytest.raises(ValueError, match="Cannot persist attribute value"):
-        zigpy.appdb._serialize_for_db(object())
-
-    # Verify that list types without serialize() also raise
-    with pytest.raises(ValueError, match="Cannot persist attribute value"):
-        zigpy.appdb._serialize_for_db([1, 2, 3])
-
-    # Verify that dict types raise
-    with pytest.raises(ValueError, match="Cannot persist attribute value"):
-        zigpy.appdb._serialize_for_db({"key": "value"})
+        zigpy.appdb._serialize_for_db(value)

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1720,6 +1720,18 @@ async def test_attribute_read_complex_type_persists(tmp_path) -> None:
         assert isinstance(row[0], bytes)
         assert row[0] == test_value.serialize()
 
+    # Load the database again and verify the value is deserialized back
+    app2 = await make_app_with_db(db)
+    dev2 = app2.get_device(t.EUI64.convert("00:1f:ee:00:00:00:96:f5"))
+    ubisys2 = dev2.endpoints[232].in_clusters[0xFC00]
+
+    loaded_value = ubisys2.get_cached_value(
+        UbisysCluster.AttributeDefs.output_configurations
+    )
+    assert list(loaded_value) == list(test_value)
+
+    await app2.shutdown()
+
 
 def test_save_attribute_cache_skips_unserializable() -> None:
     """Test that _serialize_for_db raises ValueError for unserializable types,

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1649,6 +1649,9 @@ def test_serialize_for_db_serializable_types():
         (b"\x01\x02", t.LVBytes, b"\x01\x02"),
         # Bytes value with no attr_type is returned as-is
         (b"\x01\x02", None, b"\x01\x02"),
+        # Legacy bytes value for int-subclass attr_type is not deserialized
+        (b"\x43", t.uint8_t, b"\x43"),
+        (b"\x34\x12", t.uint16_t, b"\x34\x12"),
     ],
 )
 def test_deserialize_from_db_passthrough(value, attr_type, expected):

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1649,9 +1649,6 @@ def test_serialize_for_db_serializable_types():
         (b"\x01\x02", t.LVBytes, b"\x01\x02"),
         # Bytes value with no attr_type is returned as-is
         (b"\x01\x02", None, b"\x01\x02"),
-        # Legacy bytes value for int-subclass attr_type is not deserialized
-        (b"\x43", t.uint8_t, b"\x43"),
-        (b"\x34\x12", t.uint16_t, b"\x34\x12"),
     ],
 )
 def test_deserialize_from_db_passthrough(value, attr_type, expected):

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -703,12 +703,12 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
             " VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)",
             [
                 # Unmigrated row from v13->v14 (disambiguated cluster)
-                (str(dev.ieee), 1, 0, 0xFC01, 0x0010, -1, b"\x42", 0),
+                (str(dev.ieee), 1, 0, 0xFC01, 0x0010, -1, 42, 0),
                 # Unmigrated row from v13->v14 (ambiguous cluster)
-                (str(dev.ieee), 1, 0, 0xFC02, 0x0020, -1, b"\x99", 0),
+                (str(dev.ieee), 1, 0, 0xFC02, 0x0020, -1, 99, 0),
                 # Manually read through the UI after v13->v14, duplicating the above
                 # but with a newer value
-                (str(dev.ieee), 1, 0, 0xFC01, 0x0010, 0xABCD, b"\x43", 1.0),
+                (str(dev.ieee), 1, 0, 0xFC01, 0x0010, 0xABCD, 43, 1.0),
             ],
         )
         conn.commit()
@@ -723,7 +723,7 @@ async def test_data_migration_ambiguous_attributes(tmp_path):
 
     # 2 candidates (1 manuf + 1 non-manuf): picked manuf-specific.
     # Uses the newer value from the already-resolved row, not stale/unmigrated value.
-    assert disambiguated.get("manuf_attr") == b"\x43"
+    assert disambiguated.get("manuf_attr") == 43
     assert disambiguated.get("standard_attr") is None
 
     # 3 candidates: ambiguous, skipped

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -130,12 +130,17 @@ def _serialize_for_db(value: Any) -> None | int | float | str | bytes:
 def _deserialize_from_db(value: Any, attr_type: type | None) -> Any:
     """Attempt to deserialize a bytes value loaded from the database back into its
     original ZCL type, if applicable.
+
+    Only applies to types whose live values are not natively storable in SQLite (i.e.
+    types that were serialized to bytes by ``_serialize_for_db``). Types that subclass
+    ``int``, ``float``, ``str``, or ``bytes`` are stored natively, so a ``bytes`` DB
+    value for those types is legacy data and must not be deserialized.
     """
     if (
         not isinstance(value, bytes)
         or attr_type is None
         or not hasattr(attr_type, "deserialize")
-        or issubclass(attr_type, bytes)
+        or issubclass(attr_type, (*_SQLITE_TYPES,))
     ):
         return value
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -130,17 +130,12 @@ def _serialize_for_db(value: Any) -> None | int | float | str | bytes:
 def _deserialize_from_db(value: Any, attr_type: type | None) -> Any:
     """Attempt to deserialize a bytes value loaded from the database back into its
     original ZCL type, if applicable.
-
-    Only applies to types whose live values are not natively storable in SQLite (i.e.
-    types that were serialized to bytes by ``_serialize_for_db``). Types that subclass
-    ``int``, ``float``, ``str``, or ``bytes`` are stored natively, so a ``bytes`` DB
-    value for those types is legacy data and must not be deserialized.
     """
     if (
         not isinstance(value, bytes)
         or attr_type is None
         or not hasattr(attr_type, "deserialize")
-        or issubclass(attr_type, (*_SQLITE_TYPES,))
+        or issubclass(attr_type, bytes)
     ):
         return value
 

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -127,6 +127,30 @@ def _serialize_for_db(value: Any) -> None | int | float | str | bytes:
     )
 
 
+def _deserialize_from_db(value: Any, attr_type: type | None) -> Any:
+    """Attempt to deserialize a bytes value loaded from the database back into its
+    original ZCL type, if applicable.
+    """
+    if (
+        not isinstance(value, bytes)
+        or attr_type is None
+        or not hasattr(attr_type, "deserialize")
+        or issubclass(attr_type, bytes)
+    ):
+        return value
+
+    try:
+        result, _ = attr_type.deserialize(value)  # type: ignore[attr-defined]
+    except (ValueError, KeyError):
+        LOGGER.debug(
+            "Failed to deserialize cached value for type %s, using raw bytes",
+            attr_type,
+        )
+        return value
+
+    return result
+
+
 def decode_str_attribute(value: str | bytes) -> str:
     if isinstance(value, str):
         return value
@@ -880,7 +904,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             if row.status == Status.SUCCESS:
                 cluster._attr_cache.set_value(
                     attr_def,
-                    row.value,
+                    _deserialize_from_db(row.value, attr_def.type),
                     last_updated=datetime.fromtimestamp(row.last_updated, UTC),
                 )
             else:

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -521,37 +521,24 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._db.executemany(q, clusters)
 
     async def _save_attribute_cache(self, ep: Endpoint) -> None:
-        clusters = []
-
-        for cluster in ep.clusters:
+        clusters = [
+            (
+                ep.device.ieee,
+                ep.endpoint_id,
+                cluster.cluster_type,
+                cluster.cluster_id,
+                attrid,
+                manufacturer_code,
+                Status.SUCCESS,
+                _serialize_for_db(cache_item.value),
+                cache_item.last_updated.timestamp(),
+            )
+            for cluster in ep.clusters
             for (
                 attrid,
                 manufacturer_code,
-            ), cache_item in cluster._attr_cache._cache.items():
-                try:
-                    value = _serialize_for_db(cache_item.value)
-                except ValueError:
-                    LOGGER.debug(
-                        "Cannot serialize attribute 0x%04x value for storage,"
-                        " skipping: %r",
-                        attrid,
-                        cache_item.value,
-                    )
-                    continue
-
-                clusters.append(
-                    (
-                        ep.device.ieee,
-                        ep.endpoint_id,
-                        cluster.cluster_type,
-                        cluster.cluster_id,
-                        attrid,
-                        manufacturer_code,
-                        Status.SUCCESS,
-                        value,
-                        cache_item.last_updated.timestamp(),
-                    )
-                )
+            ), cache_item in cluster._attr_cache._cache.items()
+        ]
         q = f"""INSERT INTO attributes_cache{DB_V} (ieee, endpoint_id, cluster_type, cluster_id, attr_id, manufacturer_code, status, value, last_updated)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT (ieee, endpoint_id, cluster_type, cluster_id, attr_id, manufacturer_code_idx)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -110,6 +110,23 @@ def aiosqlite_connect(
     )
 
 
+_SQLITE_TYPES = (type(None), int, float, str, bytes)
+
+
+def _serialize_for_db(value: Any) -> None | int | float | str | bytes:
+    """Convert a ZCL attribute value to a type SQLite can store natively."""
+    if isinstance(value, _SQLITE_TYPES):
+        return value
+
+    if hasattr(value, "serialize"):
+        return value.serialize()
+
+    raise ValueError(
+        f"Cannot persist attribute value of type {type(value).__name__!r} to the "
+        f"database: {value!r}"
+    )
+
+
 def decode_str_attribute(value: str | bytes) -> str:
     if isinstance(value, str):
         return value
@@ -480,24 +497,37 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._db.executemany(q, clusters)
 
     async def _save_attribute_cache(self, ep: Endpoint) -> None:
-        clusters = [
-            (
-                ep.device.ieee,
-                ep.endpoint_id,
-                cluster.cluster_type,
-                cluster.cluster_id,
-                attrid,
-                manufacturer_code,
-                Status.SUCCESS,
-                cache_item.value,
-                cache_item.last_updated.timestamp(),
-            )
-            for cluster in ep.clusters
+        clusters = []
+
+        for cluster in ep.clusters:
             for (
                 attrid,
                 manufacturer_code,
-            ), cache_item in cluster._attr_cache._cache.items()
-        ]
+            ), cache_item in cluster._attr_cache._cache.items():
+                try:
+                    value = _serialize_for_db(cache_item.value)
+                except ValueError:
+                    LOGGER.debug(
+                        "Cannot serialize attribute 0x%04x value for storage,"
+                        " skipping: %r",
+                        attrid,
+                        cache_item.value,
+                    )
+                    continue
+
+                clusters.append(
+                    (
+                        ep.device.ieee,
+                        ep.endpoint_id,
+                        cluster.cluster_type,
+                        cluster.cluster_id,
+                        attrid,
+                        manufacturer_code,
+                        Status.SUCCESS,
+                        value,
+                        cache_item.last_updated.timestamp(),
+                    )
+                )
         q = f"""INSERT INTO attributes_cache{DB_V} (ieee, endpoint_id, cluster_type, cluster_id, attr_id, manufacturer_code, status, value, last_updated)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT (ieee, endpoint_id, cluster_type, cluster_id, attr_id, manufacturer_code_idx)
@@ -568,7 +598,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 "attr_id": event.attribute_id,
                 "manufacturer_code": event.manufacturer_code,
                 "status": Status.SUCCESS,
-                "value": event.value,
+                "value": _serialize_for_db(event.value),
                 "timestamp": datetime.now(UTC).timestamp(),
                 "min_update_delta": MIN_UPDATE_DELTA,
             },


### PR DESCRIPTION
## Background

This is somewhat needed for Ubisys devices that we re-interview (LD6). We (obviously) clear the whole attribute cache, including local attributes, so we need to actually read the device-specific attribute and parse that after the (re-)interview.

This already works fine at runtime. Between HA restarts, we rely on the local attribute, so we don't technically need this for that, but we log an error about failing to save this when reading the attribute. We could also just ignore those errors and not log them...?

EDIT: Actually, we already seem to only log these errors at debug level, so we don't need to push through with this PR now if we don't like it.

For this solution, see the summary below. The code changes are relatively small.

## AI summary

- Attribute values of complex ZCL types (e.g. `LVList[LVBytes]`) could not be persisted to the SQLite database, raising `sqlite3.ProgrammingError: type 'AnonymousLVList' is not supported`. This affected custom clusters like the ubisys `0xFC00` cluster that define array-typed attributes.
- On save, values that aren't natively supported by SQLite (`None`, `int`, `float`, `str`, `bytes`) are now serialized to `bytes` via their `.serialize()` method before storage.
- On load, serialized `bytes` values are deserialized back into their original typed form using the attribute definition's type, so `cluster.get(attr)` returns the correct type after restart.

### Note: pre-existing type fidelity gap

There is a **pre-existing** issue (not introduced by this PR) where the type of simple attribute values is not preserved across restarts. For example, a `uint16_t` attribute read live returns a `t.uint16_t` instance, but after DB reload it comes back as a plain Python `int`, because SQLite stores both identically as INTEGER. This PR does not attempt to fix that — it only addresses the crash for types SQLite cannot store at all.

### Note

We could also guard the the `_save_attribute_cache` call that happens for all attributes when zigpy is shutting down, so that it doesn't fail completely, but only for attributes that can't be serialized (of which there should be none..?).
However, because of the code below, we never call `_save_attribute_cache` for quirked devices anyway, purely relying on the runtime/event attributes updates for DB persistence. Since non-quirked devices using pure ZCL attributes mostly/only use "simple" types that can be saved directly into the DB, we don't really need the extra guard?

Either way, we could revert this commit to add that guard: https://github.com/zigpy/zigpy/commit/40ac143448a361d6571104fa7dc0e9a6171cca65

Code preventing quirked devices from calling `_save_attribute_cache`:
https://github.com/zigpy/zigpy/blob/7d1ea41f37fb7f78c7202ccd21ee5df22c092a89/zigpy/appdb.py#L408-L420

