### PR TITLE
Add Zigbee Green Power (ZGP) protocol support

### DIFF
--- a/tests/zgp/test_crypto.py
+++ b/tests/zgp/test_crypto.py
@@ -44,9 +44,9 @@ class TestBuildNonce:
     def test_nonce_max_values(self) -> None:
         """Nonce with maximum 32-bit values."""
         nonce = build_nonce(source_id=0xFFFFFFFF, frame_counter=0xFFFFFFFF)
-        assert nonce[0:4] == b"\xFF\xFF\xFF\xFF"
-        assert nonce[4:8] == b"\xFF\xFF\xFF\xFF"
-        assert nonce[8:12] == b"\xFF\xFF\xFF\xFF"
+        assert nonce[0:4] == b"\xff\xff\xff\xff"
+        assert nonce[4:8] == b"\xff\xff\xff\xff"
+        assert nonce[8:12] == b"\xff\xff\xff\xff"
         assert nonce[12] == 0x05
 
 
@@ -87,7 +87,7 @@ class TestEncryptDecryptSecurityKey:
 
     def test_different_source_ids_produce_different_ciphertext(self) -> None:
         """Different sourceIDs should produce different encrypted keys."""
-        key = b"\xAA" * 16
+        key = b"\xaa" * 16
 
         enc1, mic1 = encrypt_security_key(0x11111111, key)
         enc2, mic2 = encrypt_security_key(0x22222222, key)
@@ -154,9 +154,7 @@ class TestEncryptDecryptSecurityKey:
     def test_invalid_link_key_length(self) -> None:
         """Link key must be exactly 16 bytes."""
         with pytest.raises(ValueError, match="16 bytes"):
-            encrypt_security_key(
-                0x12345678, b"\x00" * 16, link_key=b"\x00" * 15
-            )
+            encrypt_security_key(0x12345678, b"\x00" * 16, link_key=b"\x00" * 15)
 
     def test_invalid_mic_length(self) -> None:
         """MIC must be exactly 4 bytes for decrypt."""
@@ -228,15 +226,22 @@ class TestEncryptDecryptPayload:
         payload = b"\x20\x21\x22"
 
         output, mic = encrypt_payload(
-            source_id, frame_counter, key, payload,
+            source_id,
+            frame_counter,
+            key,
+            payload,
             SecurityLevel.FullFrameCounterAndMIC,
         )
 
         # Tamper with the payload
-        tampered = b"\xFF\x21\x22"
+        tampered = b"\xff\x21\x22"
         with pytest.raises(InvalidTag):
             decrypt_payload(
-                source_id, frame_counter, key, tampered, mic,
+                source_id,
+                frame_counter,
+                key,
+                tampered,
+                mic,
                 SecurityLevel.FullFrameCounterAndMIC,
             )
 
@@ -317,9 +322,7 @@ class TestEncryptDecryptPayload:
         )
 
         with pytest.raises(InvalidTag):
-            decrypt_payload(
-                source_id, 2, key, encrypted, mic, SecurityLevel.Encrypted
-            )
+            decrypt_payload(source_id, 2, key, encrypted, mic, SecurityLevel.Encrypted)
 
     def test_invalid_key_length(self) -> None:
         """Security key must be 16 bytes."""

--- a/tests/zgp/test_crypto.py
+++ b/tests/zgp/test_crypto.py
@@ -241,7 +241,7 @@ class TestEncryptDecryptPayload:
             )
 
     def test_short_frame_counter_and_mic(self) -> None:
-        """ShortFrameCounterAndMIC: auth-only with 4-byte MIC."""
+        """Reserved: auth-only with 4-byte MIC."""
         source_id = 0x55667788
         frame_counter = 0x00000010
         key = bytes(range(16))
@@ -252,7 +252,7 @@ class TestEncryptDecryptPayload:
             frame_counter,
             key,
             payload,
-            SecurityLevel.ShortFrameCounterAndMIC,
+            SecurityLevel.Reserved,
         )
         assert len(mic) == 4
         # Auth-only: payload must NOT be encrypted
@@ -264,7 +264,7 @@ class TestEncryptDecryptPayload:
             key,
             output,
             mic,
-            SecurityLevel.ShortFrameCounterAndMIC,
+            SecurityLevel.Reserved,
         )
         assert verified == payload
 

--- a/tests/zgp/test_crypto.py
+++ b/tests/zgp/test_crypto.py
@@ -1,0 +1,329 @@
+"""Tests for Green Power cryptographic primitives."""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from zigpy.zgp.crypto import (
+    build_nonce,
+    decrypt_payload,
+    decrypt_security_key,
+    encrypt_payload,
+    encrypt_security_key,
+)
+from zigpy.zgp.types import DEFAULT_GP_LINK_KEY, SecurityLevel
+
+
+class TestBuildNonce:
+    """Tests for nonce construction."""
+
+    def test_nonce_length(self) -> None:
+        """Nonce must always be 13 bytes."""
+        nonce = build_nonce(source_id=0x12345678, frame_counter=0x00000001)
+        assert len(nonce) == 13
+
+    def test_nonce_structure(self) -> None:
+        """Verify nonce byte layout: sourceID + sourceID + frameCounter + 0x05."""
+        nonce = build_nonce(source_id=0x01020304, frame_counter=0x05060708)
+
+        # Source ID (little-endian): 04 03 02 01
+        assert nonce[0:4] == b"\x04\x03\x02\x01"
+        # Source ID repeated: 04 03 02 01
+        assert nonce[4:8] == b"\x04\x03\x02\x01"
+        # Frame counter (little-endian): 08 07 06 05
+        assert nonce[8:12] == b"\x08\x07\x06\x05"
+        # Security control byte
+        assert nonce[12] == 0x05
+
+    def test_nonce_zero_values(self) -> None:
+        """Nonce with zero sourceID and frameCounter."""
+        nonce = build_nonce(source_id=0, frame_counter=0)
+        assert nonce == b"\x00" * 8 + b"\x00" * 4 + b"\x05"
+
+    def test_nonce_max_values(self) -> None:
+        """Nonce with maximum 32-bit values."""
+        nonce = build_nonce(source_id=0xFFFFFFFF, frame_counter=0xFFFFFFFF)
+        assert nonce[0:4] == b"\xFF\xFF\xFF\xFF"
+        assert nonce[4:8] == b"\xFF\xFF\xFF\xFF"
+        assert nonce[8:12] == b"\xFF\xFF\xFF\xFF"
+        assert nonce[12] == 0x05
+
+
+class TestEncryptDecryptSecurityKey:
+    """Tests for security key encryption/decryption round-trips."""
+
+    def test_encrypt_decrypt_roundtrip(self) -> None:
+        """Encrypting then decrypting should return the original key."""
+        source_id = 0x12345678
+        original_key = bytes(range(16))
+
+        encrypted_key, mic = encrypt_security_key(source_id, original_key)
+        decrypted_key = decrypt_security_key(source_id, encrypted_key, mic)
+
+        assert decrypted_key == original_key
+
+    def test_encrypt_produces_different_output(self) -> None:
+        """Encrypted key should differ from plaintext."""
+        source_id = 0xAABBCCDD
+        original_key = b"\x01" * 16
+
+        encrypted_key, mic = encrypt_security_key(source_id, original_key)
+
+        # The encrypted key should be different from the original
+        assert encrypted_key != original_key
+        # MIC should be 4 bytes
+        assert len(mic) == 4
+
+    def test_encrypted_key_length(self) -> None:
+        """Encrypted key should be 16 bytes, MIC should be 4 bytes."""
+        source_id = 0x11223344
+        key = bytes(range(16))
+
+        encrypted_key, mic = encrypt_security_key(source_id, key)
+
+        assert len(encrypted_key) == 16
+        assert len(mic) == 4
+
+    def test_different_source_ids_produce_different_ciphertext(self) -> None:
+        """Different sourceIDs should produce different encrypted keys."""
+        key = b"\xAA" * 16
+
+        enc1, mic1 = encrypt_security_key(0x11111111, key)
+        enc2, mic2 = encrypt_security_key(0x22222222, key)
+
+        assert enc1 != enc2 or mic1 != mic2
+
+    def test_decrypt_with_wrong_mic_fails(self) -> None:
+        """Decryption with tampered MIC should raise InvalidTag."""
+        source_id = 0x12345678
+        key = bytes(range(16))
+
+        encrypted_key, mic = encrypt_security_key(source_id, key)
+
+        # Tamper with MIC
+        bad_mic = bytes((b + 1) & 0xFF for b in mic)
+        with pytest.raises(InvalidTag):
+            decrypt_security_key(source_id, encrypted_key, bad_mic)
+
+    def test_decrypt_with_wrong_source_id_fails(self) -> None:
+        """Decryption with wrong sourceID should raise InvalidTag."""
+        key = bytes(range(16))
+
+        encrypted_key, mic = encrypt_security_key(0x12345678, key)
+
+        with pytest.raises(InvalidTag):
+            decrypt_security_key(0x87654321, encrypted_key, mic)
+
+    def test_custom_link_key(self) -> None:
+        """Encryption with custom link key should work for round-trip."""
+        source_id = 0xDEADBEEF
+        security_key = b"\x42" * 16
+        custom_link_key = b"\x55" * 16
+
+        encrypted, mic = encrypt_security_key(
+            source_id, security_key, link_key=custom_link_key
+        )
+        decrypted = decrypt_security_key(
+            source_id, encrypted, mic, link_key=custom_link_key
+        )
+
+        assert decrypted == security_key
+
+    def test_custom_link_key_incompatible_with_default(self) -> None:
+        """Key encrypted with custom link key can't be decrypted with default."""
+        source_id = 0xDEADBEEF
+        security_key = b"\x42" * 16
+        custom_link_key = b"\x55" * 16
+
+        encrypted, mic = encrypt_security_key(
+            source_id, security_key, link_key=custom_link_key
+        )
+
+        with pytest.raises(InvalidTag):
+            decrypt_security_key(source_id, encrypted, mic)  # default link key
+
+    def test_invalid_key_length(self) -> None:
+        """Keys must be exactly 16 bytes."""
+        with pytest.raises(ValueError, match="16 bytes"):
+            encrypt_security_key(0x12345678, b"\x00" * 15)
+
+        with pytest.raises(ValueError, match="16 bytes"):
+            encrypt_security_key(0x12345678, b"\x00" * 17)
+
+    def test_invalid_link_key_length(self) -> None:
+        """Link key must be exactly 16 bytes."""
+        with pytest.raises(ValueError, match="16 bytes"):
+            encrypt_security_key(
+                0x12345678, b"\x00" * 16, link_key=b"\x00" * 15
+            )
+
+    def test_invalid_mic_length(self) -> None:
+        """MIC must be exactly 4 bytes for decrypt."""
+        with pytest.raises(ValueError, match="4 bytes"):
+            decrypt_security_key(0x12345678, b"\x00" * 16, b"\x00" * 3)
+
+    def test_invalid_encrypted_key_length(self) -> None:
+        """Encrypted key must be 16 bytes for decrypt."""
+        with pytest.raises(ValueError, match="16 bytes"):
+            decrypt_security_key(0x12345678, b"\x00" * 15, b"\x00" * 4)
+
+
+class TestEncryptDecryptPayload:
+    """Tests for GP frame payload encryption/decryption."""
+
+    def test_encrypted_roundtrip(self) -> None:
+        """Full encryption round-trip (SecurityLevel.Encrypted)."""
+        source_id = 0xAABBCCDD
+        frame_counter = 0x00000042
+        key = bytes(range(16))
+        payload = b"Hello GP!"
+
+        encrypted, mic = encrypt_payload(
+            source_id, frame_counter, key, payload, SecurityLevel.Encrypted
+        )
+        decrypted = decrypt_payload(
+            source_id, frame_counter, key, encrypted, mic, SecurityLevel.Encrypted
+        )
+
+        assert decrypted == payload
+
+    def test_full_frame_counter_and_mic_roundtrip(self) -> None:
+        """Authentication-only round-trip (FullFrameCounterAndMIC)."""
+        source_id = 0x11223344
+        frame_counter = 0x00000001
+        key = bytes(range(16))
+        payload = b"\x20"  # Toggle command
+
+        encrypted, mic = encrypt_payload(
+            source_id,
+            frame_counter,
+            key,
+            payload,
+            SecurityLevel.FullFrameCounterAndMIC,
+        )
+        # For auth-only, encrypted == original payload (no encryption, only MIC)
+        assert len(mic) == 4
+
+        decrypted = decrypt_payload(
+            source_id,
+            frame_counter,
+            key,
+            encrypted,
+            mic,
+            SecurityLevel.FullFrameCounterAndMIC,
+        )
+        assert decrypted == payload
+
+    def test_short_frame_counter_and_mic(self) -> None:
+        """ShortFrameCounterAndMIC uses 4-byte MIC (same as Full)."""
+        source_id = 0x55667788
+        frame_counter = 0x00000010
+        key = bytes(range(16))
+        payload = b"\x22"  # Toggle
+
+        encrypted, mic = encrypt_payload(
+            source_id,
+            frame_counter,
+            key,
+            payload,
+            SecurityLevel.ShortFrameCounterAndMIC,
+        )
+        assert len(mic) == 4
+
+        decrypted = decrypt_payload(
+            source_id,
+            frame_counter,
+            key,
+            encrypted,
+            mic,
+            SecurityLevel.ShortFrameCounterAndMIC,
+        )
+        assert decrypted == payload
+
+    def test_no_security_encrypt_raises(self) -> None:
+        """Cannot encrypt with NoSecurity level."""
+        with pytest.raises(ValueError, match="NoSecurity"):
+            encrypt_payload(
+                0x12345678, 0, bytes(range(16)), b"test", SecurityLevel.NoSecurity
+            )
+
+    def test_no_security_decrypt_raises(self) -> None:
+        """Cannot decrypt with NoSecurity level."""
+        with pytest.raises(ValueError, match="NoSecurity"):
+            decrypt_payload(
+                0x12345678, 0, bytes(range(16)), b"test", b"", SecurityLevel.NoSecurity
+            )
+
+    def test_tampered_payload_fails(self) -> None:
+        """Tampered ciphertext should cause decryption failure."""
+        source_id = 0xDEADBEEF
+        frame_counter = 1
+        key = bytes(range(16))
+        payload = b"secret data here"
+
+        encrypted, mic = encrypt_payload(
+            source_id, frame_counter, key, payload, SecurityLevel.Encrypted
+        )
+
+        # Tamper with encrypted payload
+        tampered = bytearray(encrypted)
+        tampered[0] ^= 0xFF
+        with pytest.raises(InvalidTag):
+            decrypt_payload(
+                source_id,
+                frame_counter,
+                key,
+                bytes(tampered),
+                mic,
+                SecurityLevel.Encrypted,
+            )
+
+    def test_wrong_frame_counter_fails(self) -> None:
+        """Decryption with wrong frame counter should fail."""
+        source_id = 0xDEADBEEF
+        key = bytes(range(16))
+        payload = b"test"
+
+        encrypted, mic = encrypt_payload(
+            source_id, 1, key, payload, SecurityLevel.Encrypted
+        )
+
+        with pytest.raises(InvalidTag):
+            decrypt_payload(
+                source_id, 2, key, encrypted, mic, SecurityLevel.Encrypted
+            )
+
+    def test_invalid_key_length(self) -> None:
+        """Security key must be 16 bytes."""
+        with pytest.raises(ValueError, match="16 bytes"):
+            encrypt_payload(0, 0, b"\x00" * 15, b"test", SecurityLevel.Encrypted)
+
+    def test_wrong_mic_length(self) -> None:
+        """MIC length must match security level."""
+        with pytest.raises(ValueError, match="4 bytes"):
+            decrypt_payload(
+                0, 0, bytes(range(16)), b"test", b"\x00" * 2, SecurityLevel.Encrypted
+            )
+
+    def test_empty_payload_encrypted(self) -> None:
+        """Empty payload encryption should work."""
+        source_id = 0x12345678
+        key = bytes(range(16))
+
+        encrypted, mic = encrypt_payload(
+            source_id, 0, key, b"", SecurityLevel.Encrypted
+        )
+        decrypted = decrypt_payload(
+            source_id, 0, key, encrypted, mic, SecurityLevel.Encrypted
+        )
+        assert decrypted == b""
+
+
+class TestDefaultLinkKey:
+    """Tests for the default GP link key constant."""
+
+    def test_default_link_key_is_zigbee_alliance(self) -> None:
+        """Default GP link key should be 'ZigBeeAlliance09' in ASCII."""
+        assert DEFAULT_GP_LINK_KEY == b"ZigBeeAlliance09"
+        assert len(DEFAULT_GP_LINK_KEY) == 16

--- a/tests/zgp/test_crypto.py
+++ b/tests/zgp/test_crypto.py
@@ -357,3 +357,103 @@ class TestDefaultLinkKey:
         """Default GP link key should be 'ZigBeeAlliance09' in ASCII."""
         assert DEFAULT_GP_LINK_KEY == b"ZigBeeAlliance09"
         assert len(DEFAULT_GP_LINK_KEY) == 16
+
+
+class TestKnownAnswerVectors:
+    """Known-answer tests using independently computed reference values.
+
+    These vectors were generated using raw AESCCM calls with manually
+    constructed nonces (not via build_nonce/encrypt_security_key), then
+    cross-validated against the implementation. They ensure the crypto
+    output matches expected ciphertext, not just round-trip consistency.
+
+    Nonce structure per ZGP spec A.1.5.4.1:
+    - Key encryption: sourceID(LE) + sourceID(LE) + sourceID(LE) + 0x05
+    - Payload crypto: sourceID(LE) + sourceID(LE) + frameCounter(LE) + 0x05
+    """
+
+    def test_key_encryption_known_vector(self) -> None:
+        """Verify key encryption against independently computed values.
+
+        sourceID=0x12345678, link_key=ZigBeeAlliance09, plaintext=00..0F
+        nonce=78563412785634127856341205
+        """
+        encrypted, mic = encrypt_security_key(
+            source_id=0x12345678, security_key=bytes(range(16))
+        )
+        assert encrypted == bytes.fromhex("bdd7bb125e603d6670d7c3a5471ce6c0")
+        assert mic == bytes.fromhex("d8b031bc")
+
+    def test_key_decryption_known_vector(self) -> None:
+        """Verify key decryption matches the known plaintext."""
+        decrypted = decrypt_security_key(
+            source_id=0x12345678,
+            encrypted_key=bytes.fromhex("bdd7bb125e603d6670d7c3a5471ce6c0"),
+            mic=bytes.fromhex("d8b031bc"),
+        )
+        assert decrypted == bytes(range(16))
+
+    def test_payload_encryption_known_vector(self) -> None:
+        """Verify payload encryption (SecurityLevel.Encrypted) against known values.
+
+        sourceID=0x87654321, frameCounter=0x42, key=C0..CF, payload=0x20
+        nonce=21436587214365874200000005
+        """
+        encrypted, mic = encrypt_payload(
+            source_id=0x87654321,
+            frame_counter=0x42,
+            security_key=bytes(0xC0 + i for i in range(16)),
+            payload=bytes([0x20]),
+            security_level=SecurityLevel.Encrypted,
+        )
+        assert encrypted == bytes.fromhex("dd")
+        assert mic == bytes.fromhex("a4493107")
+
+    def test_payload_decryption_known_vector(self) -> None:
+        """Verify payload decryption matches the known plaintext."""
+        decrypted = decrypt_payload(
+            source_id=0x87654321,
+            frame_counter=0x42,
+            security_key=bytes(0xC0 + i for i in range(16)),
+            payload=bytes.fromhex("dd"),
+            mic=bytes.fromhex("a4493107"),
+            security_level=SecurityLevel.Encrypted,
+        )
+        assert decrypted == bytes([0x20])
+
+    def test_auth_only_known_vector(self) -> None:
+        """Verify auth-only MIC against independently computed value.
+
+        sourceID=0x11223344, frameCounter=1, key=00..0F, payload=0x20
+        nonce=44332211443322110100000005
+        Payload must NOT be encrypted (auth-only).
+        """
+        output, mic = encrypt_payload(
+            source_id=0x11223344,
+            frame_counter=1,
+            security_key=bytes(range(16)),
+            payload=bytes([0x20]),
+            security_level=SecurityLevel.FullFrameCounterAndMIC,
+        )
+        assert output == bytes([0x20])  # unchanged, not encrypted
+        assert mic == bytes.fromhex("49342b82")
+
+    def test_auth_only_verification_known_vector(self) -> None:
+        """Verify MIC check passes for known auth-only payload."""
+        verified = decrypt_payload(
+            source_id=0x11223344,
+            frame_counter=1,
+            security_key=bytes(range(16)),
+            payload=bytes([0x20]),
+            mic=bytes.fromhex("49342b82"),
+            security_level=SecurityLevel.FullFrameCounterAndMIC,
+        )
+        assert verified == bytes([0x20])
+
+    def test_nonce_known_vector(self) -> None:
+        """Verify nonce construction against manually computed value.
+
+        Per ZGP spec A.1.5.4.1, security control byte = 0x05.
+        """
+        nonce = build_nonce(source_id=0x12345678, frame_counter=0x42)
+        assert nonce == bytes.fromhex("78563412785634124200000005")

--- a/tests/zgp/test_crypto.py
+++ b/tests/zgp/test_crypto.py
@@ -189,40 +189,65 @@ class TestEncryptDecryptPayload:
         assert decrypted == payload
 
     def test_full_frame_counter_and_mic_roundtrip(self) -> None:
-        """Authentication-only round-trip (FullFrameCounterAndMIC)."""
+        """Authentication-only round-trip (FullFrameCounterAndMIC).
+
+        Per ZGP spec, this level authenticates without encrypting:
+        the payload remains in cleartext and only a MIC is appended.
+        """
         source_id = 0x11223344
         frame_counter = 0x00000001
         key = bytes(range(16))
         payload = b"\x20"  # Toggle command
 
-        encrypted, mic = encrypt_payload(
+        output, mic = encrypt_payload(
             source_id,
             frame_counter,
             key,
             payload,
             SecurityLevel.FullFrameCounterAndMIC,
         )
-        # For auth-only, encrypted == original payload (no encryption, only MIC)
         assert len(mic) == 4
+        # Auth-only: output payload must be identical to input (NOT encrypted)
+        assert output == payload
 
-        decrypted = decrypt_payload(
+        verified = decrypt_payload(
             source_id,
             frame_counter,
             key,
-            encrypted,
+            output,
             mic,
             SecurityLevel.FullFrameCounterAndMIC,
         )
-        assert decrypted == payload
+        assert verified == payload
+
+    def test_full_frame_counter_and_mic_tampered(self) -> None:
+        """Tampered payload should fail MIC verification in auth-only mode."""
+        source_id = 0x11223344
+        frame_counter = 0x00000001
+        key = bytes(range(16))
+        payload = b"\x20\x21\x22"
+
+        output, mic = encrypt_payload(
+            source_id, frame_counter, key, payload,
+            SecurityLevel.FullFrameCounterAndMIC,
+        )
+
+        # Tamper with the payload
+        tampered = b"\xFF\x21\x22"
+        with pytest.raises(InvalidTag):
+            decrypt_payload(
+                source_id, frame_counter, key, tampered, mic,
+                SecurityLevel.FullFrameCounterAndMIC,
+            )
 
     def test_short_frame_counter_and_mic(self) -> None:
-        """ShortFrameCounterAndMIC uses 4-byte MIC (same as Full)."""
+        """ShortFrameCounterAndMIC: auth-only with 4-byte MIC."""
         source_id = 0x55667788
         frame_counter = 0x00000010
         key = bytes(range(16))
         payload = b"\x22"  # Toggle
 
-        encrypted, mic = encrypt_payload(
+        output, mic = encrypt_payload(
             source_id,
             frame_counter,
             key,
@@ -230,16 +255,18 @@ class TestEncryptDecryptPayload:
             SecurityLevel.ShortFrameCounterAndMIC,
         )
         assert len(mic) == 4
+        # Auth-only: payload must NOT be encrypted
+        assert output == payload
 
-        decrypted = decrypt_payload(
+        verified = decrypt_payload(
             source_id,
             frame_counter,
             key,
-            encrypted,
+            output,
             mic,
             SecurityLevel.ShortFrameCounterAndMIC,
         )
-        assert decrypted == payload
+        assert verified == payload
 
     def test_no_security_encrypt_raises(self) -> None:
         """Cannot encrypt with NoSecurity level."""

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -255,6 +255,8 @@ class TestGPDeviceRepr:
             security_level=SecurityLevel.Encrypted,
         )
         r = repr(dev)
-        assert "0x12345678" in r.upper() or "12345678" in r.upper()
+        assert r.startswith("<GPDevice")
+        assert r.endswith(">")
+        assert "12345678" in r.upper()
         assert "GreenPower_2" in r
         assert "Encrypted" in r

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 import zigpy.types as t
 
@@ -33,7 +32,7 @@ class TestSourceIdToIeee:
     def test_max_source_id(self) -> None:
         ieee = source_id_to_ieee(0xFFFFFFFF)
         ieee_bytes = bytes(ieee)
-        assert ieee_bytes[:4] == b"\xFF\xFF\xFF\xFF"
+        assert ieee_bytes[:4] == b"\xff\xff\xff\xff"
         assert ieee_bytes[4:] == GP_IEEE_SUFFIX
 
     def test_returns_eui64(self) -> None:
@@ -184,7 +183,7 @@ class TestGPDeviceSerialization:
         dev = GPDevice(
             source_id=0x12345678,
             device_id=0x02,
-            security_key=b"\xAA" * 16,
+            security_key=b"\xaa" * 16,
             frame_counter=100,
         )
         data = dev.as_dict()
@@ -220,7 +219,6 @@ class TestGPDeviceSerialization:
 
     def test_last_seen_roundtrip(self) -> None:
         """last_seen should survive serialization/deserialization."""
-        from datetime import UTC, datetime
 
         dev = GPDevice(source_id=0x12345678, device_id=0x02)
         dev.update_frame_counter(1)  # sets last_seen

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -216,6 +216,35 @@ class TestGPDeviceSerialization:
         assert dev.gpd_commands == []
         assert dev.server_clusters == []
         assert dev.client_clusters == []
+        assert dev.last_seen is None
+
+    def test_last_seen_roundtrip(self) -> None:
+        """last_seen should survive serialization/deserialization."""
+        from datetime import UTC, datetime
+
+        dev = GPDevice(source_id=0x12345678, device_id=0x02)
+        dev.update_frame_counter(1)  # sets last_seen
+        assert dev.last_seen is not None
+
+        data = dev.as_dict()
+        assert data["last_seen"] is not None
+        assert isinstance(data["last_seen"], str)
+
+        restored = GPDevice.from_dict(data)
+        assert restored.last_seen is not None
+        # Compare with microsecond tolerance (ISO 8601 roundtrip)
+        assert abs((restored.last_seen - dev.last_seen).total_seconds()) < 0.001
+
+    def test_last_seen_none_roundtrip(self) -> None:
+        """None last_seen should survive serialization."""
+        dev = GPDevice(source_id=0x12345678, device_id=0x02)
+        assert dev.last_seen is None
+
+        data = dev.as_dict()
+        assert data["last_seen"] is None
+
+        restored = GPDevice.from_dict(data)
+        assert restored.last_seen is None
 
 
 class TestGPDeviceRepr:

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -1,0 +1,233 @@
+"""Tests for Green Power Device model."""
+
+from __future__ import annotations
+
+import pytest
+
+import zigpy.types as t
+
+from zigpy.zgp.device import (
+    GP_IEEE_SUFFIX,
+    GPDevice,
+    ieee_to_source_id,
+    source_id_to_ieee,
+)
+from zigpy.zgp.types import SecurityKeyType, SecurityLevel
+
+
+class TestSourceIdToIeee:
+    """Tests for sourceID to IEEE conversion."""
+
+    def test_basic_conversion(self) -> None:
+        """SourceID should be stored in lower 4 bytes (LE)."""
+        ieee = source_id_to_ieee(0x12345678)
+        ieee_bytes = bytes(ieee)
+        assert ieee_bytes[:4] == b"\x78\x56\x34\x12"
+        assert ieee_bytes[4:] == GP_IEEE_SUFFIX
+
+    def test_zero_source_id(self) -> None:
+        ieee = source_id_to_ieee(0)
+        ieee_bytes = bytes(ieee)
+        assert ieee_bytes == b"\x00" * 8
+
+    def test_max_source_id(self) -> None:
+        ieee = source_id_to_ieee(0xFFFFFFFF)
+        ieee_bytes = bytes(ieee)
+        assert ieee_bytes[:4] == b"\xFF\xFF\xFF\xFF"
+        assert ieee_bytes[4:] == GP_IEEE_SUFFIX
+
+    def test_returns_eui64(self) -> None:
+        ieee = source_id_to_ieee(0x12345678)
+        assert isinstance(ieee, t.EUI64)
+        assert len(ieee) == 8
+
+    def test_deterministic(self) -> None:
+        """Same sourceID should always produce same IEEE."""
+        assert source_id_to_ieee(0xAABBCCDD) == source_id_to_ieee(0xAABBCCDD)
+
+    def test_different_source_ids_different_ieee(self) -> None:
+        assert source_id_to_ieee(0x11111111) != source_id_to_ieee(0x22222222)
+
+
+class TestIeeeToSourceId:
+    """Tests for IEEE to sourceID reverse conversion."""
+
+    def test_roundtrip(self) -> None:
+        """Converting sourceID → IEEE → sourceID should be identity."""
+        original = 0x12345678
+        ieee = source_id_to_ieee(original)
+        result = ieee_to_source_id(ieee)
+        assert result == original
+
+    def test_non_gp_ieee_returns_none(self) -> None:
+        """Real IEEE addresses should return None."""
+        real_ieee = t.EUI64.convert("00:11:22:33:44:55:66:77")
+        assert ieee_to_source_id(real_ieee) is None
+
+    def test_zero_roundtrip(self) -> None:
+        ieee = source_id_to_ieee(0)
+        assert ieee_to_source_id(ieee) == 0
+
+    def test_max_roundtrip(self) -> None:
+        ieee = source_id_to_ieee(0xFFFFFFFF)
+        assert ieee_to_source_id(ieee) == 0xFFFFFFFF
+
+
+class TestGPDevice:
+    """Tests for GPDevice model."""
+
+    def test_creation(self) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02)
+        assert dev.source_id == 0x12345678
+        assert dev.device_id == 0x02
+        assert dev.security_level == SecurityLevel.NoSecurity
+        assert dev.security_key is None
+        assert dev.frame_counter == 0
+
+    def test_ieee_property(self) -> None:
+        dev = GPDevice(source_id=0xAABBCCDD, device_id=0x02)
+        expected = source_id_to_ieee(0xAABBCCDD)
+        assert dev.ieee == expected
+
+    def test_model_identifier(self) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02)
+        assert dev.model_identifier == "GreenPower_2"
+
+        dev2 = GPDevice(source_id=0x12345678, device_id=0x07)
+        assert dev2.model_identifier == "GreenPower_7"
+
+        dev3 = GPDevice(source_id=0x12345678, device_id=254)
+        assert dev3.model_identifier == "GreenPower_254"
+
+    def test_update_frame_counter_accepts_higher(self) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02, frame_counter=10)
+        assert dev.update_frame_counter(11) is True
+        assert dev.frame_counter == 11
+        assert dev.last_seen is not None
+
+    def test_update_frame_counter_rejects_same(self) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02, frame_counter=10)
+        assert dev.update_frame_counter(10) is False
+        assert dev.frame_counter == 10
+
+    def test_update_frame_counter_rejects_lower(self) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02, frame_counter=10)
+        assert dev.update_frame_counter(5) is False
+        assert dev.frame_counter == 10
+
+    def test_update_frame_counter_rejects_zero(self) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02, frame_counter=1)
+        assert dev.update_frame_counter(0) is False
+
+    def test_update_frame_counter_sequential(self) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02, frame_counter=0)
+        assert dev.update_frame_counter(1) is True
+        assert dev.update_frame_counter(2) is True
+        assert dev.update_frame_counter(100) is True
+        assert dev.update_frame_counter(100) is False
+        assert dev.update_frame_counter(99) is False
+        assert dev.update_frame_counter(101) is True
+        assert dev.frame_counter == 101
+
+
+class TestGPDeviceSerialization:
+    """Tests for GPDevice serialization/deserialization."""
+
+    def test_minimal_roundtrip(self) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02)
+        data = dev.as_dict()
+        restored = GPDevice.from_dict(data)
+
+        assert restored.source_id == dev.source_id
+        assert restored.device_id == dev.device_id
+        assert restored.security_level == SecurityLevel.NoSecurity
+        assert restored.security_key is None
+        assert restored.frame_counter == 0
+
+    def test_full_roundtrip(self) -> None:
+        dev = GPDevice(
+            source_id=0xAABBCCDD,
+            device_id=0x07,
+            security_key=bytes(range(16)),
+            security_level=SecurityLevel.Encrypted,
+            security_key_type=SecurityKeyType.IndividualKey,
+            frame_counter=42,
+            manufacturer_id=0x1021,
+            model_id=0x0002,
+            gpd_commands=[0x20, 0x21, 0x22],
+            server_clusters=[0x0006, 0x0008],
+            client_clusters=[0x0300],
+            mac_seq_num_capability=True,
+            rx_on_capability=True,
+            fixed_location=False,
+        )
+
+        data = dev.as_dict()
+        restored = GPDevice.from_dict(data)
+
+        assert restored.source_id == 0xAABBCCDD
+        assert restored.device_id == 0x07
+        assert restored.security_key == bytes(range(16))
+        assert restored.security_level == SecurityLevel.Encrypted
+        assert restored.security_key_type == SecurityKeyType.IndividualKey
+        assert restored.frame_counter == 42
+        assert restored.manufacturer_id == 0x1021
+        assert restored.model_id == 0x0002
+        assert restored.gpd_commands == [0x20, 0x21, 0x22]
+        assert restored.server_clusters == [0x0006, 0x0008]
+        assert restored.client_clusters == [0x0300]
+        assert restored.mac_seq_num_capability is True
+        assert restored.rx_on_capability is True
+        assert restored.fixed_location is False
+
+    def test_serialization_format(self) -> None:
+        dev = GPDevice(
+            source_id=0x12345678,
+            device_id=0x02,
+            security_key=b"\xAA" * 16,
+            frame_counter=100,
+        )
+        data = dev.as_dict()
+
+        assert data["source_id"] == 0x12345678
+        assert data["device_id"] == 0x02
+        assert data["security_key"] == "aa" * 16
+        assert data["frame_counter"] == 100
+
+    def test_none_security_key_serialization(self) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02)
+        data = dev.as_dict()
+        assert data["security_key"] is None
+
+        restored = GPDevice.from_dict(data)
+        assert restored.security_key is None
+
+    def test_missing_optional_fields(self) -> None:
+        """from_dict should handle missing optional fields gracefully."""
+        data = {
+            "source_id": 0x12345678,
+            "device_id": 0x02,
+        }
+        dev = GPDevice.from_dict(data)
+        assert dev.source_id == 0x12345678
+        assert dev.device_id == 0x02
+        assert dev.security_key is None
+        assert dev.frame_counter == 0
+        assert dev.gpd_commands == []
+        assert dev.server_clusters == []
+        assert dev.client_clusters == []
+
+
+class TestGPDeviceRepr:
+    """Tests for GPDevice string representation."""
+
+    def test_repr(self) -> None:
+        dev = GPDevice(
+            source_id=0x12345678,
+            device_id=0x02,
+            security_level=SecurityLevel.Encrypted,
+        )
+        r = repr(dev)
+        assert "0x12345678" in r.upper() or "12345678" in r.upper()
+        assert "GreenPower_2" in r
+        assert "Encrypted" in r

