### PR TITLE
Clean up raw device callbacks after quirk wrapping

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1862,3 +1862,48 @@ async def test_callback_wrapping_async(
             ),
         ),
     ]
+
+
+async def test_device_initialized_cleans_up_raw_device_on_quirk(app):
+    """Test that device_initialized cleans up the raw device when quirks replace it."""
+    ieee = t.EUI64(map(t.uint8_t, range(8)))
+    nwk = t.NWK(0x1234)
+
+    raw_dev = app.add_device(ieee=ieee, nwk=nwk)
+
+    # The raw device should have a PollControl callback registered
+    assert len(app._req_listeners[raw_dev]) == 1
+
+    # Make get_device return a different object (simulating quirk wrapping)
+    quirked_dev = MagicMock()
+    quirked_dev.ieee = ieee
+
+    with patch("zigpy.quirks.get_device", return_value=quirked_dev):
+        app.device_initialized(raw_dev)
+
+    # The raw device's callbacks should have been cleaned up
+    assert len(app._req_listeners[raw_dev]) == 0
+
+    # The quirked device should be in app.devices
+    assert app.devices[ieee] is quirked_dev
+
+
+async def test_device_initialized_no_cleanup_without_quirk(app):
+    """Test that device_initialized does not call on_remove when no quirk is applied."""
+    ieee = t.EUI64(map(t.uint8_t, range(8)))
+    nwk = t.NWK(0x1234)
+
+    raw_dev = app.add_device(ieee=ieee, nwk=nwk)
+
+    # The raw device should have a PollControl callback registered
+    assert len(app._req_listeners[raw_dev]) == 1
+
+    # Make get_device return the same object (no quirk match)
+    with patch("zigpy.quirks.get_device", return_value=raw_dev):
+        app.device_initialized(raw_dev)
+
+    # Callbacks should still be registered (device is still active)
+    assert len(app._req_listeners[raw_dev]) == 1
+
+    # The same device should be in app.devices
+    assert app.devices[ieee] is raw_dev

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -12,6 +12,7 @@ import pytest
 import zigpy.application
 import zigpy.config as conf
 from zigpy.datastructures import RequestLimiter
+import zigpy.device
 from zigpy.exceptions import (
     DeliveryError,
     NetworkNotFormed,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1865,31 +1865,32 @@ async def test_callback_wrapping_async(
 
 
 async def test_device_initialized_cleans_up_raw_device_on_quirk(app):
-    """Test that device_initialized cleans up the raw device when quirks replace it."""
+    """Test that device_initialized removes orphaned listeners when quirks replace it."""
     ieee = t.EUI64(map(t.uint8_t, range(8)))
     nwk = t.NWK(0x1234)
 
     raw_dev = app.add_device(ieee=ieee, nwk=nwk)
 
     # The raw device should have a PollControl callback registered
+    assert raw_dev in app._req_listeners
     assert len(app._req_listeners[raw_dev]) == 1
 
-    # Make get_device return a different object (simulating quirk wrapping)
-    quirked_dev = MagicMock()
-    quirked_dev.ieee = ieee
+    # Make get_device return a new Device (simulating quirk wrapping)
+    quirked_dev = zigpy.device.Device(app, ieee, nwk)
 
     with patch("zigpy.quirks.get_device", return_value=quirked_dev):
         app.device_initialized(raw_dev)
 
-    # The raw device's callbacks should have been cleaned up
-    assert len(app._req_listeners[raw_dev]) == 0
+    # The raw device's key should be fully removed from _req_listeners
+    assert raw_dev not in app._req_listeners
 
-    # The quirked device should be in app.devices
+    # The quirked device should be in app.devices with its own listeners
     assert app.devices[ieee] is quirked_dev
+    assert len(app._req_listeners[quirked_dev]) == 1
 
 
 async def test_device_initialized_no_cleanup_without_quirk(app):
-    """Test that device_initialized does not call on_remove when no quirk is applied."""
+    """Test that listeners are preserved when no quirk is applied."""
     ieee = t.EUI64(map(t.uint8_t, range(8)))
     nwk = t.NWK(0x1234)
 
@@ -1903,6 +1904,7 @@ async def test_device_initialized_no_cleanup_without_quirk(app):
         app.device_initialized(raw_dev)
 
     # Callbacks should still be registered (device is still active)
+    assert raw_dev in app._req_listeners
     assert len(app._req_listeners[raw_dev]) == 1
 
     # The same device should be in app.devices

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -604,11 +604,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.listener_event("raw_device_initialized", device)
         quirked = zigpy.quirks.get_device(device)
 
-        # If quirk wrapping created a new object, clean up the raw device's
-        # registered callbacks (e.g. PollControl check-in listener) so they
-        # don't leak in _req_listeners.
+        # If quirk wrapping created a new object, remove the raw device's
+        # orphaned callback listeners (e.g. PollControl check-in) from
+        # _req_listeners.  We can't call device.on_remove() here because
+        # that would also cancel the currently running _initialize_task.
         if quirked is not device:
-            device.on_remove()
+            self._req_listeners.pop(device, None)
 
         self.devices[quirked.ieee] = quirked
         if self._dblistener is not None:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -602,11 +602,18 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         device.original_signature = device.get_signature()
 
         self.listener_event("raw_device_initialized", device)
-        device = zigpy.quirks.get_device(device)
-        self.devices[device.ieee] = device
+        quirked = zigpy.quirks.get_device(device)
+
+        # If quirk wrapping created a new object, clean up the raw device's
+        # registered callbacks (e.g. PollControl check-in listener) so they
+        # don't leak in _req_listeners.
+        if quirked is not device:
+            device.on_remove()
+
+        self.devices[quirked.ieee] = quirked
         if self._dblistener is not None:
-            device.add_context_listener(self._dblistener)
-        self.listener_event("device_initialized", device)
+            quirked.add_context_listener(self._dblistener)
+        self.listener_event("device_initialized", quirked)
 
     async def remove(
         self, ieee: t.EUI64, remove_children: bool = True, rejoin: bool = False


### PR DESCRIPTION
DRAFT.

## AI summary

When `device_initialized()` applies a quirk via `get_device()`, the raw `Device` object is replaced by a new `BaseCustomDevice` instance. However, the raw device's registered callback listeners (notably the PollControl check-in listener from `Device.__init__`) were never cleaned up, leaving an orphaned `_req_listeners` entry keyed by the dead raw device object.

This removes the raw device's `_req_listeners` key entirely when quirk wrapping creates a new instance. When no quirk matches (same object returned), nothing is changed.

## Why `_req_listeners.pop()` instead of `device.on_remove()`

`device_initialized()` runs inside the device's own `_initialize_task`:

```
schedule_initialize()
  └─ _initialize_task = create_task(initialize())
       └─ initialize() → _initialize()
            ├─ _discover()
            └─ device_initialized(self)  ← here
```

`create_task()` adds the task to `self._tasks` and registers `self._tasks.remove` as a done callback. `on_remove()` calls `self._tasks.clear()`, emptying the set. When `_initialize_task` completes moments later, its done callback fires `self._tasks.remove(task)` on the now-empty set, raising `KeyError`.

`_req_listeners.pop(device, None)` directly removes the orphaned listener entry without touching tasks, avoiding this issue.

### Related

Related PR that added the `PollControl` check-in listener:
- https://github.com/zigpy/zigpy/pull/1621

Found here:
- https://github.com/zigpy/zigpy/pull/1789#discussion_r2957626612
