### PR TITLE
Fix cluster subclasses dropping same-ID attr/cmd definitions

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -965,6 +965,35 @@ async def test_request_with_kwargs(real_device):
         assert all(c == request_mock.mock_calls[0] for c in request_mock.mock_calls)
 
 
+def test_custom_cluster_subclass_keeps_same_id_attributes() -> None:
+    """Subclassing a custom cluster with two same-ID attributes keeps both."""
+
+    class MeteringBase(zigpy.quirks.CustomCluster, zcl.clusters.smartenergy.Metering):
+        class AttributeDefs(zcl.clusters.smartenergy.Metering.AttributeDefs):
+            # Shares its ID with the standard `current_summ_delivered` attribute
+            current_summ_delivered_mfg = zcl.foundation.ZCLAttributeDef(
+                id=0x0000,
+                type=t.uint48_t,
+                is_manufacturer_specific=True,
+                manufacturer_code=0x1166,
+            )
+
+    class MeteringVariant1(MeteringBase):
+        pass
+
+    class MeteringVariant2(MeteringBase):
+        pass
+
+    for cls in (MeteringBase, MeteringVariant1, MeteringVariant2):
+        assert "current_summ_delivered" in cls.attributes_by_name
+        assert "current_summ_delivered_mfg" in cls.attributes_by_name
+        assert cls.find_attribute("current_summ_delivered").id == 0x0000
+        assert (
+            cls.find_attribute(0x0000, manufacturer_code=0x1166)
+            is cls.AttributeDefs.current_summ_delivered_mfg
+        )
+
+
 def test_purge_custom_quirks(tmp_path: pathlib.Path, app_mock) -> None:
     def load_quirks():
         for importer, modname, _ in pkgutil.walk_packages(path=[str(tmp_path)]):

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -974,7 +974,6 @@ def test_custom_cluster_subclass_keeps_same_id_attributes() -> None:
             current_summ_delivered_mfg = zcl.foundation.ZCLAttributeDef(
                 id=0x0000,
                 type=t.uint48_t,
-                is_manufacturer_specific=True,
                 manufacturer_code=0x1166,
             )
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1423,6 +1423,124 @@ async def test_zcl_cluster_definition_backwards_compatibility():
     )
 
 
