### PR TITLE
Fix Identify `EffectIdentifier.Channel_change`

### DIFF
--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -551,7 +551,7 @@ class EffectIdentifier(t.enum8):
     Blink = 0x00
     Breathe = 0x01
     Okay = 0x02
-    Channel_change = 0x03
+    Channel_change = 0x0B
     Finish_effect = 0xFE
     Stop_effect = 0xFF
 


### PR DESCRIPTION
## Proposed change

This changes the field value for the `EffectIdentifier`'s `Channel_change` from `0x03` to `0x0B` to match ZCL.

## Additional information

Fixes: https://github.com/zigpy/zha/issues/720