### PR TITLE
Clean up original `Device` when a quirk replaces it

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -12,6 +12,7 @@ import pytest
 import zigpy.application
 import zigpy.config as conf
 from zigpy.datastructures import RequestLimiter
+import zigpy.device
 from zigpy.exceptions import (
     DeliveryError,
     NetworkNotFormed,
@@ -481,6 +482,53 @@ def test_register_callback_listener_cancel_is_idempotent(app):
     cancel()
     assert dev not in app._req_listeners
 
+
+async def test_device_initialized_cleans_up_replaced_device(app):
+    """When a quirk replaces the device, the original is fully released."""
+    ieee = make_ieee()
+    nwk = t.NWK(0x1234)
+
+    original = app.add_device(ieee=ieee, nwk=nwk)
+    original.node_desc = make_node_desc()
+    original.add_endpoint(1)
+    original[1].profile_id = 260
+    original[1].device_type = 0x0100
+    original[1].status = zigpy.endpoint.Status.ZDO_INIT
+
+    # Sanity check: the PollControl listener registered in Device.__init__
+    # is keyed on the device itself.
+    assert original in app._req_listeners
+
+    quirked = zigpy.device.Device(app, ieee, nwk)
+    quirked.node_desc = make_node_desc()
+
+    with patch("zigpy.quirks.get_device", return_value=quirked):
+        app.device_initialized(original)
+
+    assert app.devices[ieee] is quirked
+    # Original's PollControl listener was cancelled, dropping its slot.
+    assert original not in app._req_listeners
+    # Quirked device has its own slot (registered in its own __init__).
+    assert quirked in app._req_listeners
+
+
+async def test_device_initialized_no_quirk_keeps_device(app):
+    """If no quirk applies, the device is kept and not erroneously cleaned up."""
+    ieee = make_ieee()
+    nwk = t.NWK(0x1234)
+
+    dev = app.add_device(ieee=ieee, nwk=nwk)
+    dev.node_desc = make_node_desc()
+    dev.add_endpoint(1)
+    dev[1].profile_id = 260
+    dev[1].device_type = 0x0100
+    dev[1].status = zigpy.endpoint.Status.ZDO_INIT
+
+    with patch("zigpy.quirks.get_device", side_effect=lambda d: d):
+        app.device_initialized(dev)
+
+    assert app.devices[ieee] is dev
+    assert dev in app._req_listeners
 
 
 async def test_get_device(app):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -458,6 +458,31 @@ async def test_device_join_rejoin(is_init_mock, group_scan_mock, init_mock, app,
     init_mock.assert_called_once()
 
 
+def test_register_callback_listener_cancel_is_idempotent(app):
+    """Cancelling the same callback twice is safe (no KeyError, no resurrected slot)."""
+    dev = app.add_device(ieee=make_ieee(), nwk=t.NWK(0x1234))
+    # Clear the PollControl listener that Device.__init__ registers, so the
+    # deque slot is empty after our cancel below.
+    dev.on_remove()
+    assert dev not in app._req_listeners
+
+    cancel = app.register_callback_listener(
+        src=dev,
+        filters=[clusters.general.PollControl.ClientCommandDefs.checkin.schema()],
+        callback=lambda hdr, cmd: None,
+    )
+    assert dev in app._req_listeners
+
+    # First cancel removes the listener and drops the empty deque slot.
+    cancel()
+    assert dev not in app._req_listeners
+
+    # Second cancel hits the early-return path: no slot, no work.
+    cancel()
+    assert dev not in app._req_listeners
+
+
+
 async def test_get_device(app):
     """Test get_device."""
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1778,6 +1778,42 @@ async def test_on_remove_callbacks(dev: device.Device) -> None:
     assert not dev._on_remove_callbacks
 
 
+def test_on_remove_no_running_loop(dev: device.Device) -> None:
+    """`on_remove()` is safe to call from synchronous code (no running loop)."""
+    callback = MagicMock()
+    dev._on_remove_callbacks.append(callback)
+
+    # No event loop is running here; `asyncio.current_task()` would raise.
+    dev.on_remove()
+
+    callback.assert_called_once()
+    assert not dev._on_remove_callbacks
+    assert not dev._tasks
+
+
+async def test_on_remove_from_within_tracked_task(dev: device.Device) -> None:
+    """`on_remove()` is safe to call from inside one of the device's own tasks.
+
+    The current task should not be cancelled, and its done-callback should
+    not raise `KeyError` when `_tasks` was cleared during `on_remove()`.
+    """
+    started = asyncio.Event()
+
+    async def inner() -> str:
+        started.set()
+        dev.on_remove()
+        return "done"
+
+    task = dev.create_task(inner(), name="inner")
+    await started.wait()
+    result = await task
+
+    assert result == "done"
+    assert not task.cancelled()
+    # Done-callback ran without raising; `_tasks` is empty.
+    assert not dev._tasks
+
+
 async def test_initialize_fast_polling_failure(dev: device.Device) -> None:
     """Test that fast polling is attempted during initialization."""
     ep = dev.add_endpoint(1)

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -602,11 +602,18 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         device.original_signature = device.get_signature()
 
         self.listener_event("raw_device_initialized", device)
-        device = zigpy.quirks.get_device(device)
-        self.devices[device.ieee] = device
+        new_device = zigpy.quirks.get_device(device)
+        self.devices[new_device.ieee] = new_device
         if self._dblistener is not None:
-            device.add_context_listener(self._dblistener)
-        self.listener_event("device_initialized", device)
+            new_device.add_context_listener(self._dblistener)
+
+        # If a quirk replaced the device with a different instance, the original
+        # would otherwise leak its callbacks/tasks (notably the PollControl
+        # listener registered in Device.__init__).
+        if new_device is not device:
+            device.on_remove()
+
+        self.listener_event("device_initialized", new_device)
 
     async def remove(
         self, ieee: t.EUI64, remove_children: bool = True, rejoin: bool = False

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1385,8 +1385,15 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         def cancel_callback() -> None:
             """Remove the listener."""
-            if listener in self._req_listeners[src]:
-                self._req_listeners[src].remove(listener)
+            listeners = self._req_listeners.get(src)
+            if listeners is None:
+                return
+            if listener in listeners:
+                listeners.remove(listener)
+            # Drop the device-keyed slot so it doesn't pin Device objects
+            # (e.g. originals replaced by quirks) alive indefinitely.
+            if not listeners:
+                self._req_listeners.pop(src, None)
 
         return cancel_callback
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -148,7 +148,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         """
         task = asyncio.get_running_loop().create_task(target, name=name)
         self._tasks.add(task)
-        task.add_done_callback(self._tasks.remove)
+        # `discard` is idempotent so the callback is safe even if `on_remove()`
+        # cleared `_tasks` before the task completed.
+        task.add_done_callback(self._tasks.discard)
         return task
 
     def on_remove(self) -> None:
@@ -158,8 +160,17 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         self._on_remove_callbacks.clear()
 
+        # Don't cancel the task we're currently running in (e.g. when on_remove
+        # is called from inside `device_initialized` after a quirk replacement).
+        # `current_task()` raises if no event loop is running; on_remove can be
+        # called from sync code (tests, shutdown), so treat that as no current task.
+        try:
+            current_task = asyncio.current_task()
+        except RuntimeError:
+            current_task = None
         for task in self._tasks:
-            task.cancel()
+            if task is not current_task:
+                task.cancel()
 
         self._tasks.clear()
 


### PR DESCRIPTION
DRAFT: I'm not really happy with this yet..

I do want to poke at the entire `Device` architecture/lifecycle at a later date. For now, I want to get the re-interviewing stuff in first (https://github.com/zigpy/zigpy/pull/1789). For that, it would be nice to have this "small fix", though not absolutely critical, as re-interviewing should be done very rarely.

Maybe already have a look at the fix and description below.

## Proposed change

This PR should fully clean up references to the original `Device` object when a quirk replaces it in `device_initialized`.
This was noticed during the re-interview PR (https://github.com/zigpy/zigpy/pull/1789), but it wasn't really a real issue before.

(Extensive) LLM description of the PR below.

## AI summary

When a device finishes initialization, `ControllerApplication.device_initialized` calls `zigpy.quirks.get_device(device)`, which may return a *different* `Device` instance (a `BaseCustomDevice` for quirks v1, or a v2 quirk-built device). The new device replaces the original in `app.devices[ieee]`, but the original was being abandoned without any cleanup — leaking its callbacks and tasks for the lifetime of the application.

Concretely, every `Device.__init__` registers a PollControl check-in callback into `app._req_listeners[self]`:

https://github.com/zigpy/zigpy/blob/dev/zigpy/device.py#L135-L141

The cancel callback returned from `register_callback_listener` removes the listener from the deque but leaves the now-empty deque under the device-keyed slot, so the `Device` stays pinned as a `dict` key. Combined with the fact that the original device's `on_remove()` was never called when a quirk replaced it, this meant:

- The original `Device` (and all its endpoints, clusters, and `_event_listeners`) was held alive forever via `app._req_listeners`.
- Every paired device with a matching quirk leaked one full `Device` object graph.

The PR is structured as three commits, harden-the-primitive-then-use-it:

1. **Drop empty deque entry from `_req_listeners` on cancel** — so cancelling the last listener releases the device-keyed dict slot.
2. **Make `Device.on_remove()` robust to all calling contexts** — `create_task` now uses `set.discard` (idempotent) for its done-callback so a missing task isn't fatal, and `on_remove()` skips `asyncio.current_task()` when cancelling. `current_task()` is wrapped in `try/except RuntimeError` so `on_remove()` is also safe to call from synchronous code (tests, shutdown).
3. **Clean up the original `Device` when a quirk replaces it** — call `original.on_remove()` from `device_initialized` whenever `quirks.get_device` returns a different instance.

Each commit passes tests independently.

### Why now

This came up while reviewing the [device re-interview RFC](https://github.com/zigpy/zigpy/pull/1789), which exercises the same code path (quirks replacing a freshly-discovered "shadow" `Device`) on every re-interview rather than just once at pair time. Fixing it generically in `device_initialized` benefits both flows, so it's worth landing on its own.

### Alternatives considered

- **Move PollControl registration out of `Device.__init__` into `device_initialized`.** Tempting, but the listener exists specifically to keep sleepy devices awake during `_discover()` — i.e. *before* `device_initialized` runs. Deferring registration loses checkins from the very devices that need them.
- **Key `_req_listeners` by IEEE instead of `Device`.** The deque values are still bound methods that capture `self`, so the original would still need `on_remove()` to remove its callback. Same fixes, different shape.
- **`WeakKeyDictionary` for `_req_listeners`.** Doesn't help while the deque values strongly reference the device via bound callbacks.
- **Defer cleanup via `loop.call_soon(device.on_remove)`.** Avoids the `current_task` skip entirely, but introduces "deferred cleanup" semantics with a one-tick window where the original is still in `_req_listeners`. Direct synchronous cleanup felt more honest, and making `on_remove()` robust is a useful invariant for a public method to have anyway.

### Risk / behavior change

`Device.on_remove()` cancels everything in `self._tasks`. In the normal-join path, `device_initialized` is called from inside `Device._initialize_task`, so the original's own `_initialize_task` is on the stack at the time of cleanup. The second commit explicitly skips `asyncio.current_task()` so the caller is never cancelled. Other tasks created during discovery (notably `_fast_polling_reset_task`) are still cancelled, which is fine — the original device is being discarded.

#### ZHA impact

Verified that ZHA is not affected:

- ZHA's `raw_device_initialized` listener is synchronous and packages device info into a serialized event with no long-lived references to the pre-quirk device.
- ZHA's `device_initialized` listener creates an `async_device_initialized` task, but the `device` argument it receives is already the *quirked* one — that's what zigpy passes to the listener event after the swap. The task is tracked in ZHA's own `_tracked_completable_tasks`, not on the original zigpy device's `_tasks` set.
- ZHA cluster handlers attach themselves via `cluster.add_listener(self)` / `cluster.on_event(...)` during ZHA Device construction inside `async_device_initialized`, which runs after the swap and only sees the quirked device's clusters.
- Nothing in ZHA touches `zigpy_device._tasks`, `zigpy_device._on_remove_callbacks`, or attaches via `zigpy_device.add_listener`.
