### PR TITLE
Add coordinator support for the KeepAlive cluster

### DIFF
--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -12,7 +12,7 @@ from zigpy import device, types, zcl
 import zigpy.endpoint
 from zigpy.ota import OTA, OtaImagesResult
 from zigpy.zcl import OtaImageAvailableEvent, OtaQueryCacheUpdatedEvent, foundation
-from zigpy.zcl.clusters.general import Basic, Ota, Time
+from zigpy.zcl.clusters.general import Basic, KeepAlive, Ota, Time
 import zigpy.zcl.clusters.security as sec
 from zigpy.zdo import types as zdo_t
 
@@ -134,6 +134,39 @@ async def test_basic_cluster():
     assert rsp.status_records[2] == foundation.ReadAttributeRecord(
         attrid=Basic.AttributeDefs.serial_number.id,
         status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
+    )
+
+
+async def test_keepalive_cluster() -> None:
+    ep = MagicMock()
+    ep.reply = AsyncMock()
+
+    cluster = KeepAlive(ep)
+
+    rsp = await read_attributes(
+        cluster,
+        [
+            KeepAlive.AttributeDefs.tc_keep_alive_base.id,
+            KeepAlive.AttributeDefs.tc_keep_alive_jitter.id,
+        ],
+    )
+
+    assert rsp.status_records[0] == foundation.ReadAttributeRecord(
+        attrid=KeepAlive.AttributeDefs.tc_keep_alive_base.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.uint8,
+            value=10,
+        ),
+    )
+
+    assert rsp.status_records[1] == foundation.ReadAttributeRecord(
+        attrid=KeepAlive.AttributeDefs.tc_keep_alive_jitter.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(
+            type=foundation.DataTypeId.uint16,
+            value=300,
+        ),
     )
 
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -995,6 +995,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
                     zigpy.zcl.clusters.general.OnOff.cluster_id,
                     zigpy.zcl.clusters.general.Time.cluster_id,
                     zigpy.zcl.clusters.general.Ota.cluster_id,
+                    zigpy.zcl.clusters.general.KeepAlive.cluster_id,
                     zigpy.zcl.clusters.security.IasAce.cluster_id,
                 ],
                 output_clusters=[

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2443,3 +2443,9 @@ class KeepAlive(Cluster):
         tc_keep_alive_jitter: Final = ZCLAttributeDef(
             id=0x0001, type=t.uint16_t, access="r", mandatory=True
         )
+
+    def handle_read_attribute_tc_keep_alive_base(self) -> t.uint8_t:
+        return t.uint8_t(10)
+
+    def handle_read_attribute_tc_keep_alive_jitter(self) -> t.uint16_t:
+        return t.uint16_t(300)

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2445,7 +2445,11 @@ class KeepAlive(Cluster):
         )
 
     def handle_read_attribute_tc_keep_alive_base(self) -> t.uint8_t:
+        # Spec default (0x0A). Represents the time base (in minutes) that a Zigbee 4.0
+        # device will use to check if the trust center is alive.
         return t.uint8_t(10)
 
     def handle_read_attribute_tc_keep_alive_jitter(self) -> t.uint16_t:
+        # Spec default (0x012C). Represents the jitter (in _seconds_) that a Zigbee 4.0
+        # device will add to the time base when checking if the trust center is alive.
         return t.uint16_t(300)


### PR DESCRIPTION
Zigbee 4.0 routers read attributes from this cluster every `tc_keep_alive_base` minutes, jittered by `tc_keep_alive_jitter` seconds. They use this as a very active liveness check and will roam around the network indefinitely otherwise.