### PR TITLE
Send `image_notify` during pairing

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -108,6 +108,56 @@ async def test_initialize_read_ota(
     assert success[Ota.AttributeDefs.current_file_version.id] == 0x12345678
 
 
+async def test_initialize_sends_image_notify(
+    app: zigpy.application.ControllerApplication,
+) -> None:
+    """Test that image_notify is sent to OTA devices during initialization."""
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
+    dev.node_desc = make_node_desc()
+
+    ep = dev.add_endpoint(1)
+    ep.status = endpoint.Status.ZDO_INIT
+
+    basic = ep.add_input_cluster(Basic.cluster_id)
+    ota = ep.add_output_cluster(Ota.cluster_id)
+    ota.image_notify = AsyncMock()
+
+    with (
+        mock_attribute_reads(basic, {"model": "Model", "manufacturer": "Manufacturer"}),
+        mock_attribute_reads(ota, {"current_file_version": 0x12345678}),
+    ):
+        await dev.initialize()
+
+    ota.image_notify.assert_awaited_once_with(
+        payload_type=Ota.ImageNotifyCommand.PayloadType.QueryJitter,
+        query_jitter=100,
+    )
+
+
+async def test_initialize_image_notify_failure_does_not_block(
+    app: zigpy.application.ControllerApplication,
+) -> None:
+    """Test that a failed image_notify does not prevent initialization."""
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
+    dev.node_desc = make_node_desc()
+
+    ep = dev.add_endpoint(1)
+    ep.status = endpoint.Status.ZDO_INIT
+
+    basic = ep.add_input_cluster(Basic.cluster_id)
+    ota = ep.add_output_cluster(Ota.cluster_id)
+    ota.image_notify = AsyncMock(side_effect=TimeoutError)
+
+    with (
+        mock_attribute_reads(basic, {"model": "Model", "manufacturer": "Manufacturer"}),
+        mock_attribute_reads(ota, {"current_file_version": 0x12345678}),
+    ):
+        await dev.initialize()
+
+    assert dev.is_initialized
+    ota.image_notify.assert_awaited_once()
+
+
 async def test_initialize_read_ota_unsupported(
     app: zigpy.application.ControllerApplication,
 ) -> None:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -120,7 +120,6 @@ async def test_initialize_sends_image_notify(
 
     basic = ep.add_input_cluster(Basic.cluster_id)
     ota = ep.add_output_cluster(Ota.cluster_id)
-    ota.image_notify = AsyncMock()
 
     with (
         mock_attribute_reads(basic, {"model": "Model", "manufacturer": "Manufacturer"}),
@@ -128,10 +127,12 @@ async def test_initialize_sends_image_notify(
     ):
         await dev.initialize()
 
-    ota.image_notify.assert_awaited_once_with(
-        payload_type=Ota.ImageNotifyCommand.PayloadType.QueryJitter,
-        query_jitter=100,
-    )
+    # image_notify is the last packet sent during initialization
+    packet = app.send_packet.call_args_list[-1][0][0]
+    hdr, cmd = ota.deserialize(packet.data.serialize())
+    assert isinstance(cmd, Ota.ImageNotifyCommand)
+    assert cmd.payload_type == Ota.ImageNotifyCommand.PayloadType.QueryJitter
+    assert cmd.query_jitter == 100
 
 
 async def test_initialize_image_notify_failure_does_not_block(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -128,7 +128,7 @@ async def test_initialize_sends_image_notify(
         await dev.initialize()
 
     # image_notify is the last packet sent during initialization
-    packet = app.send_packet.call_args_list[-1][0][0]
+    packet = app.send_packet.call_args_list[0][0][0]
     hdr, cmd = ota.deserialize(packet.data.serialize())
     assert isinstance(cmd, Ota.ImageNotifyCommand)
     assert cmd.payload_type == Ota.ImageNotifyCommand.PayloadType.QueryJitter

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -516,7 +516,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     query_jitter=100,
                 )
             except Exception:  # noqa: BLE001
-                self.debug("OTA image_notify failed during initialization")
+                self.debug(
+                    "OTA image_notify failed during initialization", exc_info=True
+                )
 
         self.status = Status.ENDPOINTS_INIT
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -509,6 +509,15 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         else:
             await ota.read_attributes([Ota.AttributeDefs.current_file_version.name])
 
+            # Notify the device that OTA images may be available so it queries us
+            try:
+                await ota.image_notify(
+                    payload_type=Ota.ImageNotifyCommand.PayloadType.QueryJitter,
+                    query_jitter=100,
+                )
+            except Exception:  # noqa: BLE001
+                self.debug("OTA image_notify failed during initialization")
+
         self.status = Status.ENDPOINTS_INIT
 
         self.info("Discovered basic device information for %s", self)


### PR DESCRIPTION
## Proposed change

This sends an `image_notify` command to a device during pairing. This is to populate our query cache and immediately show upgrades, if available.

New tests are also added.

### Notes

I've included a `try/except` (with a catch-all), as I don't want to retry the interview steps 5 times just if the `image_notify` command isn't correctly sent.
At some point, the device may also check in on its own. For most devices (ignoring sleepy battery-powered ones), zigpy currently also has the OTA query broadcast sent every few hours.

This will be adjusted in the future, as we don't need to spam the network every few hours if we query OTA data on joins and after updates. Currently, device query commands are tied to zigpy fetching active updates though. This will also be adjusted in the future to be independent.

It could make sense to introduce some sort of `Device.ota_notify` method directly, with an argument to suppress exceptions or not. See both PRs below.

## Additional information

One of the follow-ups mentioned in:
- https://github.com/zigpy/zigpy/pull/1779#issuecomment-4087158285

Follow-up to:
- https://github.com/zigpy/zigpy/pull/1797