### PR TITLE
Refactor OTA checking with `OtaImageAvailableEvent`

### DIFF
--- a/tests/ota/test_ota_config.py
+++ b/tests/ota/test_ota_config.py
@@ -260,6 +260,35 @@ async def test_ota_broadcast_loop() -> None:
     assert len(mock_broadcast_notify.mock_calls) == 5
 
 
+async def test_ota_broadcast_loop_check_failure() -> None:
+    app = make_app(
+        {
+            config.CONF_OTA: {
+                config.CONF_OTA_ENABLED: True,
+                config.CONF_OTA_BROADCAST_ENABLED: True,
+                config.CONF_OTA_BROADCAST_INITIAL_DELAY: 0.1,
+                config.CONF_OTA_BROADCAST_INTERVAL: 0.2,
+            }
+        }
+    )
+
+    with (
+        patch.object(app.ota, "broadcast_notify", return_value=None),
+        patch.object(
+            app.ota,
+            "check_all_devices_for_ota",
+            side_effect=[RuntimeError("provider down"), None, None],
+        ) as mock_check,
+        patch("zigpy.ota.BROADCAST_SETTLE_DELAY", 0),
+    ):
+        await app.startup()
+        await asyncio.sleep(0.5)
+        await app.shutdown()
+
+    # Loop continues despite the first check failing
+    assert len(mock_check.mock_calls) >= 2
+
+
 async def test_ota_broadcast() -> None:
     app = make_app({config.CONF_OTA: {config.CONF_OTA_ENABLED: True}})
 

--- a/tests/ota/test_ota_config.py
+++ b/tests/ota/test_ota_config.py
@@ -242,11 +242,15 @@ async def test_ota_broadcast_loop() -> None:
         }
     )
 
-    with patch.object(
-        app.ota,
-        "broadcast_notify",
-        side_effect=[None, None, RuntimeError(), None, None, None],
-    ) as mock_broadcast_notify:
+    with (
+        patch.object(
+            app.ota,
+            "broadcast_notify",
+            side_effect=[None, None, RuntimeError(), None, None, None],
+        ) as mock_broadcast_notify,
+        patch.object(app.ota, "check_all_devices_for_ota", return_value=None),
+        patch("zigpy.ota.BROADCAST_SETTLE_DELAY", 0),
+    ):
         await app.startup()
         assert app.ota._broadcast_loop_task is not None
         await asyncio.sleep(1)

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import hashlib
 import typing
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import aiohttp
 import attrs
@@ -12,9 +13,12 @@ import pytest
 from tests.ota.test_ota_providers import SelfContainedOtaImageMetadata, make_device
 from zigpy import config
 import zigpy.device
+import zigpy.endpoint
 import zigpy.ota
 from zigpy.ota.image import FieldControl
 from zigpy.ota.providers import BaseOtaImageMetadata, BaseOtaProvider
+import zigpy.types
+from zigpy.zcl import ClusterType, OtaImageAvailableEvent
 from zigpy.zcl.clusters.general import Ota
 
 
