### PR TITLE
Cap aiohttp <3.14 in tests for aioresponses compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ zigpy = ["py.typed"]
 [dependency-groups]
 testing = [
     "aioresponses",
+    # aioresponses 0.7.8 is incompatible with aiohttp 3.14's mandatory
+    # `stream_writer` argument; remove once aioresponses PR #288 is released.
+    "aiohttp<3.14",
     "asynctest",
     "codespell==2.4.1",
     "coverage[toml]",


### PR DESCRIPTION
This caps `aiohttp <3.14` in the `testing` group. It's incompatible with `aioresponses` 3.14 and newer.

We can remove this once this PR is released:
- https://github.com/pnuckowski/aioresponses/pull/288