### PR TITLE
Create stub OTA providers for Inovelli and ThirdReality

### DIFF
--- a/tests/ota/test_ota_config.py
+++ b/tests/ota/test_ota_config.py
@@ -226,6 +226,33 @@ async def test_ota_config_complex(tmp_path: pathlib.Path) -> None:
     ]
 
 
+async def test_ota_config_stub_providers() -> None:
+    """Test YAML config loading when removed OTA providers are passed."""
+    zigpy.ota.OTA(
+        config=config.SCHEMA_OTA(
+            {
+                config.CONF_OTA_ENABLED: True,
+                config.CONF_OTA_BROADCAST_ENABLED: False,
+                config.CONF_OTA_EXTRA_PROVIDERS: [
+                    {
+                        config.CONF_OTA_PROVIDER_TYPE: "salus",
+                        config.CONF_OTA_PROVIDER_URL: "https://salus.example.org/",
+                    },
+                    {
+                        config.CONF_OTA_PROVIDER_TYPE: "thirdreality",
+                        config.CONF_OTA_PROVIDER_URL: "https://thirdreality.example.org/",
+                    },
+                    {
+                        config.CONF_OTA_PROVIDER_TYPE: "inovelli",
+                        config.CONF_OTA_PROVIDER_URL: "https://inovelli.example.org/",
+                    },
+                ],
+            }
+        ),
+        application=None,
+    )
+
+
 async def test_ota_broadcast_loop() -> None:
     app = make_app(
         {

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -372,19 +372,38 @@ class Ledvance(BaseOtaProvider):
             )
 
 
-# stub provider to keep existing configurations working
-@register_provider
-class Salus(BaseOtaProvider):
-    NAME = "salus"
-    MANUFACTURER_IDS = (4216, 43981)
-
-    VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_URL
+class StubOtaProvider(BaseOtaProvider):
+    """Stub provider to keep existing configurations working."""
 
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
         if False:
             yield  # pragma: no cover
+
+
+@register_provider
+class Salus(StubOtaProvider):
+    NAME = "salus"
+    MANUFACTURER_IDS = (4216, 43981)
+
+    VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_URL
+
+
+@register_provider
+class ThirdReality(StubOtaProvider):
+    NAME = "thirdreality"
+    MANUFACTURER_IDS = (4659, 4877, 5127)
+
+    VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_URL
+
+
+@register_provider
+class Inovelli(StubOtaProvider):
+    NAME = "inovelli"
+    MANUFACTURER_IDS = (4655,)
+
+    VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_URL
 
 
 @register_provider

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -375,10 +375,12 @@ class Ledvance(BaseOtaProvider):
 class StubOtaProvider(BaseOtaProvider):
     """Stub provider to keep existing configurations working."""
 
+    VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_URL
+
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
-        if False:
+        if typing.TYPE_CHECKING:
             yield  # pragma: no cover
 
 
@@ -387,23 +389,17 @@ class Salus(StubOtaProvider):
     NAME = "salus"
     MANUFACTURER_IDS = (4216, 43981)
 
-    VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_URL
-
 
 @register_provider
 class ThirdReality(StubOtaProvider):
     NAME = "thirdreality"
     MANUFACTURER_IDS = (4659, 4877, 5127)
 
-    VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_URL
-
 
 @register_provider
 class Inovelli(StubOtaProvider):
     NAME = "inovelli"
     MANUFACTURER_IDS = (4655,)
-
-    VOL_SCHEMA = zigpy.config.SCHEMA_OTA_PROVIDER_URL
 
 
 @register_provider


### PR DESCRIPTION
To ensure existing YAML config does not break, create stub resolvers for Inovelli and ThirdReality like we do for Salus.