### PR TITLE
Fix pytest hanging after DB test failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ if typing.TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def auto_kill_aiosqlite():
     """Aiosqlite's background thread does not let pytest exit when a failure occurs."""
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from contextlib import contextmanager
 import copy
 import logging
+import sqlite3
 import threading
 import typing
 from unittest.mock import Mock, patch
@@ -33,6 +35,27 @@ if typing.TYPE_CHECKING:
     import zigpy.device
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def auto_kill_aiosqlite():
+    """Aiosqlite's background thread does not let pytest exit when a failure occurs."""
+    yield
+
+    for thread in threading.enumerate():
+        if not isinstance(thread, aiosqlite.core.Connection):
+            continue
+
+        try:
+            conn = thread._conn
+        except ValueError:
+            pass
+        else:
+            with contextlib.suppress(sqlite3.ProgrammingError):
+                conn.close()
+
+        thread._running = False
+
 
 NCP_IEEE = t.EUI64.convert("aa:11:22:bb:33:44:be:ef")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ def auto_kill_aiosqlite():
                 conn.close()
 
         thread._stop_running()
+        thread.join(timeout=1)
 
 
 NCP_IEEE = t.EUI64.convert("aa:11:22:bb:33:44:be:ef")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def auto_kill_aiosqlite():
             with contextlib.suppress(sqlite3.ProgrammingError):
                 conn.close()
 
-        thread._running = False
+        thread._stop_running()
 
 
 NCP_IEEE = t.EUI64.convert("aa:11:22:bb:33:44:be:ef")

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -45,6 +45,8 @@ from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota
 from zigpy.zcl.foundation import Status as ZCLStatus, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
 
+pytestmark = pytest.mark.usefixtures("auto_kill_aiosqlite")
+
 
 async def make_app_with_db(database_file):
     if isinstance(database_file, pathlib.Path):

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1,8 +1,6 @@
 import asyncio
-import contextlib
 from datetime import UTC, datetime, timedelta
 import pathlib
-import threading
 import time
 
 import aiosqlite
@@ -46,26 +44,6 @@ from zigpy.zcl import ClusterType, UnsupportedAttribute
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota
 from zigpy.zcl.foundation import Status as ZCLStatus, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
-
-
-@pytest.fixture(autouse=True)
-def auto_kill_aiosqlite():
-    """Aiosqlite's background thread does not let pytest exit when a failure occurs"""
-    yield
-
-    for thread in threading.enumerate():
-        if not isinstance(thread, aiosqlite.core.Connection):
-            continue
-
-        try:
-            conn = thread._conn
-        except ValueError:
-            pass
-        else:
-            with contextlib.suppress(zigpy.appdb.sqlite3.ProgrammingError):
-                conn.close()
-
-        thread._running = False
 
 
 async def make_app_with_db(database_file):

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 import logging
 import pathlib
+import sqlite3
 from sqlite3.dump import _iterdump as iterdump
 
 from aiosqlite.context import contextmanager
@@ -8,9 +9,8 @@ import pytest
 
 from tests.async_mock import AsyncMock, MagicMock, patch
 from tests.conftest import app, make_node_desc  # noqa: F401
-from tests.test_appdb import auto_kill_aiosqlite, make_app_with_db  # noqa: F401
+from tests.test_appdb import make_app_with_db
 import zigpy.appdb
-from zigpy.appdb import sqlite3
 import zigpy.appdb_schemas
 import zigpy.endpoint
 from zigpy.profiles import zha as zha_profile
@@ -21,6 +21,8 @@ import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import BaseAttributeDefs, Status, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
+
+pytestmark = pytest.mark.usefixtures("auto_kill_aiosqlite")
 
 
 @pytest.fixture


### PR DESCRIPTION
## AI summary

- Fix `auto_kill_aiosqlite` fixture: replace `thread._running = False` with `thread._stop_running()` followed by `thread.join(timeout=1)`:
  - In aiosqlite 0.20.0+, the background thread's `run()` loop changed from polling with `get(timeout=0.1)` (which checked `_running` on each timeout) to a blocking `get()` that only exits on a sentinel.
  - Setting the flag alone no longer unblocks it. `_stop_running()` both sets the flag and puts the stop sentinel on the queue.
  - The `join()` ensures the thread is fully dead before the next test starts.
- Move fixture to `conftest.py` so it can be shared cleanly across test modules, and apply it via `pytestmark = pytest.mark.usefixtures(...)` in both `test_appdb.py` and `test_appdb_migration.py`.
  - The previous import approach technically works (pytest re-registers imported fixtures as defined in the importing module) but is [not recommended](https://docs.pytest.org/en/stable/how-to/fixtures.html#using-fixtures-from-other-projects) and may break in future pytest versions.

### Note

We'll likely need to fix this again when we finally upgrade `aiosqlite` to `0.22.1` (currently `>=0.20.0,<0.22.0`).
Of course, I've verified the issue was present before and is fixed with the changes from this PR. (Just fail an appdb test, so it doesn't shut down the DB properly.)