+def test_zcl_cluster_subclass_keeps_same_id_attributes():
+    """Subclassing a cluster keeps two attribute definitions sharing an ID."""
+
+    class TestCluster(zcl.Cluster):
+        cluster_id = 0xABCD
+        ep_attribute = "test_cluster"
+        _skip_registry = True
+
+        class AttributeDefs(zcl.BaseAttributeDefs):
+            attribute = foundation.ZCLAttributeDef(id=0x0001, type=t.uint8_t)
+            attribute_mfg = foundation.ZCLAttributeDef(
+                id=0x0001,
+                type=t.uint48_t,
+                is_manufacturer_specific=True,
+                manufacturer_code=0x1234,
+            )
+
+    class TestClusterSubclass(TestCluster):
+        pass
+
+    class TestClusterSubSubclass(TestClusterSubclass):
+        pass
+
+    for cls in (TestCluster, TestClusterSubclass, TestClusterSubSubclass):
+        assert set(cls.attributes_by_name) == {"attribute", "attribute_mfg"}
+        assert cls.find_attribute("attribute") is cls.AttributeDefs.attribute
+        assert (
+            cls.find_attribute(0x0001, manufacturer_code=0x1234)
+            is cls.AttributeDefs.attribute_mfg
+        )
+
+
+def test_zcl_cluster_subclass_keeps_same_id_commands():
+    """Subclassing a cluster keeps two command definitions sharing an ID."""
+
+    class TestCluster(zcl.Cluster):
+        cluster_id = 0xABCD
+        ep_attribute = "test_cluster"
+        _skip_registry = True
+
+        class ServerCommandDefs(zcl.BaseCommandDefs):
+            command = foundation.ZCLCommandDef(id=0x00, schema={"param1": t.uint8_t})
+            command_mfg = foundation.ZCLCommandDef(
+                id=0x00,
+                schema={"param1": t.uint8_t},
+                manufacturer_code=0x1234,
+            )
+
+        class ClientCommandDefs(zcl.BaseCommandDefs):
+            response = foundation.ZCLCommandDef(id=0x01, schema={})
+            response_mfg = foundation.ZCLCommandDef(
+                id=0x01,
+                schema={},
+                manufacturer_code=0x1234,
+            )
+
+    class TestClusterSubclass(TestCluster):
+        pass
+
+    for cls in (TestCluster, TestClusterSubclass):
+        assert set(cls.commands_by_name) == {
+            "command",
+            "command_mfg",
+            "response",
+            "response_mfg",
+        }
+        assert {cmd.name for cmd in cls.ServerCommandDefs} == {
+            "command",
+            "command_mfg",
+        }
+        assert {cmd.name for cmd in cls.ClientCommandDefs} == {
+            "response",
+            "response_mfg",
+        }
+
+
+def test_zcl_cluster_subclass_old_style_definitions():
+    """Subclasses of clusters with old-style definitions inherit the rebuilt defs."""
+
+    class TestCluster(zcl.Cluster):
+        cluster_id = 0xABCD
+        ep_attribute = "test_cluster"
+        _skip_registry = True
+
+        attributes = {
+            0x1234: ("attribute", t.uint8_t),
+            0x1235: ("attribute2", t.uint32_t, True),
+        }
+
+        server_commands = {
+            0x00: ("server_command", (t.uint8_t,), True),
+        }
+
+        client_commands = {
+            0x01: ("client_command", (t.uint8_t,), False),
+        }
+
+    class TestClusterSubclass(TestCluster):
+        pass
+
+    assert set(TestClusterSubclass.attributes_by_name) == {"attribute", "attribute2"}
+    assert TestClusterSubclass.AttributeDefs.attribute.id == 0x1234
+    assert TestClusterSubclass.AttributeDefs.attribute2.is_manufacturer_specific
+    assert set(TestClusterSubclass.commands_by_name) == {
+        "server_command",
+        "client_command",
+    }
+
+    # An explicit empty old-style dict does not wipe the inherited definitions
+    class TestClusterEmptyOverride(TestCluster):
+        attributes = {}
+
+    assert set(TestClusterEmptyOverride.attributes_by_name) == {
+        "attribute",
+        "attribute2",
+    }
+
+
 async def test_zcl_cluster_definition_invalid_name():
     # This is fine
     class TestCluster(zcl.Cluster):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1481,7 +1481,10 @@ def test_zcl_cluster_subclass_keeps_same_id_commands():
     class TestClusterSubclass(TestCluster):
         pass
 
