### PR TITLE
Allow response matching on known custom-profile ZCL endpoints

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -475,6 +475,65 @@ async def test_handle_custom_profile(dev) -> None:
     assert mock_handler.mock_calls == [call(packet)]
 
 
+async def test_custom_profile_response_matched_on_known_endpoint_profile(dev) -> None:
+    """Test that ZCL responses can match on a known custom-profile endpoint."""
+    ep = dev.add_endpoint(239)
+    ep.profile_id = 0xC001
+    ep.add_input_cluster(OnOff.cluster_id)
+
+    tsn = 0x12
+    rsp_key = device.ResponseKey(
+        endpoint_id=239,
+        cluster_id=OnOff.cluster_id,
+        direction=foundation.Direction.Server_to_Client,
+        tsn=tsn,
+    )
+    future = asyncio.get_running_loop().create_future()
+    dev._requests[rsp_key] = future
+
+    default_rsp_hdr = foundation.ZCLHeader(
+        frame_control=foundation.FrameControl(
+            frame_type=foundation.FrameType.GLOBAL_COMMAND,
+            is_manufacturer_specific=False,
+            direction=foundation.Direction.Server_to_Client,
+            disable_default_response=True,
+            reserved=0,
+        ),
+        tsn=tsn,
+        command_id=foundation.GeneralCommand.Default_Response,
+    )
+
+    default_rsp_cmd = foundation.GENERAL_COMMANDS[
+        foundation.GeneralCommand.Default_Response
+    ].schema(
+        command_id=OnOff.ServerCommandDefs.on.id,
+        status=foundation.Status.SUCCESS,
+    )
+
+    with patch.object(dev, "custom_profile_packet_received") as custom_handler:
+        dev.packet_received(
+            t.ZigbeePacket(
+                src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+                src_ep=239,
+                dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+                dst_ep=1,
+                profile_id=0xC001,
+                cluster_id=OnOff.cluster_id,
+                data=t.SerializableBytes(
+                    default_rsp_hdr.serialize() + default_rsp_cmd.serialize()
+                ),
+                lqi=255,
+                rssi=-30,
+            )
+        )
+
+    await asyncio.sleep(0)
+
+    assert custom_handler.call_count == 0
+    assert future.done()
+    assert await future == default_rsp_cmd
+
+
 async def test_handle_unknown_cluster(dev, caplog) -> None:
     """Test that unknown cluster messages are ignored."""
     dev.add_endpoint(1)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -700,6 +700,20 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             packet.profile_id,
         )
 
+    def _is_known_zcl_packet_profile(self, packet: t.ZigbeePacket) -> bool:
+        """Return whether a custom-profile packet can be handled as ZCL."""
+        if packet.src_ep not in self.endpoints:
+            return False
+
+        endpoint = self.endpoints[packet.src_ep]
+        if not isinstance(endpoint, zigpy.endpoint.Endpoint):
+            return False
+
+        return endpoint.profile_id == packet.profile_id and (
+            packet.cluster_id in endpoint.in_clusters
+            or packet.cluster_id in endpoint.out_clusters
+        )
+
     def _should_filter_packet(self, packet: t.ZigbeePacket) -> bool:
         """Check if packet should be filtered as duplicate."""
         return self._packet_debouncer.filter(
@@ -723,7 +737,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 tsn=hdr.tsn,
             )
             return hdr, rsp_key
-        elif packet.profile_id in (zha.PROFILE_ID, zll.PROFILE_ID):
+        elif packet.profile_id in (zha.PROFILE_ID, zll.PROFILE_ID) or (
+            self._is_known_zcl_packet_profile(packet)
+        ):
             hdr, _ = foundation.ZCLHeader.deserialize(data)
             rsp_key = ResponseKey(
                 endpoint_id=packet.src_ep,


### PR DESCRIPTION
## Summary

This change lets `zigpy` parse and match ZCL replies on known non-ZHA/ZLL endpoints when the incoming packet profile matches the endpoint profile and the cluster is already known on that endpoint.

In practice, this unblocks devices like Shelly Gen4 units that expose their RPC transport on endpoint `239` using profile `0xC001` and ZCL cluster `0xFC01`.

Fixes #1810.

## Root cause

`Device._parse_packet_header()` only treated packets as ZCL when `packet.profile_id` was ZHA or ZLL. For valid ZCL traffic on known custom-profile endpoints, that caused the packet to be routed down the custom-profile ignore path instead of being parsed and matched against pending requests.

## What changed

- add a small helper to identify custom-profile packets that are still known ZCL traffic for the device
- allow `_parse_packet_header()` to deserialize those packets as ZCL
- add a regression test covering response matching on a known custom-profile endpoint

## Validation

- `python -m pytest -q tests/test_device.py -k "custom_profile_response_matched_on_known_endpoint_profile or handle_custom_profile"`
- `python -m pytest -q tests/test_device.py`
