### PR TITLE
Limit the total size of read/write/report attribute commands

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -21,6 +21,7 @@ import zigpy.endpoint
 import zigpy.profiles.zha
 import zigpy.types as t
 from zigpy.zcl import (
+    MAX_ATTRIBUTE_RECORDS_BYTES,
     AttributeReadEvent,
     AttributeReportedEvent,
     AttributeUpdatedEvent,
@@ -2399,6 +2400,66 @@ async def test_configure_reporting_multiple_manufacturer_groups(app_mock) -> Non
     assert manuf_call.args[0][0].min_interval == 10
     assert manuf_call.args[0][0].max_interval == 30
     assert manuf_call.args[0][0].reportable_change == 5
+
+
+async def test_configure_reporting_multiple_chunked_by_size(app_mock) -> None:
+    """Configure_reporting_multiple splits requests so no single one exceeds
+    MAX_ATTRIBUTE_RECORDS_BYTES of serialized records.
+    """
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            # 6 uint8 attrs, each serializing to 9 bytes as a SendReports config
+            # (1 dir + 2 attrid + 1 type + 2 min + 2 max + 1 reportable_change).
+            # 6 * 9 = 54 bytes > 50, so the request must split into 2 chunks.
+            attr_a = foundation.ZCLAttributeDef(id=0xFF00, type=t.uint8_t)
+            attr_b = foundation.ZCLAttributeDef(id=0xFF01, type=t.uint8_t)
+            attr_c = foundation.ZCLAttributeDef(id=0xFF02, type=t.uint8_t)
+            attr_d = foundation.ZCLAttributeDef(id=0xFF03, type=t.uint8_t)
+            attr_e = foundation.ZCLAttributeDef(id=0xFF04, type=t.uint8_t)
+            attr_f = foundation.ZCLAttributeDef(id=0xFF05, type=t.uint8_t)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    cfg_success = zcl.foundation.ConfigureReportingResponse(
+        [zcl.foundation.ConfigureReportingResponseRecord(zcl.foundation.Status.SUCCESS)]
+    )
+
+    cfg = ReportingConfig(min_interval=1, max_interval=2, reportable_change=3)
+    attrs = [
+        TestCluster.AttributeDefs.attr_a,
+        TestCluster.AttributeDefs.attr_b,
+        TestCluster.AttributeDefs.attr_c,
+        TestCluster.AttributeDefs.attr_d,
+        TestCluster.AttributeDefs.attr_e,
+        TestCluster.AttributeDefs.attr_f,
+    ]
+
+    with patch.object(
+        cluster,
+        "_configure_reporting",
+        new_callable=AsyncMock,
+        side_effect=[[cfg_success], [cfg_success]],
+    ) as mock_configure:
+        results = await cluster.configure_reporting_multiple(dict.fromkeys(attrs, cfg))
+
+    assert mock_configure.await_count == 2
+
+    sent_attrids = []
+    for call_obj in mock_configure.call_args_list:
+        chunk_configs = call_obj.args[0]
+        chunk_size = sum(len(c.serialize()) for c in chunk_configs)
+        assert chunk_size <= MAX_ATTRIBUTE_RECORDS_BYTES
+        sent_attrids.extend(c.attrid for c in chunk_configs)
+
+    assert sent_attrids == [a.id for a in attrs]
+
+    assert len(results) == 6
+    assert all(s == zcl.foundation.Status.SUCCESS for s in results.values())
 
 
 def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -26,6 +26,7 @@ from zigpy.zcl import (
     AttributeReportedEvent,
     AttributeUpdatedEvent,
     AttributeWrittenEvent,
+    _chunk_records_by_size,
     foundation,
 )
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota
@@ -2460,6 +2461,140 @@ async def test_configure_reporting_multiple_chunked_by_size(app_mock) -> None:
 
     assert len(results) == 6
     assert all(s == zcl.foundation.Status.SUCCESS for s in results.values())
+
+
+async def test_read_attributes_chunked_by_count(app_mock) -> None:
+    """Read_attributes splits requests into chunks of at most five."""
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            attr_0 = foundation.ZCLAttributeDef(id=0xFF00, type=t.uint8_t)
+            attr_1 = foundation.ZCLAttributeDef(id=0xFF01, type=t.uint8_t)
+            attr_2 = foundation.ZCLAttributeDef(id=0xFF02, type=t.uint8_t)
+            attr_3 = foundation.ZCLAttributeDef(id=0xFF03, type=t.uint8_t)
+            attr_4 = foundation.ZCLAttributeDef(id=0xFF04, type=t.uint8_t)
+            attr_5 = foundation.ZCLAttributeDef(id=0xFF05, type=t.uint8_t)
+            attr_6 = foundation.ZCLAttributeDef(id=0xFF06, type=t.uint8_t)
+            attr_7 = foundation.ZCLAttributeDef(id=0xFF07, type=t.uint8_t)
+            attr_8 = foundation.ZCLAttributeDef(id=0xFF08, type=t.uint8_t)
+            attr_9 = foundation.ZCLAttributeDef(id=0xFF09, type=t.uint8_t)
+            attr_10 = foundation.ZCLAttributeDef(id=0xFF0A, type=t.uint8_t)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    attrs = [getattr(TestCluster.AttributeDefs, f"attr_{i}") for i in range(11)]
+
+    # Exclude 2 and 7 so the mock returns UNSUPPORTED
+    supported = {attr: i for i, attr in enumerate(attrs) if i not in (2, 7)}
+    with mock_attribute_reads(cluster, supported) as (mock_read, _):
+        success, failure = await cluster.read_attributes(attrs)
+
+    # 11 attributes, at most MAX_READ_ATTRIBUTES_PER_REQ (5) per request -> 5 + 5 + 1
+    chunks = [call_obj.args[0] for call_obj in mock_read.call_args_list]
+    assert [len(chunk) for chunk in chunks] == [5, 5, 1]
+
+    # Every attribute was requested exactly once, in order, across the chunks
+    requested_ids = []
+    for chunk in chunks:
+        requested_ids.extend(chunk)
+    assert requested_ids == [attr.id for attr in attrs]
+
+    # Supported attributes succeed; the two omitted ones fail
+    assert success == supported
+    assert failure == {
+        attrs[2]: foundation.Status.UNSUPPORTED_ATTRIBUTE,
+        attrs[7]: foundation.Status.UNSUPPORTED_ATTRIBUTE,
+    }
+
+
+async def test_write_attributes_chunked_by_size(app_mock) -> None:
+    """Write_attributes splits requests if a single one would exceed the limit."""
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            attr_a = foundation.ZCLAttributeDef(id=0xFF00, type=t.uint64_t)
+            attr_b = foundation.ZCLAttributeDef(id=0xFF01, type=t.uint64_t)
+            attr_c = foundation.ZCLAttributeDef(id=0xFF02, type=t.uint64_t)
+            attr_d = foundation.ZCLAttributeDef(id=0xFF03, type=t.uint64_t)
+            attr_e = foundation.ZCLAttributeDef(id=0xFF04, type=t.uint64_t)
+            attr_f = foundation.ZCLAttributeDef(id=0xFF05, type=t.uint64_t)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    attrs = [
+        TestCluster.AttributeDefs.attr_a,
+        TestCluster.AttributeDefs.attr_b,
+        TestCluster.AttributeDefs.attr_c,
+        TestCluster.AttributeDefs.attr_d,
+        TestCluster.AttributeDefs.attr_e,
+        TestCluster.AttributeDefs.attr_f,
+    ]
+
+    with mock_attribute_writes(
+        cluster, dict.fromkeys(attrs, foundation.Status.SUCCESS)
+    ) as (mock_write, _):
+        [results] = await cluster.write_attributes(dict.fromkeys(attrs, 1))
+
+    # 6 records of 11 bytes each split into 2 chunks: 44 bytes + 22 bytes
+    assert mock_write.call_count == 2
+
+    sent_attrids = []
+    for call_obj in mock_write.call_args_list:
+        chunk_attrs = call_obj.args[0]
+        chunk_size = sum(len(a.serialize()) for a in chunk_attrs)
+        assert chunk_size <= MAX_ATTRIBUTE_RECORDS_BYTES
+        sent_attrids.extend(a.attrid for a in chunk_attrs)
+
+    assert sent_attrids == [attr.id for attr in attrs]
+
+    assert len(results) == 6
+    assert all(r.status == foundation.Status.SUCCESS for r in results)
+
+
+@pytest.mark.parametrize(
+    ("sizes", "max_bytes", "expected"),
+    [
+        # No records produces no chunks
+        ([], 10, []),
+        # Records that all fit stay in a single chunk
+        ([3, 3, 3], 10, [[3, 3, 3]]),
+        # Filling exactly to the limit does not start a new chunk
+        ([5, 5], 10, [[5, 5]]),
+        # A single record exactly at the limit is allowed
+        ([10], 10, [[10]]),
+        # Exceeding the limit rolls over into a new chunk
+        ([5, 5, 1], 10, [[5, 5], [1]]),
+    ],
+)
+def test_chunk_records_by_size(sizes, max_bytes, expected) -> None:
+    """The chunker packs records into chunks that never exceed max_bytes."""
+    chunks = _chunk_records_by_size(sizes, lambda size: size, max_bytes=max_bytes)
+    assert chunks == expected
+
+
+@pytest.mark.parametrize(
+    ("sizes", "max_bytes"),
+    [
+        # A single record larger than the limit, on its own
+        ([15], 10),
+        # An oversized record surrounded by ones that would otherwise fit
+        ([3, 15, 4], 10),
+    ],
+)
+def test_chunk_records_by_size_oversized_record(sizes, max_bytes) -> None:
+    """A record that on its own exceeds max_bytes can never be sent, so the chunker
+    fails loudly instead of emitting an oversized chunk the transport would reject.
+    """
+    with pytest.raises(ValueError, match="too large to fit in a single request"):
+        _chunk_records_by_size(sizes, lambda size: size, max_bytes=max_bytes)
 
 
 def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import collections
 from collections import defaultdict
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Callable, Generator, Iterable, Sequence
 import contextlib
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -12,7 +12,7 @@ import functools
 import itertools
 import logging
 import types
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, TypeVar
 import warnings
 
 from zigpy import util
@@ -32,6 +32,34 @@ if TYPE_CHECKING:
 
 
 LOGGER = logging.getLogger(__name__)
+
+# Cap on the serialized size of attribute records in a single Read/Write/Configure
+# Reporting request. Matches the OTA image-block size we've validated in the wild,
+# which stays under the unfragmented Zigbee APS budget even with worst-case NWK
+# security and source routing overhead.
+MAX_ATTRIBUTE_RECORDS_BYTES = 50
+
+_RecordT = TypeVar("_RecordT")
+
+
+def _chunk_records_by_size(
+    records: Iterable[_RecordT],
+    get_size: Callable[[_RecordT], int],
+    *,
+    max_bytes: int = MAX_ATTRIBUTE_RECORDS_BYTES,
+) -> list[list[_RecordT]]:
+    """Split records into chunks not exceeding max_bytes of serialized payload."""
+    chunks: list[list[_RecordT]] = []
+    chunk_size = 0
+    for record in records:
+        record_size = get_size(record)
+        if not chunks or chunk_size + record_size > max_bytes:
+            chunks.append([])
+            chunk_size = 0
+        chunks[-1].append(record)
+        chunk_size += record_size
+    return chunks
+
 
 # Tracks (cluster_id, attrid) pairs for which AttributeUpdatedEvent should be suppressed.
 # Used during Report_Attributes handling to allow quirks that update other clusters or
@@ -1109,91 +1137,91 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
         # Now, we can perform the reads for each manufacturer code group
         for manufacturer_code, attribute_group in reads_by_manuf_code.items():
-            result = await self.read_attributes_raw(
-                [attr_def.id for attr_def in attribute_group],
-                manufacturer=manufacturer_code,
-                **kwargs,
-            )
+            # Each attribute id serializes to a 2-byte uint16
+            for chunk in _chunk_records_by_size(attribute_group, lambda _: 2):
+                result = await self.read_attributes_raw(
+                    [attr_def.id for attr_def in chunk],
+                    manufacturer=manufacturer_code,
+                    **kwargs,
+                )
 
-            # The read response should contain only these attributes
-            potential_attributes = {
-                attr_def.id: attr_def for attr_def in attribute_group
-            }
+                # The read response should contain only these attributes
+                potential_attributes = {attr_def.id: attr_def for attr_def in chunk}
 
-            if not isinstance(result[0], list):
-                # If we get back a single response status, all reads failed
-                for attr_def in attribute_group:
-                    failure[attribute_map[attr_def]] = result[0]
-            else:
-                for record in result[0]:
-                    attr_def = potential_attributes[record.attrid]
+                if not isinstance(result[0], list):
+                    # If we get back a single response status, all reads failed
+                    for attr_def in chunk:
+                        failure[attribute_map[attr_def]] = result[0]
+                else:
+                    for record in result[0]:
+                        attr_def = potential_attributes[record.attrid]
 
-                    if record.status == foundation.Status.SUCCESS:
-                        if record.value.value is None:
-                            # TODO: remove this workaround when `LocalDataCluster` and
-                            # `_VALID_ATTRIBUTES` are removed from quirks. There is no
-                            # way for `value` to actually be `None` when read from a
-                            # real device.
-                            value = None
+                        if record.status == foundation.Status.SUCCESS:
+                            if record.value.value is None:
+                                # TODO: remove this workaround when `LocalDataCluster` and
+                                # `_VALID_ATTRIBUTES` are removed from quirks. There is no
+                                # way for `value` to actually be `None` when read from a
+                                # real device.
+                                value = None
+                            else:
+                                value = attr_def.type(record.value.value)
+
+                            success[attribute_map[attr_def]] = value
+
+                            cached_value = self._legacy_apply_quirk_attribute_update(
+                                attr_def, value
+                            )
+
+                            if cached_value is None:
+                                # Quirk swallowed the attribute
+                                continue
+                            elif cached_value != value:
+                                # Quirk transformed the value, emit AttributeUpdatedEvent
+                                self.emit(
+                                    AttributeUpdatedEvent.event_type,
+                                    AttributeUpdatedEvent(
+                                        device_ieee=str(self.endpoint.device.ieee),
+                                        endpoint_id=self.endpoint.endpoint_id,
+                                        cluster_type=self._type,
+                                        cluster_id=self.cluster_id,
+                                        attribute_name=attr_def.name,
+                                        attribute_id=attr_def.id,
+                                        manufacturer_code=manufacturer_code,
+                                        value=cached_value,
+                                    ),
+                                )
+                            else:
+                                # Value unchanged, emit AttributeReadEvent
+                                self.emit(
+                                    AttributeReadEvent.event_type,
+                                    AttributeReadEvent(
+                                        device_ieee=str(self.endpoint.device.ieee),
+                                        endpoint_id=self.endpoint.endpoint_id,
+                                        cluster_type=self._type,
+                                        cluster_id=self.cluster_id,
+                                        attribute_name=attr_def.name,
+                                        attribute_id=attr_def.id,
+                                        manufacturer_code=manufacturer_code,
+                                        raw_value=record.value.value,
+                                        value=value,
+                                    ),
+                                )
                         else:
-                            value = attr_def.type(record.value.value)
+                            if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
+                                self.emit(
+                                    AttributeUnsupportedEvent.event_type,
+                                    AttributeUnsupportedEvent(
+                                        device_ieee=str(self.endpoint.device.ieee),
+                                        endpoint_id=self.endpoint.endpoint_id,
+                                        cluster_type=self._type,
+                                        cluster_id=self.cluster_id,
+                                        attribute_name=attr_def.name,
+                                        attribute_id=attr_def.id,
+                                        manufacturer_code=manufacturer_code,
+                                    ),
+                                )
 
-                        success[attribute_map[attr_def]] = value
-
-                        cached_value = self._legacy_apply_quirk_attribute_update(
-                            attr_def, value
-                        )
-
-                        if cached_value is None:
-                            # Quirk swallowed the attribute
-                            continue
-                        elif cached_value != value:
-                            # Quirk transformed the value, emit AttributeUpdatedEvent
-                            self.emit(
-                                AttributeUpdatedEvent.event_type,
-                                AttributeUpdatedEvent(
-                                    device_ieee=str(self.endpoint.device.ieee),
-                                    endpoint_id=self.endpoint.endpoint_id,
-                                    cluster_type=self._type,
-                                    cluster_id=self.cluster_id,
-                                    attribute_name=attr_def.name,
-                                    attribute_id=attr_def.id,
-                                    manufacturer_code=manufacturer_code,
-                                    value=cached_value,
-                                ),
-                            )
-                        else:
-                            # Value unchanged, emit AttributeReadEvent
-                            self.emit(
-                                AttributeReadEvent.event_type,
-                                AttributeReadEvent(
-                                    device_ieee=str(self.endpoint.device.ieee),
-                                    endpoint_id=self.endpoint.endpoint_id,
-                                    cluster_type=self._type,
-                                    cluster_id=self.cluster_id,
-                                    attribute_name=attr_def.name,
-                                    attribute_id=attr_def.id,
-                                    manufacturer_code=manufacturer_code,
-                                    raw_value=record.value.value,
-                                    value=value,
-                                ),
-                            )
-                    else:
-                        if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
-                            self.emit(
-                                AttributeUnsupportedEvent.event_type,
-                                AttributeUnsupportedEvent(
-                                    device_ieee=str(self.endpoint.device.ieee),
-                                    endpoint_id=self.endpoint.endpoint_id,
-                                    cluster_type=self._type,
-                                    cluster_id=self.cluster_id,
-                                    attribute_name=attr_def.name,
-                                    attribute_id=attr_def.id,
-                                    manufacturer_code=manufacturer_code,
-                                ),
-                            )
-
-                        failure[attribute_map[attr_def]] = record.status
+                            failure[attribute_map[attr_def]] = record.status
 
         return success, failure
 
@@ -1340,51 +1368,55 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 zcl_attr.value.value = attr_def.type(value)
                 zcl_attrs.append(zcl_attr)
 
-            result = await self.write_attributes_raw(
-                zcl_attrs, manufacturer_code=manufacturer_code, **kwargs
-            )
-
             records_group: list[foundation.WriteAttributesStatusRecord] = []
 
-            if isinstance(result[0], list):
-                # Check for global success (status=SUCCESS, attrid=None)
-                if (
-                    len(result[0]) == 1
-                    and result[0][0].status == foundation.Status.SUCCESS
-                    and result[0][0].attrid is None
-                ):
-                    # Global success: all attributes succeeded
+            for chunk in _chunk_records_by_size(
+                zcl_attrs, lambda a: len(a.serialize())
+            ):
+                result = await self.write_attributes_raw(
+                    chunk, manufacturer_code=manufacturer_code, **kwargs
+                )
+
+                if isinstance(result[0], list):
+                    # Check for global success (status=SUCCESS, attrid=None)
+                    if (
+                        len(result[0]) == 1
+                        and result[0][0].status == foundation.Status.SUCCESS
+                        and result[0][0].attrid is None
+                    ):
+                        # Global success: all attributes succeeded
+                        records_group.extend(
+                            foundation.WriteAttributesStatusRecord(
+                                status=foundation.Status.SUCCESS,
+                                attrid=zcl_attr.attrid,
+                            )
+                            for zcl_attr in chunk
+                        )
+                    else:
+                        # Only failed writes are in the response. Attributes not
+                        # present implicitly succeeded.
+                        failed_attrids = {r.attrid for r in result[0]}
+                        for zcl_attr in chunk:
+                            if zcl_attr.attrid in failed_attrids:
+                                records_group.extend(
+                                    r for r in result[0] if r.attrid == zcl_attr.attrid
+                                )
+                            else:
+                                records_group.append(
+                                    foundation.WriteAttributesStatusRecord(
+                                        status=foundation.Status.SUCCESS,
+                                        attrid=zcl_attr.attrid,
+                                    )
+                                )
+                else:
+                    # Default response: apply status to all attributes in this group
+                    status = result[0]
                     records_group.extend(
                         foundation.WriteAttributesStatusRecord(
-                            status=foundation.Status.SUCCESS, attrid=zcl_attr.attrid
+                            status=status, attrid=zcl_attr.attrid
                         )
-                        for zcl_attr in zcl_attrs
+                        for zcl_attr in chunk
                     )
-                else:
-                    # Only failed writes are in the response. Attributes not
-                    # present implicitly succeeded.
-                    failed_attrids = {r.attrid for r in result[0]}
-                    for zcl_attr in zcl_attrs:
-                        if zcl_attr.attrid in failed_attrids:
-                            records_group.extend(
-                                r for r in result[0] if r.attrid == zcl_attr.attrid
-                            )
-                        else:
-                            records_group.append(
-                                foundation.WriteAttributesStatusRecord(
-                                    status=foundation.Status.SUCCESS,
-                                    attrid=zcl_attr.attrid,
-                                )
-                            )
-            else:
-                # Default response: apply status to all attributes in this group
-                status = result[0]
-                records_group.extend(
-                    foundation.WriteAttributesStatusRecord(
-                        status=status, attrid=zcl_attr.attrid
-                    )
-                    for zcl_attr in zcl_attrs
-                )
 
             results.extend(records_group)
 
@@ -1512,40 +1544,42 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         results: dict[foundation.ZCLAttributeDef, foundation.Status] = {}
 
         for manufacturer_code, reporting_configs in reporting_by_manuf_code.items():
-            configs = [cfg for _attr_def, cfg in reporting_configs]
-
-            rsp = await self._configure_reporting(
-                configs, manufacturer=manufacturer_code
-            )
-
             group_results: dict[foundation.ZCLAttributeDef, foundation.Status] = {}
 
-            if isinstance(rsp[0], list):
-                records = rsp[0]
+            for chunk in _chunk_records_by_size(
+                reporting_configs, lambda pair: len(pair[1].serialize())
+            ):
+                rsp = await self._configure_reporting(
+                    [cfg for _attr_def, cfg in chunk],
+                    manufacturer=manufacturer_code,
+                )
 
-                # Check for global success (status=SUCCESS, attrid=None)
-                if (
-                    len(records) == 1
-                    and records[0].status == foundation.Status.SUCCESS
-                    and records[0].attrid is None
-                ):
-                    # Global success: all attributes succeeded
-                    for attr_def, _cfg in reporting_configs:
-                        group_results[attr_def] = foundation.Status.SUCCESS
-                else:
-                    # Only failed reports are in the response. Attributes not
-                    # present implicitly succeeded.
-                    failed_attrids = {r.attrid: r.status for r in records}
-                    for attr_def, _cfg in reporting_configs:
-                        if attr_def.id in failed_attrids:
-                            group_results[attr_def] = failed_attrids[attr_def.id]
-                        else:
+                if isinstance(rsp[0], list):
+                    records = rsp[0]
+
+                    # Check for global success (status=SUCCESS, attrid=None)
+                    if (
+                        len(records) == 1
+                        and records[0].status == foundation.Status.SUCCESS
+                        and records[0].attrid is None
+                    ):
+                        # Global success: all attributes succeeded
+                        for attr_def, _cfg in chunk:
                             group_results[attr_def] = foundation.Status.SUCCESS
-            else:
-                # Default response: apply status to all attributes in this group
-                status = rsp[1]
-                for attr_def, _cfg in reporting_configs:
-                    group_results[attr_def] = status
+                    else:
+                        # Only failed reports are in the response. Attributes not
+                        # present implicitly succeeded.
+                        failed_attrids = {r.attrid: r.status for r in records}
+                        for attr_def, _cfg in chunk:
+                            if attr_def.id in failed_attrids:
+                                group_results[attr_def] = failed_attrids[attr_def.id]
+                            else:
+                                group_results[attr_def] = foundation.Status.SUCCESS
+                else:
+                    # Default response: apply status to all attributes in this group
+                    status = rsp[1]
+                    for attr_def, _cfg in chunk:
+                        group_results[attr_def] = status
 
             for attr_def, status in group_results.items():
                 if status == foundation.Status.SUCCESS:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -33,11 +33,16 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-# Cap on the serialized size of attribute records in a single Read/Write/Configure
-# Reporting request. Matches the OTA image-block size we've validated in the wild,
-# which stays under the unfragmented Zigbee APS budget even with worst-case NWK
-# security and source routing overhead.
+# Cap on the serialized size of attribute records in a single Write_Attributes or
+# Configure_Reporting request. Matches the OTA image-block size we've validated in
+# the wild, which stays under the unfragmented Zigbee APS budget even with worst-
+# case NWK security and source routing overhead.
 MAX_ATTRIBUTE_RECORDS_BYTES = 50
+
+# Cap on the number of attributes per Read_Attributes request. Reads can't use a
+# byte budget because the response size depends on the (potentially variable-
+# length) attribute values, which aren't known when chunking.
+MAX_READ_ATTRIBUTES_PER_REQ = 5
 
 _RecordT = TypeVar("_RecordT")
 
@@ -1137,8 +1142,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
         # Now, we can perform the reads for each manufacturer code group
         for manufacturer_code, attribute_group in reads_by_manuf_code.items():
-            # Each attribute id serializes to a 2-byte uint16
-            for chunk in _chunk_records_by_size(attribute_group, lambda _: 2):
+            for i in range(0, len(attribute_group), MAX_READ_ATTRIBUTES_PER_REQ):
+                chunk = attribute_group[i : i + MAX_READ_ATTRIBUTES_PER_REQ]
                 result = await self.read_attributes_raw(
                     [attr_def.id for attr_def in chunk],
                     manufacturer=manufacturer_code,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -56,13 +56,23 @@ def _chunk_records_by_size(
     """Split records into chunks not exceeding max_bytes of serialized payload."""
     chunks: list[list[_RecordT]] = []
     chunk_size = 0
+
     for record in records:
         record_size = get_size(record)
+
+        if record_size > max_bytes:
+            raise ValueError(
+                f"Record {record!r} is too large to fit in a single request: "
+                f"{record_size} > {max_bytes} bytes"
+            )
+
         if not chunks or chunk_size + record_size > max_bytes:
             chunks.append([])
             chunk_size = 0
+
         chunks[-1].append(record)
         chunk_size += record_size
+
     return chunks
 
 


### PR DESCRIPTION
Our read/write/report helper methods already are abstractions on top of the underlying protocol-level functions: we batch attributes by manufacturer code so that a raw config can be passed and zigpy reads attributes with the same manufacturer code in the same packet.

This PR limits the total byte count for any request to fit under within the _very_ conservative limit of 50 bytes, similar to what we know works for OTA. This allows us to accept mixed data types in a single request and optimize based on the total byte count instead of a fixed item limit.

Attribute writes and reporting config can be dynamically computed. Reads inherit the ZHA limit of 5. We technically could do some smarter batching by computing the maximum response size for a given request based on the attribute data types.

---

The motivation for this PR is that ZHA did something similar in cluster handlers, which I'm [in the process of removing](https://github.com/zigpy/zha/pull/657). With entities now directly accessing the cluster, it makes more sense to provide this with zigpy.