-    for cls in (TestCluster, TestClusterSubclass):
+    class TestClusterSubSubclass(TestClusterSubclass):
+        pass
+
+    for cls in (TestCluster, TestClusterSubclass, TestClusterSubSubclass):
         assert set(cls.commands_by_name) == {
             "command",
             "command_mfg",
@@ -1533,10 +1536,16 @@ def test_zcl_cluster_subclass_old_style_definitions():
     # An explicit empty old-style dict does not wipe the inherited definitions
     class TestClusterEmptyOverride(TestCluster):
         attributes = {}
+        server_commands = {}
+        client_commands = {}
 
     assert set(TestClusterEmptyOverride.attributes_by_name) == {
         "attribute",
         "attribute2",
+    }
+    assert set(TestClusterEmptyOverride.commands_by_name) == {
+        "server_command",
+        "client_command",
     }
 
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1436,7 +1436,6 @@ def test_zcl_cluster_subclass_keeps_same_id_attributes():
             attribute_mfg = foundation.ZCLAttributeDef(
                 id=0x0001,
                 type=t.uint48_t,
-                is_manufacturer_specific=True,
                 manufacturer_code=0x1234,
             )
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -400,8 +400,11 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
             cls.attributes[attr.id] = attr.replace(id=attr_id)
 
-        # Create new definitions from the old-style definitions
-        if cls.attributes and "AttributeDefs" not in cls.__dict__:
+        # Create new definitions from old-style definitions authored by this class
+        # itself: an MRO-inherited `attributes` dict is keyed purely by attribute ID
+        # and cannot represent two same-ID attributes (e.g. a standard and a
+        # manufacturer-specific one), so rebuilding from it would drop one of them
+        if cls.__dict__.get("attributes") and "AttributeDefs" not in cls.__dict__:
             cls.AttributeDefs = types.new_class(
                 name="AttributeDefs",
                 bases=(BaseAttributeDefs,),
@@ -410,7 +413,10 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             for attr in cls.attributes.values():
                 setattr(cls.AttributeDefs, attr.name, attr)
 
-        if cls.server_commands and "ServerCommandDefs" not in cls.__dict__:
+        if (
+            cls.__dict__.get("server_commands")
+            and "ServerCommandDefs" not in cls.__dict__
+        ):
             cls.ServerCommandDefs = types.new_class(
                 name="ServerCommandDefs",
                 bases=(BaseCommandDefs,),
@@ -419,7 +425,10 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             for command in cls.server_commands.values():
                 setattr(cls.ServerCommandDefs, command.name, command)
 
-        if cls.client_commands and "ClientCommandDefs" not in cls.__dict__:
+        if (
+            cls.__dict__.get("client_commands")
+            and "ClientCommandDefs" not in cls.__dict__
+        ):
             cls.ClientCommandDefs = types.new_class(
                 name="ClientCommandDefs",
                 bases=(BaseCommandDefs,),


### PR DESCRIPTION
This fixes an issue where cluster subclassing without `AttributeDefs` could drop attribute and command definitions with the same ID. See the description and linked issue below for more information.

Fixes #1831

### Bug

When a cluster's `AttributeDefs` contains two attributes sharing an ID — a standard one and a manufacturer-specific one — subclassing that cluster *without redefining `AttributeDefs`* silently drops one of the two definitions from the subclass. The declaring class itself is fine; the loss appears on any further subclass.

### Root cause

`Cluster.__init_subclass__` has a backwards-compat path that reconstructs `AttributeDefs` from the legacy id-keyed `attributes` dict:

```python
if cls.attributes and "AttributeDefs" not in cls.__dict__:
    # rebuild AttributeDefs from cls.attributes ...
```

`cls.attributes` is resolved through the MRO, so a subclass that authors nothing still sees the parent's (rebuilt, non-empty) dict and triggers the rebuild. Since that dict is keyed purely by ID, two same-ID definitions have already collapsed to one — the rebuild bakes that loss into the subclass's `AttributeDefs`, `attributes_by_name`, and `_attributes_by_id`.

### Fix

Only run the legacy rebuild when the class *itself* authored a non-empty old-style dict:

```python
if cls.__dict__.get("attributes") and "AttributeDefs" not in cls.__dict__:
```

Subclasses now inherit the parent's complete `AttributeDefs` instead of reconstructing it from the lossy dict. The same change is applied to the `server_commands`/`client_commands` guards, which had the identical latent bug for same-ID commands.

Notes:

- Classes genuinely using the old-style API (`attributes = {...}` in the class body) still rebuild as before; an explicit empty `attributes = {}` override behaves as before (inherited definitions are kept).
- A subclass now shares the parent's `AttributeDefs`/`CommandDefs` class objects instead of getting freshly synthesized copies. The per-class lookup registries are still rebuilt per class, and the mutation loops in `__init_subclass__` are identity-preserving on already-compiled definitions (`with_compiled_schema()` returns `self`), so this is observable only to code mutating a subclass's defs class in place — nothing in zigpy, ZHA, or zha-quirks does.
- The public legacy `cluster.attributes` dict still cannot represent two same-ID definitions; that's inherent to its id-keyed shape.

### Test coverage

- `test_zcl_cluster_subclass_keeps_same_id_attributes` / `..._commands`: same-ID definitions survive one and two levels of subclassing (fail without the fix).
- `test_zcl_cluster_subclass_old_style_definitions`: old-style dicts still rebuild on subclasses; explicit empty `attributes = {}` doesn't wipe inherited definitions.
- `test_custom_cluster_subclass_keeps_same_id_attributes`: the real-world quirk shape — shared `CustomCluster` Metering base with two variant subclasses.
