### PR TITLE
Move unsupported attribute marking to event handler

### DIFF
--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1157,9 +1157,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
     def _on_attribute_unsupported(self, event: AttributeUnsupportedEvent) -> None:
         """Handle an attribute being reported as unsupported by the device."""
-        attr_def = self.find_attribute(
-            event.attribute_id, manufacturer_code=event.manufacturer_code
-        )
+        attr_def = self.find_attribute(event.attribute_name)
         self._attr_cache.mark_unsupported(attr_def)
 
     def update_attribute(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -445,6 +445,12 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         # We proxy `_attr_cache` because custom quirks can overwrite it with a dict
         self._attr_cache_internal: AttributeCache = AttributeCache(self)
 
+        # Register event handlers for cache side effects, allowing quirks to
+        # override emit() or the handler to prevent cache modifications.
+        self.on_event(
+            AttributeUnsupportedEvent.event_type, self._on_attribute_unsupported
+        )
+
     @property
     def _attr_cache(self) -> AttributeCache:
         """Attribute cache accessor."""
@@ -1132,7 +1138,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                             )
                     else:
                         if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
-                            self._attr_cache.mark_unsupported(attr_def)
                             self.emit(
                                 AttributeUnsupportedEvent.event_type,
                                 AttributeUnsupportedEvent(
@@ -1149,6 +1154,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         failure[attribute_map[attr_def]] = record.status
 
         return success, failure
+
+    def _on_attribute_unsupported(self, event: AttributeUnsupportedEvent) -> None:
+        """Handle an attribute being reported as unsupported by the device."""
+        attr_def = self.find_attribute(
+            event.attribute_id, manufacturer_code=event.manufacturer_code
+        )
+        self._attr_cache.mark_unsupported(attr_def)
 
     def update_attribute(
         self, attrid: int | t.uint16_t | foundation.ZCLAttributeDef, value: Any
@@ -1348,7 +1360,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         attr_def, attribute_values[record.attrid]
                     )
                 elif record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
-                    self._attr_cache.mark_unsupported(attr_def)
                     self.emit(
                         AttributeUnsupportedEvent.event_type,
                         AttributeUnsupportedEvent(
@@ -1515,7 +1526,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         ),
                     )
                 elif status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
-                    self._attr_cache.mark_unsupported(attr_def)
                     self.emit(
                         AttributeUnsupportedEvent.event_type,
                         AttributeUnsupportedEvent(
@@ -1738,7 +1748,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
     ) -> None:
         """Adds unsupported attribute."""
         attr_def = self.find_attribute(attr, manufacturer_code=manufacturer_code)
-        self._attr_cache.mark_unsupported(attr_def)
 
         self.emit(
             AttributeUnsupportedEvent.event_type,


### PR DESCRIPTION
## Proposed change

This moves `_attr_cache.mark_unsupported()` calls out of `read_attributes`, `write_attributes`, `configure_reporting_multiple`, and `add_unsupported_attribute` into a new `_on_attribute_unsupported` event handler registered in `__init__`.

This allows quirks to prevent attributes from being marked as unsupported by overriding `emit` and preventing matching events from being fired entirely (here: instantly clearing the last value from the `appdb`).

## Alternative

Alternatively, I guess we could just also have the various methods call the already existing [`add_unsupported_attribute`](https://github.com/zigpy/zigpy/blob/190043d14476b190a77345c37248f87bd60a65c9/zigpy/zcl/__init__.py#L1733-L1754) method that could be overridden by quirks?