### PR TITLE
Switch serial to serialx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "cryptography",
     "voluptuous",
     "jsonschema",
-    "serialx>=1.3.0",
+    "serialx>=1.4.0",
     "typing_extensions",
     "frozendict",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "cryptography",
     "voluptuous",
     "jsonschema",
-    'pyserial-asyncio-fast',
+    "serialx",
     "typing_extensions",
     "frozendict",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "cryptography",
     "voluptuous",
     "jsonschema",
-    "serialx",
+    "serialx>=1.3.0",
     "typing_extensions",
     "frozendict",
 ]

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -54,7 +54,7 @@ async def test_serial_normal(
         kwargs["rtscts"] = rtscts
 
     with patch(
-        "zigpy.serial.pyserial_asyncio.create_serial_connection",
+        "zigpy.serial.serialx_create_serial_connection",
         AsyncMock(
             return_value=(AsyncMock(), AsyncMock())
         ),
@@ -71,62 +71,9 @@ async def test_serial_normal(
         assert mock_calls[0].kwargs[kwarg] == expected_kwargs[kwarg]
 
 
-async def test_serial_socket() -> None:
+async def test_serial_error_remapping(tmp_path: pathlib.Path) -> None:
     loop = asyncio.get_running_loop()
     protocol_factory = Mock()
-
-    with patch.object(
-        loop,
-        "create_connection",
-        AsyncMock(
-            return_value=(AsyncMock(), AsyncMock())
-        ),
-    ):
-        await zigpy.serial.create_serial_connection(
-            loop, protocol_factory, "socket://1.2.3.4:5678"
-        )
-        await zigpy.serial.create_serial_connection(
-            loop, protocol_factory, "socket://1.2.3.4"
-        )
-
-        assert len(loop.create_connection.mock_calls) == 2
-        assert loop.create_connection.mock_calls[0].kwargs["host"] == "1.2.3.4"
-        assert loop.create_connection.mock_calls[0].kwargs["port"] == 5678
-        assert loop.create_connection.mock_calls[1].kwargs["host"] == "1.2.3.4"
-        assert loop.create_connection.mock_calls[1].kwargs["port"] == 6638
-
-
-async def test_pyserial_error_remapping(tmp_path: pathlib.Path) -> None:
-    loop = asyncio.get_running_loop()
-    protocol_factory = Mock()
-
-    # FileNotFoundError
-    missing_port = tmp_path / "missing"
-    assert not missing_port.exists()
-
-    with pytest.raises(FileNotFoundError):
-        await zigpy.serial.create_serial_connection(
-            loop, protocol_factory, url=missing_port
-        )
-
-    # PermissionError
-    denied_port = tmp_path / "denied"
-    denied_port.touch()
-    denied_port.chmod(0o000)
-
-    with pytest.raises(PermissionError):
-        await zigpy.serial.create_serial_connection(
-            loop, protocol_factory, url=denied_port
-        )
-
-    # IsADirectoryError
-    a_folder = tmp_path / "a_folder"
-    a_folder.mkdir()
-
-    with pytest.raises(IsADirectoryError):
-        await zigpy.serial.create_serial_connection(
-            loop, protocol_factory, url=a_folder
-        )
 
     # Locked
     locked_port = tmp_path / "locked"

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -75,6 +75,25 @@ async def test_serial_error_remapping(tmp_path: pathlib.Path) -> None:
     loop = asyncio.get_running_loop()
     protocol_factory = Mock()
 
+    # FileNotFoundError
+    missing_port = tmp_path / "missing"
+    assert not missing_port.exists()
+
+    with pytest.raises(FileNotFoundError):
+        await zigpy.serial.create_serial_connection(
+            loop, protocol_factory, url=missing_port
+        )
+
+    # PermissionError
+    denied_port = tmp_path / "denied"
+    denied_port.touch()
+    denied_port.chmod(0o000)
+
+    with pytest.raises(PermissionError):
+        await zigpy.serial.create_serial_connection(
+            loop, protocol_factory, url=denied_port
+        )
+
     # Locked
     locked_port = tmp_path / "locked"
     with locked_port.open("w") as f:

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -74,9 +74,7 @@ async def create_serial_connection(
     flow_control: Literal["hardware", "software"] | None | UndefinedType = UNDEFINED,
     **kwargs: Any,
 ) -> tuple[asyncio.Transport, asyncio.Protocol]:
-    """Wrapper around pyserial-asyncio that transparently substitutes a normal TCP
-    transport and protocol when a `socket` connection URI is provided.
-    """
+    """Wrapper for serialx that provides simplified flow control kwargs."""
 
     if flow_control is not UNDEFINED:
         xonxoff = flow_control == "software"

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -64,7 +64,7 @@ class SerialProtocol(asyncio.Protocol):
 
 
 async def create_serial_connection(
-    loop: asyncio.BaseEventLoop,
+    loop: asyncio.AbstractEventLoop,
     protocol_factory: Callable[[], asyncio.Protocol],
     url: pathlib.Path | str,
     *,

--- a/zigpy/serial.py
+++ b/zigpy/serial.py
@@ -1,26 +1,20 @@
 from __future__ import annotations
 
 import asyncio
-from asyncio import timeout as asyncio_timeout
+from collections.abc import Callable
+import errno
 import logging
 import pathlib
-import typing
-from typing import Literal
-import urllib.parse
+from typing import Any, Literal, cast
 
-try:
-    # serialx is API-compatible with pyserial
-    import serialx as pyserial
-    import serialx as pyserial_asyncio
-except ImportError:
-    import serial as pyserial
-    import serial_asyncio_fast as pyserial_asyncio
+from serialx import (
+    SerialTransport,
+    create_serial_connection as serialx_create_serial_connection,
+)
 
 from zigpy.typing import UNDEFINED, UndefinedType
 
 LOGGER = logging.getLogger(__name__)
-DEFAULT_SOCKET_PORT = 6638
-SOCKET_CONNECT_TIMEOUT = 5
 
 
 class SerialProtocol(asyncio.Protocol):
@@ -28,7 +22,7 @@ class SerialProtocol(asyncio.Protocol):
 
     def __init__(self) -> None:
         self._buffer = bytearray()
-        self._transport: pyserial_asyncio.SerialTransport | None = None
+        self._transport: SerialTransport | None = None
 
         self._connected_event = asyncio.Event()
         self._disconnected_event = asyncio.Event()
@@ -38,10 +32,10 @@ class SerialProtocol(asyncio.Protocol):
         """Wait for the protocol's transport to be connected."""
         await self._connected_event.wait()
 
-    def connection_made(self, transport: pyserial_asyncio.SerialTransport) -> None:
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
         LOGGER.debug("Connection made: %s", transport)
 
-        self._transport = transport
+        self._transport = cast(SerialTransport, transport)
         self._disconnected_event.clear()
         self._connected_event.set()
 
@@ -71,15 +65,14 @@ class SerialProtocol(asyncio.Protocol):
 
 async def create_serial_connection(
     loop: asyncio.BaseEventLoop,
-    protocol_factory: typing.Callable[[], asyncio.Protocol],
+    protocol_factory: Callable[[], asyncio.Protocol],
     url: pathlib.Path | str,
     *,
     baudrate: int = 115200,  # We default to 115200 instead of 9600
-    exclusive: bool | None = True,
     xonxoff: bool | UndefinedType = UNDEFINED,
     rtscts: bool | UndefinedType = UNDEFINED,
     flow_control: Literal["hardware", "software"] | None | UndefinedType = UNDEFINED,
-    **kwargs: typing.Any,
+    **kwargs: Any,
 ) -> tuple[asyncio.Transport, asyncio.Protocol]:
     """Wrapper around pyserial-asyncio that transparently substitutes a normal TCP
     transport and protocol when a `socket` connection URI is provided.
@@ -104,38 +97,24 @@ async def create_serial_connection(
     )
 
     url = str(url)
-    parsed_url = urllib.parse.urlparse(url)
 
-    if parsed_url.scheme in ("socket", "tcp"):
-        async with asyncio_timeout(SOCKET_CONNECT_TIMEOUT):
-            transport, protocol = await loop.create_connection(
-                protocol_factory=protocol_factory,
-                host=parsed_url.hostname,
-                port=parsed_url.port or DEFAULT_SOCKET_PORT,
-            )
-    else:
-        try:
-            try:
-                transport, protocol = await pyserial_asyncio.create_serial_connection(
-                    loop,
-                    protocol_factory,
-                    url=url,
-                    baudrate=baudrate,
-                    exclusive=exclusive,
-                    xonxoff=xonxoff,
-                    rtscts=rtscts,
-                    **kwargs,
-                )
-            except pyserial.SerialException as exc:
-                # Unwrap unnecessarily wrapped PySerial exceptions
-                if exc.__context__ is not None:
-                    raise exc.__context__ from None
-
-                raise
-        except BlockingIOError as exc:
+    try:
+        transport, protocol = await serialx_create_serial_connection(
+            loop,
+            protocol_factory,
+            url=url,
+            baudrate=baudrate,
+            xonxoff=xonxoff,
+            rtscts=rtscts,
+            **kwargs,
+        )
+    except OSError as exc:
+        if exc.errno == errno.EBUSY:
             # Re-raise a more useful exception
             raise PermissionError(
                 "The serial port is locked by another application"
             ) from exc
+
+        raise
 
     return transport, protocol


### PR DESCRIPTION
We initially added a runtime import "preference" for pyserial-asyncio-fast over pyserial-asyncio, later we did the same with serialx over pyserial and pyserial-asyncio. There's been no negative feedback from any ZHA users over the past few months so I think this experiment can be concluded.

This PR replaces the runtime imports with a normal dependency on serialx.