--- a/tests/zgp/test_e2e.py
+++ b/tests/zgp/test_e2e.py
@@ -7,8 +7,6 @@ events fire correctly and state is maintained throughout.
 
 from __future__ import annotations
 
-import struct
-from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -18,8 +16,7 @@ from zigpy.zcl.clusters.greenpower import (
     NotificationSchema,
 )
 import zigpy.zgp.types as zgptypes
-from zigpy.zgp.device import GPDevice, source_id_to_ieee
-from zigpy.zgp.manager import GreenPowerManager
+from zigpy.zgp.device import GPDevice
 from zigpy.zgp.types import (
     GP_CLUSTER_ID,
     GP_ENDPOINT,
@@ -220,6 +217,7 @@ class TestPacketReceivedE2E:
 
         # Let the async task run
         import asyncio
+
         await asyncio.sleep(0.05)
 
         # gp_command_received should have been fired
@@ -253,6 +251,7 @@ class TestPacketReceivedE2E:
         app.packet_received(packet)
 
         import asyncio
+
         await asyncio.sleep(0.05)
 
         app.listener_event.assert_any_call(
@@ -315,9 +314,7 @@ class TestReplayProtectionE2E:
 
         # Send 5 sequential commands
         for i in range(1, 6):
-            await gp._dispatch_gp_command(
-                source_id, i, GPDCommandID.Toggle, b""
-            )
+            await gp._dispatch_gp_command(source_id, i, GPDCommandID.Toggle, b"")
 
         assert len(commands_received) == 5
         assert dev.frame_counter == 5
@@ -346,6 +343,7 @@ class TestProxyTableE2E:
         app.packet_received(packet)
 
         import asyncio
+
         await asyncio.sleep(0.05)
 
         # Proxy should be tracked

--- a/tests/zgp/test_e2e.py
+++ b/tests/zgp/test_e2e.py
@@ -1,0 +1,422 @@
+"""End-to-end tests for Green Power.
+
+Tests the complete GP flow through the real ControllerApplication:
+commissioning → command dispatch → decommissioning, verifying that
+events fire correctly and state is maintained throughout.
+"""
+
+from __future__ import annotations
+
+import struct
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import zigpy.types as t
+from zigpy.zcl.clusters.greenpower import (
+    NotificationOptions,
+    NotificationSchema,
+)
+import zigpy.zgp.types as zgptypes
+from zigpy.zgp.device import GPDevice, source_id_to_ieee
+from zigpy.zgp.manager import GreenPowerManager
+from zigpy.zgp.types import (
+    GP_CLUSTER_ID,
+    GP_ENDPOINT,
+    GPDCommandID,
+    SecurityLevel,
+)
+
+from tests.conftest import make_app
+
+
+def _build_gp_notification_zcl(
+    source_id: int,
+    command_id: int,
+    payload: bytes = b"",
+    frame_counter: int = 1,
+    security_level: zgptypes.SecurityLevel = zgptypes.SecurityLevel.NoSecurity,
+) -> bytes:
+    """Build raw ZCL bytes for a GP Notification (server command 0x00)."""
+    options = NotificationOptions(
+        application_id=zgptypes.ApplicationID.SrcID,
+        also_unicast=0,
+        also_derived_group=0,
+        also_commissioned_group=0,
+        security_level=security_level,
+        security_key_type=zgptypes.SecurityKeyType.NoKey,
+        appoint_temp_master=0,
+        tx_queue_full=0,
+        _reserved=0,
+    )
+    notification = NotificationSchema(
+        options=options,
+        gpd_id=zgptypes.DeviceID(source_id),
+        frame_counter=t.uint32_t(frame_counter),
+        command_id=t.uint8_t(command_id),
+        payload=t.LVBytes(payload),
+    )
+    # ZCL: frame_control(cluster-specific) + seq + cmd_id(0x00) + payload
+    return bytes([0x01, 0x00, 0x00]) + notification.serialize()
+
+
+def _make_packet(
+    zcl_data: bytes,
+    src_nwk: int = 0x1234,
+) -> t.ZigbeePacket:
+    """Wrap ZCL data in a ZigbeePacket targeting the GP endpoint."""
+    return t.ZigbeePacket(
+        src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(src_nwk)),
+        src_ep=t.uint8_t(GP_ENDPOINT),
+        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+        dst_ep=t.uint8_t(GP_ENDPOINT),
+        profile_id=t.uint16_t(0xA1E0),
+        cluster_id=t.uint16_t(GP_CLUSTER_ID),
+        data=t.SerializableBytes(zcl_data),
+    )
+
+
+@pytest.fixture
+def app():
+    """Real ControllerApplication with GP manager."""
+    return make_app({})
+
+
+class TestFullCommissioningFlow:
+    """Test complete commissioning → command → decommissioning lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_commission_receive_command_decommission(self, app) -> None:
+        """Full lifecycle: commission a GPD, receive a command, then decommission."""
+        gp = app.green_power
+        source_id = 0xAABBCCDD
+
+        # --- Step 1: Open commissioning window ---
+        await gp.permit_join(time_s=60)
+        assert gp.is_commissioning
+
+        # Verify ProxyCommissioningMode was broadcast
+        assert app.send_packet.call_count >= 1
+        sent = app.send_packet.call_args_list[0][0][0]
+        assert sent.cluster_id == GP_CLUSTER_ID
+        assert sent.dst_ep == GP_ENDPOINT
+        app.send_packet.reset_mock()
+
+        # --- Step 2: Receive commissioning command ---
+        # Minimal commissioning: device_id=0x02, options=0x00 (no security)
+        commissioning_payload = bytes([0x02, 0x00])
+        await gp._process_commissioning(
+            source_id=source_id,
+            frame_counter=1,
+            payload=commissioning_payload,
+        )
+
+        # Device should be registered
+        dev = gp.get_device(source_id)
+        assert dev is not None
+        assert dev.device_id == 0x02
+        assert dev.source_id == source_id
+        assert dev.model_identifier == "GreenPower_2"
+
+        # gp_device_joined event should have fired
+        app.listener_event.assert_any_call("gp_device_joined", dev)
+
+        # GP Pairing should have been sent
+        assert app.send_packet.call_count >= 1
+        app.send_packet.reset_mock()
+        app.listener_event.reset_mock()
+
+        # --- Step 3: Receive a Toggle command ---
+        await gp._dispatch_gp_command(
+            source_id=source_id,
+            frame_counter=2,
+            command_id=GPDCommandID.Toggle,
+            payload=b"",
+        )
+
+        app.listener_event.assert_called_with(
+            "gp_command_received",
+            dev,
+            GPDCommandID.Toggle,
+            b"",
+        )
+
+        # Frame counter should be updated
+        assert dev.frame_counter == 2
+        app.listener_event.reset_mock()
+
+        # --- Step 4: Decommission ---
+        await gp._process_decommissioning(source_id)
+
+        assert gp.get_device(source_id) is None
+        app.listener_event.assert_any_call("gp_device_left", dev)
+        # GP Pairing (remove) should be sent
+        assert app.send_packet.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_commission_with_security(self, app) -> None:
+        """Commissioning with unencrypted security key."""
+        gp = app.green_power
+        source_id = 0x11223344
+
+        await gp.permit_join(time_s=60)
+        app.send_packet.reset_mock()
+
+        security_key = bytes(range(16))
+        # options: extended present = 0x80
+        # extended: Encrypted + key_present = 0x03 | 0x20 = 0x23
+        comm_payload = bytes([0x07, 0x80, 0x23]) + security_key
+
+        await gp._process_commissioning(
+            source_id=source_id,
+            frame_counter=10,
+            payload=comm_payload,
+        )
+
+        dev = gp.get_device(source_id)
+        assert dev is not None
+        assert dev.device_id == 0x07
+        assert dev.security_key == security_key
+        assert dev.security_level == SecurityLevel.Encrypted
+        assert dev.model_identifier == "GreenPower_7"
+
+    @pytest.mark.asyncio
+    async def test_commissioning_rejected_when_window_closed(self, app) -> None:
+        """Commissioning should be rejected if window is not open."""
+        gp = app.green_power
+        assert not gp.is_commissioning
+
+        await gp._process_commissioning(
+            source_id=0xDEADBEEF,
+            frame_counter=1,
+            payload=bytes([0x02, 0x00]),
+        )
+
+        assert gp.get_device(0xDEADBEEF) is None
+
+
+class TestPacketReceivedE2E:
+    """Test GP packets flowing through ControllerApplication.packet_received()."""
+
+    @pytest.mark.asyncio
+    async def test_gp_notification_through_app(self, app) -> None:
+        """GP Notification routed through packet_received to GP manager."""
+        gp = app.green_power
+        source_id = 0x55667788
+
+        # Pre-register a device
+        dev = GPDevice(source_id=source_id, device_id=0x02, frame_counter=0)
+        gp.add_device(dev)
+
+        # Build and deliver a GP Notification packet with Toggle command
+        zcl_data = _build_gp_notification_zcl(
+            source_id=source_id,
+            command_id=GPDCommandID.Toggle,
+            frame_counter=1,
+        )
+        packet = _make_packet(zcl_data, src_nwk=0x1234)
+
+        app.packet_received(packet)
+
+        # Let the async task run
+        import asyncio
+        await asyncio.sleep(0.05)
+
+        # gp_command_received should have been fired
+        app.listener_event.assert_any_call(
+            "gp_command_received",
+            dev,
+            GPDCommandID.Toggle,
+            b"",
+        )
+
+        # Frame counter should be updated
+        assert dev.frame_counter == 1
+
+    @pytest.mark.asyncio
+    async def test_gp_packet_from_unknown_proxy(self, app) -> None:
+        """GP packets from unknown NWK addresses should still be processed."""
+        gp = app.green_power
+        source_id = 0x99887766
+
+        dev = GPDevice(source_id=source_id, device_id=0x02, frame_counter=0)
+        gp.add_device(dev)
+
+        zcl_data = _build_gp_notification_zcl(
+            source_id=source_id,
+            command_id=GPDCommandID.On,
+            frame_counter=1,
+        )
+        # Use an NWK address not in app.devices - this is the key test
+        packet = _make_packet(zcl_data, src_nwk=0x9999)
+
+        app.packet_received(packet)
+
+        import asyncio
+        await asyncio.sleep(0.05)
+
+        app.listener_event.assert_any_call(
+            "gp_command_received",
+            dev,
+            GPDCommandID.On,
+            b"",
+        )
+
+
+class TestReplayProtectionE2E:
+    """Test replay protection across the full stack."""
+
+    @pytest.mark.asyncio
+    async def test_replay_rejected(self, app) -> None:
+        """Replayed frames should be silently dropped."""
+        gp = app.green_power
+        source_id = 0x12345678
+
+        dev = GPDevice(source_id=source_id, device_id=0x02, frame_counter=10)
+        gp.add_device(dev)
+
+        # Send with counter=11 (accepted)
+        await gp._dispatch_gp_command(source_id, 11, GPDCommandID.Toggle, b"")
+        assert dev.frame_counter == 11
+        app.listener_event.assert_called()
+        app.listener_event.reset_mock()
+
+        # Send with counter=11 again (replay - rejected)
+        await gp._dispatch_gp_command(source_id, 11, GPDCommandID.Toggle, b"")
+        # listener should NOT have been called for gp_command_received
+        for call in app.listener_event.call_args_list:
+            assert call[0][0] != "gp_command_received"
+
+        # Send with counter=5 (old - rejected)
+        app.listener_event.reset_mock()
+        await gp._dispatch_gp_command(source_id, 5, GPDCommandID.Toggle, b"")
+        for call in app.listener_event.call_args_list:
+            assert call[0][0] != "gp_command_received"
+
+        # Counter should still be 11
+        assert dev.frame_counter == 11
+
+    @pytest.mark.asyncio
+    async def test_sequential_commands(self, app) -> None:
+        """Sequential commands with increasing counters should all be accepted."""
+        gp = app.green_power
+        source_id = 0xAAAABBBB
+
+        dev = GPDevice(source_id=source_id, device_id=0x02, frame_counter=0)
+        gp.add_device(dev)
+
+        commands_received = []
+
+        def track_event(event_name, *args):
+            if event_name == "gp_command_received":
+                commands_received.append(args)
+
+        app.listener_event.side_effect = track_event
+
+        # Send 5 sequential commands
+        for i in range(1, 6):
+            await gp._dispatch_gp_command(
+                source_id, i, GPDCommandID.Toggle, b""
+            )
+
+        assert len(commands_received) == 5
+        assert dev.frame_counter == 5
+
+
+class TestProxyTableE2E:
+    """Test proxy table tracking through the full flow."""
+
+    @pytest.mark.asyncio
+    async def test_proxy_tracked_on_notification(self, app) -> None:
+        """Proxy should be tracked when GP Notification is received."""
+        gp = app.green_power
+        source_id = 0xAABBCCDD
+        proxy_nwk = 0x1234
+
+        dev = GPDevice(source_id=source_id, device_id=0x02, frame_counter=0)
+        gp.add_device(dev)
+
+        # Simulate notification via the internal handler
+        zcl_data = _build_gp_notification_zcl(
+            source_id=source_id,
+            command_id=GPDCommandID.Toggle,
+            frame_counter=1,
+        )
+        packet = _make_packet(zcl_data, src_nwk=proxy_nwk)
+        app.packet_received(packet)
+
+        import asyncio
+        await asyncio.sleep(0.05)
+
+        # Proxy should be tracked
+        proxies = gp.proxy_table.get_proxies_for_device(source_id)
+        assert proxy_nwk in proxies
+
+    @pytest.mark.asyncio
+    async def test_proxy_table_cleaned_on_decommission(self, app) -> None:
+        """Proxy table entries should be removed when device is decommissioned."""
+        gp = app.green_power
+        source_id = 0x55667788
+
+        dev = GPDevice(source_id=source_id, device_id=0x02, frame_counter=0)
+        gp.add_device(dev)
+
+        # Add proxy entries manually
+        gp.proxy_table.add_or_update(source_id, 0x1111)
+        gp.proxy_table.add_or_update(source_id, 0x2222)
+        assert len(gp.proxy_table) == 2
+
+        # Decommission
+        await gp._process_decommissioning(source_id)
+
+        assert len(gp.proxy_table) == 0
+
+
+class TestPersistenceE2E:
+    """Test device persistence across save/load cycle."""
+
+    def test_persist_and_restore(self, app) -> None:
+        """Devices should survive a save/load cycle."""
+        gp = app.green_power
+
+        # Commission two devices
+        dev1 = GPDevice(
+            source_id=0x11111111,
+            device_id=0x02,
+            security_key=bytes(range(16)),
+            security_level=SecurityLevel.Encrypted,
+            frame_counter=42,
+            gpd_commands=[0x20, 0x21, 0x22],
+        )
+        dev2 = GPDevice(
+            source_id=0x22222222,
+            device_id=0x07,
+            frame_counter=100,
+        )
+        gp.add_device(dev1)
+        gp.add_device(dev2)
+
+        # Save
+        data = gp.get_devices_data()
+        assert len(data) == 2
+
+        # Create new manager (simulating restart)
+        app2 = make_app({})
+        gp2 = app2.green_power
+
+        # Load
+        gp2.load_devices(data)
+
+        # Verify
+        restored1 = gp2.get_device(0x11111111)
+        assert restored1 is not None
+        assert restored1.device_id == 0x02
+        assert restored1.security_key == bytes(range(16))
+        assert restored1.security_level == SecurityLevel.Encrypted
+        assert restored1.frame_counter == 42
+        assert restored1.gpd_commands == [0x20, 0x21, 0x22]
+
+        restored2 = gp2.get_device(0x22222222)
+        assert restored2 is not None
+        assert restored2.device_id == 0x07
+        assert restored2.frame_counter == 100

--- a/tests/zgp/test_frame.py
+++ b/tests/zgp/test_frame.py
@@ -167,11 +167,7 @@ class TestGPCommissioningPayload:
         # extended: Encrypted + key_present + key_encrypted = 0x03 | 0x20 | 0x40 = 0x63
         security_key = bytes(range(16))
         key_mic = 0xDEADBEEF
-        data = (
-            bytes([0x07, 0x80, 0x63])
-            + security_key
-            + struct.pack("<I", key_mic)
-        )
+        data = bytes([0x07, 0x80, 0x63]) + security_key + struct.pack("<I", key_mic)
         payload = GPCommissioningPayload.from_bytes(data)
 
         assert payload.device_id == 0x07
@@ -194,13 +190,9 @@ class TestGPCommissioningPayload:
     def test_with_key_and_counter(self) -> None:
         """Commissioning with both key and outgoing counter."""
         # extended: key_present + outgoing_counter_present = 0x20 | 0x80 = 0xA0
-        security_key = b"\xAA" * 16
+        security_key = b"\xaa" * 16
         counter = 0x00000042
-        data = (
-            bytes([0x02, 0x80, 0xA0])
-            + security_key
-            + struct.pack("<I", counter)
-        )
+        data = bytes([0x02, 0x80, 0xA0]) + security_key + struct.pack("<I", counter)
         payload = GPCommissioningPayload.from_bytes(data)
 
         assert payload.security_key == security_key
@@ -242,7 +234,9 @@ class TestGPCommissioningPayload:
 
         data = bytearray([0x02, 0x04, 0x08])
         # length byte: lower nibble = num_server, upper = num_client
-        data.append((len(server_clusters) & 0x0F) | ((len(client_clusters) & 0x0F) << 4))
+        data.append(
+            (len(server_clusters) & 0x0F) | ((len(client_clusters) & 0x0F) << 4)
+        )
         for c in server_clusters:
             data.extend(struct.pack("<H", c))
         for c in client_clusters:
@@ -255,7 +249,7 @@ class TestGPCommissioningPayload:
 
     def test_full_commissioning_payload(self) -> None:
         """Full commissioning with all optional fields."""
-        security_key = b"\xBB" * 16
+        security_key = b"\xbb" * 16
         key_mic = 0xCAFEBABE
         counter = 0x00000100
         manufacturer_id = 0x1021
@@ -304,7 +298,7 @@ class TestGPCommissioningPayload:
 
     def test_roundtrip_serialization(self) -> None:
         """Parsing and re-serializing should produce identical bytes."""
-        security_key = b"\xCC" * 16
+        security_key = b"\xcc" * 16
         data = bytes([0x02, 0x80, 0x23]) + security_key
         payload = GPCommissioningPayload.from_bytes(data)
         serialized = payload.to_bytes()
@@ -317,7 +311,7 @@ class TestGPCommissioningPayload:
         data.append(0x07)  # device_id
         data.append(0x84)  # options: extended (bit 7) + app_info (bit 2)
         data.append(0xA0)  # extended: key_present + outgoing_counter
-        data.extend(b"\xDD" * 16)  # security key
+        data.extend(b"\xdd" * 16)  # security key
         data.extend(struct.pack("<I", 0x00000099))  # outgoing counter
         data.append(0x04)  # app_info: gpd_commands
         data.append(len(commands))
@@ -349,7 +343,7 @@ class TestGPChannelRequestPayload:
 
     def test_channel_26(self) -> None:
         """Channel 26 = offset 15."""
-        payload = GPChannelRequestPayload.from_bytes(b"\xFF")
+        payload = GPChannelRequestPayload.from_bytes(b"\xff")
         assert payload.next_channel == 26
         assert payload.second_next_channel == 26
 

--- a/tests/zgp/test_frame.py
+++ b/tests/zgp/test_frame.py
@@ -33,24 +33,32 @@ class TestGPCommissioningOptions:
         assert opts.mac_seq_num_capability
 
     def test_rx_on_capability(self) -> None:
-        opts = GPCommissioningOptions(0x04)
+        opts = GPCommissioningOptions(0x02)  # bit 1
         assert opts.rx_on_capability
 
     def test_app_info_present(self) -> None:
-        opts = GPCommissioningOptions(0x08)
+        opts = GPCommissioningOptions(0x04)  # bit 2
         assert opts.app_info_present
 
     def test_pan_id_request(self) -> None:
-        opts = GPCommissioningOptions(0x20)
+        opts = GPCommissioningOptions(0x10)  # bit 4
         assert opts.pan_id_request
 
     def test_security_key_request(self) -> None:
-        opts = GPCommissioningOptions(0x40)
+        opts = GPCommissioningOptions(0x20)  # bit 5
         assert opts.security_key_request
 
+    def test_fixed_location(self) -> None:
+        opts = GPCommissioningOptions(0x40)  # bit 6
+        assert opts.fixed_location
+
+    def test_extended_options_present(self) -> None:
+        opts = GPCommissioningOptions(0x80)  # bit 7
+        assert bool(opts.raw & (1 << 7))
+
     def test_multiple_flags(self) -> None:
-        # MAC seq + RX on + App info
-        opts = GPCommissioningOptions(0x01 | 0x04 | 0x08)
+        # MAC seq (bit 0) + RX on (bit 1) + App info (bit 2)
+        opts = GPCommissioningOptions(0x01 | 0x02 | 0x04)
         assert opts.mac_seq_num_capability
         assert opts.rx_on_capability
         assert opts.app_info_present
@@ -200,12 +208,12 @@ class TestGPCommissioningPayload:
 
     def test_with_app_info_manufacturer_and_model(self) -> None:
         """Commissioning with application info: manufacturer and model ID."""
-        # options: app_info_present = 0x08
+        # options: app_info_present = bit 2 = 0x04
         # app_info: manufacturer_id + model_id = 0x01 | 0x02 = 0x03
         manufacturer_id = 0x1234
         model_id = 0x5678
         data = (
-            bytes([0x02, 0x08, 0x03])
+            bytes([0x02, 0x04, 0x03])
             + struct.pack("<H", manufacturer_id)
             + struct.pack("<H", model_id)
         )
@@ -217,22 +225,22 @@ class TestGPCommissioningPayload:
 
     def test_with_gpd_commands(self) -> None:
         """Commissioning with GPD command list."""
-        # options: app_info_present = 0x08
+        # options: app_info_present = bit 2 = 0x04
         # app_info: gpd_commands_present = 0x04
         commands = [0x20, 0x21, 0x22]  # Off, On, Toggle
-        data = bytes([0x02, 0x08, 0x04, len(commands)]) + bytes(commands)
+        data = bytes([0x02, 0x04, 0x04, len(commands)]) + bytes(commands)
         payload = GPCommissioningPayload.from_bytes(data)
 
         assert payload.gpd_commands == commands
 
     def test_with_cluster_list(self) -> None:
         """Commissioning with server and client cluster lists."""
-        # options: app_info_present = 0x08
+        # options: app_info_present = bit 2 = 0x04
         # app_info: cluster_list_present = 0x08
         server_clusters = [0x0006, 0x0008]  # On/Off, Level Control
         client_clusters = [0x0300]  # Color Control
 
-        data = bytearray([0x02, 0x08, 0x08])
+        data = bytearray([0x02, 0x04, 0x08])
         # length byte: lower nibble = num_server, upper = num_client
         data.append((len(server_clusters) & 0x0F) | ((len(client_clusters) & 0x0F) << 4))
         for c in server_clusters:
@@ -259,8 +267,8 @@ class TestGPCommissioningPayload:
         data = bytearray()
         # device_id=2
         data.append(0x02)
-        # options: extended + app_info = 0x80 | 0x08 = 0x88
-        data.append(0x88)
+        # options: extended (bit 7) + app_info (bit 2) = 0x80 | 0x04 = 0x84
+        data.append(0x84)
         # extended: Encrypted + key_present + key_encrypted + outgoing_counter
         # = 0x03 | 0x20 | 0x40 | 0x80 = 0xE3
         data.append(0xE3)
@@ -307,7 +315,7 @@ class TestGPCommissioningPayload:
         commands = [0x20, 0x21]
         data = bytearray()
         data.append(0x07)  # device_id
-        data.append(0x88)  # options: extended + app_info
+        data.append(0x84)  # options: extended (bit 7) + app_info (bit 2)
         data.append(0xA0)  # extended: key_present + outgoing_counter
         data.extend(b"\xDD" * 16)  # security key
         data.extend(struct.pack("<I", 0x00000099))  # outgoing counter

--- a/tests/zgp/test_frame.py
+++ b/tests/zgp/test_frame.py
@@ -1,0 +1,359 @@
+"""Tests for Green Power frame parsing."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from zigpy.zgp.frame import (
+    GPChannelRequestPayload,
+    GPCommissioningAppInfo,
+    GPCommissioningExtendedOptions,
+    GPCommissioningOptions,
+    GPCommissioningPayload,
+)
+from zigpy.zgp.types import SecurityKeyType, SecurityLevel
+
+
+class TestGPCommissioningOptions:
+    """Tests for commissioning options byte parsing."""
+
+    def test_all_bits_clear(self) -> None:
+        opts = GPCommissioningOptions(0x00)
+        assert not opts.mac_seq_num_capability
+        assert not opts.rx_on_capability
+        assert not opts.app_info_present
+        assert not opts.pan_id_request
+        assert not opts.security_key_request
+        assert not opts.fixed_location
+
+    def test_mac_seq_num_capability(self) -> None:
+        opts = GPCommissioningOptions(0x01)
+        assert opts.mac_seq_num_capability
+
+    def test_rx_on_capability(self) -> None:
+        opts = GPCommissioningOptions(0x04)
+        assert opts.rx_on_capability
+
+    def test_app_info_present(self) -> None:
+        opts = GPCommissioningOptions(0x08)
+        assert opts.app_info_present
+
+    def test_pan_id_request(self) -> None:
+        opts = GPCommissioningOptions(0x20)
+        assert opts.pan_id_request
+
+    def test_security_key_request(self) -> None:
+        opts = GPCommissioningOptions(0x40)
+        assert opts.security_key_request
+
+    def test_multiple_flags(self) -> None:
+        # MAC seq + RX on + App info
+        opts = GPCommissioningOptions(0x01 | 0x04 | 0x08)
+        assert opts.mac_seq_num_capability
+        assert opts.rx_on_capability
+        assert opts.app_info_present
+        assert not opts.pan_id_request
+
+
+class TestGPCommissioningExtendedOptions:
+    """Tests for extended commissioning options byte."""
+
+    def test_security_level(self) -> None:
+        # SecurityLevel.Encrypted = 0b11
+        ext = GPCommissioningExtendedOptions(0x03)
+        assert ext.security_level == SecurityLevel.Encrypted
+
+    def test_key_type(self) -> None:
+        # IndividualKey = 0b100, shifted left 2 = 0x10
+        ext = GPCommissioningExtendedOptions(0x10)
+        assert ext.key_type == SecurityKeyType.IndividualKey
+
+    def test_key_present(self) -> None:
+        ext = GPCommissioningExtendedOptions(0x20)
+        assert ext.key_present
+        assert not ext.key_encrypted
+
+    def test_key_encrypted(self) -> None:
+        ext = GPCommissioningExtendedOptions(0x60)  # key_present + key_encrypted
+        assert ext.key_present
+        assert ext.key_encrypted
+
+    def test_outgoing_counter_present(self) -> None:
+        ext = GPCommissioningExtendedOptions(0x80)
+        assert ext.outgoing_counter_present
+
+    def test_all_clear(self) -> None:
+        ext = GPCommissioningExtendedOptions(0x00)
+        assert ext.security_level == SecurityLevel.NoSecurity
+        assert ext.key_type == SecurityKeyType.NoKey
+        assert not ext.key_present
+        assert not ext.key_encrypted
+        assert not ext.outgoing_counter_present
+
+
+class TestGPCommissioningAppInfo:
+    """Tests for application information byte."""
+
+    def test_manufacturer_id_present(self) -> None:
+        info = GPCommissioningAppInfo(0x01)
+        assert info.manufacturer_id_present
+
+    def test_model_id_present(self) -> None:
+        info = GPCommissioningAppInfo(0x02)
+        assert info.model_id_present
+
+    def test_gpd_commands_present(self) -> None:
+        info = GPCommissioningAppInfo(0x04)
+        assert info.gpd_commands_present
+
+    def test_cluster_list_present(self) -> None:
+        info = GPCommissioningAppInfo(0x08)
+        assert info.cluster_list_present
+
+
+class TestGPCommissioningPayload:
+    """Tests for full commissioning payload parsing."""
+
+    def test_minimal_payload(self) -> None:
+        """Minimal commissioning: device_id + options (no extended, no app info)."""
+        data = bytes([0x02, 0x00])  # device_id=2, options=0
+        payload = GPCommissioningPayload.from_bytes(data)
+
+        assert payload.device_id == 0x02
+        assert not payload.options.mac_seq_num_capability
+        assert payload.extended_options is None
+        assert payload.security_key is None
+        assert payload.app_info is None
+
+    def test_with_extended_options_no_key(self) -> None:
+        """Commissioning with extended options but no security key."""
+        # options: bit 7 set (extended present) = 0x80
+        # extended: security_level=0b11 (Encrypted), no key, no counter = 0x03
+        data = bytes([0x02, 0x80, 0x03])
+        payload = GPCommissioningPayload.from_bytes(data)
+
+        assert payload.device_id == 0x02
+        assert payload.extended_options is not None
+        assert payload.extended_options.security_level == SecurityLevel.Encrypted
+        assert not payload.extended_options.key_present
+        assert payload.security_key is None
+
+    def test_with_unencrypted_key(self) -> None:
+        """Commissioning with security key present but not encrypted."""
+        # options: extended present = 0x80
+        # extended: Encrypted + key_present = 0x03 | 0x20 = 0x23
+        security_key = bytes(range(16))
+        data = bytes([0x02, 0x80, 0x23]) + security_key
+        payload = GPCommissioningPayload.from_bytes(data)
+
+        assert payload.extended_options is not None
+        assert payload.extended_options.key_present
+        assert not payload.extended_options.key_encrypted
+        assert payload.security_key == security_key
+        assert payload.key_mic is None
+
+    def test_with_encrypted_key_and_mic(self) -> None:
+        """Commissioning with encrypted security key and MIC."""
+        # extended: Encrypted + key_present + key_encrypted = 0x03 | 0x20 | 0x40 = 0x63
+        security_key = bytes(range(16))
+        key_mic = 0xDEADBEEF
+        data = (
+            bytes([0x07, 0x80, 0x63])
+            + security_key
+            + struct.pack("<I", key_mic)
+        )
+        payload = GPCommissioningPayload.from_bytes(data)
+
+        assert payload.device_id == 0x07
+        assert payload.extended_options is not None
+        assert payload.extended_options.key_encrypted
+        assert payload.security_key == security_key
+        assert payload.key_mic == 0xDEADBEEF
+
+    def test_with_outgoing_counter(self) -> None:
+        """Commissioning with outgoing frame counter."""
+        # extended: outgoing_counter_present = 0x80
+        counter = 0x00001234
+        data = bytes([0x02, 0x80, 0x80]) + struct.pack("<I", counter)
+        payload = GPCommissioningPayload.from_bytes(data)
+
+        assert payload.extended_options is not None
+        assert payload.extended_options.outgoing_counter_present
+        assert payload.outgoing_counter == 0x00001234
+
+    def test_with_key_and_counter(self) -> None:
+        """Commissioning with both key and outgoing counter."""
+        # extended: key_present + outgoing_counter_present = 0x20 | 0x80 = 0xA0
+        security_key = b"\xAA" * 16
+        counter = 0x00000042
+        data = (
+            bytes([0x02, 0x80, 0xA0])
+            + security_key
+            + struct.pack("<I", counter)
+        )
+        payload = GPCommissioningPayload.from_bytes(data)
+
+        assert payload.security_key == security_key
+        assert payload.outgoing_counter == 0x00000042
+
+    def test_with_app_info_manufacturer_and_model(self) -> None:
+        """Commissioning with application info: manufacturer and model ID."""
+        # options: app_info_present = 0x08
+        # app_info: manufacturer_id + model_id = 0x01 | 0x02 = 0x03
+        manufacturer_id = 0x1234
+        model_id = 0x5678
+        data = (
+            bytes([0x02, 0x08, 0x03])
+            + struct.pack("<H", manufacturer_id)
+            + struct.pack("<H", model_id)
+        )
+        payload = GPCommissioningPayload.from_bytes(data)
+
+        assert payload.app_info is not None
+        assert payload.manufacturer_id == 0x1234
+        assert payload.model_id == 0x5678
+
+    def test_with_gpd_commands(self) -> None:
+        """Commissioning with GPD command list."""
+        # options: app_info_present = 0x08
+        # app_info: gpd_commands_present = 0x04
+        commands = [0x20, 0x21, 0x22]  # Off, On, Toggle
+        data = bytes([0x02, 0x08, 0x04, len(commands)]) + bytes(commands)
+        payload = GPCommissioningPayload.from_bytes(data)
+
+        assert payload.gpd_commands == commands
+
+    def test_with_cluster_list(self) -> None:
+        """Commissioning with server and client cluster lists."""
+        # options: app_info_present = 0x08
+        # app_info: cluster_list_present = 0x08
+        server_clusters = [0x0006, 0x0008]  # On/Off, Level Control
+        client_clusters = [0x0300]  # Color Control
+
+        data = bytearray([0x02, 0x08, 0x08])
+        # length byte: lower nibble = num_server, upper = num_client
+        data.append((len(server_clusters) & 0x0F) | ((len(client_clusters) & 0x0F) << 4))
+        for c in server_clusters:
+            data.extend(struct.pack("<H", c))
+        for c in client_clusters:
+            data.extend(struct.pack("<H", c))
+
+        payload = GPCommissioningPayload.from_bytes(bytes(data))
+
+        assert payload.server_clusters == [0x0006, 0x0008]
+        assert payload.client_clusters == [0x0300]
+
+    def test_full_commissioning_payload(self) -> None:
+        """Full commissioning with all optional fields."""
+        security_key = b"\xBB" * 16
+        key_mic = 0xCAFEBABE
+        counter = 0x00000100
+        manufacturer_id = 0x1021
+        model_id = 0x0002
+        commands = [0x20, 0x21, 0x22]
+        server_clusters = [0x0006]
+        client_clusters: list[int] = []
+
+        data = bytearray()
+        # device_id=2
+        data.append(0x02)
+        # options: extended + app_info = 0x80 | 0x08 = 0x88
+        data.append(0x88)
+        # extended: Encrypted + key_present + key_encrypted + outgoing_counter
+        # = 0x03 | 0x20 | 0x40 | 0x80 = 0xE3
+        data.append(0xE3)
+        data.extend(security_key)
+        data.extend(struct.pack("<I", key_mic))
+        data.extend(struct.pack("<I", counter))
+        # app_info: all fields = 0x01 | 0x02 | 0x04 | 0x08 = 0x0F
+        data.append(0x0F)
+        data.extend(struct.pack("<H", manufacturer_id))
+        data.extend(struct.pack("<H", model_id))
+        data.append(len(commands))
+        data.extend(commands)
+        length_byte = (len(server_clusters) & 0x0F) | (
+            (len(client_clusters) & 0x0F) << 4
+        )
+        data.append(length_byte)
+        for c in server_clusters:
+            data.extend(struct.pack("<H", c))
+
+        payload = GPCommissioningPayload.from_bytes(bytes(data))
+
+        assert payload.device_id == 0x02
+        assert payload.extended_options is not None
+        assert payload.extended_options.security_level == SecurityLevel.Encrypted
+        assert payload.security_key == security_key
+        assert payload.key_mic == key_mic
+        assert payload.outgoing_counter == counter
+        assert payload.manufacturer_id == manufacturer_id
+        assert payload.model_id == model_id
+        assert payload.gpd_commands == commands
+        assert payload.server_clusters == [0x0006]
+        assert payload.client_clusters == []
+
+    def test_roundtrip_serialization(self) -> None:
+        """Parsing and re-serializing should produce identical bytes."""
+        security_key = b"\xCC" * 16
+        data = bytes([0x02, 0x80, 0x23]) + security_key
+        payload = GPCommissioningPayload.from_bytes(data)
+        serialized = payload.to_bytes()
+        assert serialized == data
+
+    def test_roundtrip_full_payload(self) -> None:
+        """Full payload round-trip."""
+        commands = [0x20, 0x21]
+        data = bytearray()
+        data.append(0x07)  # device_id
+        data.append(0x88)  # options: extended + app_info
+        data.append(0xA0)  # extended: key_present + outgoing_counter
+        data.extend(b"\xDD" * 16)  # security key
+        data.extend(struct.pack("<I", 0x00000099))  # outgoing counter
+        data.append(0x04)  # app_info: gpd_commands
+        data.append(len(commands))
+        data.extend(commands)
+
+        payload = GPCommissioningPayload.from_bytes(bytes(data))
+        serialized = payload.to_bytes()
+        assert serialized == bytes(data)
+
+    def test_too_short_payload(self) -> None:
+        """Payload shorter than 2 bytes should raise ValueError."""
+        with pytest.raises(ValueError, match="too short"):
+            GPCommissioningPayload.from_bytes(b"\x00")
+
+    def test_empty_payload(self) -> None:
+        """Empty payload should raise ValueError."""
+        with pytest.raises(ValueError, match="too short"):
+            GPCommissioningPayload.from_bytes(b"")
+
+
+class TestGPChannelRequestPayload:
+    """Tests for channel request payload parsing."""
+
+    def test_channel_11(self) -> None:
+        """Channel 11 = offset 0."""
+        payload = GPChannelRequestPayload.from_bytes(b"\x00")
+        assert payload.next_channel == 11
+        assert payload.second_next_channel == 11
+
+    def test_channel_26(self) -> None:
+        """Channel 26 = offset 15."""
+        payload = GPChannelRequestPayload.from_bytes(b"\xFF")
+        assert payload.next_channel == 26
+        assert payload.second_next_channel == 26
+
+    def test_mixed_channels(self) -> None:
+        """Different next and second-next channels."""
+        # next=15 (offset 4), second_next=20 (offset 9)
+        byte_val = 4 | (9 << 4)
+        payload = GPChannelRequestPayload.from_bytes(bytes([byte_val]))
+        assert payload.next_channel == 15
+        assert payload.second_next_channel == 20
+
+    def test_empty_payload_raises(self) -> None:
+        """Empty data should raise ValueError."""
+        with pytest.raises(ValueError, match="at least 1 byte"):
+            GPChannelRequestPayload.from_bytes(b"")

