### PR TITLE
Shorten `OtaImageWithMetadata` repr to avoid logging fw bytes

### DIFF
--- a/tests/ota/test_ota_metadata.py
+++ b/tests/ota/test_ota_metadata.py
@@ -214,3 +214,20 @@ def test_metadata_trusted_specificity(
 
     assert img.metadata.trusted is expected_trusted
     assert img.specificity == image_with_metadata.specificity + specificity_boost
+
+
+def test_repr_with_firmware(image_with_metadata: OtaImageWithMetadata) -> None:
+    """Test that repr summarizes firmware size instead of dumping raw bytes."""
+    r = repr(image_with_metadata)
+    assert r.startswith("OtaImageWithMetadata(metadata=")
+    assert "firmware=<OTAImage: 74 bytes>" in r
+    # Ensure the raw firmware bytes are not present
+    assert "fw_image" not in r
+
+
+def test_repr_without_firmware(image_with_metadata: OtaImageWithMetadata) -> None:
+    """Test that repr handles missing firmware gracefully."""
+    img = image_with_metadata.replace(firmware=None)
+    r = repr(img)
+    assert r.startswith("OtaImageWithMetadata(metadata=")
+    assert "firmware=None)" in r

--- a/tests/ota/test_ota_metadata.py
+++ b/tests/ota/test_ota_metadata.py
@@ -220,7 +220,9 @@ def test_repr_with_firmware(image_with_metadata: OtaImageWithMetadata) -> None:
     """Test that repr summarizes firmware size instead of dumping raw bytes."""
     r = repr(image_with_metadata)
     assert r.startswith("OtaImageWithMetadata(metadata=")
-    assert "firmware=<OTAImage: 74 bytes>" in r
+    assert image_with_metadata.firmware is not None
+    expected_size = image_with_metadata.firmware.header.image_size
+    assert f"firmware=<OTAImage: {expected_size} bytes>" in r
     # Ensure the raw firmware bytes are not present
     assert "fw_image" not in r
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -61,6 +61,21 @@ class OtaImageWithMetadata(t.BaseDataclassMixin):
     metadata: zigpy.ota.providers.BaseOtaImageMetadata
     firmware: BaseOTAImage | None
 
+    def __repr__(self) -> str:
+        if self.firmware is not None:
+            firmware_repr = (
+                f"<{type(self.firmware).__name__}: "
+                f"{self.firmware.header.image_size} bytes>"
+            )
+        else:
+            firmware_repr = "None"
+
+        return (
+            f"{type(self).__name__}("
+            f"metadata={self.metadata!r}, "
+            f"firmware={firmware_repr})"
+        )
+
     @property
     def version(self) -> int:
         return self.metadata.file_version


### PR DESCRIPTION
## Proposed change

OTA checking moved to using `OtaImageAvailableEvent`, instead of a `listener_event`. This means that zigpy logs the emitted event, including the entire `OtaImageWithMetadata`(!)

This only happened at `debug` log level, so I initially accepted it, but I later came to the realization that it maybe is a bit too spammy when you have lots of devices (that use the old providers where the images need to be downloaded).

So, this PR overrides `OtaImageWithMetadata.__repr__` to only show the bytes, instead of the whole `firmware`.
A test is also added to make sure we don't crash (e.g. if `firmware` is `None`).

Follow-up to:
- https://github.com/zigpy/zigpy/pull/1799

The `__repr__` of the firmware/frames is unchanged, so if anything needs to be logged there, it won't be affected. It's just shortened when an entire `OtaImageWithMetadata` is logged.