@@ -468,3 +472,223 @@ async def test_ota_trusted_provider_missing_sha3_256_checksum(
     # Image should be removed due to missing SHA3-256 checksum
     assert len(images.upgrades) == 0
     assert "does not have SHA3-256 checksum" in caplog.text
+
+
+def _make_device_with_ota_cluster(
+    query_cmd,
+    *,
+    endpoint_id: int = 1,
+    cluster_type: ClusterType = ClusterType.Server,
+) -> tuple[zigpy.device.Device, Ota]:
+    """Create a device with an OTA cluster and a cached query command."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    ep = device.add_endpoint(endpoint_id)
+    cluster = Ota(ep)
+    cluster.last_query_cmd = query_cmd
+
+    if cluster_type == ClusterType.Server:
+        ep.in_clusters[Ota.cluster_id] = cluster
+    else:
+        ep.out_clusters[Ota.cluster_id] = cluster
+
+    return device, cluster
+
+
+async def test_check_cluster_for_ota_emits_event(query_cmd) -> None:
+    """check_cluster_for_ota calls get_ota_images and emits OtaImageAvailableEvent."""
+    device, cluster = _make_device_with_ota_cluster(query_cmd)
+
+    images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.get_ota_images = AsyncMock(return_value=images_result)
+
+    events = []
+    cluster.on_event(OtaImageAvailableEvent.event_type, events.append)
+
+    await ota.check_cluster_for_ota(cluster)
+
+    assert len(events) == 1
+    assert isinstance(events[0], OtaImageAvailableEvent)
+    assert events[0].device_ieee == str(device.ieee)
+    assert events[0].endpoint_id == 1
+    assert events[0].images_result is images_result
+    assert events[0].query_cmd is query_cmd
+    ota.get_ota_images.assert_called_once_with(device, query_cmd)
+
+
+async def test_check_cluster_for_ota_no_query_cmd(query_cmd) -> None:
+    """check_cluster_for_ota is a no-op when last_query_cmd is None."""
+    _device, cluster = _make_device_with_ota_cluster(query_cmd)
+    cluster.last_query_cmd = None
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.get_ota_images = AsyncMock()
+
+    events = []
+    cluster.on_event(OtaImageAvailableEvent.event_type, events.append)
+
+    await ota.check_cluster_for_ota(cluster)
+
+    assert len(events) == 0
+    ota.get_ota_images.assert_not_called()
+
+
+async def test_check_device_for_ota_finds_clusters(query_cmd) -> None:
+    """check_device_for_ota iterates endpoints and checks each OTA cluster."""
+    device, cluster1 = _make_device_with_ota_cluster(
+        query_cmd, endpoint_id=1, cluster_type=ClusterType.Server
+    )
+    # Add a second endpoint with an OTA cluster
+    ep2 = device.add_endpoint(2)
+    cluster2 = Ota(ep2)
+    cluster2.last_query_cmd = query_cmd
+    ep2.out_clusters[Ota.cluster_id] = cluster2
+
+    images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.get_ota_images = AsyncMock(return_value=images_result)
+
+    events1 = []
+    events2 = []
+    cluster1.on_event(OtaImageAvailableEvent.event_type, events1.append)
+    cluster2.on_event(OtaImageAvailableEvent.event_type, events2.append)
+
+    await ota.check_device_for_ota(device)
+
+    # Both clusters should have received events
+    assert len(events1) == 1
+    assert events1[0].endpoint_id == 1
+    assert len(events2) == 1
+    assert events2[0].endpoint_id == 2
+
+
+async def test_check_device_for_ota_prefers_out_clusters(query_cmd) -> None:
+    """check_device_for_ota prefers out_clusters over in_clusters on same endpoint."""
+    device, in_cluster = _make_device_with_ota_cluster(
+        query_cmd, endpoint_id=1, cluster_type=ClusterType.Server
+    )
+    ep = device.endpoints[1]
+
+    # Also add as out_cluster on the same endpoint
+    out_cluster = Ota(ep, is_server=False)
+    out_cluster.last_query_cmd = query_cmd
+    ep.out_clusters[Ota.cluster_id] = out_cluster
+
+    images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.get_ota_images = AsyncMock(return_value=images_result)
+
+    in_events = []
+    out_events = []
+    in_cluster.on_event(OtaImageAvailableEvent.event_type, in_events.append)
+    out_cluster.on_event(OtaImageAvailableEvent.event_type, out_events.append)
+
+    await ota.check_device_for_ota(device)
+
+    # Only out_cluster should receive the event (preferred)
+    assert len(out_events) == 1
+    assert len(in_events) == 0
+
+
+async def test_check_device_for_ota_skips_no_query_cmd(query_cmd) -> None:
+    """check_device_for_ota skips clusters without last_query_cmd."""
+    device, cluster = _make_device_with_ota_cluster(query_cmd)
+    cluster.last_query_cmd = None
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.get_ota_images = AsyncMock()
+
+    await ota.check_device_for_ota(device)
+
+    ota.get_ota_images.assert_not_called()
+
+
+async def test_check_all_devices_for_ota(query_cmd) -> None:
+    """check_all_devices_for_ota checks all devices, skipping those without OTA."""
+    app = AsyncMock()
+
+    device1, cluster1 = _make_device_with_ota_cluster(query_cmd)
+    device2 = zigpy.device.Device(
+        application=app,
+        ieee=zigpy.types.EUI64.convert("AA:BB:CC:DD:EE:FF:00:11"),
+        nwk=0x5678,
+    )
+    # device2 has no OTA cluster — should be skipped
+    device2.add_endpoint(1)
+
+    app.devices = {device1.ieee: device1, device2.ieee: device2}
+
+    images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=app)
+    ota.get_ota_images = AsyncMock(return_value=images_result)
+
+    events = []
+    cluster1.on_event(OtaImageAvailableEvent.event_type, events.append)
+
+    await ota.check_all_devices_for_ota()
+
+    assert len(events) == 1
+    assert events[0].device_ieee == str(device1.ieee)
+
+
+async def test_check_all_devices_for_ota_tolerates_failure(query_cmd) -> None:
+    """check_all_devices_for_ota continues if one device fails."""
+    app = AsyncMock()
+
+    device1, _cluster1 = _make_device_with_ota_cluster(query_cmd)
+
+    # Create device2 with a different IEEE address
+    device2 = zigpy.device.Device(
+        application=app,
+        ieee=zigpy.types.EUI64.convert("AA:BB:CC:DD:EE:FF:00:11"),
+        nwk=0x5678,
+    )
+    ep2 = device2.add_endpoint(1)
+    cluster2 = Ota(ep2)
+    cluster2.last_query_cmd = query_cmd
+    ep2.in_clusters[Ota.cluster_id] = cluster2
+
+    app.devices = {device1.ieee: device1, device2.ieee: device2}
+
+    images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=app)
+    ota.get_ota_images = AsyncMock(
+        side_effect=[RuntimeError("provider down"), images_result]
+    )
+
+    events2 = []
+    cluster2.on_event(OtaImageAvailableEvent.event_type, events2.append)
+
+    await ota.check_all_devices_for_ota()
+
+    # device2 should still get checked even though device1 failed
+    assert len(events2) == 1
+
+
+async def test_invalidate_provider_caches(query_cmd) -> None:
+    """invalidate_provider_caches resets all provider index timestamps."""
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.register_provider(SelfContainedProvider([]))
+    ota.register_provider(SelfContainedProvider([]))
+
+    # Simulate providers having been recently loaded
+    recent = datetime.datetime.now(datetime.UTC)
+    for provider in ota._providers:
+        provider._index_last_updated = recent
+
+    # Verify caches are populated (load_index returns None = "use cache")
+    for provider in ota._providers:
+        assert await provider.load_index() is None
+
+    ota.invalidate_provider_caches()
+
+    # After invalidation, timestamps should be reset to epoch
+    epoch = datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
+    for provider in ota._providers:
+        assert provider._index_last_updated == epoch
+
+    # load_index should now return fresh data instead of None
+    for provider in ota._providers:
+        result = await provider.load_index()
+        assert result is not None  # Empty list, not None (which means "cached")

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -587,6 +587,31 @@ async def test_check_device_for_ota_prefers_out_clusters(query_cmd) -> None:
     assert len(in_events) == 0
 
 
+async def test_check_device_for_ota_ignores_stale_in_cluster(query_cmd) -> None:
+    """check_device_for_ota ignores in_cluster when out_cluster exists on same endpoint."""
+    device, in_cluster = _make_device_with_ota_cluster(
+        query_cmd, endpoint_id=1, cluster_type=ClusterType.Server
+    )
+    ep = device.endpoints[1]
+
+    # Add out_cluster on same endpoint without a cached query
+    out_cluster = ep.add_output_cluster(Ota.cluster_id)
+    assert out_cluster.last_query_cmd is None
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.get_ota_images = AsyncMock()
+
+    in_events = []
+    in_cluster.on_event(OtaImageAvailableEvent.event_type, in_events.append)
+
+    await ota.check_device_for_ota(device)
+
+    # in_cluster has a cached query but should be ignored because the
+    # out_cluster takes precedence (in_cluster's cache is stale)
+    assert len(in_events) == 0
+    ota.get_ota_images.assert_not_called()
+
+
 async def test_check_device_for_ota_skips_no_query_cmd(query_cmd) -> None:
     """check_device_for_ota skips clusters without last_query_cmd."""
     device, cluster = _make_device_with_ota_cluster(query_cmd)

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -708,3 +708,35 @@ async def test_invalidate_provider_caches(query_cmd) -> None:
     for provider in ota._providers:
         result = await provider.load_index()
         assert result is not None  # Empty list, not None (which means "cached")
+
+
+async def test_invalidate_provider_caches_clears_image_cache(
+    query_cmd, ota_image
+) -> None:
+    """invalidate_provider_caches clears the image cache so withdrawn images disappear."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    index_with_image = [
+        SelfContainedOtaImageMetadata(
+            file_version=query_cmd.current_file_version + 1,
+            manufacturer_id=query_cmd.manufacturer_code,
+            image_type=query_cmd.image_type,
+            test_data=ota_image.serialize(),
+        ),
+    ]
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    provider = SelfContainedProvider(index_with_image)
+    ota.register_provider(provider)
+
+    # First check finds the upgrade
+    result1 = await ota.get_ota_images(device, query_cmd)
+    assert len(result1.upgrades) == 1
+
+    # Provider now returns an empty index (image was withdrawn)
+    provider._index = []
+    ota.invalidate_provider_caches()
+
+    # Second check should find no upgrades
+    result2 = await ota.get_ota_images(device, query_cmd)
+    assert len(result2.upgrades) == 0

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -484,13 +484,13 @@ def _make_device_with_ota_cluster(
     device = make_device(model="device model", manufacturer_id=0x1234)
 
     ep = device.add_endpoint(endpoint_id)
-    cluster = Ota(ep)
-    cluster.last_query_cmd = query_cmd
 
     if cluster_type == ClusterType.Client:
-        ep.out_clusters[Ota.cluster_id] = cluster
+        cluster = ep.add_output_cluster(Ota.cluster_id)
     else:
-        ep.in_clusters[Ota.cluster_id] = cluster
+        cluster = ep.add_input_cluster(Ota.cluster_id)
+
+    cluster.last_query_cmd = query_cmd
 
     return device, cluster
 
@@ -539,9 +539,8 @@ async def test_check_device_for_ota_finds_clusters(query_cmd) -> None:
     device, cluster1 = _make_device_with_ota_cluster(query_cmd, endpoint_id=1)
     # Add a second endpoint with an OTA cluster
     ep2 = device.add_endpoint(2)
-    cluster2 = Ota(ep2)
+    cluster2 = ep2.add_output_cluster(Ota.cluster_id)
     cluster2.last_query_cmd = query_cmd
-    ep2.out_clusters[Ota.cluster_id] = cluster2
 
     images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
     ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
@@ -569,9 +568,8 @@ async def test_check_device_for_ota_prefers_out_clusters(query_cmd) -> None:
     ep = device.endpoints[1]
 
     # Also add as out_cluster on the same endpoint
-    out_cluster = Ota(ep, is_server=False)
+    out_cluster = ep.add_output_cluster(Ota.cluster_id)
     out_cluster.last_query_cmd = query_cmd
-    ep.out_clusters[Ota.cluster_id] = out_cluster
 
     images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
     ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -478,7 +478,7 @@ def _make_device_with_ota_cluster(
     query_cmd,
     *,
     endpoint_id: int = 1,
-    cluster_type: ClusterType = ClusterType.Server,
+    cluster_type: ClusterType = ClusterType.Client,
 ) -> tuple[zigpy.device.Device, Ota]:
     """Create a device with an OTA cluster and a cached query command."""
     device = make_device(model="device model", manufacturer_id=0x1234)
@@ -487,10 +487,10 @@ def _make_device_with_ota_cluster(
     cluster = Ota(ep)
     cluster.last_query_cmd = query_cmd
 
-    if cluster_type == ClusterType.Server:
-        ep.in_clusters[Ota.cluster_id] = cluster
-    else:
+    if cluster_type == ClusterType.Client:
         ep.out_clusters[Ota.cluster_id] = cluster
+    else:
+        ep.in_clusters[Ota.cluster_id] = cluster
 
     return device, cluster
 
@@ -536,9 +536,7 @@ async def test_check_cluster_for_ota_no_query_cmd(query_cmd) -> None:
 
 async def test_check_device_for_ota_finds_clusters(query_cmd) -> None:
     """check_device_for_ota iterates endpoints and checks each OTA cluster."""
-    device, cluster1 = _make_device_with_ota_cluster(
-        query_cmd, endpoint_id=1, cluster_type=ClusterType.Server
-    )
+    device, cluster1 = _make_device_with_ota_cluster(query_cmd, endpoint_id=1)
     # Add a second endpoint with an OTA cluster
     ep2 = device.add_endpoint(2)
     cluster2 = Ota(ep2)

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -10,10 +10,10 @@ import aiohttp
 import attrs
 import pytest
 
+from tests.conftest import add_initialized_device, make_app
 from tests.ota.test_ota_providers import SelfContainedOtaImageMetadata, make_device
 from zigpy import config
 import zigpy.device
-import zigpy.endpoint
 import zigpy.ota
 from zigpy.ota.image import FieldControl
 from zigpy.ota.providers import BaseOtaImageMetadata, BaseOtaProvider
@@ -604,61 +604,56 @@ async def test_check_device_for_ota_skips_no_query_cmd(query_cmd) -> None:
 
 async def test_check_all_devices_for_ota(query_cmd) -> None:
     """check_all_devices_for_ota checks all devices, skipping those without OTA."""
-    app = AsyncMock()
+    app = make_app({})
 
-    device1, cluster1 = _make_device_with_ota_cluster(query_cmd)
-    device2 = zigpy.device.Device(
-        application=app,
-        ieee=zigpy.types.EUI64.convert("AA:BB:CC:DD:EE:FF:00:11"),
-        nwk=0x5678,
+    dev1 = add_initialized_device(
+        app, nwk=0x1234, ieee=zigpy.types.EUI64.convert("00:11:22:33:44:55:66:77")
     )
-    # device2 has no OTA cluster — should be skipped
-    device2.add_endpoint(1)
+    cluster1 = dev1.endpoints[1].add_output_cluster(Ota.cluster_id)
+    cluster1.last_query_cmd = query_cmd
 
-    app.devices = {device1.ieee: device1, device2.ieee: device2}
+    # device2 has no OTA cluster — should be skipped
+    add_initialized_device(
+        app, nwk=0x5678, ieee=zigpy.types.EUI64.convert("AA:BB:CC:DD:EE:FF:00:11")
+    )
 
     images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
-    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=app)
-    ota.get_ota_images = AsyncMock(return_value=images_result)
+    app.ota.get_ota_images = AsyncMock(return_value=images_result)
 
     events = []
     cluster1.on_event(OtaImageAvailableEvent.event_type, events.append)
 
-    await ota.check_all_devices_for_ota()
+    await app.ota.check_all_devices_for_ota()
 
     assert len(events) == 1
-    assert events[0].device_ieee == str(device1.ieee)
+    assert events[0].device_ieee == str(dev1.ieee)
 
 
 async def test_check_all_devices_for_ota_tolerates_failure(query_cmd) -> None:
     """check_all_devices_for_ota continues if one device fails."""
-    app = AsyncMock()
+    app = make_app({})
 
-    device1, _cluster1 = _make_device_with_ota_cluster(query_cmd)
-
-    # Create device2 with a different IEEE address
-    device2 = zigpy.device.Device(
-        application=app,
-        ieee=zigpy.types.EUI64.convert("AA:BB:CC:DD:EE:FF:00:11"),
-        nwk=0x5678,
+    dev1 = add_initialized_device(
+        app, nwk=0x1234, ieee=zigpy.types.EUI64.convert("00:11:22:33:44:55:66:77")
     )
-    ep2 = device2.add_endpoint(1)
-    cluster2 = Ota(ep2)
-    cluster2.last_query_cmd = query_cmd
-    ep2.in_clusters[Ota.cluster_id] = cluster2
+    cluster1 = dev1.endpoints[1].add_output_cluster(Ota.cluster_id)
+    cluster1.last_query_cmd = query_cmd
 
-    app.devices = {device1.ieee: device1, device2.ieee: device2}
+    dev2 = add_initialized_device(
+        app, nwk=0x5678, ieee=zigpy.types.EUI64.convert("AA:BB:CC:DD:EE:FF:00:11")
+    )
+    cluster2 = dev2.endpoints[1].add_output_cluster(Ota.cluster_id)
+    cluster2.last_query_cmd = query_cmd
 
     images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
-    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=app)
-    ota.get_ota_images = AsyncMock(
+    app.ota.get_ota_images = AsyncMock(
         side_effect=[RuntimeError("provider down"), images_result]
     )
 
     events2 = []
     cluster2.on_event(OtaImageAvailableEvent.event_type, events2.append)
 
-    await ota.check_all_devices_for_ota()
+    await app.ota.check_all_devices_for_ota()
 
     # device2 should still get checked even though device1 failed
     assert len(events2) == 1

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -10,7 +10,7 @@ import pytest
 
 from zigpy import device, types, zcl
 import zigpy.endpoint
-from zigpy.ota import OtaImagesResult
+from zigpy.ota import OTA, OtaImagesResult
 from zigpy.zcl import OtaImageAvailableEvent, OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import Basic, Ota, Time
 import zigpy.zcl.clusters.security as sec
@@ -308,6 +308,7 @@ def ota_cluster(dev):
     ep = dev.add_endpoint(1)
 
     cluster = zcl.Cluster._registry[0x0019](ep)
+    ep.in_clusters[cluster.cluster_id] = cluster
 
     with (
         patch.object(cluster, "reply", AsyncMock()),
@@ -352,8 +353,12 @@ async def test_ota_handle_query_next_image(ota_cluster):
     image_events = []
     ota_cluster.on_event(OtaImageAvailableEvent.event_type, image_events.append)
 
+    # Use the real check_device_for_ota so it emits OtaImageAvailableEvent
+    ota = dev.application.ota
+    ota.check_device_for_ota = lambda d: OTA.check_device_for_ota(ota, d)
+
     # No image is available
-    dev.application.ota.get_ota_images = AsyncMock(
+    ota.get_ota_images = AsyncMock(
         return_value=OtaImagesResult(upgrades=(), downgrades=())
     )
     ota_cluster.handle_cluster_request(hdr, cmd)
@@ -375,7 +380,7 @@ async def test_ota_handle_query_next_image(ota_cluster):
 
     # Now one is available
     img = MagicMock()
-    dev.application.ota.get_ota_images = AsyncMock(
+    ota.get_ota_images = AsyncMock(
         return_value=OtaImagesResult(upgrades=(img,), downgrades=())
     )
     ota_cluster.handle_cluster_request(hdr, cmd)

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -11,7 +11,7 @@ import pytest
 from zigpy import device, types, zcl
 import zigpy.endpoint
 from zigpy.ota import OtaImagesResult
-from zigpy.zcl import OtaQueryCacheUpdatedEvent, foundation
+from zigpy.zcl import OtaImageAvailableEvent, OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import Basic, Ota, Time
 import zigpy.zcl.clusters.security as sec
 from zigpy.zdo import types as zdo_t
@@ -340,9 +340,6 @@ async def test_ota_handle_query_next_image(ota_cluster):
     ota_cluster.query_next_image_response = AsyncMock()
     dev.ota_in_progress = False
 
-    listener = MagicMock()
-    dev.add_listener(listener)
-
     # TODO: get rid of `sentinel` and mock the actual command
     hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
         tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
@@ -351,6 +348,9 @@ async def test_ota_handle_query_next_image(ota_cluster):
 
     cache_events = []
     ota_cluster.on_event(OtaQueryCacheUpdatedEvent.event_type, cache_events.append)
+
+    image_events = []
+    ota_cluster.on_event(OtaImageAvailableEvent.event_type, image_events.append)
 
     # No image is available
     dev.application.ota.get_ota_images = AsyncMock(
@@ -362,15 +362,16 @@ async def test_ota_handle_query_next_image(ota_cluster):
     assert ota_cluster.query_next_image_response.mock_calls == [
         call(zcl.foundation.Status.NO_IMAGE_AVAILABLE, tsn=hdr.tsn)
     ]
-    assert listener.device_ota_image_query_result.mock_calls == [
-        call(OtaImagesResult(upgrades=(), downgrades=()), cmd)
-    ]
+    assert len(image_events) == 1
+    assert isinstance(image_events[0], OtaImageAvailableEvent)
+    assert image_events[0].images_result == OtaImagesResult(upgrades=(), downgrades=())
+    assert image_events[0].query_cmd is cmd
     assert ota_cluster.last_query_cmd is cmd
     assert len(cache_events) == 1
     assert isinstance(cache_events[0], OtaQueryCacheUpdatedEvent)
 
     ota_cluster.query_next_image_response.reset_mock()
-    listener.device_ota_image_query_result.reset_mock()
+    image_events.clear()
 
     # Now one is available
     img = MagicMock()
@@ -383,9 +384,11 @@ async def test_ota_handle_query_next_image(ota_cluster):
     assert ota_cluster.query_next_image_response.mock_calls == [
         call(zcl.foundation.Status.NO_IMAGE_AVAILABLE, tsn=hdr.tsn)
     ]
-    assert listener.device_ota_image_query_result.mock_calls == [
-        call(OtaImagesResult(upgrades=(img,), downgrades=()), cmd)
-    ]
+    assert len(image_events) == 1
+    assert image_events[0].images_result == OtaImagesResult(
+        upgrades=(img,), downgrades=()
+    )
+    assert image_events[0].query_cmd is cmd
 
 
 async def test_ota_handle_image_block_req(ota_cluster):

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -353,9 +353,9 @@ async def test_ota_handle_query_next_image(ota_cluster):
     image_events = []
     ota_cluster.on_event(OtaImageAvailableEvent.event_type, image_events.append)
 
-    # Use the real check_device_for_ota so it emits OtaImageAvailableEvent
+    # Use the real check_cluster_for_ota so it emits OtaImageAvailableEvent
     ota = dev.application.ota
-    ota.check_device_for_ota = lambda d: OTA.check_device_for_ota(ota, d)
+    ota.check_cluster_for_ota = lambda c: OTA.check_cluster_for_ota(ota, c)
 
     # No image is available
     ota.get_ota_images = AsyncMock(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -309,6 +309,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 interval=self._config[conf.CONF_OTA][conf.CONF_OTA_BROADCAST_INTERVAL],
             )
 
+        if self.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED]:
+            self.create_task(self.ota.check_all_devices_for_ota())
+
     async def startup(self, *, auto_form: bool = False) -> None:
         """Starts a network, optionally forming one with random settings if necessary."""
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -309,9 +309,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                 interval=self._config[conf.CONF_OTA][conf.CONF_OTA_BROADCAST_INTERVAL],
             )
 
-        if self.config[conf.CONF_OTA][conf.CONF_OTA_ENABLED]:
-            self.create_task(self.ota.check_all_devices_for_ota())
-
     async def startup(self, *, auto_form: bool = False) -> None:
         """Starts a network, optionally forming one with random settings if necessary."""
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -273,14 +273,40 @@ class OTA:
             self._broadcast_loop_task.cancel()
             self._broadcast_loop_task = None
 
+    async def check_cluster_for_ota(self, cluster: Ota) -> None:
+        """Check OTA image availability for a single OTA cluster.
+
+        If the cluster has a cached query command, calls get_ota_images and emits
+        OtaImageAvailableEvent on the cluster. Intended to be called by consumers
+        (e.g. ZHA) during entity setup after registering their event listener.
+        """
+        cmd = cluster.last_query_cmd
+        if cmd is None:
+            return
+
+        device = cluster.endpoint.device
+        images_result = await self.get_ota_images(device, cmd)
+
+        cluster.emit(
+            OtaImageAvailableEvent.event_type,
+            OtaImageAvailableEvent(
+                device_ieee=str(device.ieee),
+                endpoint_id=cluster.endpoint.endpoint_id,
+                cluster_type=cluster.cluster_type,
+                cluster_id=cluster.cluster_id,
+                images_result=images_result,
+                query_cmd=cmd,
+            ),
+        )
+
     async def check_device_for_ota(
         self,
         device: zigpy.device.Device,
     ) -> None:
         """Check OTA image availability for a single device.
 
-        Iterates the device's endpoints looking for an OTA cluster with a cached
-        query command, calls get_ota_images, and emits OtaImageAvailableEvent.
+        Iterates the device's endpoints looking for OTA clusters with cached
+        query commands and calls check_cluster_for_ota for each.
         """
         for ep_id, ep in device.endpoints.items():
             if ep_id == 0:
@@ -293,25 +319,9 @@ class OTA:
                 if not isinstance(cluster, Ota):
                     continue
 
-                cmd = cluster.last_query_cmd
-                if cmd is None:
-                    continue
+                await self.check_cluster_for_ota(cluster)
 
-                images_result = await self.get_ota_images(device, cmd)
-
-                cluster.emit(
-                    OtaImageAvailableEvent.event_type,
-                    OtaImageAvailableEvent(
-                        device_ieee=str(device.ieee),
-                        endpoint_id=ep.endpoint_id,
-                        cluster_type=cluster.cluster_type,
-                        cluster_id=cluster.cluster_id,
-                        images_result=images_result,
-                        query_cmd=cmd,
-                    ),
-                )
-
-                # Only emit for the first OTA cluster found per endpoint
+                # Only check the first OTA cluster found per endpoint
                 break
 
     async def check_all_devices_for_ota(self) -> None:

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -281,6 +281,11 @@ class OTA:
                 0, tz=datetime.UTC
             )
 
+        # Clear the image cache so withdrawn images are not returned.
+        # This means untrusted provider images will be re-downloaded on the
+        # next check, but this is acceptable for a user-initiated action.
+        self._image_cache.clear()
+
     async def check_cluster_for_ota(self, cluster: Ota) -> None:
         """Check OTA image availability for a single OTA cluster.
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -275,15 +275,17 @@ class OTA:
             self._broadcast_loop_task = None
 
     def invalidate_provider_caches(self) -> None:
-        """Invalidate all provider index caches, forcing a refresh on next check."""
+        """Invalidate all provider index caches, forcing a refresh on next check.
+
+        Also clears the image cache so withdrawn images are not returned.
+        Downloaded firmware will be re-fetched from untrusted providers on
+        the next check, but this is acceptable for a user-initiated action.
+        """
         for provider in self._providers:
             provider._index_last_updated = datetime.datetime.fromtimestamp(
                 0, tz=datetime.UTC
             )
 
-        # Clear the image cache so withdrawn images are not returned.
-        # This means untrusted provider images will be re-downloaded on the
-        # next check, but this is acceptable for a user-initiated action.
         self._image_cache.clear()
 
     async def check_cluster_for_ota(self, cluster: Ota) -> None:

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -321,15 +321,15 @@ class OTA:
                 continue
 
             # Prefer out_clusters (client) since that's where runtime routing
-            # places it when both cluster types exist.
+            # places query_next_image when both cluster types exist. If an
+            # out_cluster exists, always use it (the in_cluster's cached query
+            # would be stale and never updated again).
             for clusters in (ep.out_clusters, ep.in_clusters):
                 cluster = clusters.get(Ota.cluster_id)
                 if not isinstance(cluster, Ota):
                     continue
 
                 await self.check_cluster_for_ota(cluster)
-
-                # Only check the first OTA cluster found per endpoint
                 break
 
     async def check_all_devices_for_ota(self) -> None:

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -342,8 +342,8 @@ class OTA:
     async def check_all_devices_for_ota(self) -> None:
         """Check OTA image availability for all devices with cached query commands.
 
-        Called on startup after the OTA query cache is loaded, and periodically
-        from the broadcast loop.
+        Called periodically from the broadcast loop and by consumers (e.g. ZHA)
+        for user-initiated "check for updates" after invalidate_provider_caches().
         """
         for device in self._application.devices.values():
             try:

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -273,50 +273,62 @@ class OTA:
             self._broadcast_loop_task.cancel()
             self._broadcast_loop_task = None
 
+    async def check_device_for_ota(
+        self,
+        device: zigpy.device.Device,
+    ) -> None:
+        """Check OTA image availability for a single device.
+
+        Iterates the device's endpoints looking for an OTA cluster with a cached
+        query command, calls get_ota_images, and emits OtaImageAvailableEvent.
+        """
+        for ep_id, ep in device.endpoints.items():
+            if ep_id == 0:
+                continue
+
+            # Prefer out_clusters (client) since that's where runtime routing
+            # places it when both cluster types exist.
+            for clusters in (ep.out_clusters, ep.in_clusters):
+                cluster = clusters.get(Ota.cluster_id)
+                if not isinstance(cluster, Ota):
+                    continue
+
+                cmd = cluster.last_query_cmd
+                if cmd is None:
+                    continue
+
+                images_result = await self.get_ota_images(device, cmd)
+
+                cluster.emit(
+                    OtaImageAvailableEvent.event_type,
+                    OtaImageAvailableEvent(
+                        device_ieee=str(device.ieee),
+                        endpoint_id=ep.endpoint_id,
+                        cluster_type=cluster.cluster_type,
+                        cluster_id=cluster.cluster_id,
+                        images_result=images_result,
+                        query_cmd=cmd,
+                    ),
+                )
+
+                # Only emit for the first OTA cluster found per endpoint
+                break
+
     async def check_all_devices_for_ota(self) -> None:
         """Check OTA image availability for all devices with cached query commands.
 
-        Called on startup after the OTA query cache is loaded, and can also be called
-        when provider indexes are refreshed.
+        Called on startup after the OTA query cache is loaded, and periodically
+        from the broadcast loop.
         """
         for device in self._application.devices.values():
-            for ep_id, ep in device.endpoints.items():
-                if ep_id == 0:
-                    continue
-
-                for clusters in (ep.out_clusters, ep.in_clusters):
-                    cluster = clusters.get(Ota.cluster_id)
-                    if not isinstance(cluster, Ota):
-                        continue
-
-                    cmd = cluster.last_query_cmd
-                    if cmd is None:
-                        continue
-
-                    try:
-                        images_result = await self.get_ota_images(device, cmd)
-                    except Exception:  # noqa: BLE001
-                        _LOGGER.debug(
-                            "Failed to check OTA images for %s",
-                            device.ieee,
-                            exc_info=True,
-                        )
-                        continue
-
-                    cluster.emit(
-                        OtaImageAvailableEvent.event_type,
-                        OtaImageAvailableEvent(
-                            device_ieee=str(device.ieee),
-                            endpoint_id=ep.endpoint_id,
-                            cluster_type=cluster.cluster_type,
-                            cluster_id=cluster.cluster_id,
-                            images_result=images_result,
-                            query_cmd=cmd,
-                        ),
-                    )
-
-                    # Only emit for the first OTA cluster found per endpoint
-                    break
+            try:
+                await self.check_device_for_ota(device)
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Failed to check OTA images for %s",
+                    device.ieee,
+                    exc_info=True,
+                )
 
     def _register_providers(self, config: dict[str, typing.Any]) -> None:
         # Config gets a little complicated when you mix deprecated config and the new

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -560,8 +560,10 @@ class OTA:
             # image with downloaded firmware.
             img = result
 
-            # Cache the image if it isn't already cached
-            if self._image_cache[img.metadata].firmware is None:
+            # Cache the image if it isn't already cached (or was cleared by
+            # invalidate_provider_caches() during the download await)
+            cached = self._image_cache.get(img.metadata)
+            if cached is None or cached.firmware is None:
                 _LOGGER.debug("Caching image %s", img)
                 self._image_cache[img.metadata] = img
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -7,6 +7,7 @@ from asyncio import timeout as asyncio_timeout
 from collections import defaultdict
 import contextlib
 import dataclasses
+import datetime
 import hashlib
 import logging
 import typing
@@ -272,6 +273,13 @@ class OTA:
         if self._broadcast_loop_task is not None:
             self._broadcast_loop_task.cancel()
             self._broadcast_loop_task = None
+
+    def invalidate_provider_caches(self) -> None:
+        """Invalidate all provider index caches, forcing a refresh on next check."""
+        for provider in self._providers:
+            provider._index_last_updated = datetime.datetime.fromtimestamp(
+                0, tz=datetime.UTC
+            )
 
     async def check_cluster_for_ota(self, cluster: Ota) -> None:
         """Check OTA image availability for a single OTA cluster.

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -35,7 +35,7 @@ import zigpy.ota.providers
 import zigpy.profiles.zha
 import zigpy.types as t
 import zigpy.util
-from zigpy.zcl import foundation
+from zigpy.zcl import OtaImageAvailableEvent, foundation
 from zigpy.zcl.clusters.general import Ota, QueryNextImageCommand
 
 if typing.TYPE_CHECKING:
@@ -46,6 +46,7 @@ _LOGGER = logging.getLogger(__name__)
 
 OTA_FETCH_TIMEOUT = 20
 MAX_DEVICES_CHECKING_IN_PER_BROADCAST = 15
+BROADCAST_SETTLE_DELAY = 60
 
 
 @dataclasses.dataclass(frozen=True)
@@ -247,6 +248,14 @@ class OTA:
             except Exception:  # noqa: BLE001
                 _LOGGER.debug("OTA broadcast failed", exc_info=True)
 
+            # Wait for devices to respond with query_next_image before checking
+            await asyncio.sleep(BROADCAST_SETTLE_DELAY)
+
+            try:
+                await self.check_all_devices_for_ota()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("OTA image check failed", exc_info=True)
+
             await asyncio.sleep(interval)
 
     def start_periodic_broadcasts(self, initial_delay: float, interval: float) -> None:
@@ -263,6 +272,51 @@ class OTA:
         if self._broadcast_loop_task is not None:
             self._broadcast_loop_task.cancel()
             self._broadcast_loop_task = None
+
+    async def check_all_devices_for_ota(self) -> None:
+        """Check OTA image availability for all devices with cached query commands.
+
+        Called on startup after the OTA query cache is loaded, and can also be called
+        when provider indexes are refreshed.
+        """
+        for device in self._application.devices.values():
+            for ep_id, ep in device.endpoints.items():
+                if ep_id == 0:
+                    continue
+
+                for clusters in (ep.out_clusters, ep.in_clusters):
+                    cluster = clusters.get(Ota.cluster_id)
+                    if not isinstance(cluster, Ota):
+                        continue
+
+                    cmd = cluster.last_query_cmd
+                    if cmd is None:
+                        continue
+
+                    try:
+                        images_result = await self.get_ota_images(device, cmd)
+                    except Exception:  # noqa: BLE001
+                        _LOGGER.debug(
+                            "Failed to check OTA images for %s",
+                            device.ieee,
+                            exc_info=True,
+                        )
+                        continue
+
+                    cluster.emit(
+                        OtaImageAvailableEvent.event_type,
+                        OtaImageAvailableEvent(
+                            device_ieee=str(device.ieee),
+                            endpoint_id=ep.endpoint_id,
+                            cluster_type=cluster.cluster_type,
+                            cluster_id=cluster.cluster_id,
+                            images_result=images_result,
+                            query_cmd=cmd,
+                        ),
+                    )
+
+                    # Only emit for the first OTA cluster found per endpoint
+                    break
 
     def _register_providers(self, config: dict[str, typing.Any]) -> None:
         # Config gets a little complicated when you mix deprecated config and the new

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -217,6 +217,20 @@ class OtaQueryCacheUpdatedEvent:
 
 
 @dataclass(kw_only=True, frozen=True)
+class OtaImageAvailableEvent:
+    """Event generated when OTA image availability has been checked for a device."""
+
+    event_type: Final[str] = "ota_image_available"
+
+    device_ieee: str
+    endpoint_id: int
+    cluster_type: ClusterType
+    cluster_id: int
+    images_result: object  # OtaImagesResult, untyped to avoid circular import
+    query_cmd: object  # QueryNextImageCommand
+
+
+@dataclass(kw_only=True, frozen=True)
 class OtaQueryCacheClearedEvent:
     """Event generated when OTA query cache is cleared after a successful update."""
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -27,6 +27,8 @@ from .helpers import AttributeCache, ReportingConfig, UnsupportedAttribute
 
 if TYPE_CHECKING:
     from zigpy.endpoint import Endpoint
+    from zigpy.ota import OtaImagesResult
+    from zigpy.zcl.clusters.general import QueryNextImageCommand
 
 
 LOGGER = logging.getLogger(__name__)
@@ -226,8 +228,8 @@ class OtaImageAvailableEvent:
     endpoint_id: int
     cluster_type: ClusterType
     cluster_id: int
-    images_result: object  # OtaImagesResult, untyped to avoid circular import
-    query_cmd: object  # QueryNextImageCommand
+    images_result: OtaImagesResult
+    query_cmd: QueryNextImageCommand
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2180,8 +2180,7 @@ class Ota(Cluster):
             foundation.Status.NO_IMAGE_AVAILABLE, tsn=hdr.tsn
         )
 
-        device = self.endpoint.device
-        await device.application.ota.check_device_for_ota(device)
+        await self.endpoint.device.application.ota.check_cluster_for_ota(self)
 
     async def _handle_image_block_req(self, hdr, cmd):
         # Abort any running firmware update (i.e. the integration is reloaded midway)

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -6,12 +6,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Final, Self
 
 import zigpy.types as t
-from zigpy.zcl import (
-    Cluster,
-    OtaImageAvailableEvent,
-    OtaQueryCacheUpdatedEvent,
-    foundation,
-)
+from zigpy.zcl import Cluster, OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
@@ -2186,19 +2181,7 @@ class Ota(Cluster):
         )
 
         device = self.endpoint.device
-        images_result = await device.application.ota.get_ota_images(device, cmd)
-
-        self.emit(
-            OtaImageAvailableEvent.event_type,
-            OtaImageAvailableEvent(
-                device_ieee=str(device.ieee),
-                endpoint_id=self.endpoint.endpoint_id,
-                cluster_type=self.cluster_type,
-                cluster_id=self.cluster_id,
-                images_result=images_result,
-                query_cmd=cmd,
-            ),
-        )
+        await device.application.ota.check_device_for_ota(device)
 
     async def _handle_image_block_req(self, hdr, cmd):
         # Abort any running firmware update (i.e. the integration is reloaded midway)

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -6,7 +6,12 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Final, Self
 
 import zigpy.types as t
-from zigpy.zcl import Cluster, OtaQueryCacheUpdatedEvent, foundation
+from zigpy.zcl import (
+    Cluster,
+    OtaImageAvailableEvent,
+    OtaQueryCacheUpdatedEvent,
+    foundation,
+)
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
@@ -2183,10 +2188,16 @@ class Ota(Cluster):
         device = self.endpoint.device
         images_result = await device.application.ota.get_ota_images(device, cmd)
 
-        device.listener_event(
-            "device_ota_image_query_result",
-            images_result,
-            cmd,
+        self.emit(
+            OtaImageAvailableEvent.event_type,
+            OtaImageAvailableEvent(
+                device_ieee=str(device.ieee),
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_type=self.cluster_type,
+                cluster_id=self.cluster_id,
+                images_result=images_result,
+                query_cmd=cmd,
+            ),
         )
 
     async def _handle_image_block_req(self, hdr, cmd):


### PR DESCRIPTION
## AI summary

Replaces the old `listener_event("device_ota_image_query_result")` pattern with a typed `OtaImageAvailableEvent` emitted on the OTA cluster, consistent with how all other cluster events work. Adds three levels of OTA image checking:

- **`check_cluster_for_ota(cluster)`** — single cluster, called by the query handler and by consumers (e.g. ZHA update entity) during setup
- **`check_device_for_ota(device)`** — finds all OTA clusters on a device, calls `check_cluster_for_ota` for each
- **`check_all_devices_for_ota()`** — iterates all devices, called periodically from the broadcast loop (with a 60s settle delay for device responses)

### Changes

- **`OtaImageAvailableEvent`**: new typed event carrying `images_result` and `query_cmd`, emitted on the OTA cluster
- **`OTA.check_cluster_for_ota(cluster)`**: checks a single OTA cluster. Calls `get_ota_images` and emits the event. Intended to be called per update entity during setup.
- **`OTA.check_device_for_ota(device)`**: iterates a device's endpoints, calls `check_cluster_for_ota` for each OTA cluster found. Prefers out_clusters (client) unconditionally when both exist on the same endpoint, since the in_cluster's cached query would be stale.
- **`OTA.check_all_devices_for_ota()`**: iterates all devices, called in the broadcast loop for periodic refresh
- **`OTA.invalidate_provider_caches()`**: resets the 24h index cache on all providers and clears `_image_cache`. Intended for user-initiated "check for updates".
- **`_handle_query_next_image`**: now delegates to `check_cluster_for_ota` instead of duplicating get+emit logic
- **Broadcast loop**: runs `check_all_devices_for_ota` after each broadcast with a 60s settle delay

### Image cache behavior

`_image_cache` is add-only during normal operation. When provider indexes refresh on their 24h cycle, new entries are added but old entries are never removed. This means withdrawn images persist in the cache until:
- The application restarts, or
- The user triggers a manual "check for updates" (which calls `invalidate_provider_caches()`, clearing the entire cache)

For untrusted providers (e.g. LEDVANCE), `get_ota_images` downloads firmware proactively to verify hardware compatibility from image headers. After `invalidate_provider_caches()`, these downloads will be repeated. This is acceptable since it's user-initiated and infrequent. Some untrusted providers throttle downloads, but in practice only 1-2 images per device model are compatible, and identical metadata entries across devices share the same cache slot.

For trusted providers (e.g. zigpy-ota), firmware is never downloaded proactively — it's deferred to install time. Installed firmware stays in `_image_cache` for the lifetime of the application (until the cache is cleared).

### Future improvement

Once all untrusted providers have been removed and only the trusted zigpy-ota provider remains, the image cache can safely be pruned during automatic 24h index refreshes. Since trusted providers never download firmware proactively (deferred to install time), clearing `_image_cache` on every refresh has zero re-download cost. With a single provider, the fresh index is the complete truth — no need for multi-provider origin tracking.

### Required ZHA changes

In `FirmwareUpdateEntity.on_add()` / `FirmwareUpdateServerEntity.on_add()`:

**Remove:**
- `self.device.device.add_listener(self)` and corresponding `remove_listener` cleanup
- `device_ota_image_query_result` method (called via old `listener_event` pattern)

**Add:**
```python
def on_add(self) -> None:
    super().on_add()
    self._on_remove_callbacks.append(
        self._ota_cluster_handler.cluster.on_event(
            OtaImageAvailableEvent.event_type,
            self._handle_ota_image_available,
        )
    )
    # Trigger initial check — listener is already registered so event won't be missed
    self.device.device.application.ota.check_cluster_for_ota(
        self._ota_cluster_handler.cluster
    )
```

Where `_handle_ota_image_available` receives an `OtaImageAvailableEvent` (with `.images_result` and `.query_cmd` attributes) instead of separate positional args.

**Replace** `ZHAFirmwareUpdateCoordinator.async_update_data` (HA's "check for updates" button) with:
```python
async def async_update_data(self) -> None:
    self.controller_application.ota.invalidate_provider_caches()
    await self.controller_application.ota.check_all_devices_for_ota()
```

No `broadcast_notify` needed — the cached `last_query_cmd` per device is sufficient.

### Breaking changes

- `device_ota_image_query_result` listener event is removed. Consumers should listen to `OtaImageAvailableEvent` on the OTA cluster instead.



## Additional information

Related PRs:
- https://github.com/zigpy/zigpy/pull/1779
- https://github.com/zigpy/zigpy/pull/1797
- https://github.com/zigpy/zigpy/pull/1798