--- a/tests/zgp/test_integration.py
+++ b/tests/zgp/test_integration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock
+from tests.async_mock import AsyncMock, Mock
 
 import pytest
 

--- a/tests/zgp/test_integration.py
+++ b/tests/zgp/test_integration.py
@@ -1,0 +1,133 @@
+"""Integration tests for Green Power with ControllerApplication."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+import zigpy.types as t
+from zigpy.zgp.device import GPDevice
+from zigpy.zgp.manager import GreenPowerManager
+from zigpy.zgp.types import (
+    GP_CLUSTER_ID,
+    GP_ENDPOINT,
+    GPDCommandID,
+    SecurityLevel,
+)
+
+# Import test fixtures from conftest
+from tests.conftest import make_app
+
+
+@pytest.fixture
+def app():
+    """Create a real ControllerApplication with GP manager."""
+    return make_app({})
+
+
+class TestApplicationGPIntegration:
+    """Test GP integration in ControllerApplication."""
+
+    def test_app_has_gp_manager(self, app) -> None:
+        """Application should have a green_power manager attribute."""
+        assert hasattr(app, "green_power")
+        assert isinstance(app.green_power, GreenPowerManager)
+
+    def test_gp_manager_references_app(self, app) -> None:
+        """GP manager should reference its parent application."""
+        assert app.green_power._application is app
+
+    @pytest.mark.asyncio
+    async def test_packet_received_routes_gp_to_manager(self, app) -> None:
+        """GP packets should be routed to the GP manager."""
+        # Patch the GP manager's handle_packet
+        app.green_power.handle_packet = Mock(return_value=True)
+
+        # Create a GP notification packet from a known proxy device
+        # First add a "proxy" device to the app so get_device_with_address works
+        from tests.conftest import add_initialized_device
+
+        proxy_ieee = t.EUI64.convert("00:11:22:33:44:55:66:88")
+        proxy_nwk = t.NWK(0x1234)
+        add_initialized_device(app, nwk=proxy_nwk, ieee=proxy_ieee)
+
+        packet = t.ZigbeePacket(
+            src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=proxy_nwk),
+            src_ep=t.uint8_t(GP_ENDPOINT),
+            dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+            dst_ep=t.uint8_t(GP_ENDPOINT),
+            profile_id=t.uint16_t(0xA1E0),
+            cluster_id=t.uint16_t(GP_CLUSTER_ID),
+            data=t.SerializableBytes(b"\x01\x00\x00" + b"\x00" * 20),
+        )
+
+        app.packet_received(packet)
+
+        # GP manager should have been called
+        app.green_power.handle_packet.assert_called_once_with(packet)
+
+    @pytest.mark.asyncio
+    async def test_non_gp_packet_not_routed_to_manager(self, app) -> None:
+        """Non-GP packets should NOT be routed to the GP manager."""
+        app.green_power.handle_packet = Mock(return_value=True)
+
+        from tests.conftest import add_initialized_device
+
+        dev_ieee = t.EUI64.convert("00:11:22:33:44:55:66:99")
+        dev_nwk = t.NWK(0x5678)
+        dev = add_initialized_device(app, nwk=dev_nwk, ieee=dev_ieee)
+
+        packet = t.ZigbeePacket(
+            src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev_nwk),
+            src_ep=t.uint8_t(1),
+            dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+            dst_ep=t.uint8_t(1),
+            profile_id=t.uint16_t(0x0104),  # HA profile
+            cluster_id=t.uint16_t(0x0006),  # On/Off
+            data=t.SerializableBytes(b"\x01\x00\x00"),
+        )
+
+        app.packet_received(packet)
+
+        # GP manager should NOT have been called
+        app.green_power.handle_packet.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gp_packet_from_unknown_device(self, app) -> None:
+        """GP packets from unknown devices should still be routed to GP manager."""
+        app.green_power.handle_packet = Mock(return_value=True)
+
+        # Don't add any device - the source is "unknown"
+        packet = t.ZigbeePacket(
+            src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x9999)),
+            src_ep=t.uint8_t(GP_ENDPOINT),
+            dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+            dst_ep=t.uint8_t(GP_ENDPOINT),
+            profile_id=t.uint16_t(0xA1E0),
+            cluster_id=t.uint16_t(GP_CLUSTER_ID),
+            data=t.SerializableBytes(b"\x01\x00\x00" + b"\x00" * 10),
+        )
+
+        app.packet_received(packet)
+
+        # GP packets should be intercepted BEFORE the unknown device check
+        app.green_power.handle_packet.assert_called_once_with(packet)
+
+    @pytest.mark.asyncio
+    async def test_permit_gp(self, app) -> None:
+        """permit_gp should delegate to GP manager."""
+        app.green_power.permit_join = AsyncMock()
+
+        await app.permit_gp(time_s=120)
+
+        app.green_power.permit_join.assert_called_once_with(120)
+
+    @pytest.mark.asyncio
+    async def test_permit_gp_close(self, app) -> None:
+        """permit_gp(0) should close the window."""
+        app.green_power.permit_join = AsyncMock()
+
+        await app.permit_gp(time_s=0)
+
+        app.green_power.permit_join.assert_called_once_with(0)

--- a/tests/zgp/test_integration.py
+++ b/tests/zgp/test_integration.py
@@ -2,18 +2,15 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 import zigpy.types as t
-from zigpy.zgp.device import GPDevice
 from zigpy.zgp.manager import GreenPowerManager
 from zigpy.zgp.types import (
     GP_CLUSTER_ID,
     GP_ENDPOINT,
-    GPDCommandID,
-    SecurityLevel,
 )
 
 # Import test fixtures from conftest
@@ -76,7 +73,7 @@ class TestApplicationGPIntegration:
 
         dev_ieee = t.EUI64.convert("00:11:22:33:44:55:66:99")
         dev_nwk = t.NWK(0x5678)
-        dev = add_initialized_device(app, nwk=dev_nwk, ieee=dev_ieee)
+        add_initialized_device(app, nwk=dev_nwk, ieee=dev_ieee)
 
         packet = t.ZigbeePacket(
             src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev_nwk),

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -368,6 +368,26 @@ class TestCommissioning:
         mock_app.listener_event.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_commissioning_rejects_unspecified_source_id(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """SourceID 0x00000000 is unspecified per ZGP spec and must be rejected."""
+        await manager.permit_join(time_s=60)
+        mock_app.send_packet.reset_mock()
+        mock_app.listener_event.reset_mock()
+
+        await manager._process_commissioning(
+            source_id=0x00000000,
+            frame_counter=1,
+            payload=bytes([0x02, 0x00]),
+        )
+
+        assert manager.get_device(0x00000000) is None
+        # No gp_device_joined event should have fired
+        for call in mock_app.listener_event.call_args_list:
+            assert call[0][0] != "gp_device_joined"
+
+    @pytest.mark.asyncio
     async def test_commissioning_with_security_key(
         self, manager: GreenPowerManager, mock_app: MagicMock
     ) -> None:

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -371,13 +371,20 @@ class TestCommissioning:
     async def test_commissioning_with_security_key(
         self, manager: GreenPowerManager, mock_app: MagicMock
     ) -> None:
-        """Commissioning with unencrypted security key."""
+        """Commissioning with unencrypted security key.
+
+        Extended options byte 0x23 = 0b00100011:
+        - Bits 0-1 = 0b11 = SecurityLevel.Encrypted (Table 54)
+        - Bits 2-4 = 0b000 = SecurityKeyType.NoKey (Table 54)
+        - Bit 5 = 1 = key_present
+        - Bits 6-7 = 0
+        """
         await manager.permit_join(time_s=60)
         mock_app.send_packet.reset_mock()
 
         security_key = bytes(range(16))
-        # options: extended present = 0x80
-        # extended: Encrypted level + key_present = 0x03 | 0x20 = 0x23
+        # options: bit 7 = extended present (Table 53) = 0x80
+        # extended: Encrypted + key_present = 0x03 | 0x20 = 0x23 (Table 54)
         comm_payload = bytes([0x02, 0x80, 0x23]) + security_key
 
         await manager._process_commissioning(
@@ -390,6 +397,8 @@ class TestCommissioning:
         assert dev is not None
         assert dev.security_key == security_key
         assert dev.security_level == SecurityLevel.Encrypted
+        # Extended byte 0x23: bits 2-4 = 0b000 = NoKey (Table 54)
+        assert dev.security_key_type == SecurityKeyType.NoKey
 
     @pytest.mark.asyncio
     async def test_commissioning_with_outgoing_counter(
@@ -580,7 +589,13 @@ class TestChannelConfigResponse:
     async def test_channel_config_contains_correct_channel(
         self, manager: GreenPowerManager, mock_app: MagicMock
     ) -> None:
-        """Channel Config response should contain the coordinator's channel."""
+        """Channel Config payload must contain the coordinator's channel.
+
+        Per ZGP spec, GP Channel Configuration (0xF3) payload is 1 byte:
+        bits 0-3 = operational channel offset (channel - 11),
+        bit 4 = basic (1).
+        For channel 20: offset = 9, basic = 1 => byte = 0x19.
+        """
         mock_app.state.network_info.channel = 20
 
         await manager._process_channel_request(
@@ -590,6 +605,12 @@ class TestChannelConfigResponse:
         )
 
         assert mock_app.send_packet.call_count == 1
+        sent = mock_app.send_packet.call_args[0][0]
+        zcl_data = sent.data.serialize()
+        # The GP Response wraps the Channel Config payload.
+        # Channel 20 => offset 9, basic=1 => 0x09 | 0x10 = 0x19
+        # This byte must appear in the serialized ZCL frame.
+        assert bytes([0x19]) in zcl_data
 
     @pytest.mark.asyncio
     async def test_channel_request_without_proxy(
@@ -672,11 +693,18 @@ class TestCommissioningReply:
     async def test_commissioning_reply_uses_proxy_as_temp_master(
         self, manager: GreenPowerManager, mock_app: MagicMock
     ) -> None:
-        """Commissioning Reply should route through the forwarding proxy."""
+        """Commissioning Reply should be a GP Response (cmd 0x06) with 0xF0.
+
+        Per ZGP spec, the GP Commissioning Reply (0xF0) is sent via
+        GP Response (client cmd 0x06) through the temp master proxy.
+        The ZCL frame must contain:
+        - command_id 0x06 (GP Response) in byte 2
+        - gpd_command_id 0xF0 (Commissioning Reply) in the payload
+        """
         await manager.permit_join(time_s=60)
         mock_app.send_packet.reset_mock()
 
-        comm_payload = bytes([0x02, 0x82, 0x00])  # rx_on=True
+        comm_payload = bytes([0x02, 0x82, 0x00])  # rx_on=True (bit 1, Table 53)
 
         await manager._process_commissioning(
             source_id=0xAABBCCDD,
@@ -685,8 +713,16 @@ class TestCommissioningReply:
             proxy_nwk=0x5678,
         )
 
-        # First packet should be the Commissioning Reply
-        assert mock_app.send_packet.call_count >= 1
+        # First packet = Commissioning Reply, second = GP Pairing
+        assert mock_app.send_packet.call_count == 2
+
+        # Verify first packet is GP Response (cmd 0x06) with gpd_cmd 0xF0
+        reply_packet = mock_app.send_packet.call_args_list[0][0][0]
+        reply_data = reply_packet.data.serialize()
+        # ZCL byte 2 = command_id = 0x06 (GP Response)
+        assert reply_data[2] == 0x06
+        # The payload must contain 0xF0 (GP Commissioning Reply command)
+        assert bytes([0xF0]) in reply_data
 
 
 class TestSendGPResponse:

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -803,3 +803,169 @@ class TestSendGPResponse:
         )
 
         # Should not raise, just log warning
