### PR TITLE
Add radio library metadata for the `zigpy.radio` entry point

### DIFF
--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -53,9 +53,18 @@ _P = ParamSpec("_P")
 CHANNEL_CHANGE_BROADCAST_DELAY_S = 1.0
 CHANNEL_CHANGE_SETTINGS_RELOAD_DELAY_S = 1.0
 
+# Entry point group used by radio libraries to advertise their controller class:
+# the entry point name is the radio type and its value is the controller class
+RADIO_ENTRY_POINT_GROUP = "zigpy.radio"
+
 
 class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     SCHEMA = conf.CONFIG_SCHEMA
+
+    # User-facing metadata, set by radio libraries advertising themselves via the
+    # `zigpy.radio` entry point group
+    DISPLAY_NAME: str
+    DESCRIPTION: str
 
     _watchdog_period: int = 30
     _probe_configs: list[dict[str, Any]] = []

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -15,7 +15,7 @@ import os
 import random
 import time
 import typing
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, ClassVar, ParamSpec, TypeVar
 import warnings
 
 import zigpy.appdb
@@ -63,8 +63,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     # User-facing metadata, set by radio libraries advertising themselves via the
     # `zigpy.radio` entry point group
-    DISPLAY_NAME: str
-    DESCRIPTION: str
+    DISPLAY_NAME: ClassVar[str | None] = None
+    DESCRIPTION: ClassVar[str | None] = None
 
     _watchdog_period: int = 30
     _probe_configs: list[dict[str, Any]] = []


### PR DESCRIPTION
This is mostly a cosmetic/documentation PR for external radio types. You can expose a radio module to zigpy via `pyproject.toml`:

```toml
[project.entry-points."zigpy.radio"]
your_radio_type = "your_radio_module.zigbee.application:ControllerApplication"
```

And then add a description in the radio module itself:

```python
class ControllerApplication(zigpy.application.ControllerApplication):
    DISPLAY_NAME = "Friendly Name"
    DESCRIPTION = "Very short description string"

     def __init__(self, ...
```

---

See https://github.com/zigpy/zha/pull/461 for the ZHA side.