### PR TITLE
Add DST attribute handlers to Time cluster

### DIFF
--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -176,38 +176,224 @@ def _make_patched_datetime(fake_now):
 
 
 @pytest.mark.parametrize(
-    ("fake_now", "expected_utc", "expected_tz", "expected_standard", "expected_local"),
+    (
+        "fake_now",
+        "expected_utc",
+        "expected_tz",
+        "expected_standard",
+        "expected_local",
+        "expected_dst_start",
+        "expected_dst_end",
+        "expected_dst_shift",
+    ),
     [
+        # ── America/Los_Angeles (UTC-8 standard / UTC-7 DST) ──
         pytest.param(
-            # January: PST (UTC-8), no DST
-            datetime(2000, 1, 2, 0, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
-            # UTC time: midnight Jan 2 PST = 08:00 Jan 2 UTC = 1 day + 8 hours
-            24 * 60 * 60 + 8 * 60 * 60,
-            # Standard timezone offset: UTC-8
-            -(8 * 60 * 60),
-            # Standard time: Time + TimeZone = midnight Jan 2 local (no DST)
-            24 * 60 * 60,
-            # Local time: midnight Jan 2 = 1 day from epoch
-            24 * 60 * 60,
-            id="winter_no_dst",
+            # January: PST (UTC-8), before DST
+            datetime(2025, 1, 15, 12, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            790286400,  # UTC: 2025-01-15 20:00
+            -28800,  # standard offset UTC-8
+            790257600,  # standard_time (no DST active)
+            790257600,  # local_time = standard_time (no DST)
+            794829600,  # DST start: 2025-03-09 10:00 UTC
+            815389200,  # DST end: 2025-11-02 09:00 UTC
+            3600,
+            id="la_jan_before_dst",
         ),
         pytest.param(
-            # July: PDT (UTC-7), DST active
-            datetime(2000, 7, 2, 0, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
-            # UTC time: midnight Jul 2 PDT = 07:00 Jul 2 UTC
-            183 * 24 * 60 * 60 + 7 * 60 * 60,
-            # Standard timezone offset: still UTC-8 (DST not included)
-            -(8 * 60 * 60),
-            # Standard time: Time + TimeZone = 11 PM Jul 1 standard (no DST adjustment)
-            183 * 24 * 60 * 60 - 1 * 60 * 60,
-            # Local time: midnight Jul 2 local
-            183 * 24 * 60 * 60,
-            id="summer_with_dst",
+            # April: PDT (UTC-7), during DST
+            datetime(2025, 4, 15, 12, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            798058800,  # UTC: 2025-04-15 19:00
+            -28800,  # standard offset UTC-8
+            798030000,  # standard_time
+            798033600,  # local_time = standard + 3600 (DST active)
+            794829600,  # DST start: 2025-03-09 10:00 UTC
+            815389200,  # DST end: 2025-11-02 09:00 UTC
+            3600,
+            id="la_apr_during_dst",
+        ),
+        pytest.param(
+            # July: PDT (UTC-7), during DST
+            datetime(2025, 7, 15, 12, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            805921200,  # UTC: 2025-07-15 19:00
+            -28800,  # standard offset UTC-8
+            805892400,  # standard_time
+            805896000,  # local_time = standard + 3600 (DST active)
+            794829600,  # DST start: 2025-03-09 10:00 UTC
+            815389200,  # DST end: 2025-11-02 09:00 UTC
+            3600,
+            id="la_jul_during_dst",
+        ),
+        pytest.param(
+            # November: PST (UTC-8), after DST — next period is 2026
+            datetime(2025, 11, 15, 12, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            816552000,  # UTC: 2025-11-15 20:00
+            -28800,  # standard offset UTC-8
+            816523200,  # standard_time (no DST active)
+            816523200,  # local_time = standard_time (no DST)
+            826279200,  # DST start: 2026-03-08 10:00 UTC
+            846838800,  # DST end: 2026-11-01 09:00 UTC
+            3600,
+            id="la_nov_after_dst",
+        ),
+        # ── Europe/Sofia (UTC+2 standard / UTC+3 DST) ──
+        pytest.param(
+            # January: EET (UTC+2), before DST
+            datetime(2025, 1, 15, 12, 0, 0, tzinfo=ZoneInfo("Europe/Sofia")),
+            790250400,  # UTC: 2025-01-15 10:00
+            7200,  # standard offset UTC+2
+            790257600,  # standard_time (no DST active)
+            790257600,  # local_time = standard_time (no DST)
+            796611600,  # DST start: 2025-03-30 01:00 UTC
+            814755600,  # DST end: 2025-10-26 01:00 UTC
+            3600,
+            id="sofia_jan_before_dst",
+        ),
+        pytest.param(
+            # April: EEST (UTC+3), during DST
+            datetime(2025, 4, 15, 12, 0, 0, tzinfo=ZoneInfo("Europe/Sofia")),
+            798022800,  # UTC: 2025-04-15 09:00
+            7200,  # standard offset UTC+2
+            798030000,  # standard_time
+            798033600,  # local_time = standard + 3600 (DST active)
+            796611600,  # DST start: 2025-03-30 01:00 UTC
+            814755600,  # DST end: 2025-10-26 01:00 UTC
+            3600,
+            id="sofia_apr_during_dst",
+        ),
+        pytest.param(
+            # July: EEST (UTC+3), during DST
+            datetime(2025, 7, 15, 12, 0, 0, tzinfo=ZoneInfo("Europe/Sofia")),
+            805885200,  # UTC: 2025-07-15 09:00
+            7200,  # standard offset UTC+2
+            805892400,  # standard_time
+            805896000,  # local_time = standard + 3600 (DST active)
+            796611600,  # DST start: 2025-03-30 01:00 UTC
+            814755600,  # DST end: 2025-10-26 01:00 UTC
+            3600,
+            id="sofia_jul_during_dst",
+        ),
+        pytest.param(
+            # November: EET (UTC+2), after DST — next period is 2026
+            datetime(2025, 11, 15, 12, 0, 0, tzinfo=ZoneInfo("Europe/Sofia")),
+            816516000,  # UTC: 2025-11-15 10:00
+            7200,  # standard offset UTC+2
+            816523200,  # standard_time (no DST active)
+            816523200,  # local_time = standard_time (no DST)
+            828061200,  # DST start: 2026-03-29 01:00 UTC
+            846205200,  # DST end: 2026-10-25 01:00 UTC
+            3600,
+            id="sofia_nov_after_dst",
+        ),
+        # ── Australia/Sydney (UTC+10 standard / UTC+11 DST, southern hemisphere) ──
+        pytest.param(
+            # January: AEDT (UTC+11), during DST from previous Oct
+            datetime(2025, 1, 15, 12, 0, 0, tzinfo=ZoneInfo("Australia/Sydney")),
+            790218000,  # UTC: 2025-01-15 01:00
+            36000,  # standard offset UTC+10
+            790254000,  # standard_time
+            790257600,  # local_time = standard + 3600 (DST active)
+            781459200,  # DST start: 2024-10-05 16:00 UTC
+            797184000,  # DST end: 2025-04-05 16:00 UTC
+            3600,
+            id="sydney_jan_during_dst",
+        ),
+        pytest.param(
+            # April: AEST (UTC+10), after DST ended
+            datetime(2025, 4, 15, 12, 0, 0, tzinfo=ZoneInfo("Australia/Sydney")),
+            797997600,  # UTC: 2025-04-15 02:00
+            36000,  # standard offset UTC+10
+            798033600,  # standard_time (no DST active)
+            798033600,  # local_time = standard_time (no DST)
+            812908800,  # DST start: 2025-10-04 16:00 UTC (next period)
+            828633600,  # DST end: 2026-04-04 16:00 UTC
+            3600,
+            id="sydney_apr_after_dst",
+        ),
+        pytest.param(
+            # July: AEST (UTC+10), winter, before next DST
+            datetime(2025, 7, 15, 12, 0, 0, tzinfo=ZoneInfo("Australia/Sydney")),
+            805860000,  # UTC: 2025-07-15 02:00
+            36000,  # standard offset UTC+10
+            805896000,  # standard_time (no DST active)
+            805896000,  # local_time = standard_time (no DST)
+            812908800,  # DST start: 2025-10-04 16:00 UTC (next period)
+            828633600,  # DST end: 2026-04-04 16:00 UTC
+            3600,
+            id="sydney_jul_before_dst",
+        ),
+        pytest.param(
+            # November: AEDT (UTC+11), during DST from Oct
+            datetime(2025, 11, 15, 12, 0, 0, tzinfo=ZoneInfo("Australia/Sydney")),
+            816483600,  # UTC: 2025-11-15 01:00
+            36000,  # standard offset UTC+10
+            816519600,  # standard_time
+            816523200,  # local_time = standard + 3600 (DST active)
+            812908800,  # DST start: 2025-10-04 16:00 UTC
+            828633600,  # DST end: 2026-04-04 16:00 UTC
+            3600,
+            id="sydney_nov_during_dst",
+        ),
+        # ── Pacific/Auckland (UTC+12 standard / UTC+13 DST, southern hemisphere) ──
+        pytest.param(
+            # January: NZDT (UTC+13), during DST from previous Sep
+            datetime(2025, 1, 15, 12, 0, 0, tzinfo=ZoneInfo("Pacific/Auckland")),
+            790210800,  # UTC: 2025-01-14 23:00
+            43200,  # standard offset UTC+12
+            790254000,  # standard_time
+            790257600,  # local_time = standard + 3600 (DST active)
+            780847200,  # DST start: 2024-09-28 14:00 UTC
+            797176800,  # DST end: 2025-04-05 14:00 UTC
+            3600,
+            id="auckland_jan_during_dst",
+        ),
+        pytest.param(
+            # April: NZST (UTC+12), after DST ended
+            datetime(2025, 4, 15, 12, 0, 0, tzinfo=ZoneInfo("Pacific/Auckland")),
+            797990400,  # UTC: 2025-04-15 00:00
+            43200,  # standard offset UTC+12
+            798033600,  # standard_time (no DST active)
+            798033600,  # local_time = standard_time (no DST)
+            812296800,  # DST start: 2025-09-27 14:00 UTC (next period)
+            828626400,  # DST end: 2026-04-04 14:00 UTC
+            3600,
+            id="auckland_apr_after_dst",
+        ),
+        pytest.param(
+            # July: NZST (UTC+12), winter, before next DST
+            datetime(2025, 7, 15, 12, 0, 0, tzinfo=ZoneInfo("Pacific/Auckland")),
+            805852800,  # UTC: 2025-07-15 00:00
+            43200,  # standard offset UTC+12
+            805896000,  # standard_time (no DST active)
+            805896000,  # local_time = standard_time (no DST)
+            812296800,  # DST start: 2025-09-27 14:00 UTC (next period)
+            828626400,  # DST end: 2026-04-04 14:00 UTC
+            3600,
+            id="auckland_jul_before_dst",
+        ),
+        pytest.param(
+            # November: NZDT (UTC+13), during DST from Sep
+            datetime(2025, 11, 15, 12, 0, 0, tzinfo=ZoneInfo("Pacific/Auckland")),
+            816476400,  # UTC: 2025-11-14 23:00
+            43200,  # standard offset UTC+12
+            816519600,  # standard_time
+            816523200,  # local_time = standard + 3600 (DST active)
+            812296800,  # DST start: 2025-09-27 14:00 UTC
+            828626400,  # DST end: 2026-04-04 14:00 UTC
+            3600,
+            id="auckland_nov_during_dst",
         ),
     ],
 )
 async def test_time_cluster(
-    fake_now, expected_utc, expected_tz, expected_standard, expected_local
+    fake_now,
+    expected_utc,
+    expected_tz,
+    expected_standard,
+    expected_local,
+    expected_dst_start,
+    expected_dst_end,
+    expected_dst_shift,
 ):
     ep = MagicMock()
     ep.reply = AsyncMock()
@@ -278,6 +464,48 @@ async def test_time_cluster(
         ),
     )
 
+    # DST attributes — mock _get_dst_info to use the test timezone and year
+    def _fake_get_dst_info(self):
+        now_utc = fake_now.astimezone(UTC)
+        return Time._find_dst_transitions(fake_now.year, fake_now.tzinfo, now_utc)
+
+    with patch.object(Time, "_get_dst_info", _fake_get_dst_info):
+        rsp_dst = await read_attributes(
+            cluster,
+            [
+                Time.AttributeDefs.dst_start.id,
+                Time.AttributeDefs.dst_end.id,
+                Time.AttributeDefs.dst_shift.id,
+            ],
+        )
+
+    assert rsp_dst.status_records[0] == foundation.ReadAttributeRecord(
+        attrid=Time.AttributeDefs.dst_start.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.uint32,
+            value=expected_dst_start,
+        ),
+    )
+
+    assert rsp_dst.status_records[1] == foundation.ReadAttributeRecord(
+        attrid=Time.AttributeDefs.dst_end.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.uint32,
+            value=expected_dst_end,
+        ),
+    )
+
+    assert rsp_dst.status_records[2] == foundation.ReadAttributeRecord(
+        attrid=Time.AttributeDefs.dst_shift.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.int32,
+            value=expected_dst_shift,
+        ),
+    )
+
     # Unsupported
     rsp2 = await read_attributes(cluster, [0xABCD])
     assert rsp2 == Read_Attributes_rsp(
@@ -287,6 +515,59 @@ async def test_time_cluster(
                 status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
             )
         ]
+    )
+
+
+async def test_time_cluster_no_dst():
+    """Test DST attributes for a timezone that does not observe DST."""
+    ep = MagicMock()
+    ep.reply = AsyncMock()
+
+    cluster = Time(ep)
+
+    # UTC+9 (Asia/Tokyo) has no DST
+    fake_now = datetime(2025, 7, 15, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+    def _fake_get_dst_info_no_dst(self):
+        now_utc = fake_now.astimezone(UTC)
+        return Time._find_dst_transitions(fake_now.year, fake_now.tzinfo, now_utc)
+
+    with patch.object(Time, "_get_dst_info", _fake_get_dst_info_no_dst):
+        rsp = await read_attributes(
+            cluster,
+            [
+                Time.AttributeDefs.dst_start.id,
+                Time.AttributeDefs.dst_end.id,
+                Time.AttributeDefs.dst_shift.id,
+            ],
+        )
+
+    # No DST: dst_start and dst_end should be 0xFFFFFFFF, dst_shift should be 0
+    assert rsp.status_records[0] == foundation.ReadAttributeRecord(
+        attrid=Time.AttributeDefs.dst_start.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.uint32,
+            value=0xFFFFFFFF,
+        ),
+    )
+
+    assert rsp.status_records[1] == foundation.ReadAttributeRecord(
+        attrid=Time.AttributeDefs.dst_end.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.uint32,
+            value=0xFFFFFFFF,
+        ),
+    )
+
+    assert rsp.status_records[2] == foundation.ReadAttributeRecord(
+        attrid=Time.AttributeDefs.dst_shift.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.int32,
+            value=0,
+        ),
     )
 
 