+
+
+class TestMissingPathCoverage:
+    """Tests for previously untested code paths."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_encrypted_payload(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Command dispatch should decrypt payload when security is active.
+
+        Tests the decryption path in _dispatch_gp_command that was
+        previously uncovered (SecurityLevel != NoSecurity).
+        """
+        from zigpy.zgp.crypto import encrypt_payload
+
+        source_id = 0xAABBCCDD
+        security_key = bytes(range(16))
+        plaintext = bytes([0x20])  # Toggle command
+        frame_counter = 5
+
+        # Encrypt the payload to simulate what a GPD would send
+        encrypted, mic = encrypt_payload(
+            source_id,
+            frame_counter,
+            security_key,
+            plaintext,
+            SecurityLevel.Encrypted,
+        )
+
+        dev = GPDevice(
+            source_id=source_id,
+            device_id=0x02,
+            security_key=security_key,
+            security_level=SecurityLevel.Encrypted,
+            frame_counter=0,
+        )
+        manager.add_device(dev)
+
+        # Dispatch with encrypted payload + MIC concatenated
+        await manager._dispatch_gp_command(
+            source_id=source_id,
+            frame_counter=frame_counter,
+            command_id=GPDCommandID.Toggle,
+            payload=encrypted + mic,
+        )
+
+        # Should fire event with DECRYPTED payload
+        mock_app.listener_event.assert_called_with(
+            "gp_command_received",
+            dev,
+            GPDCommandID.Toggle,
+            plaintext,
+        )
+
+    @pytest.mark.asyncio
+    async def test_commissioning_with_encrypted_key(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Commissioning with key_encrypted=True should decrypt the key.
+
+        Tests the path in _process_commissioning where the GPD provides
+        its security key encrypted with the GP link key.
+        """
+        import struct
+
+        from zigpy.zgp.crypto import encrypt_security_key
+
+        await manager.permit_join(time_s=60)
+        mock_app.send_packet.reset_mock()
+
+        source_id = 0x11223344
+        original_key = bytes(range(16))
+
+        # Encrypt the key as a GPD would during commissioning
+        encrypted_key, key_mic_bytes = encrypt_security_key(source_id, original_key)
+        key_mic_int = struct.unpack("<I", key_mic_bytes)[0]
+
+        # Extended: Encrypted(0b11) + key_present(bit5) + key_encrypted(bit6)
+        # = 0x03 | 0x20 | 0x40 = 0x63  (Table 54)
+        comm_payload = (
+            bytes([0x02, 0x80, 0x63]) + encrypted_key + struct.pack("<I", key_mic_int)
+        )
+
+        await manager._process_commissioning(
+            source_id=source_id,
+            frame_counter=1,
+            payload=comm_payload,
+        )
+
+        dev = manager.get_device(source_id)
+        assert dev is not None
+        # The key must be DECRYPTED to the original
+        assert dev.security_key == original_key
+        assert dev.security_level == SecurityLevel.Encrypted
+
+    # NOTE: _handle_commissioning_notification (server cmd 0x04) cannot be
+    # tested because CommissioningNotificationOptions in greenpower.py has
+    # a bit-field alignment issue (18 bits instead of 16), preventing the
+    # schema from serializing/deserializing. The fix belongs in the cluster
+    # definition (PR #1659), not in the GP manager module.
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_commissioning(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Shutdown should cancel the commissioning timer and reset state."""
+        await manager.permit_join(time_s=300)
+        assert manager.is_commissioning
+
+        await manager.shutdown()
+
+        assert not manager.is_commissioning
+        assert manager._commissioning_task is None
+
+    @pytest.mark.asyncio
+    async def test_dedup_in_notification_flow(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Duplicate filtering should work within _handle_gp_notification.
+
+        When two proxies forward the same GPD frame, only the first
+        should dispatch a command.
+        """
+        source_id = 0x12345678
+        dev = GPDevice(source_id=source_id, device_id=0x02, frame_counter=0)
+        manager.add_device(dev)
+
+        from zigpy.zcl.clusters.greenpower import (
+            NotificationOptions,
+            NotificationSchema,
+        )
+        import zigpy.zgp.types as zgptypes
+
+        options = NotificationOptions(
+            application_id=zgptypes.ApplicationID.SrcID,
+            also_unicast=0,
+            also_derived_group=0,
+            also_commissioned_group=0,
+            security_level=zgptypes.SecurityLevel.NoSecurity,
+            security_key_type=zgptypes.SecurityKeyType.NoKey,
+            appoint_temp_master=0,
+            tx_queue_full=0,
+            _reserved=0,
+        )
+        notification = NotificationSchema(
+            options=options,
+            gpd_id=zgptypes.DeviceID(source_id),
+            frame_counter=t.uint32_t(1),
+            command_id=t.uint8_t(GPDCommandID.Toggle),
+            payload=t.LVBytes(b""),
+        )
+        payload = notification.serialize()
+
+        # First proxy delivers
+        await manager._handle_gp_notification(payload, proxy_nwk=0x1111)
+        # Second proxy delivers same frame
+        await manager._handle_gp_notification(payload, proxy_nwk=0x2222)
+
+        # Only ONE gp_command_received should fire
+        command_events = [
+            c
+            for c in mock_app.listener_event.call_args_list
+            if c[0][0] == "gp_command_received"
+        ]
+        assert len(command_events) == 1

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -27,6 +27,7 @@ def mock_app() -> MagicMock:
     app = MagicMock()
     app.state.node_info.ieee = t.EUI64.convert("00:11:22:33:44:55:66:77")
     app.state.node_info.nwk = t.NWK(0x0000)
+    app.state.network_info.channel = 15
     app.send_packet = AsyncMock()
     app.listener_event = Mock()
     app.create_task = Mock(
@@ -550,3 +551,192 @@ class TestBuildZclFrame:
             command_id=0x06, is_client=True, payload=b""
         )
         assert len(frame) == 3
+
+
+class TestChannelConfigResponse:
+    """Tests for GP Channel Configuration response."""
+
+    @pytest.mark.asyncio
+    async def test_channel_request_sends_response(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Channel Request should trigger a GP Response with Channel Config."""
+        # Channel Request payload: next_channel=15 (offset 4), second=20 (offset 9)
+        channel_req_payload = bytes([4 | (9 << 4)])
+
+        await manager._process_channel_request(
+            source_id=0x12345678,
+            payload=channel_req_payload,
+            proxy_nwk=0x1234,
+        )
+
+        # Should have sent a GP Response
+        assert mock_app.send_packet.call_count == 1
+        sent = mock_app.send_packet.call_args[0][0]
+        assert sent.dst_ep == GP_ENDPOINT
+        assert sent.cluster_id == GP_CLUSTER_ID
+
+    @pytest.mark.asyncio
+    async def test_channel_config_contains_correct_channel(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Channel Config response should contain the coordinator's channel."""
+        mock_app.state.network_info.channel = 20
+
+        await manager._process_channel_request(
+            source_id=0x12345678,
+            payload=bytes([0x00]),
+            proxy_nwk=0x1234,
+        )
+
+        assert mock_app.send_packet.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_channel_request_without_proxy(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Channel Request without proxy_nwk should use coordinator NWK."""
+        await manager._process_channel_request(
+            source_id=0x12345678,
+            payload=bytes([0x00]),
+            proxy_nwk=None,
+        )
+
+        assert mock_app.send_packet.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_channel_request_ignored(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Invalid channel request payload should be ignored."""
+        await manager._process_channel_request(
+            source_id=0x12345678,
+            payload=b"",
+            proxy_nwk=0x1234,
+        )
+
+        mock_app.send_packet.assert_not_called()
+
+
+class TestCommissioningReply:
+    """Tests for GP Commissioning Reply to RX-capable GPDs."""
+
+    @pytest.mark.asyncio
+    async def test_rx_capable_gets_commissioning_reply(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """RX-capable GPD commissioning should send a Commissioning Reply."""
+        await manager.permit_join(time_s=60)
+        mock_app.send_packet.reset_mock()
+
+        # Commissioning with rx_on_capability=True (bit 1 of options)
+        # options: extended (bit 7) + rx_on (bit 1) = 0x82
+        comm_payload = bytes([0x02, 0x82, 0x00])
+
+        await manager._process_commissioning(
+            source_id=0xAABBCCDD,
+            frame_counter=1,
+            payload=comm_payload,
+            proxy_nwk=0x1234,
+        )
+
+        # Should have sent: Commissioning Reply + GP Pairing = 2 packets
+        assert mock_app.send_packet.call_count == 2
+
+        dev = manager.get_device(0xAABBCCDD)
+        assert dev is not None
+        assert dev.rx_on_capability is True
+
+    @pytest.mark.asyncio
+    async def test_non_rx_skips_commissioning_reply(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Non-RX GPD should NOT get a Commissioning Reply."""
+        await manager.permit_join(time_s=60)
+        mock_app.send_packet.reset_mock()
+
+        # options: extended (bit 7) only, no rx_on = 0x80
+        comm_payload = bytes([0x02, 0x80, 0x00])
+
+        await manager._process_commissioning(
+            source_id=0x11223344,
+            frame_counter=1,
+            payload=comm_payload,
+            proxy_nwk=0x1234,
+        )
+
+        # Should have sent: GP Pairing only = 1 packet
+        assert mock_app.send_packet.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_commissioning_reply_uses_proxy_as_temp_master(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Commissioning Reply should route through the forwarding proxy."""
+        await manager.permit_join(time_s=60)
+        mock_app.send_packet.reset_mock()
+
+        comm_payload = bytes([0x02, 0x82, 0x00])  # rx_on=True
+
+        await manager._process_commissioning(
+            source_id=0xAABBCCDD,
+            frame_counter=1,
+            payload=comm_payload,
+            proxy_nwk=0x5678,
+        )
+
+        # First packet should be the Commissioning Reply
+        assert mock_app.send_packet.call_count >= 1
+
+
+class TestSendGPResponse:
+    """Tests for the generic GP Response sender."""
+
+    @pytest.mark.asyncio
+    async def test_gp_response_packet_structure(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """GP Response should be sent with correct endpoint/cluster/profile."""
+        await manager._send_gp_response(
+            source_id=0x12345678,
+            gpd_command_id=0xF3,
+            gpd_command_payload=bytes([0x14]),
+            proxy_nwk=0x1234,
+        )
+
+        assert mock_app.send_packet.call_count == 1
+        sent = mock_app.send_packet.call_args[0][0]
+        assert sent.dst_ep == GP_ENDPOINT
+        assert sent.src_ep == GP_ENDPOINT
+        assert sent.cluster_id == GP_CLUSTER_ID
+        assert sent.profile_id == 0xA1E0
+
+    @pytest.mark.asyncio
+    async def test_gp_response_without_proxy(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """GP Response without proxy should use coordinator as temp master."""
+        await manager._send_gp_response(
+            source_id=0x12345678,
+            gpd_command_id=0xF0,
+            gpd_command_payload=bytes([0x00]),
+            proxy_nwk=None,
+        )
+
+        assert mock_app.send_packet.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_gp_response_send_failure(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """GP Response send failure should be handled gracefully."""
+        mock_app.send_packet = AsyncMock(side_effect=TimeoutError)
+
+        await manager._send_gp_response(
+            source_id=0x12345678,
+            gpd_command_id=0xF3,
+            gpd_command_payload=bytes([0x14]),
+            proxy_nwk=0x1234,
+        )
+
+        # Should not raise, just log warning

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import time
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
@@ -29,7 +28,9 @@ def mock_app() -> MagicMock:
     app.state.node_info.nwk = t.NWK(0x0000)
     app.send_packet = AsyncMock()
     app.listener_event = Mock()
-    app.create_task = Mock(side_effect=lambda coro, name=None: asyncio.ensure_future(coro))
+    app.create_task = Mock(
+        side_effect=lambda coro, name=None: asyncio.ensure_future(coro)
+    )
     return app
 
 
@@ -527,17 +528,17 @@ class TestBuildZclFrame:
 
     def test_client_frame(self) -> None:
         frame = GreenPowerManager._build_zcl_frame(
-            command_id=0x02, is_client=True, payload=b"\xAA\xBB"
+            command_id=0x02, is_client=True, payload=b"\xaa\xbb"
         )
         # frame_control: 0x01 (cluster-specific) | 0x10 (disable default resp) = 0x11
         assert frame[0] == 0x11
         assert frame[1] == 0x00  # seq_num
         assert frame[2] == 0x02  # command_id
-        assert frame[3:] == b"\xAA\xBB"
+        assert frame[3:] == b"\xaa\xbb"
 
     def test_server_frame(self) -> None:
         frame = GreenPowerManager._build_zcl_frame(
-            command_id=0x00, is_client=False, payload=b"\xCC"
+            command_id=0x00, is_client=False, payload=b"\xcc"
         )
         # frame_control: 0x01 | 0x08 (direction) | 0x10 = 0x19
         assert frame[0] == 0x19

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -1,0 +1,516 @@
+"""Tests for Green Power Manager."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+import zigpy.types as t
+
+from zigpy.zgp.device import GPDevice
+from zigpy.zgp.manager import GreenPowerManager
+from zigpy.zgp.types import (
+    GP_CLUSTER_ID,
+    GP_ENDPOINT,
+    GPDCommandID,
+    SecurityKeyType,
+    SecurityLevel,
+)
+
+
+@pytest.fixture
+def mock_app() -> MagicMock:
+    """Create a mock ControllerApplication."""
+    app = MagicMock()
+    app.state.node_info.ieee = t.EUI64.convert("00:11:22:33:44:55:66:77")
+    app.state.node_info.nwk = t.NWK(0x0000)
+    app.send_packet = AsyncMock()
+    app.listener_event = Mock()
+    app.create_task = Mock(side_effect=lambda coro, name=None: asyncio.ensure_future(coro))
+    return app
+
+
+@pytest.fixture
+def manager(mock_app: MagicMock) -> GreenPowerManager:
+    """Create a GreenPowerManager with mock app."""
+    return GreenPowerManager(mock_app)
+
+
+def _make_gp_notification_packet(
+    source_id: int,
+    command_id: int,
+    payload: bytes = b"",
+    frame_counter: int = 1,
+    proxy_nwk: int = 0x1234,
+) -> t.ZigbeePacket:
+    """Build a ZigbeePacket containing a GP Notification.
+
+    Constructs a minimal ZCL cluster-specific server command (0x00)
+    wrapping a GP Notification with the given GPD command.
+    """
+    from zigpy.zcl.clusters.greenpower import (
+        NotificationOptions,
+        NotificationSchema,
+    )
+    import zigpy.zgp.types as zgptypes
+
+    options = NotificationOptions(
+        application_id=zgptypes.ApplicationID.SrcID,
+        also_unicast=0,
+        also_derived_group=0,
+        also_commissioned_group=0,
+        security_level=zgptypes.SecurityLevel.NoSecurity,
+        security_key_type=zgptypes.SecurityKeyType.NoKey,
+        appoint_temp_master=0,
+        tx_queue_full=0,
+        _reserved=0,
+    )
+
+    notification = NotificationSchema(
+        options=options,
+        gpd_id=zgptypes.DeviceID(source_id),
+        frame_counter=t.uint32_t(frame_counter),
+        command_id=t.uint8_t(command_id),
+        payload=t.LVBytes(payload),
+    )
+
+    # ZCL frame: frame_control + seq_num + command_id(0x00) + notification payload
+    zcl_frame = bytes([0x01, 0x00, 0x00]) + notification.serialize()
+
+    return t.ZigbeePacket(
+        src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(proxy_nwk)),
+        src_ep=t.uint8_t(GP_ENDPOINT),
+        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+        dst_ep=t.uint8_t(GP_ENDPOINT),
+        profile_id=t.uint16_t(0xA1E0),
+        cluster_id=t.uint16_t(GP_CLUSTER_ID),
+        data=t.SerializableBytes(zcl_frame),
+    )
+
+
+class TestGreenPowerManagerBasics:
+    """Basic manager tests."""
+
+    def test_creation(self, manager: GreenPowerManager) -> None:
+        assert manager.devices == {}
+        assert not manager.is_commissioning
+
+    def test_add_device(self, manager: GreenPowerManager) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02)
+        manager.add_device(dev)
+        assert manager.get_device(0x12345678) is dev
+        assert len(manager.devices) == 1
+
+    def test_remove_device(self, manager: GreenPowerManager) -> None:
+        dev = GPDevice(source_id=0x12345678, device_id=0x02)
+        manager.add_device(dev)
+        removed = manager.remove_device(0x12345678)
+        assert removed is dev
+        assert manager.get_device(0x12345678) is None
+
+    def test_remove_nonexistent_device(self, manager: GreenPowerManager) -> None:
+        removed = manager.remove_device(0xDEADBEEF)
+        assert removed is None
+
+    def test_get_device_nonexistent(self, manager: GreenPowerManager) -> None:
+        assert manager.get_device(0xDEADBEEF) is None
+
+
+class TestHandlePacket:
+    """Tests for packet handling."""
+
+    def test_rejects_non_gp_packet(self, manager: GreenPowerManager) -> None:
+        """Non-GP packets should be rejected."""
+        packet = t.ZigbeePacket(
+            src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x1234)),
+            dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+            dst_ep=t.uint8_t(1),  # Not GP endpoint
+            cluster_id=t.uint16_t(0x0006),  # On/Off cluster
+            data=t.SerializableBytes(b"\x00\x00\x00"),
+        )
+        assert manager.handle_packet(packet) is False
+
+    def test_rejects_wrong_cluster(self, manager: GreenPowerManager) -> None:
+        packet = t.ZigbeePacket(
+            src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x1234)),
+            dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+            dst_ep=t.uint8_t(GP_ENDPOINT),
+            cluster_id=t.uint16_t(0x0006),  # Wrong cluster
+            data=t.SerializableBytes(b"\x00\x00\x00"),
+        )
+        assert manager.handle_packet(packet) is False
+
+    def test_rejects_too_short_data(self, manager: GreenPowerManager) -> None:
+        packet = t.ZigbeePacket(
+            src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x1234)),
+            dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+            dst_ep=t.uint8_t(GP_ENDPOINT),
+            cluster_id=t.uint16_t(GP_CLUSTER_ID),
+            data=t.SerializableBytes(b"\x00\x00"),  # Too short
+        )
+        assert manager.handle_packet(packet) is False
+
+    def test_rejects_non_cluster_specific(self, manager: GreenPowerManager) -> None:
+        packet = t.ZigbeePacket(
+            src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x1234)),
+            dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+            dst_ep=t.uint8_t(GP_ENDPOINT),
+            cluster_id=t.uint16_t(GP_CLUSTER_ID),
+            data=t.SerializableBytes(b"\x00\x00\x00"),  # frame_control bit 0 = 0
+        )
+        assert manager.handle_packet(packet) is False
+
+    @pytest.mark.asyncio
+    async def test_accepts_gp_notification(self, manager: GreenPowerManager) -> None:
+        packet = _make_gp_notification_packet(
+            source_id=0x12345678,
+            command_id=GPDCommandID.Toggle,
+        )
+        assert manager.handle_packet(packet) is True
+
+
+class TestGPCommandDispatch:
+    """Tests for GP command dispatching."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_known_device(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Commands from known devices should fire listener_event."""
+        dev = GPDevice(source_id=0x12345678, device_id=0x02, frame_counter=0)
+        manager.add_device(dev)
+
+        await manager._dispatch_gp_command(
+            source_id=0x12345678,
+            frame_counter=1,
+            command_id=GPDCommandID.Toggle,
+            payload=b"",
+        )
+
+        mock_app.listener_event.assert_called_with(
+            "gp_command_received",
+            dev,
+            GPDCommandID.Toggle,
+            b"",
+        )
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unknown_device_ignored(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Commands from unknown devices should be ignored."""
+        await manager._dispatch_gp_command(
+            source_id=0xDEADBEEF,
+            frame_counter=1,
+            command_id=GPDCommandID.Toggle,
+            payload=b"",
+        )
+
+        mock_app.listener_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_replay_rejected(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Replayed frames (same or lower counter) should be rejected."""
+        dev = GPDevice(source_id=0x12345678, device_id=0x02, frame_counter=10)
+        manager.add_device(dev)
+
+        await manager._dispatch_gp_command(
+            source_id=0x12345678,
+            frame_counter=10,  # Same as stored
+            command_id=GPDCommandID.Toggle,
+            payload=b"",
+        )
+
+        mock_app.listener_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_increments_counter(
+        self, manager: GreenPowerManager
+    ) -> None:
+        """Successful dispatch should update the frame counter."""
+        dev = GPDevice(source_id=0x12345678, device_id=0x02, frame_counter=0)
+        manager.add_device(dev)
+
+        await manager._dispatch_gp_command(
+            source_id=0x12345678,
+            frame_counter=42,
+            command_id=GPDCommandID.Toggle,
+            payload=b"",
+        )
+
+        assert dev.frame_counter == 42
+
+
+class TestCommissioning:
+    """Tests for GP commissioning."""
+
+    @pytest.mark.asyncio
+    async def test_commissioning_window(self, manager: GreenPowerManager) -> None:
+        """Opening and closing commissioning window."""
+        assert not manager.is_commissioning
+
+        await manager.permit_join(time_s=60)
+        assert manager.is_commissioning
+
+        await manager.permit_join(time_s=0)
+        assert not manager.is_commissioning
+
+    @pytest.mark.asyncio
+    async def test_commissioning_sends_proxy_mode(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Opening commissioning should send ProxyCommissioningMode."""
+        await manager.permit_join(time_s=60)
+
+        assert mock_app.send_packet.call_count == 1
+        sent_packet = mock_app.send_packet.call_args[0][0]
+        assert sent_packet.dst_ep == GP_ENDPOINT
+        assert sent_packet.cluster_id == GP_CLUSTER_ID
+
+    @pytest.mark.asyncio
+    async def test_close_commissioning_sends_exit(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Closing commissioning should send ProxyCommissioningMode exit."""
+        await manager.permit_join(time_s=60)
+        mock_app.send_packet.reset_mock()
+
+        await manager.permit_join(time_s=0)
+
+        assert mock_app.send_packet.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_process_commissioning_creates_device(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Commissioning command should create a GPDevice."""
+        # Open commissioning window
+        await manager.permit_join(time_s=60)
+        mock_app.send_packet.reset_mock()
+
+        # Minimal commissioning payload: device_id=0x02, options=0x00
+        comm_payload = bytes([0x02, 0x00])
+
+        await manager._process_commissioning(
+            source_id=0xAABBCCDD,
+            frame_counter=1,
+            payload=comm_payload,
+        )
+
+        # Device should be registered
+        dev = manager.get_device(0xAABBCCDD)
+        assert dev is not None
+        assert dev.device_id == 0x02
+        assert dev.source_id == 0xAABBCCDD
+
+        # Listener event should fire
+        mock_app.listener_event.assert_any_call("gp_device_joined", dev)
+
+        # GP Pairing should be sent
+        assert mock_app.send_packet.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_commissioning_ignored_when_window_closed(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Commissioning should be ignored if window is not open."""
+        comm_payload = bytes([0x02, 0x00])
+
+        await manager._process_commissioning(
+            source_id=0xAABBCCDD,
+            frame_counter=1,
+            payload=comm_payload,
+        )
+
+        assert manager.get_device(0xAABBCCDD) is None
+        mock_app.listener_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_commissioning_with_security_key(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Commissioning with unencrypted security key."""
+        await manager.permit_join(time_s=60)
+        mock_app.send_packet.reset_mock()
+
+        security_key = bytes(range(16))
+        # options: extended present = 0x80
+        # extended: Encrypted level + key_present = 0x03 | 0x20 = 0x23
+        comm_payload = bytes([0x02, 0x80, 0x23]) + security_key
+
+        await manager._process_commissioning(
+            source_id=0x11223344,
+            frame_counter=5,
+            payload=comm_payload,
+        )
+
+        dev = manager.get_device(0x11223344)
+        assert dev is not None
+        assert dev.security_key == security_key
+        assert dev.security_level == SecurityLevel.Encrypted
+
+    @pytest.mark.asyncio
+    async def test_commissioning_with_outgoing_counter(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Commissioning with outgoing frame counter."""
+        await manager.permit_join(time_s=60)
+
+        import struct
+
+        # extended: outgoing_counter_present = 0x80
+        comm_payload = bytes([0x02, 0x80, 0x80]) + struct.pack("<I", 42)
+
+        await manager._process_commissioning(
+            source_id=0x55667788,
+            frame_counter=1,
+            payload=comm_payload,
+        )
+
+        dev = manager.get_device(0x55667788)
+        assert dev is not None
+        assert dev.frame_counter == 42
+
+
+class TestDecommissioning:
+    """Tests for GP decommissioning."""
+
+    @pytest.mark.asyncio
+    async def test_decommission_known_device(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Decommissioning a known device should remove it."""
+        dev = GPDevice(source_id=0x12345678, device_id=0x02)
+        manager.add_device(dev)
+
+        await manager._process_decommissioning(0x12345678)
+
+        assert manager.get_device(0x12345678) is None
+        mock_app.listener_event.assert_any_call("gp_device_left", dev)
+        # GP Pairing (remove) should be sent
+        assert mock_app.send_packet.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_decommission_unknown_device(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Decommissioning unknown device should be a no-op."""
+        await manager._process_decommissioning(0xDEADBEEF)
+        mock_app.listener_event.assert_not_called()
+
+
+class TestPersistence:
+    """Tests for device persistence."""
+
+    def test_load_devices(self, manager: GreenPowerManager) -> None:
+        """Loading persisted device data."""
+        data = [
+            {
+                "source_id": 0x12345678,
+                "device_id": 0x02,
+                "security_key": "00" * 16,
+                "security_level": 3,
+                "security_key_type": 4,
+                "frame_counter": 100,
+            },
+            {
+                "source_id": 0xAABBCCDD,
+                "device_id": 0x07,
+            },
+        ]
+
+        manager.load_devices(data)
+
+        assert len(manager.devices) == 2
+        dev1 = manager.get_device(0x12345678)
+        assert dev1 is not None
+        assert dev1.device_id == 0x02
+        assert dev1.frame_counter == 100
+        assert dev1.security_level == SecurityLevel.Encrypted
+
+        dev2 = manager.get_device(0xAABBCCDD)
+        assert dev2 is not None
+        assert dev2.device_id == 0x07
+
+    def test_get_devices_data(self, manager: GreenPowerManager) -> None:
+        """Serializing devices for persistence."""
+        dev1 = GPDevice(source_id=0x12345678, device_id=0x02, frame_counter=10)
+        dev2 = GPDevice(source_id=0xAABBCCDD, device_id=0x07)
+        manager.add_device(dev1)
+        manager.add_device(dev2)
+
+        data = manager.get_devices_data()
+
+        assert len(data) == 2
+        source_ids = {d["source_id"] for d in data}
+        assert source_ids == {0x12345678, 0xAABBCCDD}
+
+    def test_load_save_roundtrip(self, manager: GreenPowerManager) -> None:
+        """Saving and loading should preserve all data."""
+        dev = GPDevice(
+            source_id=0x12345678,
+            device_id=0x02,
+            security_key=bytes(range(16)),
+            security_level=SecurityLevel.Encrypted,
+            security_key_type=SecurityKeyType.IndividualKey,
+            frame_counter=42,
+            gpd_commands=[0x20, 0x21, 0x22],
+        )
+        manager.add_device(dev)
+
+        data = manager.get_devices_data()
+
+        manager2 = GreenPowerManager(MagicMock())
+        manager2.load_devices(data)
+
+        restored = manager2.get_device(0x12345678)
+        assert restored is not None
+        assert restored.source_id == dev.source_id
+        assert restored.device_id == dev.device_id
+        assert restored.security_key == dev.security_key
+        assert restored.security_level == dev.security_level
+        assert restored.frame_counter == dev.frame_counter
+        assert restored.gpd_commands == dev.gpd_commands
+
+    def test_load_invalid_data_skipped(self, manager: GreenPowerManager) -> None:
+        """Invalid device data should be skipped without crashing."""
+        data = [
+            {"invalid": "data"},
+            {"source_id": 0x12345678, "device_id": 0x02},
+        ]
+
+        manager.load_devices(data)
+        assert len(manager.devices) == 1
+
+
+class TestBuildZclFrame:
+    """Tests for ZCL frame construction."""
+
+    def test_client_frame(self) -> None:
+        frame = GreenPowerManager._build_zcl_frame(
+            command_id=0x02, is_client=True, payload=b"\xAA\xBB"
+        )
+        # frame_control: 0x01 (cluster-specific) | 0x10 (disable default resp) = 0x11
+        assert frame[0] == 0x11
+        assert frame[1] == 0x00  # seq_num
+        assert frame[2] == 0x02  # command_id
+        assert frame[3:] == b"\xAA\xBB"
+
+    def test_server_frame(self) -> None:
+        frame = GreenPowerManager._build_zcl_frame(
+            command_id=0x00, is_client=False, payload=b"\xCC"
+        )
+        # frame_control: 0x01 | 0x08 (direction) | 0x10 = 0x19
+        assert frame[0] == 0x19
+        assert frame[2] == 0x00
+
+    def test_empty_payload(self) -> None:
+        frame = GreenPowerManager._build_zcl_frame(
+            command_id=0x06, is_client=True, payload=b""
+        )
+        assert len(frame) == 3

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -422,6 +422,33 @@ class TestCommissioning:
         assert dev is not None
         assert dev.frame_counter == 42
 
+    @pytest.mark.asyncio
+    async def test_commissioning_with_outgoing_counter_zero(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """Outgoing counter of 0 must be used, not confused with None.
+
+        Per the ZGP spec, outgoing_counter=0 is a valid initial frame
+        counter. It must not be treated as absent (Python falsy).
+        """
+        await manager.permit_join(time_s=60)
+
+        import struct
+
+        # extended: outgoing_counter_present (bit 7) = 0x80
+        comm_payload = bytes([0x02, 0x80, 0x80]) + struct.pack("<I", 0)
+
+        await manager._process_commissioning(
+            source_id=0x99887766,
+            frame_counter=999,  # GP Notification frame counter
+            payload=comm_payload,
+        )
+
+        dev = manager.get_device(0x99887766)
+        assert dev is not None
+        # Must use outgoing_counter=0 from payload, NOT frame_counter=999
+        assert dev.frame_counter == 0
+
 
 class TestDecommissioning:
     """Tests for GP decommissioning."""

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -477,6 +477,46 @@ class TestDecommissioning:
         mock_app.listener_event.assert_not_called()
 
 
+class TestSendPairingKeyEncryption:
+    """Tests for security key encryption in GP Pairing."""
+
+    @pytest.mark.asyncio
+    async def test_pairing_encrypts_security_key(
+        self, manager: GreenPowerManager, mock_app: MagicMock
+    ) -> None:
+        """GP Pairing must encrypt the security key before sending.
+
+        The key in the GP Pairing should NOT be the plaintext key.
+        It should be encrypted via encrypt_security_key(sourceID, key)
+        matching zigbee-herdsman's behavior.
+        """
+        from zigpy.zgp.crypto import encrypt_security_key
+
+        source_id = 0x12345678
+        plaintext_key = bytes(range(16))
+
+        dev = GPDevice(
+            source_id=source_id,
+            device_id=0x02,
+            security_key=plaintext_key,
+            security_level=SecurityLevel.Encrypted,
+            security_key_type=SecurityKeyType.NoKey,
+        )
+        manager.add_device(dev)
+
+        await manager.send_pairing(dev, add_sink=True)
+
+        assert mock_app.send_packet.call_count == 1
+        sent_data = mock_app.send_packet.call_args[0][0].data.serialize()
+
+        # The plaintext key must NOT appear in the sent packet
+        assert plaintext_key not in sent_data
+
+        # The encrypted key MUST appear instead
+        encrypted_key, _ = encrypt_security_key(source_id, plaintext_key)
+        assert bytes(encrypted_key) in sent_data
+
+
 class TestPersistence:
     """Tests for device persistence."""
 

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, Mock
+
+from tests.async_mock import AsyncMock, MagicMock, Mock
 
 import pytest
 

--- a/tests/zgp/test_manager.py
+++ b/tests/zgp/test_manager.py
@@ -246,6 +246,40 @@ class TestGPCommandDispatch:
         assert dev.frame_counter == 42
 
 
+class TestDeduplication:
+    """Tests for GP duplicate filtering (spec A.3.6.1.2)."""
+
+    def test_first_notification_passes(self, manager: GreenPowerManager) -> None:
+        """First occurrence of (sourceID, frameCounter) should pass."""
+        assert not manager._is_duplicate(0x12345678, 1)
+
+    def test_second_notification_blocked(self, manager: GreenPowerManager) -> None:
+        """Same (sourceID, frameCounter) within timeout should be blocked."""
+        assert not manager._is_duplicate(0x12345678, 1)
+        assert manager._is_duplicate(0x12345678, 1)
+
+    def test_different_source_id_passes(self, manager: GreenPowerManager) -> None:
+        """Different sourceID with same counter should pass."""
+        assert not manager._is_duplicate(0x11111111, 1)
+        assert not manager._is_duplicate(0x22222222, 1)
+
+    def test_different_counter_passes(self, manager: GreenPowerManager) -> None:
+        """Same sourceID with different counter should pass."""
+        assert not manager._is_duplicate(0x12345678, 1)
+        assert not manager._is_duplicate(0x12345678, 2)
+
+    def test_expired_entry_passes(self, manager: GreenPowerManager) -> None:
+        """Entries older than DEDUP_TIMEOUT_S should be purged."""
+        manager._is_duplicate(0x12345678, 1)
+
+        # Manually expire the entry
+        for key in manager._dedup_cache:
+            manager._dedup_cache[key] -= manager.DEDUP_TIMEOUT_S + 1
+
+        # Should pass again after expiry
+        assert not manager._is_duplicate(0x12345678, 1)
+
+
 class TestCommissioning:
     """Tests for GP commissioning."""
 

--- a/tests/zgp/test_proxy.py
+++ b/tests/zgp/test_proxy.py
@@ -1,0 +1,152 @@
+"""Tests for Green Power Proxy Table management."""
+
+from __future__ import annotations
+
+import pytest
+
+from zigpy.zgp.proxy import GPProxyTable, GPProxyTableEntry
+from zigpy.zgp.types import CommunicationMode, SecurityLevel
+
+
+class TestGPProxyTableEntry:
+    """Tests for individual proxy table entries."""
+
+    def test_creation(self) -> None:
+        entry = GPProxyTableEntry(source_id=0x12345678, proxy_nwk=0x1234)
+        assert entry.source_id == 0x12345678
+        assert entry.proxy_nwk == 0x1234
+        assert entry.communication_mode == CommunicationMode.UnicastLightweight
+        assert entry.security_level == SecurityLevel.NoSecurity
+        assert entry.frame_counter == 0
+
+    def test_touch_updates_last_seen(self) -> None:
+        entry = GPProxyTableEntry(source_id=0x12345678, proxy_nwk=0x1234)
+        first_seen = entry.last_seen
+        entry.touch()
+        # last_seen should be >= first_seen (same or later)
+        assert entry.last_seen >= first_seen
+
+
+class TestGPProxyTable:
+    """Tests for the proxy table."""
+
+    def test_empty_table(self) -> None:
+        table = GPProxyTable()
+        assert len(table) == 0
+        assert table.entries == []
+
+    def test_add_entry(self) -> None:
+        table = GPProxyTable()
+        entry = table.add_or_update(source_id=0xAABBCCDD, proxy_nwk=0x1234)
+
+        assert len(table) == 1
+        assert entry.source_id == 0xAABBCCDD
+        assert entry.proxy_nwk == 0x1234
+
+    def test_update_existing_entry(self) -> None:
+        table = GPProxyTable()
+        entry1 = table.add_or_update(
+            source_id=0xAABBCCDD, proxy_nwk=0x1234, frame_counter=10
+        )
+        entry2 = table.add_or_update(
+            source_id=0xAABBCCDD, proxy_nwk=0x1234, frame_counter=20
+        )
+
+        # Should be same entry, not a new one
+        assert len(table) == 1
+        assert entry1 is entry2
+        assert entry2.frame_counter == 20
+
+    def test_update_doesnt_decrease_counter(self) -> None:
+        table = GPProxyTable()
+        table.add_or_update(
+            source_id=0xAABBCCDD, proxy_nwk=0x1234, frame_counter=20
+        )
+        entry = table.add_or_update(
+            source_id=0xAABBCCDD, proxy_nwk=0x1234, frame_counter=10
+        )
+
+        assert entry.frame_counter == 20  # Should not decrease
+
+    def test_multiple_proxies_for_one_device(self) -> None:
+        table = GPProxyTable()
+        table.add_or_update(source_id=0xAABBCCDD, proxy_nwk=0x1111)
+        table.add_or_update(source_id=0xAABBCCDD, proxy_nwk=0x2222)
+        table.add_or_update(source_id=0xAABBCCDD, proxy_nwk=0x3333)
+
+        assert len(table) == 3
+        proxies = table.get_proxies_for_device(0xAABBCCDD)
+        assert set(proxies) == {0x1111, 0x2222, 0x3333}
+
+    def test_one_proxy_multiple_devices(self) -> None:
+        table = GPProxyTable()
+        table.add_or_update(source_id=0x11111111, proxy_nwk=0x1234)
+        table.add_or_update(source_id=0x22222222, proxy_nwk=0x1234)
+
+        assert len(table) == 2
+        devices = table.get_devices_for_proxy(0x1234)
+        assert set(devices) == {0x11111111, 0x22222222}
+
+    def test_remove_by_source_id(self) -> None:
+        table = GPProxyTable()
+        table.add_or_update(source_id=0xAABBCCDD, proxy_nwk=0x1111)
+        table.add_or_update(source_id=0xAABBCCDD, proxy_nwk=0x2222)
+        table.add_or_update(source_id=0x11111111, proxy_nwk=0x1111)
+
+        removed = table.remove_by_source_id(0xAABBCCDD)
+
+        assert removed == 2
+        assert len(table) == 1
+        assert table.get_proxies_for_device(0xAABBCCDD) == []
+        assert table.get_proxies_for_device(0x11111111) == [0x1111]
+
+    def test_remove_by_source_id_nonexistent(self) -> None:
+        table = GPProxyTable()
+        removed = table.remove_by_source_id(0xDEADBEEF)
+        assert removed == 0
+
+    def test_remove_by_proxy(self) -> None:
+        table = GPProxyTable()
+        table.add_or_update(source_id=0x11111111, proxy_nwk=0x1234)
+        table.add_or_update(source_id=0x22222222, proxy_nwk=0x1234)
+        table.add_or_update(source_id=0x11111111, proxy_nwk=0x5678)
+
+        removed = table.remove_by_proxy(0x1234)
+
+        assert removed == 2
+        assert len(table) == 1
+        assert table.get_devices_for_proxy(0x1234) == []
+
+    def test_get_entry(self) -> None:
+        table = GPProxyTable()
+        table.add_or_update(source_id=0xAABBCCDD, proxy_nwk=0x1234)
+
+        entry = table.get_entry(0xAABBCCDD, 0x1234)
+        assert entry is not None
+        assert entry.source_id == 0xAABBCCDD
+
+        assert table.get_entry(0xDEADBEEF, 0x1234) is None
+        assert table.get_entry(0xAABBCCDD, 0x9999) is None
+
+    def test_clear(self) -> None:
+        table = GPProxyTable()
+        table.add_or_update(source_id=0x11111111, proxy_nwk=0x1111)
+        table.add_or_update(source_id=0x22222222, proxy_nwk=0x2222)
+
+        table.clear()
+        assert len(table) == 0
+
+    def test_repr(self) -> None:
+        table = GPProxyTable()
+        assert "0 entries" in repr(table)
+
+        table.add_or_update(source_id=0x11111111, proxy_nwk=0x1111)
+        assert "1 entries" in repr(table)
+
+    def test_get_proxies_for_nonexistent_device(self) -> None:
+        table = GPProxyTable()
+        assert table.get_proxies_for_device(0xDEADBEEF) == []
+
+    def test_get_devices_for_nonexistent_proxy(self) -> None:
+        table = GPProxyTable()
+        assert table.get_devices_for_proxy(0x9999) == []

--- a/tests/zgp/test_proxy.py
+++ b/tests/zgp/test_proxy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from zigpy.zgp.proxy import GPProxyTable, GPProxyTableEntry
 from zigpy.zgp.types import CommunicationMode, SecurityLevel
@@ -59,9 +58,7 @@ class TestGPProxyTable:
 
     def test_update_doesnt_decrease_counter(self) -> None:
         table = GPProxyTable()
-        table.add_or_update(
-            source_id=0xAABBCCDD, proxy_nwk=0x1234, frame_counter=20
-        )
+        table.add_or_update(source_id=0xAABBCCDD, proxy_nwk=0x1234, frame_counter=20)
         entry = table.add_or_update(
             source_id=0xAABBCCDD, proxy_nwk=0x1234, frame_counter=10
         )

--- a/tests/zgp/test_proxy.py
+++ b/tests/zgp/test_proxy.py
@@ -140,10 +140,15 @@ class TestGPProxyTable:
 
     def test_repr(self) -> None:
         table = GPProxyTable()
-        assert "0 entries" in repr(table)
+        r = repr(table)
+        assert r.startswith("<GPProxyTable")
+        assert "0 entries" in r
 
         table.add_or_update(source_id=0x11111111, proxy_nwk=0x1111)
-        assert "1 entries" in repr(table)
+        assert "1 entry>" in repr(table)
+
+        table.add_or_update(source_id=0x22222222, proxy_nwk=0x2222)
+        assert "2 entries>" in repr(table)
 
     def test_get_proxies_for_nonexistent_device(self) -> None:
         table = GPProxyTable()

--- a/tests/zgp/test_proxy.py
+++ b/tests/zgp/test_proxy.py
@@ -117,6 +117,11 @@ class TestGPProxyTable:
         assert len(table) == 1
         assert table.get_devices_for_proxy(0x1234) == []
 
+    def test_remove_by_proxy_nonexistent(self) -> None:
+        table = GPProxyTable()
+        removed = table.remove_by_proxy(0x9999)
+        assert removed == 0
+
     def test_get_entry(self) -> None:
         table = GPProxyTable()
         table.add_or_update(source_id=0xAABBCCDD, proxy_nwk=0x1234)

--- a/tests/zgp/test_types.py
+++ b/tests/zgp/test_types.py
@@ -1,0 +1,149 @@
+"""Tests for Green Power type definitions."""
+
+from __future__ import annotations
+
+from zigpy.zgp.types import (
+    DEFAULT_GP_LINK_KEY,
+    GP_CLUSTER_ID,
+    GP_ENDPOINT,
+    GP_GROUP_ID,
+    ApplicationID,
+    CommunicationDirection,
+    CommunicationMode,
+    DeviceID,
+    FrameType,
+    GPDCommandID,
+    ProxyCommissioningModeExitMode,
+    SecurityKeyType,
+    SecurityLevel,
+)
+
+
+class TestConstants:
+    """Tests for GP constants."""
+
+    def test_gp_endpoint(self) -> None:
+        assert GP_ENDPOINT == 242
+
+    def test_gp_cluster_id(self) -> None:
+        assert GP_CLUSTER_ID == 0x0021
+
+    def test_gp_group_id(self) -> None:
+        assert GP_GROUP_ID == 0x0B84
+
+    def test_default_link_key(self) -> None:
+        assert DEFAULT_GP_LINK_KEY == b"ZigBeeAlliance09"
+        assert len(DEFAULT_GP_LINK_KEY) == 16
+
+
+class TestDeviceID:
+    """Tests for GP Device ID type."""
+
+    def test_device_id_is_uint32(self) -> None:
+        d = DeviceID(0x12345678)
+        assert int(d) == 0x12345678
+
+    def test_device_id_hex_repr(self) -> None:
+        d = DeviceID(0x02)
+        assert "0x" in repr(d).lower()
+
+
+class TestSecurityLevel:
+    """Tests for SecurityLevel enum."""
+
+    def test_no_security(self) -> None:
+        assert SecurityLevel.NoSecurity == 0b00
+
+    def test_short_counter_mic(self) -> None:
+        assert SecurityLevel.ShortFrameCounterAndMIC == 0b01
+
+    def test_full_counter_mic(self) -> None:
+        assert SecurityLevel.FullFrameCounterAndMIC == 0b10
+
+    def test_encrypted(self) -> None:
+        assert SecurityLevel.Encrypted == 0b11
+
+
+class TestSecurityKeyType:
+    """Tests for SecurityKeyType enum."""
+
+    def test_values(self) -> None:
+        assert SecurityKeyType.NoKey == 0b000
+        assert SecurityKeyType.NWKKey == 0b001
+        assert SecurityKeyType.GPDGroupKey == 0b010
+        assert SecurityKeyType.NWKKeyDerivedGPD == 0b011
+        assert SecurityKeyType.IndividualKey == 0b100
+        assert SecurityKeyType.DerivedIndividual == 0b111
+
+
+class TestGPDCommandID:
+    """Tests for GPD command identifiers."""
+
+    def test_commissioning_commands(self) -> None:
+        assert GPDCommandID.CommissioningRequest == 0xE0
+        assert GPDCommandID.DecommissioningRequest == 0xE1
+        assert GPDCommandID.SuccessReport == 0xE2
+        assert GPDCommandID.ChannelRequest == 0xE3
+
+    def test_on_off_commands(self) -> None:
+        assert GPDCommandID.Off == 0x20
+        assert GPDCommandID.On == 0x21
+        assert GPDCommandID.Toggle == 0x22
+
+    def test_level_commands(self) -> None:
+        assert GPDCommandID.MoveUp == 0x30
+        assert GPDCommandID.MoveDown == 0x31
+        assert GPDCommandID.StepUp == 0x32
+        assert GPDCommandID.StepDown == 0x33
+
+
+class TestFrameType:
+    """Tests for GP frame types."""
+
+    def test_data_frame(self) -> None:
+        assert FrameType.DataFrame == 0x00
+
+    def test_maintenance_frame(self) -> None:
+        assert FrameType.MaintenanceFrame == 0x01
+
+
+class TestApplicationID:
+    """Tests for Application ID values."""
+
+    def test_src_id(self) -> None:
+        assert ApplicationID.SrcID == 0b000
+
+    def test_ieee(self) -> None:
+        assert ApplicationID.IEEE == 0b010
+
+
+class TestCommunicationMode:
+    """Tests for communication mode enum."""
+
+    def test_unicast(self) -> None:
+        assert CommunicationMode.Unicast == 0b00
+
+    def test_groupcast(self) -> None:
+        assert CommunicationMode.GroupcastForwardToDGroup == 0b01
+        assert CommunicationMode.GroupcastForwardToCommGroup == 0b10
+
+    def test_lightweight(self) -> None:
+        assert CommunicationMode.UnicastLightweight == 0b11
+
+
+class TestCommunicationDirection:
+    """Tests for communication direction enum."""
+
+    def test_directions(self) -> None:
+        assert CommunicationDirection.GPDtoGPP == 0
+        assert CommunicationDirection.GPPtoGPD == 1
+
+
+class TestProxyCommissioningModeExitMode:
+    """Tests for proxy commissioning exit mode."""
+
+    def test_exit_modes(self) -> None:
+        assert ProxyCommissioningModeExitMode.NotDefined == 0b000
+        assert ProxyCommissioningModeExitMode.OnExpire == 0b001
+        assert ProxyCommissioningModeExitMode.OnFirstPairing == 0b010
+        assert ProxyCommissioningModeExitMode.OnExplicitExit == 0b100

--- a/tests/zgp/test_types.py
+++ b/tests/zgp/test_types.py
@@ -95,6 +95,36 @@ class TestGPDCommandID:
         assert GPDCommandID.MoveDown == 0x31
         assert GPDCommandID.StepUp == 0x32
         assert GPDCommandID.StepDown == 0x33
+        assert GPDCommandID.LevelControlStop == 0x34
+
+    def test_identify(self) -> None:
+        assert GPDCommandID.Identify == 0x00
+
+    def test_scene_commands(self) -> None:
+        assert GPDCommandID.RecallScene0 == 0x10
+        assert GPDCommandID.RecallScene7 == 0x17
+        assert GPDCommandID.StoreScene0 == 0x18
+        assert GPDCommandID.StoreScene7 == 0x1F
+
+    def test_color_commands(self) -> None:
+        assert GPDCommandID.MoveHueStop == 0x40
+        assert GPDCommandID.MoveHueUp == 0x41
+        assert GPDCommandID.StepColor == 0x4B
+
+    def test_door_lock_commands(self) -> None:
+        assert GPDCommandID.LockDoor == 0x50
+        assert GPDCommandID.UnlockDoor == 0x51
+
+    def test_reporting_commands(self) -> None:
+        assert GPDCommandID.AttributeReporting == 0xA0
+        assert GPDCommandID.ManufacturerSpecificReporting == 0xA1
+        assert GPDCommandID.MultiClusterReporting == 0xA2
+
+    def test_application_description(self) -> None:
+        assert GPDCommandID.ApplicationDescription == 0xE4
+
+    def test_any_command(self) -> None:
+        assert GPDCommandID.AnyCommand == 0xFF
 
 
 class TestFrameType:
@@ -115,6 +145,9 @@ class TestApplicationID:
 
     def test_ieee(self) -> None:
         assert ApplicationID.IEEE == 0b010
+
+    def test_lped(self) -> None:
+        assert ApplicationID.LPED == 0b001
 
 
 class TestCommunicationMode:
@@ -147,3 +180,7 @@ class TestProxyCommissioningModeExitMode:
         assert ProxyCommissioningModeExitMode.OnExpire == 0b001
         assert ProxyCommissioningModeExitMode.OnFirstPairing == 0b010
         assert ProxyCommissioningModeExitMode.OnExplicitExit == 0b100
+
+    def test_combined_exit_modes(self) -> None:
+        assert ProxyCommissioningModeExitMode.OnExpireOrFirstPairing == 0b011
+        assert ProxyCommissioningModeExitMode.OnExpireOrExplicitExit == 0b101

--- a/tests/zgp/test_types.py
+++ b/tests/zgp/test_types.py
@@ -55,7 +55,7 @@ class TestSecurityLevel:
         assert SecurityLevel.NoSecurity == 0b00
 
     def test_short_counter_mic(self) -> None:
-        assert SecurityLevel.ShortFrameCounterAndMIC == 0b01
+        assert SecurityLevel.Reserved == 0b01
 
     def test_full_counter_mic(self) -> None:
         assert SecurityLevel.FullFrameCounterAndMIC == 0b10

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -38,6 +38,8 @@ import zigpy.util
 import zigpy.zcl
 import zigpy.zdo
 import zigpy.zdo.types as zdo_types
+from zigpy.zgp.manager import GreenPowerManager
+from zigpy.zgp.types import GP_CLUSTER_ID, GP_ENDPOINT
 
 DEFAULT_ENDPOINT_ID = 1
 LOGGER = logging.getLogger(__name__)
@@ -80,6 +82,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.ota = zigpy.ota.OTA(self._config[conf.CONF_OTA], self)
         self.backups: zigpy.backups.BackupManager = zigpy.backups.BackupManager(self)
         self.topology: zigpy.topology.Topology = zigpy.topology.Topology(self)
+        self.green_power: GreenPowerManager = GreenPowerManager(self)
 
         self._req_listeners: collections.defaultdict[
             zigpy.device.Device | zigpy.listeners.AnyDeviceType,
@@ -1194,6 +1197,11 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         if zigpy.zdo.ZDO_ENDPOINT in (packet.src_ep, packet.dst_ep):
             self._maybe_parse_zdo(packet)
 
+        # Intercept Green Power frames (endpoint 242, cluster 0x0021)
+        if packet.dst_ep == GP_ENDPOINT and packet.cluster_id == GP_CLUSTER_ID:
+            if self.green_power.handle_packet(packet):
+                return None
+
         try:
             device = self.get_device_with_address(packet.src)
         except KeyError:
@@ -1578,6 +1586,18 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             broadcast_address=t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
         )
         await self.permit_ncp(time_s)
+
+    async def permit_gp(self, time_s: int = 180) -> None:
+        """Open the Green Power commissioning window.
+
+        This is separate from standard ``permit()`` to avoid accidentally
+        commissioning GP devices during normal pairing and vice versa.
+
+        Args:
+            time_s: Duration of the commissioning window in seconds.
+                   Pass 0 to close the window immediately.
+        """
+        await self.green_power.permit_join(time_s)
 
     def get_sequence(self) -> int:
         self._send_sequence = (self._send_sequence + 1) % 256

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -565,6 +565,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.ota.stop_periodic_broadcasts()
         self.backups.stop_periodic_backups()
         self.topology.stop_periodic_scans()
+        await self.green_power.shutdown()
 
         for device in self.devices.values():
             try:

--- a/zigpy/zgp/__init__.py
+++ b/zigpy/zgp/__init__.py
@@ -1,1 +1,26 @@
 from .types import *  # noqa: F403, F401
+from .types import (  # noqa: F401
+    DEFAULT_GP_LINK_KEY,
+    GP_CLUSTER_ID,
+    GP_ENDPOINT,
+    GP_GROUP_ID,
+)
+from .crypto import (  # noqa: F401
+    build_nonce,
+    decrypt_payload,
+    decrypt_security_key,
+    encrypt_payload,
+    encrypt_security_key,
+)
+from .frame import (  # noqa: F401
+    GPChannelRequestPayload,
+    GPCommissioningAppInfo,
+    GPCommissioningExtendedOptions,
+    GPCommissioningOptions,
+    GPCommissioningPayload,
+)
+from .device import GPDevice, source_id_to_ieee, ieee_to_source_id  # noqa: F401
+
+# Note: GreenPowerManager is not imported here to avoid circular imports
+# with zigpy.zcl.clusters.greenpower. Import it directly:
+#   from zigpy.zgp.manager import GreenPowerManager

--- a/zigpy/zgp/crypto.py
+++ b/zigpy/zgp/crypto.py
@@ -137,6 +137,20 @@ def decrypt_security_key(
     return aesccm.decrypt(nonce, encrypted_key + mic, associated_data=None)
 
 
+def _is_auth_only(security_level: SecurityLevel) -> bool:
+    """Return True if the security level uses authentication only (no encryption).
+
+    Per ZGP spec Table 12:
+    - SecurityLevel 0b10 (FullFrameCounterAndMIC): 4-byte FC + 4-byte MIC, no encryption
+    - SecurityLevel 0b01 (Reserved/Short): similar auth-only semantics
+    - SecurityLevel 0b11 (Encrypted): full encryption + authentication
+    """
+    return security_level in (
+        SecurityLevel.FullFrameCounterAndMIC,
+        SecurityLevel.ShortFrameCounterAndMIC,
+    )
+
+
 def encrypt_payload(
     source_id: int,
     frame_counter: int,
@@ -144,17 +158,23 @@ def encrypt_payload(
     payload: bytes,
     security_level: SecurityLevel = SecurityLevel.Encrypted,
 ) -> tuple[bytes, bytes]:
-    """Encrypt a GP frame payload.
+    """Encrypt or authenticate a GP frame payload.
+
+    For SecurityLevel.Encrypted: payload is encrypted and authenticated.
+    For FullFrameCounterAndMIC/ShortFrameCounterAndMIC: payload is
+    authenticated only (MIC computed over plaintext, payload not encrypted).
 
     Args:
         source_id: 32-bit GPD source identifier.
         frame_counter: 32-bit frame counter.
         security_key: 16-byte security key.
-        payload: Plaintext payload to encrypt.
-        security_level: Security level determining MIC length.
+        payload: Plaintext payload.
+        security_level: Security level determining behavior.
 
     Returns:
-        Tuple of (encrypted_payload, mic).
+        Tuple of (output_payload, mic) where output_payload is the
+        encrypted payload (Encrypted level) or the original plaintext
+        (auth-only levels).
     """
     if len(security_key) != 16:
         raise ValueError(f"Security key must be 16 bytes, got {len(security_key)}")
@@ -166,14 +186,19 @@ def encrypt_payload(
     nonce = build_nonce(source_id, frame_counter)
     aesccm = AESCCM(security_key, tag_length=mic_length)
 
-    # AES-CCM: encrypt produces ciphertext + MIC appended
-    ciphertext_and_mic = aesccm.encrypt(nonce, payload, associated_data=None)
-
-    # Split into encrypted payload and MIC
-    encrypted = ciphertext_and_mic[:-mic_length]
-    mic = ciphertext_and_mic[-mic_length:]
-
-    return encrypted, mic
+    if _is_auth_only(security_level):
+        # Authentication only: payload is passed as associated data (AAD),
+        # plaintext message is empty. The MIC authenticates the payload
+        # without encrypting it. Per ZGP spec, FullFrameCounterAndMIC
+        # provides integrity protection but the payload remains in cleartext.
+        mic = aesccm.encrypt(nonce, b"", associated_data=payload)
+        return payload, mic
+    else:
+        # Full encryption: payload is encrypted and authenticated
+        ciphertext_and_mic = aesccm.encrypt(nonce, payload, associated_data=None)
+        encrypted = ciphertext_and_mic[:-mic_length]
+        mic = ciphertext_and_mic[-mic_length:]
+        return encrypted, mic
 
 
 def decrypt_payload(
@@ -184,18 +209,22 @@ def decrypt_payload(
     mic: bytes,
     security_level: SecurityLevel = SecurityLevel.Encrypted,
 ) -> bytes:
-    """Decrypt a GP frame payload.
+    """Decrypt or verify a GP frame payload.
+
+    For SecurityLevel.Encrypted: payload is decrypted and MIC verified.
+    For FullFrameCounterAndMIC/ShortFrameCounterAndMIC: MIC is verified
+    against the plaintext payload (no decryption needed).
 
     Args:
         source_id: 32-bit GPD source identifier.
         frame_counter: 32-bit frame counter.
         security_key: 16-byte security key.
-        payload: Encrypted payload (or plaintext for auth-only levels).
+        payload: Encrypted payload (Encrypted level) or plaintext (auth-only).
         mic: Message Integrity Code.
-        security_level: Security level determining MIC length and behavior.
+        security_level: Security level determining behavior.
 
     Returns:
-        Decrypted payload bytes.
+        Decrypted/verified payload bytes.
 
     Raises:
         cryptography.exceptions.InvalidTag: If MIC verification fails.
@@ -213,5 +242,11 @@ def decrypt_payload(
     nonce = build_nonce(source_id, frame_counter)
     aesccm = AESCCM(security_key, tag_length=mic_length)
 
-    # AES-CCM: decrypt expects ciphertext + MIC concatenated
-    return aesccm.decrypt(nonce, payload + mic, associated_data=None)
+    if _is_auth_only(security_level):
+        # Authentication only: verify MIC with payload as AAD.
+        # The "ciphertext" is empty, only the MIC tag is present.
+        aesccm.decrypt(nonce, mic, associated_data=payload)
+        return payload
+    else:
+        # Full decryption: ciphertext + MIC concatenated
+        return aesccm.decrypt(nonce, payload + mic, associated_data=None)

--- a/zigpy/zgp/crypto.py
+++ b/zigpy/zgp/crypto.py
@@ -60,6 +60,7 @@ def build_nonce(source_id: int, frame_counter: int) -> bytes:
 
     Returns:
         13-byte nonce for AES-CCM.
+
     """
     return struct.pack(
         "<IIIB",
@@ -93,6 +94,7 @@ def encrypt_security_key(
         Tuple of (encrypted_key, mic) where:
         - encrypted_key is the 16-byte encrypted security key
         - mic is the 4-byte Message Integrity Code
+
     """
     if len(security_key) != 16:
         raise ValueError(f"Security key must be 16 bytes, got {len(security_key)}")
@@ -132,11 +134,10 @@ def decrypt_security_key(
 
     Raises:
         cryptography.exceptions.InvalidTag: If MIC verification fails.
+
     """
     if len(encrypted_key) != 16:
-        raise ValueError(
-            f"Encrypted key must be 16 bytes, got {len(encrypted_key)}"
-        )
+        raise ValueError(f"Encrypted key must be 16 bytes, got {len(encrypted_key)}")
     if len(mic) != 4:
         raise ValueError(f"MIC must be 4 bytes, got {len(mic)}")
     if len(link_key) != 16:
@@ -186,6 +187,7 @@ def encrypt_payload(
         Tuple of (output_payload, mic) where output_payload is the
         encrypted payload (Encrypted level) or the original plaintext
         (auth-only levels).
+
     """
     if len(security_key) != 16:
         raise ValueError(f"Security key must be 16 bytes, got {len(security_key)}")
@@ -240,6 +242,7 @@ def decrypt_payload(
     Raises:
         cryptography.exceptions.InvalidTag: If MIC verification fails.
         ValueError: If security level is NoSecurity.
+
     """
     if len(security_key) != 16:
         raise ValueError(f"Security key must be 16 bytes, got {len(security_key)}")

--- a/zigpy/zgp/crypto.py
+++ b/zigpy/zgp/crypto.py
@@ -1,0 +1,217 @@
+"""Green Power security primitives.
+
+Implements AES-128-CCM encryption/decryption for Zigbee Green Power frames
+as specified in the ZGP specification (A.1.5.4).
+
+The GP security uses CCM* (CCM-star) mode with:
+- 128-bit AES key
+- 13-byte nonce constructed from sourceID and frame counter
+- Variable MIC length depending on SecurityLevel
+"""
+
+from __future__ import annotations
+
+import struct
+
+from cryptography.hazmat.primitives.ciphers.aead import AESCCM
+
+from zigpy.zgp.types import DEFAULT_GP_LINK_KEY, SecurityLevel
+
+# Security level to MIC length mapping (Table 12 in ZGP spec)
+# Note: ShortFrameCounterAndMIC uses a 2-byte counter (LSBytes only) for
+# frame counter but still uses a 4-byte MIC for authentication per the spec.
+# The AESCCM library requires tag_length >= 4.
+SECURITY_LEVEL_MIC_LENGTH: dict[SecurityLevel, int] = {
+    SecurityLevel.NoSecurity: 0,
+    SecurityLevel.ShortFrameCounterAndMIC: 4,
+    SecurityLevel.FullFrameCounterAndMIC: 4,
+    SecurityLevel.Encrypted: 4,
+}
+
+# Security control byte for nonce construction
+# Bits 0-2: Security level (always 0b101 = 5 for GP CCM*)
+# Ref: ZGP spec A.1.5.4.1
+GP_SECURITY_CONTROL_BYTE: int = 0x05
+
+
+def build_nonce(source_id: int, frame_counter: int) -> bytes:
+    """Construct the 13-byte CCM nonce per ZGP spec A.1.5.4.1.
+
+    Nonce structure (13 bytes):
+    - Bytes 0-3: Source ID (little-endian)
+    - Bytes 4-7: Source ID (repeated, little-endian)
+    - Bytes 8-11: Frame counter (little-endian)
+    - Byte 12: Security control byte (0x05)
+
+    Args:
+        source_id: 32-bit GP device source identifier.
+        frame_counter: 32-bit frame counter value.
+
+    Returns:
+        13-byte nonce for AES-CCM.
+    """
+    return struct.pack(
+        "<IIIb",
+        source_id,
+        source_id,
+        frame_counter,
+        GP_SECURITY_CONTROL_BYTE,
+    )
+
+
+def encrypt_security_key(
+    source_id: int,
+    security_key: bytes,
+    link_key: bytes = DEFAULT_GP_LINK_KEY,
+) -> tuple[bytes, bytes]:
+    """Encrypt a GP security key for transmission during commissioning.
+
+    Used when the sink sends a security key to an RX-capable GPD via
+    a GP Commissioning Reply. The key is encrypted using AES-128-CCM
+    with the GP link key and a nonce derived from the sourceID.
+
+    For key encryption, the frame counter in the nonce is set to the
+    sourceID value itself (per ZGP spec A.1.5.4.3).
+
+    Args:
+        source_id: 32-bit GPD source identifier.
+        security_key: 16-byte security key to encrypt.
+        link_key: 16-byte link key for encryption (default: ZigBeeAlliance09).
+
+    Returns:
+        Tuple of (encrypted_key, mic) where:
+        - encrypted_key is the 16-byte encrypted security key
+        - mic is the 4-byte Message Integrity Code
+    """
+    if len(security_key) != 16:
+        raise ValueError(f"Security key must be 16 bytes, got {len(security_key)}")
+    if len(link_key) != 16:
+        raise ValueError(f"Link key must be 16 bytes, got {len(link_key)}")
+
+    # For key encryption, frame counter = sourceID
+    nonce = build_nonce(source_id, source_id)
+
+    # AES-CCM with 4-byte tag (MIC)
+    aesccm = AESCCM(link_key, tag_length=4)
+    ciphertext_and_mic = aesccm.encrypt(nonce, security_key, associated_data=None)
+
+    # Split into encrypted key (16 bytes) and MIC (4 bytes)
+    encrypted_key = ciphertext_and_mic[:16]
+    mic = ciphertext_and_mic[16:]
+
+    return encrypted_key, mic
+
+
+def decrypt_security_key(
+    source_id: int,
+    encrypted_key: bytes,
+    mic: bytes,
+    link_key: bytes = DEFAULT_GP_LINK_KEY,
+) -> bytes:
+    """Decrypt a GP security key received during commissioning.
+
+    Args:
+        source_id: 32-bit GPD source identifier.
+        encrypted_key: 16-byte encrypted security key.
+        mic: 4-byte Message Integrity Code.
+        link_key: 16-byte link key for decryption (default: ZigBeeAlliance09).
+
+    Returns:
+        16-byte decrypted security key.
+
+    Raises:
+        cryptography.exceptions.InvalidTag: If MIC verification fails.
+    """
+    if len(encrypted_key) != 16:
+        raise ValueError(
+            f"Encrypted key must be 16 bytes, got {len(encrypted_key)}"
+        )
+    if len(mic) != 4:
+        raise ValueError(f"MIC must be 4 bytes, got {len(mic)}")
+    if len(link_key) != 16:
+        raise ValueError(f"Link key must be 16 bytes, got {len(link_key)}")
+
+    nonce = build_nonce(source_id, source_id)
+    aesccm = AESCCM(link_key, tag_length=4)
+
+    return aesccm.decrypt(nonce, encrypted_key + mic, associated_data=None)
+
+
+def encrypt_payload(
+    source_id: int,
+    frame_counter: int,
+    security_key: bytes,
+    payload: bytes,
+    security_level: SecurityLevel = SecurityLevel.Encrypted,
+) -> tuple[bytes, bytes]:
+    """Encrypt a GP frame payload.
+
+    Args:
+        source_id: 32-bit GPD source identifier.
+        frame_counter: 32-bit frame counter.
+        security_key: 16-byte security key.
+        payload: Plaintext payload to encrypt.
+        security_level: Security level determining MIC length.
+
+    Returns:
+        Tuple of (encrypted_payload, mic).
+    """
+    if len(security_key) != 16:
+        raise ValueError(f"Security key must be 16 bytes, got {len(security_key)}")
+
+    mic_length = SECURITY_LEVEL_MIC_LENGTH[security_level]
+    if mic_length == 0:
+        raise ValueError("Cannot encrypt with SecurityLevel.NoSecurity")
+
+    nonce = build_nonce(source_id, frame_counter)
+    aesccm = AESCCM(security_key, tag_length=mic_length)
+
+    # AES-CCM: encrypt produces ciphertext + MIC appended
+    ciphertext_and_mic = aesccm.encrypt(nonce, payload, associated_data=None)
+
+    # Split into encrypted payload and MIC
+    encrypted = ciphertext_and_mic[:-mic_length]
+    mic = ciphertext_and_mic[-mic_length:]
+
+    return encrypted, mic
+
+
+def decrypt_payload(
+    source_id: int,
+    frame_counter: int,
+    security_key: bytes,
+    payload: bytes,
+    mic: bytes,
+    security_level: SecurityLevel = SecurityLevel.Encrypted,
+) -> bytes:
+    """Decrypt a GP frame payload.
+
+    Args:
+        source_id: 32-bit GPD source identifier.
+        frame_counter: 32-bit frame counter.
+        security_key: 16-byte security key.
+        payload: Encrypted payload (or plaintext for auth-only levels).
+        mic: Message Integrity Code.
+        security_level: Security level determining MIC length and behavior.
+
+    Returns:
+        Decrypted payload bytes.
+
+    Raises:
+        cryptography.exceptions.InvalidTag: If MIC verification fails.
+        ValueError: If security level is NoSecurity.
+    """
+    if len(security_key) != 16:
+        raise ValueError(f"Security key must be 16 bytes, got {len(security_key)}")
+
+    mic_length = SECURITY_LEVEL_MIC_LENGTH[security_level]
+    if mic_length == 0:
+        raise ValueError("Cannot decrypt with SecurityLevel.NoSecurity")
+    if len(mic) != mic_length:
+        raise ValueError(f"MIC must be {mic_length} bytes, got {len(mic)}")
+
+    nonce = build_nonce(source_id, frame_counter)
+    aesccm = AESCCM(security_key, tag_length=mic_length)
+
+    # AES-CCM: decrypt expects ciphertext + MIC concatenated
+    return aesccm.decrypt(nonce, payload + mic, associated_data=None)

--- a/zigpy/zgp/crypto.py
+++ b/zigpy/zgp/crypto.py
@@ -18,12 +18,12 @@ from cryptography.hazmat.primitives.ciphers.aead import AESCCM
 from zigpy.zgp.types import DEFAULT_GP_LINK_KEY, SecurityLevel
 
 # Security level to MIC length mapping (Table 12 in ZGP spec)
-# Note: ShortFrameCounterAndMIC uses a 2-byte counter (LSBytes only) for
+# Note: Reserved uses a 2-byte counter (LSBytes only) for
 # frame counter but still uses a 4-byte MIC for authentication per the spec.
 # The AESCCM library requires tag_length >= 4.
 SECURITY_LEVEL_MIC_LENGTH: dict[SecurityLevel, int] = {
     SecurityLevel.NoSecurity: 0,
-    SecurityLevel.ShortFrameCounterAndMIC: 4,
+    SecurityLevel.Reserved: 4,
     SecurityLevel.FullFrameCounterAndMIC: 4,
     SecurityLevel.Encrypted: 4,
 }
@@ -147,7 +147,7 @@ def _is_auth_only(security_level: SecurityLevel) -> bool:
     """
     return security_level in (
         SecurityLevel.FullFrameCounterAndMIC,
-        SecurityLevel.ShortFrameCounterAndMIC,
+        SecurityLevel.Reserved,
     )
 
 
@@ -161,7 +161,7 @@ def encrypt_payload(
     """Encrypt or authenticate a GP frame payload.
 
     For SecurityLevel.Encrypted: payload is encrypted and authenticated.
-    For FullFrameCounterAndMIC/ShortFrameCounterAndMIC: payload is
+    For FullFrameCounterAndMIC/Reserved: payload is
     authenticated only (MIC computed over plaintext, payload not encrypted).
 
     Args:
@@ -212,7 +212,7 @@ def decrypt_payload(
     """Decrypt or verify a GP frame payload.
 
     For SecurityLevel.Encrypted: payload is decrypted and MIC verified.
-    For FullFrameCounterAndMIC/ShortFrameCounterAndMIC: MIC is verified
+    For FullFrameCounterAndMIC/Reserved: MIC is verified
     against the plaintext payload (no decryption needed).
 
     Args:

--- a/zigpy/zgp/crypto.py
+++ b/zigpy/zgp/crypto.py
@@ -51,7 +51,7 @@ def build_nonce(source_id: int, frame_counter: int) -> bytes:
         13-byte nonce for AES-CCM.
     """
     return struct.pack(
-        "<IIIb",
+        "<IIIB",
         source_id,
         source_id,
         frame_counter,

--- a/zigpy/zgp/crypto.py
+++ b/zigpy/zgp/crypto.py
@@ -7,6 +7,17 @@ The GP security uses CCM* (CCM-star) mode with:
 - 128-bit AES key
 - 13-byte nonce constructed from sourceID and frame counter
 - Variable MIC length depending on SecurityLevel
+
+Limitation: per the ZGP spec (A.1.5.4.3), the CCM* associated data (AAD)
+should include the GPDF header (NWK Frame Control, Extended NWK FC, SrcID,
+Security Frame Counter). However, when GP frames arrive via GP Notification
+ZCL commands, the original GPDF header is no longer available — only the
+extracted fields (sourceID, frameCounter, commandID, payload) are present.
+Furthermore, radio adapters (EZSP, Z-Stack) typically handle GP decryption
+in firmware before delivering the payload to the host. This matches the
+approach used by zigbee-herdsman. If raw GPDF header data becomes available
+in the future, the encrypt/decrypt functions should be updated to accept
+an optional ``header`` parameter for AAD.
 """
 
 from __future__ import annotations

--- a/zigpy/zgp/device.py
+++ b/zigpy/zgp/device.py
@@ -152,7 +152,17 @@ class GPDevice:
         return True
 
     def as_dict(self) -> dict:
-        """Serialize to a dictionary for database persistence."""
+        """Serialize to a dictionary for database persistence.
+
+        Required keys: ``source_id``, ``device_id``.
+        Optional keys (with defaults in ``from_dict``): ``security_key``
+        (hex str or None), ``security_level`` (int, default 0),
+        ``security_key_type`` (int, default 0), ``frame_counter`` (int,
+        default 0), ``manufacturer_id``, ``model_id``, ``gpd_commands``
+        (list), ``server_clusters`` (list), ``client_clusters`` (list),
+        ``mac_seq_num_capability`` (bool), ``rx_on_capability`` (bool),
+        ``fixed_location`` (bool), ``last_seen`` (ISO 8601 str or None).
+        """
         return {
             "source_id": self.source_id,
             "device_id": self.device_id,

--- a/zigpy/zgp/device.py
+++ b/zigpy/zgp/device.py
@@ -16,7 +16,6 @@ from datetime import UTC, datetime
 import zigpy.types as t
 
 from zigpy.zgp.types import (
-    DeviceID,
     SecurityKeyType,
     SecurityLevel,
 )
@@ -41,6 +40,7 @@ def source_id_to_ieee(source_id: int) -> t.EUI64:
 
     Returns:
         Synthetic 8-byte EUI64 address.
+
     """
     ieee_bytes = struct.pack("<I", source_id) + GP_IEEE_SUFFIX
     return t.EUI64([t.uint8_t(b) for b in ieee_bytes])
@@ -61,6 +61,7 @@ def ieee_to_source_id(ieee: t.EUI64) -> int | None:
 
     Returns:
         32-bit sourceID if this is a GP synthetic address, None otherwise.
+
     """
     ieee_bytes = bytes(ieee)
     if ieee_bytes[4:] != GP_IEEE_SUFFIX:
@@ -134,6 +135,7 @@ class GPDevice:
             True if the counter was accepted and updated.
             False if the counter is not greater than the stored value
             (potential replay attack).
+
         """
         if counter <= self.frame_counter:
             LOGGER.warning(
@@ -178,6 +180,7 @@ class GPDevice:
 
         Returns:
             GPDevice instance.
+
         """
         security_key_hex = data.get("security_key")
         last_seen_str = data.get("last_seen")
@@ -199,9 +202,7 @@ class GPDevice:
             rx_on_capability=data.get("rx_on_capability", False),
             fixed_location=data.get("fixed_location", False),
             last_seen=(
-                datetime.fromisoformat(last_seen_str)
-                if last_seen_str
-                else None
+                datetime.fromisoformat(last_seen_str) if last_seen_str else None
             ),
         )
 

--- a/zigpy/zgp/device.py
+++ b/zigpy/zgp/device.py
@@ -166,6 +166,7 @@ class GPDevice:
             "mac_seq_num_capability": self.mac_seq_num_capability,
             "rx_on_capability": self.rx_on_capability,
             "fixed_location": self.fixed_location,
+            "last_seen": self.last_seen.isoformat() if self.last_seen else None,
         }
 
     @classmethod
@@ -179,6 +180,7 @@ class GPDevice:
             GPDevice instance.
         """
         security_key_hex = data.get("security_key")
+        last_seen_str = data.get("last_seen")
         return cls(
             source_id=data["source_id"],
             device_id=data["device_id"],
@@ -196,6 +198,11 @@ class GPDevice:
             mac_seq_num_capability=data.get("mac_seq_num_capability", False),
             rx_on_capability=data.get("rx_on_capability", False),
             fixed_location=data.get("fixed_location", False),
+            last_seen=(
+                datetime.fromisoformat(last_seen_str)
+                if last_seen_str
+                else None
+            ),
         )
 
     def __repr__(self) -> str:

--- a/zigpy/zgp/device.py
+++ b/zigpy/zgp/device.py
@@ -208,8 +208,10 @@ class GPDevice:
 
     def __repr__(self) -> str:
         return (
-            f"GPDevice(source_id=0x{self.source_id:08X}, "
-            f"device_id=0x{self.device_id:02X}, "
-            f"model={self.model_identifier}, "
-            f"security={self.security_level.name})"
+            f"<{type(self).__name__}"
+            f" source_id=0x{self.source_id:08X}"
+            f" device_id=0x{self.device_id:02X}"
+            f" model={self.model_identifier!r}"
+            f" security={self.security_level.name}"
+            f">"
         )

--- a/zigpy/zgp/device.py
+++ b/zigpy/zgp/device.py
@@ -1,0 +1,203 @@
+"""Green Power Device model.
+
+Represents a commissioned Green Power Device (GPD) within zigpy's
+device registry. Unlike standard zigpy Device objects, GPDevices
+use 32-bit sourceIDs, have no real network address, and communicate
+through GP Proxy devices.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import struct
+from datetime import UTC, datetime
+
+import zigpy.types as t
+
+from zigpy.zgp.types import (
+    DeviceID,
+    SecurityKeyType,
+    SecurityLevel,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+# Prefix for synthetic IEEE addresses generated from GP sourceIDs.
+# This uses a distinctive pattern to avoid collision with real IEEE addresses.
+# Format: sourceID (4 bytes LE) + GP_IEEE_SUFFIX (4 bytes)
+GP_IEEE_SUFFIX: bytes = b"\x00\x00\x00\x00"
+
+
+def source_id_to_ieee(source_id: int) -> t.EUI64:
+    """Convert a GP sourceID to a synthetic IEEE address.
+
+    The synthetic IEEE is constructed by placing the sourceID in the
+    lower 4 bytes (little-endian) and padding the upper 4 bytes with zeros.
+    This matches the convention used by zigbee-herdsman/zigbee2mqtt.
+
+    Args:
+        source_id: 32-bit GP device source identifier.
+
+    Returns:
+        Synthetic 8-byte EUI64 address.
+    """
+    ieee_bytes = struct.pack("<I", source_id) + GP_IEEE_SUFFIX
+    return t.EUI64([t.uint8_t(b) for b in ieee_bytes])
+
+
+def ieee_to_source_id(ieee: t.EUI64) -> int | None:
+    """Extract a GP sourceID from a synthetic IEEE address.
+
+    Returns None if the IEEE address doesn't look like a GP synthetic address
+    (i.e., upper 4 bytes are not all zeros).
+
+    Args:
+        ieee: EUI64 address to check.
+
+    Returns:
+        32-bit sourceID if this is a GP synthetic address, None otherwise.
+    """
+    ieee_bytes = bytes(ieee)
+    if ieee_bytes[4:] != GP_IEEE_SUFFIX:
+        return None
+    return struct.unpack("<I", ieee_bytes[:4])[0]
+
+
+@dataclasses.dataclass
+class GPDevice:
+    """Represents a commissioned Green Power Device.
+
+    Unlike standard zigpy Device objects, GPDevices:
+    - Use sourceID (32-bit) as primary identifier
+    - Have synthetic IEEE addresses (derived from sourceID)
+    - Have no real NWK address
+    - Do not have standard ZCL endpoints or clusters
+    - Maintain their own frame counter for replay protection
+    - Store their security key and security level
+    - Are receive-only (commands flow GPD → coordinator, never reverse
+      except during commissioning for RX-capable GPDs)
+    """
+
+    source_id: int
+    device_id: int
+
+    # Security configuration
+    security_key: bytes | None = None
+    security_level: SecurityLevel = SecurityLevel.NoSecurity
+    security_key_type: SecurityKeyType = SecurityKeyType.NoKey
+    frame_counter: int = 0
+
+    # Device information (from commissioning)
+    manufacturer_id: int | None = None
+    model_id: int | None = None
+    gpd_commands: list[int] = dataclasses.field(default_factory=list)
+    server_clusters: list[int] = dataclasses.field(default_factory=list)
+    client_clusters: list[int] = dataclasses.field(default_factory=list)
+
+    # Capabilities from commissioning
+    mac_seq_num_capability: bool = False
+    rx_on_capability: bool = False
+    fixed_location: bool = False
+
+    # Timestamps
+    last_seen: datetime | None = None
+
+    @property
+    def ieee(self) -> t.EUI64:
+        """Synthetic IEEE address derived from sourceID."""
+        return source_id_to_ieee(self.source_id)
+
+    @property
+    def model_identifier(self) -> str:
+        """Return a model string for quirks matching.
+
+        Pattern matches zigbee2mqtt convention: 'GreenPower_{device_id_value}'.
+        """
+        return f"GreenPower_{self.device_id}"
+
+    def update_frame_counter(self, counter: int) -> bool:
+        """Update frame counter with replay protection.
+
+        The frame counter must be strictly greater than the stored value
+        to prevent replay attacks. This is a core security mechanism
+        for Green Power devices.
+
+        Args:
+            counter: New frame counter value from received frame.
+
+        Returns:
+            True if the counter was accepted and updated.
+            False if the counter is not greater than the stored value
+            (potential replay attack).
+        """
+        if counter <= self.frame_counter:
+            LOGGER.warning(
+                "GP device 0x%08X: frame counter %d <= stored %d, "
+                "possible replay attack",
+                self.source_id,
+                counter,
+                self.frame_counter,
+            )
+            return False
+
+        self.frame_counter = counter
+        self.last_seen = datetime.now(UTC)
+        return True
+
+    def as_dict(self) -> dict:
+        """Serialize to a dictionary for database persistence."""
+        return {
+            "source_id": self.source_id,
+            "device_id": self.device_id,
+            "security_key": self.security_key.hex() if self.security_key else None,
+            "security_level": int(self.security_level),
+            "security_key_type": int(self.security_key_type),
+            "frame_counter": self.frame_counter,
+            "manufacturer_id": self.manufacturer_id,
+            "model_id": self.model_id,
+            "gpd_commands": self.gpd_commands,
+            "server_clusters": self.server_clusters,
+            "client_clusters": self.client_clusters,
+            "mac_seq_num_capability": self.mac_seq_num_capability,
+            "rx_on_capability": self.rx_on_capability,
+            "fixed_location": self.fixed_location,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> GPDevice:
+        """Deserialize from a dictionary.
+
+        Args:
+            data: Dictionary as produced by as_dict().
+
+        Returns:
+            GPDevice instance.
+        """
+        security_key_hex = data.get("security_key")
+        return cls(
+            source_id=data["source_id"],
+            device_id=data["device_id"],
+            security_key=(
+                bytes.fromhex(security_key_hex) if security_key_hex else None
+            ),
+            security_level=SecurityLevel(data.get("security_level", 0)),
+            security_key_type=SecurityKeyType(data.get("security_key_type", 0)),
+            frame_counter=data.get("frame_counter", 0),
+            manufacturer_id=data.get("manufacturer_id"),
+            model_id=data.get("model_id"),
+            gpd_commands=data.get("gpd_commands", []),
+            server_clusters=data.get("server_clusters", []),
+            client_clusters=data.get("client_clusters", []),
+            mac_seq_num_capability=data.get("mac_seq_num_capability", False),
+            rx_on_capability=data.get("rx_on_capability", False),
+            fixed_location=data.get("fixed_location", False),
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"GPDevice(source_id=0x{self.source_id:08X}, "
+            f"device_id=0x{self.device_id:02X}, "
+            f"model={self.model_identifier}, "
+            f"security={self.security_level.name})"
+        )

--- a/zigpy/zgp/device.py
+++ b/zigpy/zgp/device.py
@@ -52,6 +52,10 @@ def ieee_to_source_id(ieee: t.EUI64) -> int | None:
     Returns None if the IEEE address doesn't look like a GP synthetic address
     (i.e., upper 4 bytes are not all zeros).
 
+    Note: sourceID 0x00000000 is "unspecified" per the ZGP spec and should
+    not be used by real GPDs. This function does not reject it — callers
+    should validate the returned sourceID if needed.
+
     Args:
         ieee: EUI64 address to check.
 

--- a/zigpy/zgp/frame.py
+++ b/zigpy/zgp/frame.py
@@ -26,23 +26,23 @@ from zigpy.zgp.types import (
 class GPCommissioningOptions:
     """Options byte from GP Commissioning command (0xE0) payload.
 
-    Bit layout (Table 53):
-    - Bit 0-1: MAC Sequence Number Capability
-    - Bit 2: RX On Capability
-    - Bit 3: Application Information present
-    - Bit 4: reserved
-    - Bit 5: PAN ID request
-    - Bit 6: GP Security Key request
-    - Bit 7: Fixed Location
-    - Bit 8: Extended Options field present (actually bit 7 in some specs)
+    Bit layout (Table 53, ZGP spec / Wireshark zbee-nwk-gp dissector):
+    - Bit 0: MAC Sequence Number Capability
+    - Bit 1: RX On Capability
+    - Bit 2: Application Information present
+    - Bit 3: reserved
+    - Bit 4: PAN ID request
+    - Bit 5: GP Security Key request
+    - Bit 6: Fixed Location
+    - Bit 7: Extended Options field present
     """
 
+    RX_ON_CAPABILITY_BIT: ClassVar[int] = 1
+    APP_INFO_PRESENT_BIT: ClassVar[int] = 2
+    PAN_ID_REQUEST_BIT: ClassVar[int] = 4
+    SECURITY_KEY_REQUEST_BIT: ClassVar[int] = 5
+    FIXED_LOCATION_BIT: ClassVar[int] = 6
     EXTENDED_OPTIONS_PRESENT_BIT: ClassVar[int] = 7
-    RX_ON_CAPABILITY_BIT: ClassVar[int] = 2
-    APP_INFO_PRESENT_BIT: ClassVar[int] = 3
-    PAN_ID_REQUEST_BIT: ClassVar[int] = 5
-    SECURITY_KEY_REQUEST_BIT: ClassVar[int] = 6
-    FIXED_LOCATION_BIT: ClassVar[int] = 7
 
     raw: int
 

--- a/zigpy/zgp/frame.py
+++ b/zigpy/zgp/frame.py
@@ -1,0 +1,353 @@
+"""Green Power Data Frame (GPDF) parsing and construction.
+
+Implements parsing of GP frames as delivered by GP Proxy devices via
+GP Notification commands on cluster 0x0021, endpoint 242.
+
+Reference: ZGP specification, section A.1.4 (GPDF format).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import struct
+from typing import ClassVar
+
+from zigpy.zgp.types import (
+    ApplicationID,
+    DeviceID,
+    FrameType,
+    GPDCommandID,
+    SecurityKeyType,
+    SecurityLevel,
+)
+
+
+@dataclasses.dataclass
+class GPCommissioningOptions:
+    """Options byte from GP Commissioning command (0xE0) payload.
+
+    Bit layout (Table 53):
+    - Bit 0-1: MAC Sequence Number Capability
+    - Bit 2: RX On Capability
+    - Bit 3: Application Information present
+    - Bit 4: reserved
+    - Bit 5: PAN ID request
+    - Bit 6: GP Security Key request
+    - Bit 7: Fixed Location
+    - Bit 8: Extended Options field present (actually bit 7 in some specs)
+    """
+
+    EXTENDED_OPTIONS_PRESENT_BIT: ClassVar[int] = 7
+    RX_ON_CAPABILITY_BIT: ClassVar[int] = 2
+    APP_INFO_PRESENT_BIT: ClassVar[int] = 3
+    PAN_ID_REQUEST_BIT: ClassVar[int] = 5
+    SECURITY_KEY_REQUEST_BIT: ClassVar[int] = 6
+    FIXED_LOCATION_BIT: ClassVar[int] = 7
+
+    raw: int
+
+    @property
+    def mac_seq_num_capability(self) -> bool:
+        return bool(self.raw & 0x01)
+
+    @property
+    def rx_on_capability(self) -> bool:
+        return bool(self.raw & (1 << self.RX_ON_CAPABILITY_BIT))
+
+    @property
+    def app_info_present(self) -> bool:
+        return bool(self.raw & (1 << self.APP_INFO_PRESENT_BIT))
+
+    @property
+    def pan_id_request(self) -> bool:
+        return bool(self.raw & (1 << self.PAN_ID_REQUEST_BIT))
+
+    @property
+    def security_key_request(self) -> bool:
+        return bool(self.raw & (1 << self.SECURITY_KEY_REQUEST_BIT))
+
+    @property
+    def fixed_location(self) -> bool:
+        return bool(self.raw & (1 << self.FIXED_LOCATION_BIT))
+
+
+@dataclasses.dataclass
+class GPCommissioningExtendedOptions:
+    """Extended options byte from GP Commissioning command payload.
+
+    Bit layout (Table 54):
+    - Bit 0-1: Security Level Capabilities
+    - Bit 2-4: Key Type
+    - Bit 5: GPD Key present
+    - Bit 6: GPD Key Encrypted
+    - Bit 7: GPD Outgoing Counter present
+    """
+
+    raw: int
+
+    @property
+    def security_level(self) -> SecurityLevel:
+        return SecurityLevel(self.raw & 0x03)
+
+    @property
+    def key_type(self) -> SecurityKeyType:
+        return SecurityKeyType((self.raw >> 2) & 0x07)
+
+    @property
+    def key_present(self) -> bool:
+        return bool(self.raw & (1 << 5))
+
+    @property
+    def key_encrypted(self) -> bool:
+        return bool(self.raw & (1 << 6))
+
+    @property
+    def outgoing_counter_present(self) -> bool:
+        return bool(self.raw & (1 << 7))
+
+
+@dataclasses.dataclass
+class GPCommissioningAppInfo:
+    """Application Information byte from GP Commissioning command payload.
+
+    Bit layout (Table 55):
+    - Bit 0: Manufacturer ID present
+    - Bit 1: Model ID present
+    - Bit 2: GPD Commands present
+    - Bit 3: Cluster List present
+    - Bit 4-7: reserved
+    """
+
+    raw: int
+
+    @property
+    def manufacturer_id_present(self) -> bool:
+        return bool(self.raw & 0x01)
+
+    @property
+    def model_id_present(self) -> bool:
+        return bool(self.raw & (1 << 1))
+
+    @property
+    def gpd_commands_present(self) -> bool:
+        return bool(self.raw & (1 << 2))
+
+    @property
+    def cluster_list_present(self) -> bool:
+        return bool(self.raw & (1 << 3))
+
+
+@dataclasses.dataclass
+class GPCommissioningPayload:
+    """Parsed GP Commissioning command (0xE0) payload.
+
+    Contains device capabilities, optional security key, and
+    application information that the GPD advertises during commissioning.
+    """
+
+    device_id: int
+    options: GPCommissioningOptions
+
+    # Extended options (present if options bit 7 set)
+    extended_options: GPCommissioningExtendedOptions | None = None
+
+    # Security key (present if extended_options.key_present)
+    security_key: bytes | None = None
+
+    # Key MIC (present if extended_options.key_encrypted)
+    key_mic: int | None = None
+
+    # Outgoing frame counter (present if extended_options.outgoing_counter_present)
+    outgoing_counter: int | None = None
+
+    # Application info fields
+    app_info: GPCommissioningAppInfo | None = None
+    manufacturer_id: int | None = None
+    model_id: int | None = None
+    gpd_commands: list[int] = dataclasses.field(default_factory=list)
+    server_clusters: list[int] = dataclasses.field(default_factory=list)
+    client_clusters: list[int] = dataclasses.field(default_factory=list)
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> GPCommissioningPayload:
+        """Parse a GP Commissioning command payload.
+
+        Args:
+            data: Raw commissioning payload bytes (after command ID).
+
+        Returns:
+            Parsed GPCommissioningPayload.
+        """
+        if len(data) < 2:
+            raise ValueError(
+                f"Commissioning payload too short: {len(data)} bytes, need at least 2"
+            )
+
+        offset = 0
+
+        # Device ID (1 byte)
+        device_id = data[offset]
+        offset += 1
+
+        # Options (1 byte)
+        options = GPCommissioningOptions(data[offset])
+        offset += 1
+
+        extended_options = None
+        security_key = None
+        key_mic = None
+        outgoing_counter = None
+
+        # Extended options (1 byte, conditional)
+        has_extended = bool(data[offset - 1] & 0x80)  # bit 7 of options
+        if has_extended and offset < len(data):
+            extended_options = GPCommissioningExtendedOptions(data[offset])
+            offset += 1
+
+            # Security key (16 bytes, conditional)
+            if extended_options.key_present and offset + 16 <= len(data):
+                security_key = bytes(data[offset : offset + 16])
+                offset += 16
+
+                # Key MIC (4 bytes, conditional on key_encrypted)
+                if extended_options.key_encrypted and offset + 4 <= len(data):
+                    (key_mic,) = struct.unpack_from("<I", data, offset)
+                    offset += 4
+
+            # Outgoing counter (4 bytes, conditional)
+            if extended_options.outgoing_counter_present and offset + 4 <= len(data):
+                (outgoing_counter,) = struct.unpack_from("<I", data, offset)
+                offset += 4
+
+        # Application information (conditional on options bit 3)
+        app_info = None
+        manufacturer_id = None
+        model_id = None
+        gpd_commands: list[int] = []
+        server_clusters: list[int] = []
+        client_clusters: list[int] = []
+
+        if options.app_info_present and offset < len(data):
+            app_info = GPCommissioningAppInfo(data[offset])
+            offset += 1
+
+            if app_info.manufacturer_id_present and offset + 2 <= len(data):
+                (manufacturer_id,) = struct.unpack_from("<H", data, offset)
+                offset += 2
+
+            if app_info.model_id_present and offset + 2 <= len(data):
+                (model_id,) = struct.unpack_from("<H", data, offset)
+                offset += 2
+
+            if app_info.gpd_commands_present and offset < len(data):
+                num_commands = data[offset]
+                offset += 1
+                gpd_commands = list(data[offset : offset + num_commands])
+                offset += num_commands
+
+            if app_info.cluster_list_present and offset < len(data):
+                length_byte = data[offset]
+                offset += 1
+                num_server = length_byte & 0x0F
+                num_client = (length_byte >> 4) & 0x0F
+
+                for _ in range(num_server):
+                    if offset + 2 <= len(data):
+                        (cluster_id,) = struct.unpack_from("<H", data, offset)
+                        server_clusters.append(cluster_id)
+                        offset += 2
+
+                for _ in range(num_client):
+                    if offset + 2 <= len(data):
+                        (cluster_id,) = struct.unpack_from("<H", data, offset)
+                        client_clusters.append(cluster_id)
+                        offset += 2
+
+        return cls(
+            device_id=device_id,
+            options=options,
+            extended_options=extended_options,
+            security_key=security_key,
+            key_mic=key_mic,
+            outgoing_counter=outgoing_counter,
+            app_info=app_info,
+            manufacturer_id=manufacturer_id,
+            model_id=model_id,
+            gpd_commands=gpd_commands,
+            server_clusters=server_clusters,
+            client_clusters=client_clusters,
+        )
+
+    def to_bytes(self) -> bytes:
+        """Serialize the commissioning payload to bytes."""
+        result = bytearray()
+
+        # Device ID
+        result.append(self.device_id & 0xFF)
+
+        # Options
+        result.append(self.options.raw & 0xFF)
+
+        # Extended options
+        if self.extended_options is not None:
+            result.append(self.extended_options.raw & 0xFF)
+
+            if self.extended_options.key_present and self.security_key is not None:
+                result.extend(self.security_key)
+
+                if self.extended_options.key_encrypted and self.key_mic is not None:
+                    result.extend(struct.pack("<I", self.key_mic))
+
+            if (
+                self.extended_options.outgoing_counter_present
+                and self.outgoing_counter is not None
+            ):
+                result.extend(struct.pack("<I", self.outgoing_counter))
+
+        # Application info
+        if self.app_info is not None:
+            result.append(self.app_info.raw & 0xFF)
+
+            if self.app_info.manufacturer_id_present and self.manufacturer_id is not None:
+                result.extend(struct.pack("<H", self.manufacturer_id))
+
+            if self.app_info.model_id_present and self.model_id is not None:
+                result.extend(struct.pack("<H", self.model_id))
+
+            if self.app_info.gpd_commands_present:
+                result.append(len(self.gpd_commands))
+                result.extend(self.gpd_commands)
+
+            if self.app_info.cluster_list_present:
+                length_byte = (len(self.server_clusters) & 0x0F) | (
+                    (len(self.client_clusters) & 0x0F) << 4
+                )
+                result.append(length_byte)
+                for cluster_id in self.server_clusters:
+                    result.extend(struct.pack("<H", cluster_id))
+                for cluster_id in self.client_clusters:
+                    result.extend(struct.pack("<H", cluster_id))
+
+        return bytes(result)
+
+
+@dataclasses.dataclass
+class GPChannelRequestPayload:
+    """Parsed GP Channel Request command (0xE3) payload.
+
+    Contains the channel the GPD wants to operate on.
+    """
+
+    next_channel: int
+    second_next_channel: int
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> GPChannelRequestPayload:
+        """Parse channel request payload (1 byte)."""
+        if len(data) < 1:
+            raise ValueError("Channel request payload requires at least 1 byte")
+        byte = data[0]
+        return cls(
+            next_channel=(byte & 0x0F) + 11,  # Channel offset from 11
+            second_next_channel=((byte >> 4) & 0x0F) + 11,
+        )

--- a/zigpy/zgp/frame.py
+++ b/zigpy/zgp/frame.py
@@ -153,7 +153,9 @@ class GPCommissioningPayload:
     # Key MIC (present if extended_options.key_encrypted)
     key_mic: int | None = None
 
-    # Outgoing frame counter (present if extended_options.outgoing_counter_present)
+    # Outgoing frame counter (present if extended_options.outgoing_counter_present).
+    # None means the field is absent from the payload; 0 is a valid initial
+    # value and must not be confused with absent (see manager.py commissioning).
     outgoing_counter: int | None = None
 
     # Application info fields

--- a/zigpy/zgp/frame.py
+++ b/zigpy/zgp/frame.py
@@ -197,8 +197,10 @@ class GPCommissioningPayload:
         key_mic = None
         outgoing_counter = None
 
-        # Extended options (1 byte, conditional)
-        has_extended = bool(data[offset - 1] & 0x80)  # bit 7 of options
+        # Extended options (1 byte, conditional on bit 7 of options)
+        has_extended = bool(
+            options.raw & (1 << GPCommissioningOptions.EXTENDED_OPTIONS_PRESENT_BIT)
+        )
         if has_extended and offset < len(data):
             extended_options = GPCommissioningExtendedOptions(data[offset])
             offset += 1
@@ -241,8 +243,10 @@ class GPCommissioningPayload:
             if app_info.gpd_commands_present and offset < len(data):
                 num_commands = data[offset]
                 offset += 1
-                gpd_commands = list(data[offset : offset + num_commands])
-                offset += num_commands
+                available = len(data) - offset
+                count = min(num_commands, available)
+                gpd_commands = list(data[offset : offset + count])
+                offset += count
 
             if app_info.cluster_list_present and offset < len(data):
                 length_byte = data[offset]

--- a/zigpy/zgp/frame.py
+++ b/zigpy/zgp/frame.py
@@ -13,10 +13,6 @@ import struct
 from typing import ClassVar
 
 from zigpy.zgp.types import (
-    ApplicationID,
-    DeviceID,
-    FrameType,
-    GPDCommandID,
     SecurityKeyType,
     SecurityLevel,
 )
@@ -177,6 +173,7 @@ class GPCommissioningPayload:
 
         Returns:
             Parsed GPCommissioningPayload.
+
         """
         if len(data) < 2:
             raise ValueError(
@@ -308,7 +305,10 @@ class GPCommissioningPayload:
         if self.app_info is not None:
             result.append(self.app_info.raw & 0xFF)
 
-            if self.app_info.manufacturer_id_present and self.manufacturer_id is not None:
+            if (
+                self.app_info.manufacturer_id_present
+                and self.manufacturer_id is not None
+            ):
                 result.extend(struct.pack("<H", self.manufacturer_id))
 
             if self.app_info.model_id_present and self.model_id is not None:

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -70,6 +70,17 @@ class GreenPowerManager:
         self._commissioning_task: asyncio.Task[None] | None = None
         self.proxy_table: GPProxyTable = GPProxyTable()
 
+    async def shutdown(self) -> None:
+        """Clean up GP manager state.
+
+        Cancels any running commissioning timer. Should be called
+        during ControllerApplication shutdown.
+        """
+        if self._commissioning_task is not None:
+            self._commissioning_task.cancel()
+            self._commissioning_task = None
+        self._commissioning_window_end = 0
+
     @property
     def devices(self) -> dict[int, GPDevice]:
         """Return the dictionary of commissioned GP devices."""

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -416,6 +416,16 @@ class GreenPowerManager:
         # Register the device
         self.add_device(device)
 
+        if device.rx_on_capability:
+            # TODO: implement GP Commissioning Reply (cmd 0xF0) via GP Response
+            # for RX-capable GPDs that need key provisioning from the sink
+            LOGGER.warning(
+                "GP device 0x%08X is RX-capable but GP Commissioning Reply "
+                "is not yet implemented. Device may not complete commissioning "
+                "if it requires key provisioning via Commissioning Reply",
+                source_id,
+            )
+
         # Send GP Pairing to proxies
         await self.send_pairing(device, add_sink=True)
 

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -24,7 +24,7 @@ from zigpy.zcl.clusters.greenpower import (
     ProxyCommissioningModeSchema,
 )
 import zigpy.zgp.types as zgptypes
-from zigpy.zgp.crypto import decrypt_payload, encrypt_security_key
+from zigpy.zgp.crypto import decrypt_payload
 from zigpy.zgp.device import GPDevice, source_id_to_ieee
 from zigpy.zgp.proxy import GPProxyTable
 from zigpy.zgp.frame import (

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -63,12 +63,17 @@ class GreenPowerManager:
       was received from a commissioned device
     """
 
+    # Duplicate filtering timeout per ZGP spec A.3.6.1.2
+    DEDUP_TIMEOUT_S: float = 2.0
+
     def __init__(self, application: ControllerApplication) -> None:
         self._application = application
         self._devices: dict[int, GPDevice] = {}  # sourceID -> GPDevice
         self._commissioning_window_end: float = 0
         self._commissioning_task: asyncio.Task[None] | None = None
         self.proxy_table: GPProxyTable = GPProxyTable()
+        # Duplicate filtering table: (source_id, frame_counter) -> monotonic timestamp
+        self._dedup_cache: dict[tuple[int, int], float] = {}
 
     async def shutdown(self) -> None:
         """Clean up GP manager state.
@@ -94,6 +99,35 @@ class GreenPowerManager:
     def get_device(self, source_id: int) -> GPDevice | None:
         """Get a commissioned GP device by sourceID."""
         return self._devices.get(source_id)
+
+    def _is_duplicate(self, source_id: int, frame_counter: int) -> bool:
+        """Check if a GP notification is a duplicate from another proxy.
+
+        Per ZGP spec A.3.6.1.2, the sink maintains a duplicate filtering
+        table indexed by (sourceID, frameCounter) with a 2-second timeout.
+        Multiple proxies forwarding the same GPD frame is normal behavior
+        and should be silently deduplicated, not treated as a replay attack.
+        """
+        key = (source_id, frame_counter)
+        now = time.monotonic()
+
+        # Purge expired entries
+        self._dedup_cache = {
+            k: ts
+            for k, ts in self._dedup_cache.items()
+            if now - ts < self.DEDUP_TIMEOUT_S
+        }
+
+        if key in self._dedup_cache:
+            LOGGER.debug(
+                "GP dedup: dropping duplicate from 0x%08X (fc=%d)",
+                source_id,
+                frame_counter,
+            )
+            return True
+
+        self._dedup_cache[key] = now
+        return False
 
     def add_device(self, device: GPDevice) -> None:
         """Add or update a GP device in the registry."""
@@ -238,6 +272,11 @@ class GreenPowerManager:
                 proxy_nwk=proxy_nwk,
                 frame_counter=frame_counter,
             )
+
+        # Duplicate filtering: when multiple proxies forward the same GPD
+        # frame, only process the first one (spec A.3.6.1.2)
+        if self._is_duplicate(source_id, frame_counter):
+            return
 
         # Check if this is a commissioning-related command
         if gpd_command_id == GPDCommandID.CommissioningRequest:

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -31,6 +31,7 @@ from zigpy.zgp.crypto import (
     SECURITY_LEVEL_MIC_LENGTH,
     decrypt_payload,
     decrypt_security_key,
+    encrypt_security_key,
 )
 from zigpy.zgp.device import GPDevice
 from zigpy.zgp.proxy import GPProxyTable
@@ -758,12 +759,15 @@ class GreenPowerManager:
             schema_kwargs["frame_counter"] = t.uint32_t(device.frame_counter)
 
             if device.security_key is not None:
-                # TODO: zigbee-herdsman re-encrypts the key via
-                # encryptSecurityKey(sourceID, key) before including it in
-                # the Pairing. Investigate whether proxies expect the key
-                # encrypted or in cleartext in this field.
+                # Encrypt the key for transport in the GP Pairing, matching
+                # zigbee-herdsman's sendPairingCommand() behavior. Proxies
+                # receive the encrypted key and can decrypt it with the GP
+                # link key to populate their proxy tables.
+                encrypted_key, _ = encrypt_security_key(
+                    device.source_id, device.security_key
+                )
                 schema_kwargs["key"] = t.KeyData(
-                    [t.uint8_t(b) for b in device.security_key]
+                    [t.uint8_t(b) for b in encrypted_key]
                 )
 
         try:

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -672,6 +672,19 @@ class GreenPowerManager:
         Tells GP Proxy devices to add or remove a GPD from their
         proxy tables and start/stop forwarding its frames.
 
+        Limitation: communication_mode is always UnicastLightweight.
+        zigbee-herdsman dynamically chooses between Groupcast and Unicast
+        depending on whether the commissioning notification was broadcast
+        or unicast. UnicastLightweight works for most home networks but
+        may fail in extended networks where groupcast forwarding is needed.
+
+        Limitation: the security key is sent as-is in the Pairing command.
+        zigbee-herdsman re-encrypts the key via encryptSecurityKey() before
+        placing it in the GP Pairing. This may cause interoperability issues
+        with proxies that expect the key to be encrypted in the Pairing.
+        In practice, EZSP/Z-Stack firmware manages the GP Sink Table
+        internally, so this field is less critical at the application level.
+
         Args:
             device: The GP device to pair/unpair.
             add_sink: True to add pairing, False to remove.
@@ -680,6 +693,9 @@ class GreenPowerManager:
         coordinator_ieee = self._application.state.node_info.ieee
         coordinator_nwk = self._application.state.node_info.nwk
 
+        # TODO: dynamically select communication mode based on commissioning
+        # context (broadcast vs unicast) instead of always UnicastLightweight.
+        # See zigbee-herdsman sendPairingCommand() for reference.
         options = PairingOptions(
             application_id=zgptypes.ApplicationID.SrcID,
             add_sink=int(add_sink),
@@ -710,6 +726,10 @@ class GreenPowerManager:
                 schema_kwargs["frame_counter"] = t.uint32_t(device.frame_counter)
 
             if device.security_key is not None:
+                # TODO: zigbee-herdsman re-encrypts the key via
+                # encryptSecurityKey(sourceID, key) before including it in
+                # the Pairing. Investigate whether proxies expect the key
+                # encrypted or in cleartext in this field.
                 schema_kwargs["key"] = t.KeyData(
                     [t.uint8_t(b) for b in device.security_key]
                 )

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -22,6 +22,8 @@ from zigpy.zcl.clusters.greenpower import (
     PairingSchema,
     ProxyCommissioningModeOptions,
     ProxyCommissioningModeSchema,
+    ResponseOptions,
+    ResponseSchema,
 )
 import zigpy.zgp.types as zgptypes
 from zigpy.zgp.crypto import decrypt_payload
@@ -280,7 +282,9 @@ class GreenPowerManager:
 
         # Check if this is a commissioning-related command
         if gpd_command_id == GPDCommandID.CommissioningRequest:
-            await self._process_commissioning(source_id, frame_counter, gpd_payload)
+            await self._process_commissioning(
+                source_id, frame_counter, gpd_payload, proxy_nwk
+            )
             return
 
         if gpd_command_id == GPDCommandID.DecommissioningRequest:
@@ -288,7 +292,7 @@ class GreenPowerManager:
             return
 
         if gpd_command_id == GPDCommandID.ChannelRequest:
-            await self._process_channel_request(source_id, gpd_payload)
+            await self._process_channel_request(source_id, gpd_payload, proxy_nwk)
             return
 
         if gpd_command_id == GPDCommandID.SuccessReport:
@@ -328,21 +332,28 @@ class GreenPowerManager:
         )
 
         if gpd_command_id == GPDCommandID.CommissioningRequest:
-            await self._process_commissioning(source_id, frame_counter, gpd_payload)
+            await self._process_commissioning(
+                source_id, frame_counter, gpd_payload, proxy_nwk
+            )
         elif gpd_command_id == GPDCommandID.DecommissioningRequest:
             await self._process_decommissioning(source_id)
         elif gpd_command_id == GPDCommandID.ChannelRequest:
-            await self._process_channel_request(source_id, gpd_payload)
+            await self._process_channel_request(source_id, gpd_payload, proxy_nwk)
 
     # --- Commissioning ---
 
     async def _process_commissioning(
-        self, source_id: int, frame_counter: int, payload: bytes
+        self,
+        source_id: int,
+        frame_counter: int,
+        payload: bytes,
+        proxy_nwk: int | None = None,
     ) -> None:
         """Process a GP Commissioning command (0xE0).
 
         Creates a new GPDevice, configures security, and sends
-        GP Pairing to all proxies.
+        GP Pairing to all proxies. For RX-capable GPDs, sends a
+        GP Commissioning Reply via the forwarding proxy.
         """
         if not self.is_commissioning:
             LOGGER.debug(
@@ -419,14 +430,7 @@ class GreenPowerManager:
         self.add_device(device)
 
         if device.rx_on_capability:
-            # TODO: implement GP Commissioning Reply (cmd 0xF0) via GP Response
-            # for RX-capable GPDs that need key provisioning from the sink
-            LOGGER.warning(
-                "GP device 0x%08X is RX-capable but GP Commissioning Reply "
-                "is not yet implemented. Device may not complete commissioning "
-                "if it requires key provisioning via Commissioning Reply",
-                source_id,
-            )
+            await self._send_commissioning_reply(source_id, proxy_nwk)
 
         # Send GP Pairing to proxies
         await self.send_pairing(device, add_sink=True)
@@ -463,28 +467,49 @@ class GreenPowerManager:
                 source_id,
             )
 
-    async def _process_channel_request(self, source_id: int, payload: bytes) -> None:
+    async def _process_channel_request(
+        self,
+        source_id: int,
+        payload: bytes,
+        proxy_nwk: int | None = None,
+    ) -> None:
         """Process a GP Channel Request command (0xE3).
 
-        The GPD is asking which channel to use. We respond with the
-        coordinator's current operating channel.
+        The GPD is asking which channel to use. We respond with a
+        GP Channel Configuration (0xF3) containing the coordinator's
+        current operating channel.
         """
         try:
             channel_req = GPChannelRequestPayload.from_bytes(payload)
         except (ValueError, IndexError):
-            LOGGER.warning("Failed to parse Channel Request from 0x%08X", source_id)
+            LOGGER.warning(
+                "Failed to parse Channel Request from 0x%08X", source_id
+            )
             return
 
+        channel = self._application.state.network_info.channel
+
         LOGGER.debug(
-            "GP Channel Request from 0x%08X: next=%d, second=%d",
+            "GP Channel Request from 0x%08X: next=%d, second=%d, "
+            "responding with channel %d",
             source_id,
             channel_req.next_channel,
             channel_req.second_next_channel,
+            channel,
         )
 
-        # TODO: Send GP Channel Configuration response via GP Response command
-        # This requires knowing the coordinator's current channel and
-        # sending it via the GP Response ZCL command
+        # GP Channel Configuration payload (1 byte):
+        # Bits 0-3: operational channel (offset from 11)
+        # Bit 4: basic (1 = basic operation, 0 = enhanced)
+        # Bits 5-7: reserved
+        channel_config_byte = ((channel - 11) & 0x0F) | 0x10  # basic=1
+
+        await self._send_gp_response(
+            source_id=source_id,
+            gpd_command_id=0xF3,  # GP Channel Configuration
+            gpd_command_payload=bytes([channel_config_byte]),
+            proxy_nwk=proxy_nwk,
+        )
 
     # --- Command dispatch ---
 
@@ -765,6 +790,111 @@ class GreenPowerManager:
                 device.source_id,
                 exc_info=True,
             )
+
+    # --- GP Response (sink-to-GPD via proxy) ---
+
+    async def _send_gp_response(
+        self,
+        source_id: int,
+        gpd_command_id: int,
+        gpd_command_payload: bytes,
+        proxy_nwk: int | None = None,
+    ) -> None:
+        """Send a GP Response command via a proxy (temp master).
+
+        The GP Response (client command 0x06) instructs a proxy to transmit
+        a GPDF to a GPD during its rxAfterTx window. Used for Channel
+        Configuration (0xF3) and Commissioning Reply (0xF0).
+
+        Args:
+            source_id: Target GPD source identifier.
+            gpd_command_id: GPD command to send (0xF0, 0xF3, etc.).
+            gpd_command_payload: Payload for the GPD command.
+            proxy_nwk: NWK address of the proxy to use as temp master.
+                If None, the coordinator address is used.
+
+        """
+        channel = self._application.state.network_info.channel
+        temp_master = proxy_nwk or self._application.state.node_info.nwk
+
+        response = ResponseSchema(
+            options=ResponseOptions(
+                application_id=zgptypes.ApplicationID.SrcID,
+                _reserved=0,
+            ),
+            temp_master_short_addr=t.uint16_t(temp_master),
+            temp_master_tx_channel=t.uint8_t(channel - 11),
+            gpd_id=zgptypes.DeviceID(source_id),
+            gpd_command_id=t.uint8_t(gpd_command_id),
+            gpd_command_payload=t.LVBytes(gpd_command_payload),
+        )
+
+        try:
+            frame_data = self._build_zcl_frame(
+                command_id=0x06,  # GP Response
+                is_client=True,
+                payload=response.serialize(),
+            )
+
+            packet = t.ZigbeePacket(
+                dst=t.AddrModeAddress(
+                    addr_mode=t.AddrMode.Broadcast,
+                    address=t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
+                ),
+                dst_ep=t.uint8_t(GP_ENDPOINT),
+                src_ep=t.uint8_t(GP_ENDPOINT),
+                profile_id=t.uint16_t(0xA1E0),
+                cluster_id=t.uint16_t(GP_CLUSTER_ID),
+                data=t.SerializableBytes(frame_data),
+            )
+
+            await self._application.send_packet(packet)
+            LOGGER.debug(
+                "Sent GP Response (cmd=0x%02X) for GPD 0x%08X via proxy 0x%04X",
+                gpd_command_id,
+                source_id,
+                temp_master,
+            )
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                "Failed to send GP Response for 0x%08X",
+                source_id,
+                exc_info=True,
+            )
+
+    async def _send_commissioning_reply(
+        self, source_id: int, proxy_nwk: int | None = None
+    ) -> None:
+        """Send a GP Commissioning Reply (0xF0) to an RX-capable GPD.
+
+        This is a minimal implementation matching zigbee-herdsman: the reply
+        does not include a security key (options=0x00). The GPD will complete
+        commissioning but must use a pre-shared (OOB) key or operate without
+        security. Full key provisioning via Commissioning Reply would require
+        encrypting the key and including it in the payload.
+
+        Args:
+            source_id: GPD source identifier.
+            proxy_nwk: NWK address of the proxy that forwarded the
+                commissioning notification (used as temp master).
+
+        """
+        LOGGER.info(
+            "Sending GP Commissioning Reply to RX-capable GPD 0x%08X",
+            source_id,
+        )
+
+        # Commissioning Reply payload (cmd 0xF0):
+        # 1 byte options: 0x00 = no PAN ID, no key, no key encryption,
+        #                 no security level
+        commissioning_reply_payload = bytes([0x00])
+
+        await self._send_gp_response(
+            source_id=source_id,
+            gpd_command_id=0xF0,  # GP Commissioning Reply
+            gpd_command_payload=commissioning_reply_payload,
+            proxy_nwk=proxy_nwk,
+        )
 
     # --- Helpers ---
 

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -69,8 +69,9 @@ class GreenPowerManager:
       was received from a commissioned device
     """
 
-    # Duplicate filtering timeout per ZGP spec A.3.6.1.2
+    # Duplicate filtering per ZGP spec A.3.6.1.2
     DEDUP_TIMEOUT_S: float = 2.0
+    DEDUP_MAX_ENTRIES: int = 64
 
     def __init__(self, application: ControllerApplication) -> None:
         self._application = application
@@ -113,24 +114,27 @@ class GreenPowerManager:
         table indexed by (sourceID, frameCounter) with a 2-second timeout.
         Multiple proxies forwarding the same GPD frame is normal behavior
         and should be silently deduplicated, not treated as a replay attack.
+
+        The cache is bounded to DEDUP_MAX_ENTRIES to prevent unbounded
+        memory growth under heavy GP traffic.
         """
         key = (source_id, frame_counter)
         now = time.monotonic()
 
-        # Purge expired entries
-        self._dedup_cache = {
-            k: ts
-            for k, ts in self._dedup_cache.items()
-            if now - ts < self.DEDUP_TIMEOUT_S
-        }
-
         if key in self._dedup_cache:
-            LOGGER.debug(
-                "GP dedup: dropping duplicate from 0x%08X (fc=%d)",
-                source_id,
-                frame_counter,
-            )
-            return True
+            if now - self._dedup_cache[key] < self.DEDUP_TIMEOUT_S:
+                LOGGER.debug(
+                    "GP dedup: dropping duplicate from 0x%08X (fc=%d)",
+                    source_id,
+                    frame_counter,
+                )
+                return True
+            # Entry expired, will be overwritten below
+
+        # Purge oldest entries if cache is full
+        if len(self._dedup_cache) >= self.DEDUP_MAX_ENTRIES:
+            oldest_key = min(self._dedup_cache, key=self._dedup_cache.get)
+            del self._dedup_cache[oldest_key]
 
         self._dedup_cache[key] = now
         return False
@@ -199,7 +203,7 @@ class GreenPowerManager:
             )
             return True
 
-        except Exception:
+        except (ValueError, IndexError, KeyError, AttributeError):
             LOGGER.debug("Error processing GP packet", exc_info=True)
             return False
 

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -415,7 +415,11 @@ class GreenPowerManager:
             security_key=security_key,
             security_level=security_level,
             security_key_type=security_key_type,
-            frame_counter=comm.outgoing_counter or frame_counter,
+            frame_counter=(
+                comm.outgoing_counter
+                if comm.outgoing_counter is not None
+                else frame_counter
+            ),
             manufacturer_id=comm.manufacturer_id,
             model_id=comm.model_id,
             gpd_commands=comm.gpd_commands,
@@ -730,7 +734,7 @@ class GreenPowerManager:
             gpd_mac_seq_num_cap=int(device.mac_seq_num_capability),
             security_level=device.security_level,
             security_key_type=device.security_key_type,
-            security_frame_counter_present=int(add_sink and device.frame_counter > 0),
+            security_frame_counter_present=int(add_sink),
             security_key_present=int(add_sink and device.security_key is not None),
             assigned_alias_present=0,
             forwarding_radius_present=0,
@@ -747,8 +751,7 @@ class GreenPowerManager:
             schema_kwargs["sink_nwk_addr"] = coordinator_nwk
             schema_kwargs["device_id"] = t.uint8_t(device.device_id)
 
-            if device.frame_counter > 0:
-                schema_kwargs["frame_counter"] = t.uint32_t(device.frame_counter)
+            schema_kwargs["frame_counter"] = t.uint32_t(device.frame_counter)
 
             if device.security_key is not None:
                 # TODO: zigbee-herdsman re-encrypts the key via

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -42,6 +42,7 @@ from zigpy.zgp.frame import (
 from zigpy.zgp.types import (
     GP_CLUSTER_ID,
     GP_ENDPOINT,
+    GP_GROUP_ID,
     CommunicationMode,
     GPDCommandID,
     SecurityKeyType,
@@ -444,7 +445,7 @@ class GreenPowerManager:
             await self._send_commissioning_reply(source_id, proxy_nwk)
 
         # Send GP Pairing to proxies
-        await self.send_pairing(device, add_sink=True)
+        await self.send_pairing(device, add_sink=True, proxy_nwk=proxy_nwk)
 
         # Notify listeners
         self._application.listener_event("gp_device_joined", device)
@@ -700,41 +701,44 @@ class GreenPowerManager:
                 exc_info=True,
             )
 
-    async def send_pairing(self, device: GPDevice, add_sink: bool = True) -> None:
+    async def send_pairing(
+        self,
+        device: GPDevice,
+        add_sink: bool = True,
+        proxy_nwk: int | None = None,
+    ) -> None:
         """Broadcast GP Pairing command to all proxies.
 
         Tells GP Proxy devices to add or remove a GPD from their
         proxy tables and start/stop forwarding its frames.
 
-        Limitation: communication_mode is always UnicastLightweight.
-        zigbee-herdsman dynamically chooses between Groupcast and Unicast
-        depending on whether the commissioning notification was broadcast
-        or unicast. UnicastLightweight works for most home networks but
-        may fail in extended networks where groupcast forwarding is needed.
-
-        Limitation: the security key is sent as-is in the Pairing command.
-        zigbee-herdsman re-encrypts the key via encryptSecurityKey() before
-        placing it in the GP Pairing. This may cause interoperability issues
-        with proxies that expect the key to be encrypted in the Pairing.
-        In practice, EZSP/Z-Stack firmware manages the GP Sink Table
-        internally, so this field is less critical at the application level.
+        The communication mode is selected based on context: if a specific
+        proxy forwarded the commissioning notification (proxy_nwk provided),
+        UnicastLightweight is used. Otherwise, GroupcastForwardToDGroup is
+        used to reach all proxies via the GP group. This matches
+        zigbee-herdsman's sendPairingCommand() behavior.
 
         Args:
             device: The GP device to pair/unpair.
             add_sink: True to add pairing, False to remove.
+            proxy_nwk: NWK address of the proxy that forwarded the
+                commissioning notification. If None, groupcast is used.
 
         """
         coordinator_ieee = self._application.state.node_info.ieee
         coordinator_nwk = self._application.state.node_info.nwk
 
-        # TODO: dynamically select communication mode based on commissioning
-        # context (broadcast vs unicast) instead of always UnicastLightweight.
-        # See zigbee-herdsman sendPairingCommand() for reference.
+        # Select communication mode based on commissioning context
+        if proxy_nwk is not None:
+            comm_mode = CommunicationMode.UnicastLightweight
+        else:
+            comm_mode = CommunicationMode.GroupcastForwardToDGroup
+
         options = PairingOptions(
             application_id=zgptypes.ApplicationID.SrcID,
             add_sink=int(add_sink),
             remove_gpd=int(not add_sink),
-            communication_mode=CommunicationMode.UnicastLightweight,
+            communication_mode=comm_mode,
             gpd_fixed=int(device.fixed_location),
             gpd_mac_seq_num_cap=int(device.mac_seq_num_capability),
             security_level=device.security_level,
@@ -752,8 +756,14 @@ class GreenPowerManager:
         }
 
         if add_sink:
-            schema_kwargs["sink_ieee"] = coordinator_ieee
-            schema_kwargs["sink_nwk_addr"] = coordinator_nwk
+            if comm_mode in (
+                CommunicationMode.Unicast,
+                CommunicationMode.UnicastLightweight,
+            ):
+                schema_kwargs["sink_ieee"] = coordinator_ieee
+                schema_kwargs["sink_nwk_addr"] = coordinator_nwk
+            else:
+                schema_kwargs["sink_group"] = t.Group(GP_GROUP_ID)
             schema_kwargs["device_id"] = t.uint8_t(device.device_id)
 
             schema_kwargs["frame_counter"] = t.uint32_t(device.frame_counter)

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -929,6 +929,12 @@ class GreenPowerManager:
     def _build_zcl_frame(command_id: int, is_client: bool, payload: bytes) -> bytes:
         """Build a minimal ZCL frame for GP cluster commands.
 
+        This constructs the frame manually rather than using zigpy's ZCL
+        Foundation.Frame because GP frames are sent on the GP profile
+        (0xA1E0) and endpoint (242), which are outside the standard ZCL
+        device/endpoint/cluster lifecycle. The GP cluster schemas handle
+        payload serialization; this method only adds the 3-byte ZCL header.
+
         Args:
             command_id: ZCL command ID.
             is_client: True for client-to-server direction.

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import struct
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -26,7 +27,11 @@ from zigpy.zcl.clusters.greenpower import (
     ResponseSchema,
 )
 import zigpy.zgp.types as zgptypes
-from zigpy.zgp.crypto import decrypt_payload
+from zigpy.zgp.crypto import (
+    SECURITY_LEVEL_MIC_LENGTH,
+    decrypt_payload,
+    decrypt_security_key,
+)
 from zigpy.zgp.device import GPDevice
 from zigpy.zgp.proxy import GPProxyTable
 from zigpy.zgp.frame import (
@@ -390,14 +395,11 @@ class GreenPowerManager:
                 if comm.extended_options.key_encrypted and comm.key_mic is not None:
                     # Key is encrypted - decrypt it
                     try:
-                        from zigpy.zgp.crypto import decrypt_security_key
-
+                        mic_bytes = struct.pack("<I", comm.key_mic)
                         security_key = decrypt_security_key(
                             source_id,
                             comm.security_key,
-                            comm.key_mic.to_bytes(4, "little")
-                            if isinstance(comm.key_mic, int)
-                            else comm.key_mic,
+                            mic_bytes,
                         )
                     except Exception:
                         LOGGER.warning(
@@ -552,8 +554,6 @@ class GreenPowerManager:
         ):
             try:
                 # For encrypted payloads, the MIC is appended to the payload
-                from zigpy.zgp.crypto import SECURITY_LEVEL_MIC_LENGTH
-
                 mic_length = SECURITY_LEVEL_MIC_LENGTH[device.security_level]
                 if mic_length > 0 and len(payload) >= mic_length:
                     encrypted_data = payload[:-mic_length]

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -702,15 +702,15 @@ class GreenPowerManager:
         Returns:
             Complete ZCL frame bytes.
         """
-        # Frame control:
-        # Bit 0: Frame type = 1 (cluster-specific)
-        # Bit 1: Manufacturer specific = 0
-        # Bit 2: Direction: 0 = client-to-server, 1 = server-to-client
-        # Bit 3: Disable default response = 1
+        # ZCL Frame Control byte (ZCL spec 2.4.1.1):
+        # Bits 0-1: Frame type (0b01 = cluster-specific)
+        # Bit 2:    Manufacturer specific (0 = no)
+        # Bit 3:    Direction (0 = client-to-server, 1 = server-to-client)
+        # Bit 4:    Disable default response (1 = yes)
         frame_control = 0x01  # cluster-specific
         if not is_client:
-            frame_control |= 0x08  # server-to-client direction
-        frame_control |= 0x10  # disable default response
+            frame_control |= 0x08  # bit 3: server-to-client direction
+        frame_control |= 0x10  # bit 4: disable default response
 
         seq_num = 0x00  # GP doesn't use seq numbers meaningfully
 

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -64,6 +64,10 @@ class GreenPowerManager:
     Attached to ControllerApplication. Processes GP frames arriving
     on endpoint 242, cluster 0x0021.
 
+    Limitation: only ApplicationID.SrcID (0b000) is supported. GPDs using
+    ApplicationID.IEEE (0b010) are not handled. This matches zigbee-herdsman
+    which also only supports SrcID. No known consumer GPD uses IEEE mode.
+
     Fires the following listener events on the application:
     - ``gp_device_joined(gp_device)``: A new GP device was commissioned
     - ``gp_device_left(gp_device)``: A GP device was decommissioned

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -17,6 +17,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.greenpower import (
     GreenPowerProxy,
     PairingOptions,
@@ -175,26 +176,18 @@ class GreenPowerManager:
             return False
 
         try:
-            # Parse the ZCL frame to extract command and payload
+            # Parse the ZCL header using zigpy's ZCLHeader struct
             data = packet.data.serialize()
-            if len(data) < 3:
-                LOGGER.debug("GP packet too short: %d bytes", len(data))
-                return False
+            hdr, zcl_payload = foundation.ZCLHeader.deserialize(data)
 
-            # ZCL frame: frame_control(1) + seq_num(1) + command_id(1) + payload
-            frame_control = data[0]
-            # seq_num = data[1]
-            zcl_command_id = data[2]
-            zcl_payload = data[3:]
-
-            # Determine if this is cluster-specific (bit 0 of frame_control)
-            is_cluster_specific = bool(frame_control & 0x01)
-            if not is_cluster_specific:
+            if hdr.frame_control.frame_type != foundation.FrameType.CLUSTER_COMMAND:
                 LOGGER.debug("GP frame is not cluster-specific, ignoring")
                 return False
 
-            # Direction bit (bit 3): 0 = client-to-server, 1 = server-to-client
-            is_server_to_client = bool(frame_control & 0x08)
+            is_server_to_client = (
+                hdr.frame_control.direction
+                == foundation.Direction.Server_to_Client
+            )
 
             # Get proxy NWK address from packet source
             proxy_nwk = None
@@ -203,9 +196,9 @@ class GreenPowerManager:
 
             self._application.create_task(
                 self._process_zcl_command(
-                    zcl_command_id, zcl_payload, is_server_to_client, proxy_nwk
+                    hdr.command_id, zcl_payload, is_server_to_client, proxy_nwk
                 ),
-                f"gp_process_command-0x{zcl_command_id:02x}",
+                f"gp_process_command-0x{hdr.command_id:02x}",
             )
             return True
 
@@ -931,13 +924,12 @@ class GreenPowerManager:
 
     @staticmethod
     def _build_zcl_frame(command_id: int, is_client: bool, payload: bytes) -> bytes:
-        """Build a minimal ZCL frame for GP cluster commands.
+        """Build a ZCL frame for GP cluster commands.
 
-        This constructs the frame manually rather than using zigpy's ZCL
-        Foundation.Frame because GP frames are sent on the GP profile
-        (0xA1E0) and endpoint (242), which are outside the standard ZCL
-        device/endpoint/cluster lifecycle. The GP cluster schemas handle
-        payload serialization; this method only adds the 3-byte ZCL header.
+        Uses zigpy's ZCLHeader for proper frame construction. GP frames
+        are sent on the GP profile (0xA1E0) and endpoint (242), outside
+        the standard ZCL device/endpoint/cluster lifecycle, but the ZCL
+        header format is the same.
 
         Args:
             command_id: ZCL command ID.
@@ -948,19 +940,25 @@ class GreenPowerManager:
             Complete ZCL frame bytes.
 
         """
-        # ZCL Frame Control byte (ZCL spec 2.4.1.1):
-        # Bits 0-1: Frame type (0b01 = cluster-specific)
-        # Bit 2:    Manufacturer specific (0 = no)
-        # Bit 3:    Direction (0 = client-to-server, 1 = server-to-client)
-        # Bit 4:    Disable default response (1 = yes)
-        frame_control = 0x01  # cluster-specific
-        if not is_client:
-            frame_control |= 0x08  # bit 3: server-to-client direction
-        frame_control |= 0x10  # bit 4: disable default response
+        direction = (
+            foundation.Direction.Client_to_Server
+            if is_client
+            else foundation.Direction.Server_to_Client
+        )
 
-        seq_num = 0x00  # GP doesn't use seq numbers meaningfully
+        hdr = foundation.ZCLHeader(
+            frame_control=foundation.FrameControl(
+                frame_type=foundation.FrameType.CLUSTER_COMMAND,
+                is_manufacturer_specific=False,
+                direction=direction,
+                disable_default_response=True,
+                reserved=0b000,
+            ),
+            tsn=0,
+            command_id=command_id,
+        )
 
-        return bytes([frame_control, seq_num, command_id]) + payload
+        return hdr.serialize() + payload
 
     # --- Persistence ---
 

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -373,6 +373,12 @@ class GreenPowerManager:
             )
             return
 
+        if source_id == 0x00000000:
+            LOGGER.warning(
+                "GP Commissioning with unspecified sourceID 0x00000000, ignoring"
+            )
+            return
+
         try:
             comm = GPCommissioningPayload.from_bytes(payload)
         except (ValueError, IndexError):

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -26,6 +26,7 @@ from zigpy.zcl.clusters.greenpower import (
 import zigpy.zgp.types as zgptypes
 from zigpy.zgp.crypto import decrypt_payload, encrypt_security_key
 from zigpy.zgp.device import GPDevice, source_id_to_ieee
+from zigpy.zgp.proxy import GPProxyTable
 from zigpy.zgp.frame import (
     GPChannelRequestPayload,
     GPCommissioningPayload,
@@ -67,6 +68,7 @@ class GreenPowerManager:
         self._devices: dict[int, GPDevice] = {}  # sourceID -> GPDevice
         self._commissioning_window_end: float = 0
         self._commissioning_task: asyncio.Task[None] | None = None
+        self.proxy_table: GPProxyTable = GPProxyTable()
 
     @property
     def devices(self) -> dict[int, GPDevice]:
@@ -217,6 +219,14 @@ class GreenPowerManager:
             gpd_command_id,
             frame_counter,
         )
+
+        # Track the proxy that forwarded this notification
+        if proxy_nwk is not None:
+            self.proxy_table.add_or_update(
+                source_id=source_id,
+                proxy_nwk=proxy_nwk,
+                frame_counter=frame_counter,
+            )
 
         # Check if this is a commissioning-related command
         if gpd_command_id == GPDCommandID.CommissioningRequest:
@@ -372,6 +382,9 @@ class GreenPowerManager:
         device = self.remove_device(source_id)
 
         if device is not None:
+            # Clean up proxy table entries for this device
+            self.proxy_table.remove_by_source_id(source_id)
+
             # Send GP Pairing (remove) to proxies
             await self.send_pairing(device, add_sink=False)
 

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -25,7 +25,7 @@ from zigpy.zcl.clusters.greenpower import (
 )
 import zigpy.zgp.types as zgptypes
 from zigpy.zgp.crypto import decrypt_payload
-from zigpy.zgp.device import GPDevice, source_id_to_ieee
+from zigpy.zgp.device import GPDevice
 from zigpy.zgp.proxy import GPProxyTable
 from zigpy.zgp.frame import (
     GPChannelRequestPayload,
@@ -34,7 +34,6 @@ from zigpy.zgp.frame import (
 from zigpy.zgp.types import (
     GP_CLUSTER_ID,
     GP_ENDPOINT,
-    DEFAULT_GP_LINK_KEY,
     CommunicationMode,
     GPDCommandID,
     SecurityKeyType,
@@ -153,6 +152,7 @@ class GreenPowerManager:
 
         Returns:
             True if the packet was handled as a GP frame, False otherwise.
+
         """
         if packet.dst_ep != GP_ENDPOINT or packet.cluster_id != GP_CLUSTER_ID:
             return False
@@ -296,7 +296,9 @@ class GreenPowerManager:
             return
 
         # Regular data command - dispatch to listeners
-        await self._dispatch_gp_command(source_id, frame_counter, gpd_command_id, gpd_payload)
+        await self._dispatch_gp_command(
+            source_id, frame_counter, gpd_command_id, gpd_payload
+        )
 
     async def _handle_commissioning_notification(
         self, payload: bytes, proxy_nwk: int | None
@@ -461,9 +463,7 @@ class GreenPowerManager:
                 source_id,
             )
 
-    async def _process_channel_request(
-        self, source_id: int, payload: bytes
-    ) -> None:
+    async def _process_channel_request(self, source_id: int, payload: bytes) -> None:
         """Process a GP Channel Request command (0xE3).
 
         The GPD is asking which channel to use. We respond with the
@@ -572,6 +572,7 @@ class GreenPowerManager:
         Args:
             time_s: Duration of the commissioning window in seconds.
                    Pass 0 to close the window immediately.
+
         """
         if time_s == 0:
             await self._close_commissioning_window()
@@ -623,10 +624,12 @@ class GreenPowerManager:
         Args:
             enter: True to enter commissioning, False to exit.
             window: Commissioning window duration in seconds (optional).
+
         """
         options = ProxyCommissioningModeOptions(
             enter=int(enter),
-            exit_mode=zgptypes.ProxyCommissioningModeExitMode.OnExpire if enter
+            exit_mode=zgptypes.ProxyCommissioningModeExitMode.OnExpire
+            if enter
             else zgptypes.ProxyCommissioningModeExitMode.NotDefined,
             channel_present=0,
             unicast=0,
@@ -672,6 +675,7 @@ class GreenPowerManager:
         Args:
             device: The GP device to pair/unpair.
             add_sink: True to add pairing, False to remove.
+
         """
         coordinator_ieee = self._application.state.node_info.ieee
         coordinator_nwk = self._application.state.node_info.nwk
@@ -685,12 +689,8 @@ class GreenPowerManager:
             gpd_mac_seq_num_cap=int(device.mac_seq_num_capability),
             security_level=device.security_level,
             security_key_type=device.security_key_type,
-            security_frame_counter_present=int(
-                add_sink and device.frame_counter > 0
-            ),
-            security_key_present=int(
-                add_sink and device.security_key is not None
-            ),
+            security_frame_counter_present=int(add_sink and device.frame_counter > 0),
+            security_key_present=int(add_sink and device.security_key is not None),
             assigned_alias_present=0,
             forwarding_radius_present=0,
             _reserved=0,
@@ -749,9 +749,7 @@ class GreenPowerManager:
     # --- Helpers ---
 
     @staticmethod
-    def _build_zcl_frame(
-        command_id: int, is_client: bool, payload: bytes
-    ) -> bytes:
+    def _build_zcl_frame(command_id: int, is_client: bool, payload: bytes) -> bytes:
         """Build a minimal ZCL frame for GP cluster commands.
 
         Args:
@@ -761,6 +759,7 @@ class GreenPowerManager:
 
         Returns:
             Complete ZCL frame bytes.
+
         """
         # ZCL Frame Control byte (ZCL spec 2.4.1.1):
         # Bits 0-1: Frame type (0b01 = cluster-specific)
@@ -785,6 +784,7 @@ class GreenPowerManager:
 
         Args:
             devices_data: List of dictionaries from GPDevice.as_dict().
+
         """
         for data in devices_data:
             try:
@@ -803,5 +803,6 @@ class GreenPowerManager:
 
         Returns:
             List of dictionaries suitable for JSON/database storage.
+
         """
         return [device.as_dict() for device in self._devices.values()]

--- a/zigpy/zgp/manager.py
+++ b/zigpy/zgp/manager.py
@@ -1,0 +1,734 @@
+"""Green Power Manager.
+
+Central manager for Green Power protocol handling. Processes GP Notification
+and GP Commissioning Notification ZCL commands arriving on cluster 0x0021,
+endpoint 242. Manages GP device lifecycle (commissioning, decommissioning)
+and dispatches GP commands to listeners.
+
+This is the equivalent of zigbee-herdsman's `greenPower.ts`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import zigpy.types as t
+from zigpy.zcl.clusters.greenpower import (
+    GreenPowerProxy,
+    PairingOptions,
+    PairingSchema,
+    ProxyCommissioningModeOptions,
+    ProxyCommissioningModeSchema,
+)
+import zigpy.zgp.types as zgptypes
+from zigpy.zgp.crypto import decrypt_payload, encrypt_security_key
+from zigpy.zgp.device import GPDevice, source_id_to_ieee
+from zigpy.zgp.frame import (
+    GPChannelRequestPayload,
+    GPCommissioningPayload,
+)
+from zigpy.zgp.types import (
+    GP_CLUSTER_ID,
+    GP_ENDPOINT,
+    DEFAULT_GP_LINK_KEY,
+    CommunicationMode,
+    GPDCommandID,
+    SecurityKeyType,
+    SecurityLevel,
+)
+
+if TYPE_CHECKING:
+    from zigpy.application import ControllerApplication
+
+LOGGER = logging.getLogger(__name__)
+
+# Default commissioning window duration in seconds
+DEFAULT_COMMISSIONING_WINDOW_S: int = 180
+
+
+class GreenPowerManager:
+    """Central manager for Green Power protocol handling.
+
+    Attached to ControllerApplication. Processes GP frames arriving
+    on endpoint 242, cluster 0x0021.
+
+    Fires the following listener events on the application:
+    - ``gp_device_joined(gp_device)``: A new GP device was commissioned
+    - ``gp_device_left(gp_device)``: A GP device was decommissioned
+    - ``gp_command_received(gp_device, command_id, payload)``: A GP command
+      was received from a commissioned device
+    """
+
+    def __init__(self, application: ControllerApplication) -> None:
+        self._application = application
+        self._devices: dict[int, GPDevice] = {}  # sourceID -> GPDevice
+        self._commissioning_window_end: float = 0
+        self._commissioning_task: asyncio.Task[None] | None = None
+
+    @property
+    def devices(self) -> dict[int, GPDevice]:
+        """Return the dictionary of commissioned GP devices."""
+        return self._devices
+
+    @property
+    def is_commissioning(self) -> bool:
+        """Return True if the GP commissioning window is currently open."""
+        return time.monotonic() < self._commissioning_window_end
+
+    def get_device(self, source_id: int) -> GPDevice | None:
+        """Get a commissioned GP device by sourceID."""
+        return self._devices.get(source_id)
+
+    def add_device(self, device: GPDevice) -> None:
+        """Add or update a GP device in the registry."""
+        self._devices[device.source_id] = device
+
+    def remove_device(self, source_id: int) -> GPDevice | None:
+        """Remove a GP device from the registry."""
+        return self._devices.pop(source_id, None)
+
+    # --- Frame processing ---
+
+    def handle_packet(self, packet: t.ZigbeePacket) -> bool:
+        """Process a packet if it's a GP frame.
+
+        Called from ControllerApplication.packet_received() when
+        dst_ep == 242 and cluster_id == 0x0021.
+
+        This method is synchronous and dispatches async processing
+        as background tasks.
+
+        Args:
+            packet: Incoming ZigbeePacket.
+
+        Returns:
+            True if the packet was handled as a GP frame, False otherwise.
+        """
+        if packet.dst_ep != GP_ENDPOINT or packet.cluster_id != GP_CLUSTER_ID:
+            return False
+
+        try:
+            # Parse the ZCL frame to extract command and payload
+            data = packet.data.serialize()
+            if len(data) < 3:
+                LOGGER.debug("GP packet too short: %d bytes", len(data))
+                return False
+
+            # ZCL frame: frame_control(1) + seq_num(1) + command_id(1) + payload
+            frame_control = data[0]
+            # seq_num = data[1]
+            zcl_command_id = data[2]
+            zcl_payload = data[3:]
+
+            # Determine if this is cluster-specific (bit 0 of frame_control)
+            is_cluster_specific = bool(frame_control & 0x01)
+            if not is_cluster_specific:
+                LOGGER.debug("GP frame is not cluster-specific, ignoring")
+                return False
+
+            # Direction bit (bit 3): 0 = client-to-server, 1 = server-to-client
+            is_server_to_client = bool(frame_control & 0x08)
+
+            # Get proxy NWK address from packet source
+            proxy_nwk = None
+            if packet.src and packet.src.addr_mode == t.AddrMode.NWK:
+                proxy_nwk = packet.src.address
+
+            self._application.create_task(
+                self._process_zcl_command(
+                    zcl_command_id, zcl_payload, is_server_to_client, proxy_nwk
+                ),
+                f"gp_process_command-0x{zcl_command_id:02x}",
+            )
+            return True
+
+        except Exception:
+            LOGGER.debug("Error processing GP packet", exc_info=True)
+            return False
+
+    async def _process_zcl_command(
+        self,
+        command_id: int,
+        payload: bytes,
+        is_server_to_client: bool,
+        proxy_nwk: int | None,
+    ) -> None:
+        """Process a parsed ZCL command on the GP cluster.
+
+        Server commands (from proxy to sink/coordinator):
+        - 0x00: GP Notification
+        - 0x01: GP Pairing Search
+        - 0x04: GP Commissioning Notification
+
+        Client commands (from sink to proxies):
+        - 0x00: GP Notification Response
+        - 0x01: GP Pairing
+        - 0x02: GP Proxy Commissioning Mode
+        - 0x06: GP Response
+        """
+        if not is_server_to_client:
+            # Server commands (proxy → sink)
+            if command_id == 0x00:
+                await self._handle_gp_notification(payload, proxy_nwk)
+            elif command_id == 0x04:
+                await self._handle_commissioning_notification(payload, proxy_nwk)
+            else:
+                LOGGER.debug("Unhandled GP server command: 0x%02X", command_id)
+        else:
+            LOGGER.debug(
+                "Received GP client command 0x%02X (unexpected direction)",
+                command_id,
+            )
+
+    async def _handle_gp_notification(
+        self, payload: bytes, proxy_nwk: int | None
+    ) -> None:
+        """Handle a GP Notification command (server command 0x00).
+
+        This is the main data path for GP devices. A GP Proxy has
+        received a GPDF and forwarded it as a GP Notification.
+
+        Notification payload structure (after ZCL header):
+        - options (2 bytes)
+        - gpd_id (4 bytes)
+        - frame_counter (4 bytes)
+        - command_id (1 byte)
+        - payload (variable, length-prefixed)
+        - [optional] short_addr (2 bytes)
+        - [optional] distance (1 byte)
+        """
+        try:
+            notification = GreenPowerProxy.NotificationSchema.deserialize(payload)[0]
+        except (ValueError, IndexError):
+            LOGGER.warning("Failed to parse GP Notification payload")
+            return
+
+        source_id = int(notification.gpd_id)
+        gpd_command_id = int(notification.command_id)
+        gpd_payload = bytes(notification.payload) if notification.payload else b""
+        frame_counter = int(notification.frame_counter)
+
+        LOGGER.debug(
+            "GP Notification: source_id=0x%08X, cmd=0x%02X, counter=%d",
+            source_id,
+            gpd_command_id,
+            frame_counter,
+        )
+
+        # Check if this is a commissioning-related command
+        if gpd_command_id == GPDCommandID.CommissioningRequest:
+            await self._process_commissioning(source_id, frame_counter, gpd_payload)
+            return
+
+        if gpd_command_id == GPDCommandID.DecommissioningRequest:
+            await self._process_decommissioning(source_id)
+            return
+
+        if gpd_command_id == GPDCommandID.ChannelRequest:
+            await self._process_channel_request(source_id, gpd_payload)
+            return
+
+        if gpd_command_id == GPDCommandID.SuccessReport:
+            LOGGER.debug("GP Success from 0x%08X", source_id)
+            return
+
+        # Regular data command - dispatch to listeners
+        await self._dispatch_gp_command(source_id, frame_counter, gpd_command_id, gpd_payload)
+
+    async def _handle_commissioning_notification(
+        self, payload: bytes, proxy_nwk: int | None
+    ) -> None:
+        """Handle a GP Commissioning Notification command (server command 0x04).
+
+        This arrives during the commissioning window when a proxy
+        forwards a GPD's commissioning frame.
+        """
+        try:
+            notification = GreenPowerProxy.CommissioningNotificationSchema.deserialize(
+                payload
+            )[0]
+        except (ValueError, IndexError):
+            LOGGER.warning("Failed to parse GP Commissioning Notification")
+            return
+
+        source_id = int(notification.gpd_id)
+        gpd_command_id = int(notification.command_id)
+        gpd_payload = bytes(notification.payload) if notification.payload else b""
+        frame_counter = int(notification.frame_counter)
+
+        LOGGER.debug(
+            "GP Commissioning Notification: source_id=0x%08X, cmd=0x%02X",
+            source_id,
+            gpd_command_id,
+        )
+
+        if gpd_command_id == GPDCommandID.CommissioningRequest:
+            await self._process_commissioning(source_id, frame_counter, gpd_payload)
+        elif gpd_command_id == GPDCommandID.DecommissioningRequest:
+            await self._process_decommissioning(source_id)
+        elif gpd_command_id == GPDCommandID.ChannelRequest:
+            await self._process_channel_request(source_id, gpd_payload)
+
+    # --- Commissioning ---
+
+    async def _process_commissioning(
+        self, source_id: int, frame_counter: int, payload: bytes
+    ) -> None:
+        """Process a GP Commissioning command (0xE0).
+
+        Creates a new GPDevice, configures security, and sends
+        GP Pairing to all proxies.
+        """
+        if not self.is_commissioning:
+            LOGGER.debug(
+                "GP Commissioning from 0x%08X ignored: window not open",
+                source_id,
+            )
+            return
+
+        try:
+            comm = GPCommissioningPayload.from_bytes(payload)
+        except (ValueError, IndexError):
+            LOGGER.warning(
+                "Failed to parse GP Commissioning payload from 0x%08X",
+                source_id,
+            )
+            return
+
+        LOGGER.info(
+            "GP device commissioning: source_id=0x%08X, device_id=0x%02X",
+            source_id,
+            comm.device_id,
+        )
+
+        # Determine security configuration
+        security_level = SecurityLevel.NoSecurity
+        security_key_type = SecurityKeyType.NoKey
+        security_key = None
+
+        if comm.extended_options is not None:
+            security_level = comm.extended_options.security_level
+            security_key_type = comm.extended_options.key_type
+
+            if comm.extended_options.key_present and comm.security_key is not None:
+                if comm.extended_options.key_encrypted and comm.key_mic is not None:
+                    # Key is encrypted - decrypt it
+                    try:
+                        from zigpy.zgp.crypto import decrypt_security_key
+
+                        security_key = decrypt_security_key(
+                            source_id,
+                            comm.security_key,
+                            comm.key_mic.to_bytes(4, "little")
+                            if isinstance(comm.key_mic, int)
+                            else comm.key_mic,
+                        )
+                    except Exception:
+                        LOGGER.warning(
+                            "Failed to decrypt security key from 0x%08X",
+                            source_id,
+                        )
+                        return
+                else:
+                    security_key = comm.security_key
+
+        # Create GP device
+        device = GPDevice(
+            source_id=source_id,
+            device_id=comm.device_id,
+            security_key=security_key,
+            security_level=security_level,
+            security_key_type=security_key_type,
+            frame_counter=comm.outgoing_counter or frame_counter,
+            manufacturer_id=comm.manufacturer_id,
+            model_id=comm.model_id,
+            gpd_commands=comm.gpd_commands,
+            server_clusters=comm.server_clusters,
+            client_clusters=comm.client_clusters,
+            mac_seq_num_capability=comm.options.mac_seq_num_capability,
+            rx_on_capability=comm.options.rx_on_capability,
+            fixed_location=comm.options.fixed_location,
+        )
+
+        # Register the device
+        self.add_device(device)
+
+        # Send GP Pairing to proxies
+        await self.send_pairing(device, add_sink=True)
+
+        # Notify listeners
+        self._application.listener_event("gp_device_joined", device)
+
+        LOGGER.info(
+            "GP device commissioned: %r",
+            device,
+        )
+
+    async def _process_decommissioning(self, source_id: int) -> None:
+        """Process a GP Decommissioning command (0xE1)."""
+        device = self.remove_device(source_id)
+
+        if device is not None:
+            # Send GP Pairing (remove) to proxies
+            await self.send_pairing(device, add_sink=False)
+
+            # Notify listeners
+            self._application.listener_event("gp_device_left", device)
+
+            LOGGER.info(
+                "GP device decommissioned: source_id=0x%08X",
+                source_id,
+            )
+        else:
+            LOGGER.debug(
+                "GP Decommissioning for unknown device 0x%08X",
+                source_id,
+            )
+
+    async def _process_channel_request(
+        self, source_id: int, payload: bytes
+    ) -> None:
+        """Process a GP Channel Request command (0xE3).
+
+        The GPD is asking which channel to use. We respond with the
+        coordinator's current operating channel.
+        """
+        try:
+            channel_req = GPChannelRequestPayload.from_bytes(payload)
+        except (ValueError, IndexError):
+            LOGGER.warning("Failed to parse Channel Request from 0x%08X", source_id)
+            return
+
+        LOGGER.debug(
+            "GP Channel Request from 0x%08X: next=%d, second=%d",
+            source_id,
+            channel_req.next_channel,
+            channel_req.second_next_channel,
+        )
+
+        # TODO: Send GP Channel Configuration response via GP Response command
+        # This requires knowing the coordinator's current channel and
+        # sending it via the GP Response ZCL command
+
+    # --- Command dispatch ---
+
+    async def _dispatch_gp_command(
+        self,
+        source_id: int,
+        frame_counter: int,
+        command_id: int,
+        payload: bytes,
+    ) -> None:
+        """Dispatch a GP data command from a commissioned device.
+
+        Verifies the frame counter, decrypts if necessary, and fires
+        the gp_command_received listener event.
+        """
+        device = self.get_device(source_id)
+
+        if device is None:
+            LOGGER.debug(
+                "GP command from unknown device 0x%08X (cmd=0x%02X)",
+                source_id,
+                command_id,
+            )
+            return
+
+        # Frame counter replay protection
+        if not device.update_frame_counter(frame_counter):
+            return
+
+        # Decrypt payload if security is active
+        decrypted_payload = payload
+        if (
+            device.security_level != SecurityLevel.NoSecurity
+            and device.security_key is not None
+            and payload
+        ):
+            try:
+                # For encrypted payloads, the MIC is appended to the payload
+                from zigpy.zgp.crypto import SECURITY_LEVEL_MIC_LENGTH
+
+                mic_length = SECURITY_LEVEL_MIC_LENGTH[device.security_level]
+                if mic_length > 0 and len(payload) >= mic_length:
+                    encrypted_data = payload[:-mic_length]
+                    mic = payload[-mic_length:]
+                    decrypted_payload = decrypt_payload(
+                        source_id,
+                        frame_counter,
+                        device.security_key,
+                        encrypted_data,
+                        mic,
+                        device.security_level,
+                    )
+            except Exception:
+                LOGGER.warning(
+                    "Failed to decrypt GP payload from 0x%08X",
+                    source_id,
+                    exc_info=True,
+                )
+                return
+
+        LOGGER.debug(
+            "GP command from 0x%08X: cmd=0x%02X, payload=%s",
+            source_id,
+            command_id,
+            decrypted_payload.hex() if decrypted_payload else "empty",
+        )
+
+        # Fire listener event
+        self._application.listener_event(
+            "gp_command_received",
+            device,
+            command_id,
+            decrypted_payload,
+        )
+
+    # --- Commissioning window control ---
+
+    async def permit_join(self, time_s: int = DEFAULT_COMMISSIONING_WINDOW_S) -> None:
+        """Open the GP commissioning window.
+
+        Broadcasts a ProxyCommissioningMode command to all routers
+        telling them to enter commissioning mode and forward
+        GP commissioning frames.
+
+        Args:
+            time_s: Duration of the commissioning window in seconds.
+                   Pass 0 to close the window immediately.
+        """
+        if time_s == 0:
+            await self._close_commissioning_window()
+            return
+
+        self._commissioning_window_end = time.monotonic() + time_s
+
+        LOGGER.info("Opening GP commissioning window for %d seconds", time_s)
+
+        # Send ProxyCommissioningMode (enter)
+        await self._send_proxy_commissioning_mode(enter=True, window=time_s)
+
+        # Schedule window closure
+        if self._commissioning_task is not None:
+            self._commissioning_task.cancel()
+
+        self._commissioning_task = self._application.create_task(
+            self._commissioning_window_timer(time_s),
+            "gp_commissioning_window_timer",
+        )
+
+    async def _commissioning_window_timer(self, time_s: int) -> None:
+        """Timer task that closes the commissioning window after expiry."""
+        try:
+            await asyncio.sleep(time_s)
+            await self._close_commissioning_window()
+        except asyncio.CancelledError:
+            pass
+
+    async def _close_commissioning_window(self) -> None:
+        """Close the GP commissioning window."""
+        self._commissioning_window_end = 0
+
+        LOGGER.info("Closing GP commissioning window")
+
+        # Send ProxyCommissioningMode (exit)
+        await self._send_proxy_commissioning_mode(enter=False)
+
+    # --- Outgoing GP commands ---
+
+    async def _send_proxy_commissioning_mode(
+        self, enter: bool, window: int | None = None
+    ) -> None:
+        """Send GP Proxy Commissioning Mode command.
+
+        Broadcasts to all routers and coordinator (0xFFFC) to
+        enter or exit GP commissioning mode.
+
+        Args:
+            enter: True to enter commissioning, False to exit.
+            window: Commissioning window duration in seconds (optional).
+        """
+        options = ProxyCommissioningModeOptions(
+            enter=int(enter),
+            exit_mode=zgptypes.ProxyCommissioningModeExitMode.OnExpire if enter
+            else zgptypes.ProxyCommissioningModeExitMode.NotDefined,
+            channel_present=0,
+            unicast=0,
+            _reserved=0,
+        )
+
+        schema_kwargs: dict[str, Any] = {"options": options}
+        if window is not None and enter:
+            schema_kwargs["window"] = window
+
+        try:
+            frame_data = self._build_zcl_frame(
+                command_id=0x02,  # proxy_commissioning_mode
+                is_client=True,
+                payload=ProxyCommissioningModeSchema(**schema_kwargs).serialize(),
+            )
+
+            packet = t.ZigbeePacket(
+                dst=t.AddrModeAddress(
+                    addr_mode=t.AddrMode.Broadcast,
+                    address=t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
+                ),
+                dst_ep=t.uint8_t(GP_ENDPOINT),
+                src_ep=t.uint8_t(GP_ENDPOINT),
+                profile_id=t.uint16_t(0xA1E0),  # GP profile
+                cluster_id=t.uint16_t(GP_CLUSTER_ID),
+                data=t.SerializableBytes(frame_data),
+            )
+
+            await self._application.send_packet(packet)
+        except Exception:
+            LOGGER.warning(
+                "Failed to send GP Proxy Commissioning Mode",
+                exc_info=True,
+            )
+
+    async def send_pairing(self, device: GPDevice, add_sink: bool = True) -> None:
+        """Broadcast GP Pairing command to all proxies.
+
+        Tells GP Proxy devices to add or remove a GPD from their
+        proxy tables and start/stop forwarding its frames.
+
+        Args:
+            device: The GP device to pair/unpair.
+            add_sink: True to add pairing, False to remove.
+        """
+        coordinator_ieee = self._application.state.node_info.ieee
+        coordinator_nwk = self._application.state.node_info.nwk
+
+        options = PairingOptions(
+            application_id=zgptypes.ApplicationID.SrcID,
+            add_sink=int(add_sink),
+            remove_gpd=int(not add_sink),
+            communication_mode=CommunicationMode.UnicastLightweight,
+            gpd_fixed=int(device.fixed_location),
+            gpd_mac_seq_num_cap=int(device.mac_seq_num_capability),
+            security_level=device.security_level,
+            security_key_type=device.security_key_type,
+            security_frame_counter_present=int(
+                add_sink and device.frame_counter > 0
+            ),
+            security_key_present=int(
+                add_sink and device.security_key is not None
+            ),
+            assigned_alias_present=0,
+            forwarding_radius_present=0,
+            _reserved=0,
+        )
+
+        schema_kwargs: dict[str, Any] = {
+            "options": options,
+            "gpd_id": zgptypes.DeviceID(device.source_id),
+        }
+
+        if add_sink:
+            schema_kwargs["sink_ieee"] = coordinator_ieee
+            schema_kwargs["sink_nwk_addr"] = coordinator_nwk
+            schema_kwargs["device_id"] = t.uint8_t(device.device_id)
+
+            if device.frame_counter > 0:
+                schema_kwargs["frame_counter"] = t.uint32_t(device.frame_counter)
+
+            if device.security_key is not None:
+                schema_kwargs["key"] = t.KeyData(
+                    [t.uint8_t(b) for b in device.security_key]
+                )
+
+        try:
+            frame_data = self._build_zcl_frame(
+                command_id=0x01,  # pairing
+                is_client=True,
+                payload=PairingSchema(**schema_kwargs).serialize(),
+            )
+
+            packet = t.ZigbeePacket(
+                dst=t.AddrModeAddress(
+                    addr_mode=t.AddrMode.Broadcast,
+                    address=t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
+                ),
+                dst_ep=t.uint8_t(GP_ENDPOINT),
+                src_ep=t.uint8_t(GP_ENDPOINT),
+                profile_id=t.uint16_t(0xA1E0),
+                cluster_id=t.uint16_t(GP_CLUSTER_ID),
+                data=t.SerializableBytes(frame_data),
+            )
+
+            await self._application.send_packet(packet)
+            LOGGER.debug(
+                "Sent GP Pairing for 0x%08X (add_sink=%s)",
+                device.source_id,
+                add_sink,
+            )
+        except Exception:
+            LOGGER.warning(
+                "Failed to send GP Pairing for 0x%08X",
+                device.source_id,
+                exc_info=True,
+            )
+
+    # --- Helpers ---
+
+    @staticmethod
+    def _build_zcl_frame(
+        command_id: int, is_client: bool, payload: bytes
+    ) -> bytes:
+        """Build a minimal ZCL frame for GP cluster commands.
+
+        Args:
+            command_id: ZCL command ID.
+            is_client: True for client-to-server direction.
+            payload: Serialized command payload.
+
+        Returns:
+            Complete ZCL frame bytes.
+        """
+        # Frame control:
+        # Bit 0: Frame type = 1 (cluster-specific)
+        # Bit 1: Manufacturer specific = 0
+        # Bit 2: Direction: 0 = client-to-server, 1 = server-to-client
+        # Bit 3: Disable default response = 1
+        frame_control = 0x01  # cluster-specific
+        if not is_client:
+            frame_control |= 0x08  # server-to-client direction
+        frame_control |= 0x10  # disable default response
+
+        seq_num = 0x00  # GP doesn't use seq numbers meaningfully
+
+        return bytes([frame_control, seq_num, command_id]) + payload
+
+    # --- Persistence ---
+
+    def load_devices(self, devices_data: list[dict]) -> None:
+        """Load GP devices from persisted data.
+
+        Called during startup to restore previously commissioned devices.
+
+        Args:
+            devices_data: List of dictionaries from GPDevice.as_dict().
+        """
+        for data in devices_data:
+            try:
+                device = GPDevice.from_dict(data)
+                self._devices[device.source_id] = device
+                LOGGER.debug("Loaded GP device: %r", device)
+            except (KeyError, ValueError, TypeError):
+                LOGGER.warning(
+                    "Failed to load GP device from data: %s",
+                    data,
+                    exc_info=True,
+                )
+
+    def get_devices_data(self) -> list[dict]:
+        """Serialize all GP devices for persistence.
+
+        Returns:
+            List of dictionaries suitable for JSON/database storage.
+        """
+        return [device.as_dict() for device in self._devices.values()]

--- a/zigpy/zgp/proxy.py
+++ b/zigpy/zgp/proxy.py
@@ -1,0 +1,197 @@
+"""Green Power Proxy Table management.
+
+Tracks which GP Proxy devices are forwarding frames for which GPDs.
+The coordinator (GP Sink) maintains this state to understand the
+network topology of GP frame forwarding.
+
+The coordinator does not directly write proxy tables on remote devices.
+Instead, it sends GP Pairing commands that instruct proxies to update
+their own local tables. This module tracks the expected state from
+the sink's perspective.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from datetime import UTC, datetime
+
+from zigpy.zgp.types import CommunicationMode, SecurityLevel
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class GPProxyTableEntry:
+    """An entry representing a proxy's knowledge of a GPD.
+
+    Tracks which GP Proxy device is forwarding frames for a given GPD
+    source ID, along with the security and communication parameters.
+    """
+
+    source_id: int
+    proxy_nwk: int
+    communication_mode: CommunicationMode = CommunicationMode.UnicastLightweight
+    security_level: SecurityLevel = SecurityLevel.NoSecurity
+    frame_counter: int = 0
+    first_seen: datetime = dataclasses.field(
+        default_factory=lambda: datetime.now(UTC)
+    )
+    last_seen: datetime = dataclasses.field(
+        default_factory=lambda: datetime.now(UTC)
+    )
+
+    def touch(self) -> None:
+        """Update last_seen timestamp."""
+        self.last_seen = datetime.now(UTC)
+
+
+class GPProxyTable:
+    """Manages the coordinator's view of GP Proxy forwarding state.
+
+    Tracks which proxy NWK addresses have forwarded frames for which
+    GPD source IDs. This information is useful for:
+    - Understanding which proxies are in range of a GPD
+    - Choosing unicast targets for GP Response commands
+    - Diagnosing connectivity issues
+    """
+
+    def __init__(self) -> None:
+        # Key: (source_id, proxy_nwk) -> GPProxyTableEntry
+        self._entries: dict[tuple[int, int], GPProxyTableEntry] = {}
+
+    @property
+    def entries(self) -> list[GPProxyTableEntry]:
+        """Return all entries as a list."""
+        return list(self._entries.values())
+
+    def add_or_update(
+        self,
+        source_id: int,
+        proxy_nwk: int,
+        communication_mode: CommunicationMode = CommunicationMode.UnicastLightweight,
+        security_level: SecurityLevel = SecurityLevel.NoSecurity,
+        frame_counter: int = 0,
+    ) -> GPProxyTableEntry:
+        """Add or update a proxy table entry.
+
+        Called when a GP Notification is received from a proxy,
+        indicating the proxy is forwarding for this GPD.
+
+        Args:
+            source_id: GPD source identifier.
+            proxy_nwk: NWK address of the forwarding proxy.
+            communication_mode: Communication mode in use.
+            security_level: Security level of the GPD.
+            frame_counter: Latest frame counter seen.
+
+        Returns:
+            The created or updated entry.
+        """
+        key = (source_id, proxy_nwk)
+        entry = self._entries.get(key)
+
+        if entry is not None:
+            entry.touch()
+            if frame_counter > entry.frame_counter:
+                entry.frame_counter = frame_counter
+            return entry
+
+        entry = GPProxyTableEntry(
+            source_id=source_id,
+            proxy_nwk=proxy_nwk,
+            communication_mode=communication_mode,
+            security_level=security_level,
+            frame_counter=frame_counter,
+        )
+        self._entries[key] = entry
+
+        LOGGER.debug(
+            "New proxy entry: GPD 0x%08X via proxy 0x%04X",
+            source_id,
+            proxy_nwk,
+        )
+        return entry
+
+    def remove_by_source_id(self, source_id: int) -> int:
+        """Remove all entries for a given GPD source ID.
+
+        Called when a GPD is decommissioned.
+
+        Args:
+            source_id: GPD source identifier.
+
+        Returns:
+            Number of entries removed.
+        """
+        keys_to_remove = [
+            key for key in self._entries if key[0] == source_id
+        ]
+        for key in keys_to_remove:
+            del self._entries[key]
+
+        if keys_to_remove:
+            LOGGER.debug(
+                "Removed %d proxy entries for GPD 0x%08X",
+                len(keys_to_remove),
+                source_id,
+            )
+        return len(keys_to_remove)
+
+    def remove_by_proxy(self, proxy_nwk: int) -> int:
+        """Remove all entries for a given proxy NWK address.
+
+        Called when a proxy device leaves the network.
+
+        Args:
+            proxy_nwk: NWK address of the proxy.
+
+        Returns:
+            Number of entries removed.
+        """
+        keys_to_remove = [
+            key for key in self._entries if key[1] == proxy_nwk
+        ]
+        for key in keys_to_remove:
+            del self._entries[key]
+        return len(keys_to_remove)
+
+    def get_proxies_for_device(self, source_id: int) -> list[int]:
+        """Get NWK addresses of all proxies forwarding for a GPD.
+
+        Args:
+            source_id: GPD source identifier.
+
+        Returns:
+            List of proxy NWK addresses.
+        """
+        return [
+            key[1] for key in self._entries if key[0] == source_id
+        ]
+
+    def get_devices_for_proxy(self, proxy_nwk: int) -> list[int]:
+        """Get source IDs of all GPDs forwarded by a proxy.
+
+        Args:
+            proxy_nwk: NWK address of the proxy.
+
+        Returns:
+            List of GPD source IDs.
+        """
+        return [
+            key[0] for key in self._entries if key[1] == proxy_nwk
+        ]
+
+    def get_entry(self, source_id: int, proxy_nwk: int) -> GPProxyTableEntry | None:
+        """Get a specific entry."""
+        return self._entries.get((source_id, proxy_nwk))
+
+    def clear(self) -> None:
+        """Remove all entries."""
+        self._entries.clear()
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __repr__(self) -> str:
+        return f"GPProxyTable({len(self._entries)} entries)"

--- a/zigpy/zgp/proxy.py
+++ b/zigpy/zgp/proxy.py
@@ -187,4 +187,5 @@ class GPProxyTable:
         return len(self._entries)
 
     def __repr__(self) -> str:
-        return f"GPProxyTable({len(self._entries)} entries)"
+        count = len(self._entries)
+        return f"<{type(self).__name__} {count} {'entry' if count == 1 else 'entries'}>"

--- a/zigpy/zgp/proxy.py
+++ b/zigpy/zgp/proxy.py
@@ -34,12 +34,8 @@ class GPProxyTableEntry:
     communication_mode: CommunicationMode = CommunicationMode.UnicastLightweight
     security_level: SecurityLevel = SecurityLevel.NoSecurity
     frame_counter: int = 0
-    first_seen: datetime = dataclasses.field(
-        default_factory=lambda: datetime.now(UTC)
-    )
-    last_seen: datetime = dataclasses.field(
-        default_factory=lambda: datetime.now(UTC)
-    )
+    first_seen: datetime = dataclasses.field(default_factory=lambda: datetime.now(UTC))
+    last_seen: datetime = dataclasses.field(default_factory=lambda: datetime.now(UTC))
 
     def touch(self) -> None:
         """Update last_seen timestamp."""
@@ -87,6 +83,7 @@ class GPProxyTable:
 
         Returns:
             The created or updated entry.
+
         """
         key = (source_id, proxy_nwk)
         entry = self._entries.get(key)
@@ -123,10 +120,9 @@ class GPProxyTable:
 
         Returns:
             Number of entries removed.
+
         """
-        keys_to_remove = [
-            key for key in self._entries if key[0] == source_id
-        ]
+        keys_to_remove = [key for key in self._entries if key[0] == source_id]
         for key in keys_to_remove:
             del self._entries[key]
 
@@ -148,10 +144,9 @@ class GPProxyTable:
 
         Returns:
             Number of entries removed.
+
         """
-        keys_to_remove = [
-            key for key in self._entries if key[1] == proxy_nwk
-        ]
+        keys_to_remove = [key for key in self._entries if key[1] == proxy_nwk]
         for key in keys_to_remove:
             del self._entries[key]
         return len(keys_to_remove)
@@ -164,10 +159,9 @@ class GPProxyTable:
 
         Returns:
             List of proxy NWK addresses.
+
         """
-        return [
-            key[1] for key in self._entries if key[0] == source_id
-        ]
+        return [key[1] for key in self._entries if key[0] == source_id]
 
     def get_devices_for_proxy(self, proxy_nwk: int) -> list[int]:
         """Get source IDs of all GPDs forwarded by a proxy.
@@ -177,10 +171,9 @@ class GPProxyTable:
 
         Returns:
             List of GPD source IDs.
+
         """
-        return [
-            key[0] for key in self._entries if key[1] == proxy_nwk
-        ]
+        return [key[0] for key in self._entries if key[1] == proxy_nwk]
 
     def get_entry(self, source_id: int, proxy_nwk: int) -> GPProxyTableEntry | None:
         """Get a specific entry."""

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -2,9 +2,117 @@ from __future__ import annotations
 
 from zigpy.types import basic
 
+# Green Power endpoint as defined in the ZGP specification
+GP_ENDPOINT: int = 242
+
+# Green Power cluster ID
+GP_CLUSTER_ID: int = 0x0021
+
+# Green Power group ID used for groupcast forwarding
+GP_GROUP_ID: int = 0x0B84
+
+# Default ZigBee Green Power shared key (ZigBeeAlliance09 TC link key)
+# Used as the default key for encrypting/decrypting GP security keys
+DEFAULT_GP_LINK_KEY: bytes = bytes(
+    [
+        0x5A,
+        0x69,
+        0x67,
+        0x42,
+        0x65,
+        0x65,
+        0x41,
+        0x6C,
+        0x6C,
+        0x69,
+        0x61,
+        0x6E,
+        0x63,
+        0x65,
+        0x30,
+        0x39,
+    ]
+)
+
 
 class DeviceID(basic.uint32_t, repr="hex"):
     pass
+
+
+# GPD Command IDs (Table 49 in ZGP specification)
+class GPDCommandID(basic.enum8):
+    """GPD command identifiers sent by Green Power Devices."""
+
+    # Identify
+    Identify = 0x00
+
+    # Scenes
+    RecallScene0 = 0x10
+    RecallScene1 = 0x11
+    RecallScene2 = 0x12
+    RecallScene3 = 0x13
+    RecallScene4 = 0x14
+    RecallScene5 = 0x15
+    RecallScene6 = 0x16
+    RecallScene7 = 0x17
+    StoreScene0 = 0x18
+    StoreScene1 = 0x19
+    StoreScene2 = 0x1A
+    StoreScene3 = 0x1B
+    StoreScene4 = 0x1C
+    StoreScene5 = 0x1D
+    StoreScene6 = 0x1E
+    StoreScene7 = 0x1F
+
+    # On/Off
+    Off = 0x20
+    On = 0x21
+    Toggle = 0x22
+
+    # Level Control
+    LevelControlStop = 0x34
+    MoveUp = 0x30
+    MoveDown = 0x31
+    StepUp = 0x32
+    StepDown = 0x33
+
+    # Color Control
+    MoveHueStop = 0x40
+    MoveHueUp = 0x41
+    MoveHueDown = 0x42
+    StepHueUp = 0x43
+    StepHueDown = 0x44
+    MoveSaturationStop = 0x45
+    MoveSaturationUp = 0x46
+    MoveSaturationDown = 0x47
+    StepSaturationUp = 0x48
+    StepSaturationDown = 0x49
+    MoveColor = 0x4A
+    StepColor = 0x4B
+
+    # Door Lock
+    LockDoor = 0x50
+    UnlockDoor = 0x51
+
+    # Attribute Reporting
+    AttributeReporting = 0xA0
+    ManufacturerSpecificReporting = 0xA1
+
+    # Multi-Cluster Reporting
+    MultiClusterReporting = 0xA2
+    ManufacturerSpecificMultiClusterReporting = 0xA3
+
+    # Commissioning
+    CommissioningRequest = 0xE0
+    DecommissioningRequest = 0xE1
+    SuccessReport = 0xE2
+    ChannelRequest = 0xE3
+
+    # Application Description
+    ApplicationDescription = 0xE4
+
+    # Any GPD command
+    AnyCommand = 0xFF
 
 
 class FrameType(basic.enum2):

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -145,13 +145,19 @@ class SecurityKeyType(basic.enum3):
 
 
 # ZGP spec Figure 22
+# This is semantically a 3-bit bitmask (each bit is an independent exit
+# condition) but modeled as enum3 due to zigpy's type system constraints.
+# The enum3 type integrates with t.Struct bit-level serialization, which
+# a standard IntFlag would not. All valid bit combinations are listed.
 class ProxyCommissioningModeExitMode(basic.enum3):
     NotDefined = 0b000
     OnExpire = 0b001
     OnFirstPairing = 0b010
-    OnExplicitExit = 0b100
     OnExpireOrFirstPairing = 0b011
+    OnExplicitExit = 0b100
     OnExpireOrExplicitExit = 0b101
+    OnFirstPairingOrExplicitExit = 0b110
+    OnExpireOrFirstPairingOrExplicitExit = 0b111
 
 
 # Table 29

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -129,7 +129,7 @@ class ApplicationID(basic.enum3):
 # Table 13
 class SecurityLevel(basic.enum2):
     NoSecurity = 0b00
-    ShortFrameCounterAndMIC = 0b01
+    Reserved = 0b01
     FullFrameCounterAndMIC = 0b10
     Encrypted = 0b11
 

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -2,6 +2,22 @@ from __future__ import annotations
 
 from zigpy.types import basic
 
+__all__ = [
+    "GP_ENDPOINT",
+    "GP_CLUSTER_ID",
+    "GP_GROUP_ID",
+    "DEFAULT_GP_LINK_KEY",
+    "DeviceID",
+    "GPDCommandID",
+    "FrameType",
+    "ApplicationID",
+    "SecurityLevel",
+    "SecurityKeyType",
+    "ProxyCommissioningModeExitMode",
+    "CommunicationMode",
+    "CommunicationDirection",
+]
+
 # Green Power endpoint as defined in the ZGP specification
 GP_ENDPOINT: int = 242
 


### PR DESCRIPTION
## Summary

Add comprehensive Zigbee Green Power (ZGP) protocol support to zigpy, implementing the GP Sink role as defined in the ZGP specification. This is the most requested missing feature (#341, 175+ thumbs-up).

### New modules (`zigpy/zgp/`)

- **`types.py`**: GP constants (endpoint 242, cluster 0x0021, default link key) and enums (SecurityLevel, GPDCommandID, CommunicationMode, etc.) per ZGP spec tables
- **`crypto.py`**: AES-128-CCM* encrypt/decrypt for GP security keys and frame payloads, with auth-only (SecurityLevel 0b10) and full encryption (0b11) modes per spec A.1.5.4
- **`frame.py`**: GP Commissioning payload parser (Tables 53/54/55) and Channel Request parser
- **`device.py`**: GPDevice dataclass with sourceID-to-IEEE conversion (matching zigbee2mqtt convention), frame counter replay protection, and dict serialization for persistence
- **`proxy.py`**: GP Proxy Table tracking which proxy devices forward for which GPDs
- **`manager.py`**: Central GP protocol handler (equivalent to zigbee-herdsman's `greenPower.ts`):
  - GP Notification and Commissioning Notification processing
  - Commissioning flow with security key decryption (encrypted and plaintext keys)
  - GP Commissioning Reply for RX-capable GPDs
  - GP Channel Configuration response
  - GP Pairing broadcast with encrypted key and dynamic communication mode (unicast/groupcast)
  - Duplicate filtering per spec A.3.6.1.2 (bounded cache, 2s timeout)
  - Commissioning window management via ProxyCommissioningMode broadcast
  - Shutdown cleanup

### Integration (`application.py`)

- GP frames (endpoint 242, cluster 0x0021) intercepted in `packet_received()` **before** device lookup, so frames from unknown proxy NWK addresses don't trigger device discovery
- `permit_gp(time_s)` method separate from standard `permit()` to avoid accidental GP commissioning during normal Zigbee pairing
- `green_power.shutdown()` called during controller shutdown

### Known limitations

- Only `ApplicationID.SrcID` (0b000) supported — same as zigbee-herdsman; no known consumer GPD uses IEEE mode
- `CommissioningNotificationSchema` has a bit-field alignment issue (18 bits instead of 16) in the existing GP cluster definition from #1659 — documented in tests
- GP Commissioning Reply is minimal (options=0x00, no key provisioning) — matches zigbee-herdsman's approach
- AAD (GPDF header) not included in CCM* associated data — radio firmware (EZSP, Z-Stack) handles this natively; same as zigbee-herdsman; documented in module docstring

## Testing

- **216 new GP tests** + **102 existing application tests** = **318 total, 0 regressions**
- **Known-answer crypto vectors** independently generated (not round-trip only) for key encryption, payload encryption, and auth-only MIC
- **End-to-end lifecycle tests**: commission → command dispatch → decommission
- **Spec-validated**: test values verified against ZGP spec Tables 12/13/14/29/49/53/54/55
- `ruff check` + `ruff format`: **0 violations**

## Test plan

- [x] `pytest tests/zgp/` — 216 GP tests pass
- [x] `pytest tests/test_application.py` — 102 existing tests pass (no regression)
- [x] `ruff check zigpy/zgp/ tests/zgp/` — 0 violations
- [ ] Manual test with EZSP coordinator + EnOcean PTM 215Z GPD

Resolves #341