@@ -310,9 +591,8 @@ def ota_cluster(dev):
     cluster = zcl.Cluster._registry[0x0019](ep)
     ep.in_clusters[cluster.cluster_id] = cluster
 
-    with (
-        patch.object(cluster, "reply", AsyncMock()),
-        patch.object(cluster, "request", AsyncMock()),
+    with patch.object(cluster, "reply", AsyncMock()), patch.object(
+        cluster, "request", AsyncMock()
     ):
         yield cluster
 

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+import os
+from pathlib import Path
 from typing import Any, Final, Self
+from zoneinfo import ZoneInfo
 
 import zigpy.types as t
 from zigpy.zcl import Cluster, OtaQueryCacheUpdatedEvent, foundation
@@ -1159,6 +1162,184 @@ class Time(Cluster):
 
         utc_seconds = (now_local - ZIGBEE_EPOCH).total_seconds()
         return t.LocalTime(utc_seconds + utc_offset.total_seconds())
+
+    @staticmethod
+    def _find_dst_boundary(
+        start: datetime,
+        end: datetime,
+        tz: Any,
+    ) -> datetime:
+        """Binary search for the exact DST transition between start and end.
+
+        Returns the UTC datetime of the transition to the second.
+        """
+        lo = start
+        hi = end
+        prev_is_dst = (lo.astimezone(tz).dst() or timedelta(0)) != timedelta(0)
+
+        while (hi - lo) > timedelta(seconds=1):
+            mid = lo + (hi - lo) / 2
+            mid_is_dst = (mid.astimezone(tz).dst() or timedelta(0)) != timedelta(0)
+            if mid_is_dst == prev_is_dst:
+                lo = mid
+            else:
+                hi = mid
+
+        return hi
+
+    @staticmethod
+    def _scan_dst_transitions(
+        scan_start: datetime,
+        scan_end: datetime,
+        tz: Any,
+    ) -> list[tuple[datetime, bool]]:
+        """Scan a time range hourly to find all DST transitions.
+
+        Returns a list of (transition_utc, entering_dst) tuples.
+        """
+        dt = scan_start
+        prev_dst = (dt.astimezone(tz).dst() or timedelta(0)) != timedelta(0)
+        transitions: list[tuple[datetime, bool]] = []
+
+        while dt < scan_end:
+            dt += timedelta(hours=1)
+            cur_dst_offset = dt.astimezone(tz).dst() or timedelta(0)
+            cur_is_dst = cur_dst_offset != timedelta(0)
+
+            if cur_is_dst != prev_dst:
+                boundary = Time._find_dst_boundary(dt - timedelta(hours=1), dt, tz)
+                transitions.append((boundary, cur_is_dst))
+                prev_dst = cur_is_dst
+
+        return transitions
+
+    @staticmethod
+    def _find_dst_transitions(
+        year: int,
+        tz: Any,
+        now: datetime | None = None,
+    ) -> tuple[datetime | None, datetime | None, timedelta]:
+        """Find the relevant DST period for the given year and timezone.
+
+        If currently in DST, returns the active DST period.
+        If not in DST, returns the next upcoming DST period.
+        Ensures dst_end > dst_start always.
+
+        Returns a tuple of (dst_start_utc, dst_end_utc, dst_offset) where
+        dst_start_utc/dst_end_utc are timezone-aware UTC datetimes of the
+        transitions, or None if the timezone does not observe DST.
+        dst_offset is the DST offset applied during the DST period.
+        """
+        # Scan previous year through next year for all transitions
+        prev_year_start = datetime(year - 1, 1, 1, tzinfo=UTC)
+        next_year_end = datetime(year + 2, 1, 1, tzinfo=UTC)
+
+        transitions = Time._scan_dst_transitions(prev_year_start, next_year_end, tz)
+
+        if len(transitions) < 2:
+            return None, None, timedelta(0)
+
+        # Determine the DST offset from any entering-DST transition
+        dst_offset = timedelta(0)
+        for transition_utc, entering_dst in transitions:
+            if entering_dst:
+                local = transition_utc.astimezone(tz)
+                dst_offset = local.dst() or timedelta(0)
+                break
+
+        # Build list of complete DST periods (start, end) pairs
+        periods: list[tuple[datetime, datetime]] = []
+        current_start = None
+        for transition_utc, entering_dst in transitions:
+            if entering_dst:
+                current_start = transition_utc
+            elif current_start is not None:
+                periods.append((current_start, transition_utc))
+                current_start = None
+
+        if not periods:
+            return None, None, timedelta(0)
+
+        if now is None:
+            now = datetime.now(UTC)
+
+        # If currently in DST, return the active period
+        for start, end in periods:
+            if start <= now < end:
+                return start, end, dst_offset
+
+        # Not in DST — return the next upcoming period
+        for start, end in periods:
+            if start > now:
+                return start, end, dst_offset
+
+        # All periods are in the past — return the last one
+        return periods[-1][0], periods[-1][1], dst_offset
+
+    @staticmethod
+    def _get_local_tz() -> Any:
+        """Get the system's IANA timezone as a ZoneInfo object.
+
+        Tries the TZ environment variable, then resolves /etc/localtime,
+        then reads /etc/timezone. Falls back to the fixed-offset timezone
+        from datetime (which won't support DST transitions).
+        """
+        # Try TZ environment variable
+        tz_env = os.environ.get("TZ")
+        if tz_env:
+            try:
+                return ZoneInfo(tz_env)
+            except KeyError:
+                pass
+
+        # Try resolving /etc/localtime symlink
+        try:
+            parts = Path("/etc/localtime").resolve().parts
+            for i, part in enumerate(parts):
+                if part == "zoneinfo":
+                    return ZoneInfo("/".join(parts[i + 1 :]))
+        except (OSError, KeyError):
+            pass
+
+        # Try reading /etc/timezone
+        try:
+            tz_name = Path("/etc/timezone").read_text().strip()
+            if tz_name:
+                return ZoneInfo(tz_name)
+        except (OSError, KeyError):
+            pass
+
+        # Fallback: fixed-offset timezone (no DST support)
+        return datetime.now().astimezone().tzinfo
+
+    def _get_dst_info(
+        self,
+    ) -> tuple[datetime | None, datetime | None, timedelta]:
+        """Get DST transitions for the current year using the system timezone."""
+        tz = self._get_local_tz()
+        now = datetime.now(tz)
+        return self._find_dst_transitions(now.year, tz, datetime.now(UTC))
+
+    def handle_read_attribute_dst_start(self) -> t.uint32_t:
+        dst_start, _, _ = self._get_dst_info()
+
+        if dst_start is None:
+            return t.uint32_t(0xFFFFFFFF)
+
+        return t.uint32_t((dst_start - ZIGBEE_EPOCH).total_seconds())
+
+    def handle_read_attribute_dst_end(self) -> t.uint32_t:
+        _, dst_end, _ = self._get_dst_info()
+
+        if dst_end is None:
+            return t.uint32_t(0xFFFFFFFF)
+
+        return t.uint32_t((dst_end - ZIGBEE_EPOCH).total_seconds())
+
+    def handle_read_attribute_dst_shift(self) -> t.int32s:
+        _, _, dst_offset = self._get_dst_info()
+
+        return t.int32s(dst_offset.total_seconds())
 
     # For backwards compatibility
     TimeStatus: Final = TimeStatus


### PR DESCRIPTION
Add handle_read_attribute_dst_start, handle_read_attribute_dst_end, and handle_read_attribute_dst_shift methods to the Time cluster. These were previously missing, causing UNSUPPORTED_ATTRIBUTE responses when devices requested DST information from the coordinator.

The implementation scans the current year's timezone transitions to find DST start/end times, using binary search for second-level precision. For timezones without DST, returns 0xFFFFFFFF for start/end and 0 for shift.

Tests cover:
- Northern hemisphere winter (LA, PST)
- Northern hemisphere summer (LA, PDT)
- Eastern Europe summer (Sofia, EEST)
- Southern hemisphere winter (Sydney, AEST) - reversed DST schedule
- Timezone without DST (Tokyo, JST)

#1805 