### PR TITLE
Cache OTA images per provider and combine index refreshes

### DIFF
--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import hashlib
+import logging
 import typing
 from unittest.mock import ANY, AsyncMock, patch
 
@@ -746,6 +747,108 @@ async def test_invalidate_provider_caches_clears_image_cache(
     # Second check should find no upgrades
     result2 = await ota.get_ota_images(device, query_cmd)
     assert len(result2.upgrades) == 0
+
+
+async def test_ota_index_refresh_revokes_withdrawn_images(
+    query_cmd, ota_hdr, ota_subelements
+) -> None:
+    """Images withdrawn from a refreshed index are no longer offered."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    meta_kept = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 1,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=zigpy.ota.image.OTAImage(
+            header=ota_hdr,
+            subelements=ota_subelements,
+        ).serialize(),
+    )
+    meta_withdrawn = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 2,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=zigpy.ota.image.OTAImage(
+            header=ota_hdr.replace(file_version=query_cmd.current_file_version + 2),
+            subelements=ota_subelements,
+        ).serialize(),
+    )
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    provider = SelfContainedProvider([meta_kept, meta_withdrawn])
+    ota.register_provider(provider)
+
+    images1 = await ota.get_ota_images(device, query_cmd)
+    assert len(images1.upgrades) == 2
+
+    cached_kept = ota._image_cache[provider][meta_kept]
+    assert cached_kept.firmware is not None
+
+    # The newest image is pulled from the index, which then expires
+    provider._index = [meta_kept]
+    provider._index_last_updated = datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
+
+    images2 = await ota.get_ota_images(device, query_cmd)
+    assert len(images2.upgrades) == 1
+    assert images2.upgrades[0].metadata == meta_kept
+
+    # The already-downloaded firmware was carried over, not re-downloaded
+    assert ota._image_cache[provider][meta_kept] is cached_kept
+
+
+async def test_ota_index_refresh_failure_keeps_cached_images(
+    query_cmd, ota_image
+) -> None:
+    """A provider outage during an index refresh does not withdraw its images."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    meta = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 1,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=ota_image.serialize(),
+    )
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    provider = SelfContainedProvider([meta])
+    ota.register_provider(provider)
+
+    images1 = await ota.get_ota_images(device, query_cmd)
+    assert len(images1.upgrades) == 1
+
+    # The provider goes down and the index expires
+    provider._index_last_updated = datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
+
+    with patch.object(provider, "_load_index", side_effect=RuntimeError("offline")):
+        images2 = await ota.get_ota_images(device, query_cmd)
+
+    assert images2 == images1
+
+
+async def test_ota_concurrent_checks_load_and_log_index_once(
+    query_cmd, ota_image, caplog
+) -> None:
+    """A burst of concurrent device checks loads and logs each index only once."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    meta = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 1,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=ota_image.serialize(),
+    )
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    provider = SelfContainedProvider([meta], load_index_delay=0.1)
+    ota.register_provider(provider)
+
+    with (
+        patch.object(provider, "_load_index", wraps=provider._load_index) as load_index,
+        caplog.at_level(logging.DEBUG, logger="zigpy.ota"),
+    ):
+        results = await asyncio.gather(
+            *(ota.get_ota_images(device, query_cmd) for _ in range(5))
+        )
+
+    assert all(result == results[0] for result in results)
+    assert len(load_index.mock_calls) == 1
+    assert caplog.text.count("Loaded 1 images from provider") == 1
 
 
 async def test_ota_provider_equality_requires_exact_type() -> None:

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -717,36 +717,51 @@ async def test_invalidate_provider_caches(query_cmd) -> None:
         assert result is not None  # Empty list, not None (which means "cached")
 
 
-async def test_invalidate_provider_caches_clears_image_cache(
-    query_cmd, ota_image
+async def test_invalidate_provider_caches_revokes_withdrawn_images(
+    query_cmd, ota_hdr, ota_subelements
 ) -> None:
-    """invalidate_provider_caches clears the image cache so withdrawn images disappear."""
+    """invalidate_provider_caches refreshes the indexes so withdrawn images disappear."""
     device = make_device(model="device model", manufacturer_id=0x1234)
 
-    index_with_image = [
-        SelfContainedOtaImageMetadata(
-            file_version=query_cmd.current_file_version + 1,
-            manufacturer_id=query_cmd.manufacturer_code,
-            image_type=query_cmd.image_type,
-            test_data=ota_image.serialize(),
-        ),
-    ]
+    meta_kept = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 1,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=zigpy.ota.image.OTAImage(
+            header=ota_hdr,
+            subelements=ota_subelements,
+        ).serialize(),
+    )
+    meta_withdrawn = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 2,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=zigpy.ota.image.OTAImage(
+            header=ota_hdr.replace(file_version=query_cmd.current_file_version + 2),
+            subelements=ota_subelements,
+        ).serialize(),
+    )
 
     ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
-    provider = SelfContainedProvider(index_with_image)
+    provider = SelfContainedProvider([meta_kept, meta_withdrawn])
     ota.register_provider(provider)
 
-    # First check finds the upgrade
+    # First check finds both upgrades
     result1 = await ota.get_ota_images(device, query_cmd)
-    assert len(result1.upgrades) == 1
+    assert len(result1.upgrades) == 2
 
-    # Provider now returns an empty index (image was withdrawn)
-    provider._index = []
+    cached_kept = ota._image_cache[provider][meta_kept]
+    assert cached_kept.firmware is not None
+
+    # Provider now only serves the first image (the other was withdrawn)
+    provider._index = [meta_kept]
     ota.invalidate_provider_caches()
 
-    # Second check should find no upgrades
+    # Second check should only find the remaining upgrade
     result2 = await ota.get_ota_images(device, query_cmd)
-    assert len(result2.upgrades) == 0
+    assert len(result2.upgrades) == 1
+    assert result2.upgrades[0].metadata == meta_kept
+
+    # The already-downloaded firmware was carried over, not re-downloaded
+    assert ota._image_cache[provider][meta_kept] is cached_kept
 
 
 async def test_ota_index_refresh_revokes_withdrawn_images(

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -291,16 +291,14 @@ class OTA:
     def invalidate_provider_caches(self) -> None:
         """Invalidate all provider index caches, forcing a refresh on next check.
 
-        Also clears the image cache so withdrawn images are not returned.
-        Downloaded firmware will be re-fetched from untrusted providers on
-        the next check, but this is acceptable for a user-initiated action.
+        The refresh revokes images withdrawn from the new indexes and carries
+        over already-downloaded firmware for images still being served, so no
+        firmware is re-downloaded.
         """
         for provider in self._providers:
             provider._index_last_updated = datetime.datetime.fromtimestamp(
                 0, tz=datetime.UTC
             )
-
-        self._image_cache.clear()
 
     async def check_cluster_for_ota(self, cluster: Ota) -> None:
         """Check OTA image availability for a single OTA cluster.

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -241,7 +241,8 @@ class OTA:
 
         self._providers: list[zigpy.ota.providers.BaseOtaProvider] = []
         self._image_cache: dict[
-            zigpy.ota.providers.BaseOtaImageMetadata, OtaImageWithMetadata
+            zigpy.ota.providers.BaseOtaProvider,
+            dict[zigpy.ota.providers.BaseOtaImageMetadata, OtaImageWithMetadata],
         ] = {}
 
         self._broadcast_loop_task = None
@@ -465,12 +466,52 @@ class OTA:
         self._providers.append(provider)
 
     @zigpy.util.combine_concurrent_calls
-    async def _load_provider_index(
+    async def _refresh_provider_index(
         self, provider: zigpy.ota.providers.BaseOtaProvider
-    ) -> list[zigpy.ota.providers.BaseOtaImageMetadata] | None:
-        """Load the index of a provider."""
-        async with asyncio_timeout(OTA_FETCH_TIMEOUT):
-            return await provider.load_index()
+    ) -> None:
+        """Load a provider's index, if it expired, and rebuild its image cache.
+
+        Concurrent calls for the same provider are combined so a burst of device
+        checks (e.g. at startup) downloads, caches, and logs each index once.
+        """
+        try:
+            async with asyncio_timeout(OTA_FETCH_TIMEOUT):
+                index = await provider.load_index()
+        except Exception as exc:  # noqa: BLE001
+            # Keep the previously-cached images: a provider outage should not
+            # withdraw its images
+            _LOGGER.debug("Failed to load provider %s", provider, exc_info=exc)
+            return
+
+        # The cached index is still fresh
+        if index is None:
+            return
+
+        _LOGGER.debug("Loaded %d images from provider: %s", len(index), provider)
+
+        old_images = self._image_cache.get(provider, {})
+        new_images: dict[
+            zigpy.ota.providers.BaseOtaImageMetadata, OtaImageWithMetadata
+        ] = {}
+
+        for meta in index:
+            # Mark metadata as trusted if it comes from a trusted provider
+            if provider.TRUSTED and not meta.trusted:
+                meta = meta.replace(trusted=True)
+
+            if meta in new_images:
+                continue
+
+            # Carry over already-downloaded firmware for unchanged metadata
+            cached = old_images.get(meta)
+            if cached is None or cached.firmware is None:
+                cached = OtaImageWithMetadata(metadata=meta, firmware=None)
+
+            new_images[meta] = cached
+
+        # Replace the provider's images wholesale so images withdrawn from the
+        # index are revoked
+        self._image_cache[provider] = new_images
 
     @zigpy.util.combine_concurrent_calls
     async def _fetch_image(self, image: OtaImageWithMetadata) -> OtaImageWithMetadata:
@@ -490,33 +531,27 @@ class OTA:
             p for p in self._providers if p.compatible_with_device(device)
         ]
 
-        # Load the index of every provider
+        # Refresh the index of every provider whose cache expired
         for provider in compatible_providers:
-            try:
-                index = await self._load_provider_index(provider)
-            except Exception as exc:  # noqa: BLE001
-                _LOGGER.debug("Failed to load provider %s", provider, exc_info=exc)
-                continue
+            await self._refresh_provider_index(provider)
 
-            if index is None:
-                _LOGGER.debug(
-                    "Provider %s was recently contacted, using cached response",
-                    provider,
-                )
-                continue
+        # Merge the cached images of all compatible providers. The same metadata can
+        # be served by multiple providers so prefer entries with downloaded firmware.
+        images: dict[
+            zigpy.ota.providers.BaseOtaImageMetadata, OtaImageWithMetadata
+        ] = {}
+        image_providers: dict[
+            zigpy.ota.providers.BaseOtaImageMetadata,
+            zigpy.ota.providers.BaseOtaProvider,
+        ] = {}
 
-            _LOGGER.debug("Loaded %d images from provider: %s", len(index), provider)
-
-            # Cache its images. If the concurrent call's result was shared, the first
-            # caller will cache these images
-            for meta in index:
-                if meta not in self._image_cache:
-                    # Mark metadata as trusted if it comes from a trusted provider
-                    if provider.TRUSTED and not meta.trusted:
-                        meta = meta.replace(trusted=True)
-                    self._image_cache[meta] = OtaImageWithMetadata(
-                        metadata=meta, firmware=None
-                    )
+        for provider in compatible_providers:
+            for meta, img in self._image_cache.get(provider, {}).items():
+                if meta not in images or (
+                    images[meta].firmware is None and img.firmware is not None
+                ):
+                    images[meta] = img
+                    image_providers[meta] = provider
 
         # Find all superficially compatible images. Note that if an image's contents
         # are unknown and its metadata does not describe hardware compatibility, we will
@@ -524,7 +559,7 @@ class OTA:
         candidates = sorted(
             [
                 img
-                for img in self._image_cache.values()
+                for img in images.values()
                 if img.check_compatibility(device, query_cmd)
             ],
             key=lambda img: img.version,
@@ -565,12 +600,16 @@ class OTA:
             # image with downloaded firmware.
             img = result
 
-            # Cache the image if it isn't already cached (or was cleared by
-            # invalidate_provider_caches() during the download await)
-            cached = self._image_cache.get(img.metadata)
-            if cached is None or cached.firmware is None:
+            # Cache the downloaded firmware, unless the image was withdrawn by an
+            # index refresh (or invalidate_provider_caches()) during the download
+            provider_images = self._image_cache.get(image_providers[img.metadata])
+            if (
+                provider_images is not None
+                and img.metadata in provider_images
+                and provider_images[img.metadata].firmware is None
+            ):
                 _LOGGER.debug("Caching image %s", img)
-                self._image_cache[img.metadata] = img
+                provider_images[img.metadata] = img
 
             if not img.check_compatibility(device, query_cmd):
                 # Ignore images that become incompatible once downloaded

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -291,9 +291,9 @@ class OTA:
     def invalidate_provider_caches(self) -> None:
         """Invalidate all provider index caches, forcing a refresh on next check.
 
-        The refresh revokes images withdrawn from the new indexes and carries
-        over already-downloaded firmware for images still being served, so no
-        firmware is re-downloaded.
+        The refresh revokes images withdrawn from the new indexes.
+        Already-downloaded firmware is carried over for images whose metadata
+        is unchanged and is otherwise re-downloaded.
         """
         for provider in self._providers:
             provider._index_last_updated = datetime.datetime.fromtimestamp(


### PR DESCRIPTION
Related PRs / follow-up to:
- https://github.com/zigpy/zigpy/pull/1799
- https://github.com/zigpy/zigpy/pull/1779

See the AI summary below. Also, in one or more follow-up PRs, I wanna look at the two main future improvements listed at the bottom.


## Problem

Two related issues in the OTA manager:

1. **Log spam at startup.** ZHA spawns a `check_cluster_for_ota()` task for every update entity when it starts, producing a burst of concurrent `get_ota_images()` calls. The index HTTP download itself was already deduplicated via `combine_concurrent_calls`, but the decorator shares the *result* with every concurrent caller — so each of the N device checks logged `Loaded X images from provider: ...` and re-ran the cache population loop, once per device per provider. Later (non-concurrent) calls each logged `Provider ... was recently contacted, using cached response` instead.

2. **Withdrawn images could not be revoked.** `OTA._image_cache` was a flat `{metadata: image}` dict that was only ever added to. When a provider's index was re-downloaded after `INDEX_EXPIRATION_TIME` (24 h), images that had been pulled from the index (e.g. withdrawn firmware) stayed cached and kept being offered to devices until restart or a user-initiated `invalidate_provider_caches()`.

## Changes

- The image cache is now keyed by provider: `{provider: {metadata: image}}`.
- Index loading, cache population, and logging moved into a single `_refresh_provider_index()` method wrapped in `@combine_concurrent_calls`, so a startup burst downloads, caches, and logs each index exactly once. The per-device "recently contacted" log line is gone.
- On a real refresh, the provider's bucket is replaced wholesale from the new index, so withdrawn images are revoked. Already-downloaded firmware is carried over for metadata still present in the new index (metadata is frozen/hashable and equality covers URL and checksum, so carry-over is safe).
- A failed refresh keeps the provider's previous images, so a provider outage does not withdraw them.
- Downloaded firmware is written back into the owning provider's bucket — and only if the image is still published, so an image withdrawn (or invalidated) *during* the download is not re-cached.
- Provider identity (exact-type `__eq__`/`__hash__`, required for keying the cache by provider) landed separately in #1838.
- `invalidate_provider_caches()` no longer clears the image cache — it only resets the index timestamps. Clearing was required to revoke withdrawn images, but the refresh now does that itself, so a user-initiated re-check no longer re-downloads firmware for images still being served.
  - Human note: We did not use it in Core before. But with this, we can – without redownloading all (non zigpy-ota provider) images every time this is called. Though I think I have another PR ready to go that improves this "check for update" behavior a bit.

## Behavior notes

- Candidate images are now drawn only from providers compatible with the querying device (manufacturer-ID filter). Previously the flat cache let one device match images cached from another manufacturer's provider index; per-image compatibility checks still applied, so this mostly formalizes existing intent.
- A failed index download still sets `_index_last_updated`, so it is not retried for 24 h — unchanged from before.

## Testing

- New tests: withdrawn images revoked after index refresh, downloaded firmware carried over (same object identity, no re-download), failed refresh keeps cached images, concurrent burst loads and logs the index once, `invalidate_provider_caches()` revokes withdrawn images while keeping downloaded firmware.
- Full suite passes (1131 tests), `zigpy/ota/__init__.py` at 99 % coverage.

## Future improvements

### Persist provider index metadata in the appdb

<details>
<summary>Details</summary>

The device-side half (`ota_query_cache`) is already persisted, so after a restart only the index download stands between ZHA and an instantly-populated update entity. Persisting each trusted provider's image metadata together with `_index_last_updated` (the per-provider buckets and exact-type provider identity from this PR are the prerequisites) would let `get_ota_images()` complete without network I/O right after startup.

It would also make the 24 h index TTL survive restarts — today every restart immediately re-downloads all indexes, defeating the rate-limiting. Since users may expect a restart to refresh the index, the restored data should not simply inherit the remaining TTL: schedule a refresh 10–30 minutes after startup (immediately if there is no cached data or it is older than 24 h), so entities populate instantly from the cache while still picking up new firmware shortly after a restart.

Restoring trusted providers only avoids both proactive firmware downloads at startup and storing multi-MB firmware blobs in the database. Needs a DB schema bump, metadata (de)serialization, and an index-refresh event mirroring `OtaQueryCacheUpdatedEvent`.

</details>

### Refresh indexes on user-initiated "Check for updates" (HA/ZHA side)

<details>
<summary>Details</summary>

Pressing "Check for updates" in HA currently does **not** refresh the provider indexes. HA's `ZHAFirmwareUpdateCoordinator` is shared by all update entities and its (debounced, so combined across entities) refresh only calls `ota.broadcast_notify(jitter=100)` — devices respond with `query_next_image`, but those checks are served from the cached indexes (24 h TTL). The ZHA-lib entity's own `async_update()` is a no-op.

So newly-published firmware does not appear until the TTL expires, and `invalidate_provider_caches()` — which exists exactly for this — currently has **no callers** in ZHA or HA.

The user-initiated refresh path should call `invalidate_provider_caches()` and then `check_all_devices_for_ota()` (instant results from cached query commands and the fresh indexes, no need to wake devices) before/alongside the broadcast, possibly rate-limited (e.g. only if the index is older than ~1 h). This PR makes that cheap: invalidation no longer discards downloaded firmware, so a button press only re-downloads the indexes.

</details>

### Split downloaded firmware into a separate `_firmware_cache`

<details>
<summary>Details</summary>

**Note**: This is more of an idea. I'm not sure I want to go with this. For now, the approach in this PR is way better than what we have currently.

Downloaded firmware is currently embedded in the per-provider index buckets (`OtaImageWithMetadata.firmware`), which entangles two different lifecycles: index entries live until the next refresh, while firmware should live as long as *any* metadata still references the same bytes. The carry-over logic — and its limitation that any metadata field change (e.g. `release_notes`) forces a re-download — is the symptom of that entanglement.

**Shape.** Index buckets hold only metadata; blobs live in `_firmware_cache: dict[key, BaseOTAImage]` and are assembled into `OtaImageWithMetadata` results inside `get_ota_images()`.

**Key = fetch identity.** The key must capture "fetching this metadata yields the same validated bytes": roughly `(type(meta), url-or-path, file_version, checksum, file_size)` — excluding cosmetic fields (`release_notes`, `source`, `trusted`) and transport details (`ssl_ctx`). Metadata classes without distinguishing fetch fields fall back to the metadata object itself as the key (exactly today's maximally-conservative behavior). `file_version` is included defensively so a checksum-less provider republishing new bytes behind an unchanged URL cannot be served stale firmware as a new version. When a checksum is in the key, a cache hit is exactly as validated as a fresh download.

**Upsides.**

- The firmware cache becomes a *pure* cache with no correctness semantics: revocation lives entirely in the index buckets (a blob no metadata references is unreachable), so any eviction policy is safe — including none. Today's carry-over is correctness-entangled; this converts it into plain eviction.
- The carry-over loop in `_refresh_provider_index()` and the write-back bookkeeping in `get_ota_images()` (`image_providers` map, bucket-membership checks) disappear; refresh becomes pure index replacement, and the "prefer entries with downloaded firmware" merge tweak goes away since firmware presence is no longer a per-entry property.
- Cosmetic metadata changes no longer force re-downloads, structurally resolving the `invalidate_provider_caches()` docstring caveat.
- The same image served by multiple providers (or duplicate registrations) downloads once — including concurrently, if `_fetch_image`'s `combine_concurrent_calls` is re-keyed on the cache key.
- It is the natural substrate for two other planned improvements: bounding firmware memory (an LRU/size cap over one dict; images are ~100 KB–2 MB, so tens of MB worst case today) and the appdb persistence (persist exactly the index buckets, never blobs — and a disk-backed firmware cache becomes possible later).
- Trusted-provider preference is unaffected: trusted/untrusted twins keep separate metadata entries (specificity still decides ordering) while potentially sharing one downloaded blob.

**Downsides / costs.**

- Pruning no longer falls out of bucket replacement: withdrawn images leave orphaned blobs, so either a mark-and-sweep over live keys after refresh or the eviction policy itself must reclaim them. Complexity moves from carry-over to GC — roughly a wash in code, but cleaner separation of concerns.
- The key becomes load-bearing for correctness: a too-coarse key serves the wrong bytes, a bug class today's full-metadata key cannot produce. Mitigated by the conservative fallback default and including `file_version`/`checksum`/`file_size`.
- Internal churn: tests that reach into `_image_cache[provider][meta].firmware` need rewriting, and install-time fetches (`update_firmware()` calls `image.fetch()` directly today) could optionally consult the same cache for consistency.

**Minimal alternative.** Keep the current structure but key the refresh *carry-over* lookup by fetch identity instead of full metadata equality (a few lines: build an old-bucket map keyed by fetch identity during rebuild). That fixes only the re-download-on-cosmetic-change issue — no sharing, no eviction substrate, no persistence boundary — but is worth doing if the full split is deferred for long.

</details>

## Other possible improvements (likely not important)

<details>
<summary>Details</summary>

- **Clear a provider's images after a prolonged outage.** A failed refresh keeps the cached images, so a provider that is down cannot withdraw anything — and dead providers are real (the ThirdReality and Inovelli servers shut down permanently). Track the last *successful* refresh per provider (the failure backoff needs it anyway) and clear the provider's bucket, with a single warning, when a refresh fails and the data is older than a stale cap (e.g. 3× the TTL, 72 h). Age-based, not failure-count-based, to avoid flapping update entities on transient outages; recovery repopulates on the next check. The appdb restore path should respect the same cap, since persisted data could be weeks old.
- **Refresh provider indexes concurrently.** `get_ota_images()` awaits `_refresh_provider_index()` per provider sequentially, so one slow/unreachable provider delays the others — with several bad providers a device check can stall for `OTA_FETCH_TIMEOUT` (20 s) each. An `asyncio.gather` over the compatible providers would cap the wait at the slowest single provider. (Was sequential before this PR too.)
- **Shorter retry interval after a failed index download.** `load_index()` sets `_index_last_updated` in a `finally`, so a transient network failure locks the provider out for the full 24 h expiration. A separate, shorter failure backoff (e.g. 30–60 min) would distinguish "fresh" from "failed recently".
- **Deduplicate equal providers at registration time.** Implemented in #1839. Duplicate logical providers can be registered (e.g. the same provider listed in both `providers` and `extra_providers`); each instance keeps its own `_index_last_updated`, so the index is downloaded once per duplicate per 24 h cycle (pre-existing behavior, raised by Copilot review). Correctness is unaffected since equal providers share one cache bucket. Since providers now compare by exact type, `register_provider()` can simply skip providers that are already registered, fixing this for every consumer instead of filtering per call.
- **Dedupe per-device WARNING logs.** `_remove_colliding_images()` runs on every `get_ota_images()` call, so "Trusted image … does not have SHA3-256 checksum" and the version-collision warning fire once per affected device, every check cycle — visible without debug logging. An "already warned" set keyed by metadata/collision group (cleared on invalidation) would make these fire once.
- **Bound the memory held by downloaded firmware.** Untrusted providers proactively download every upgrade candidate and the bytes stay cached until shutdown. Revocation now drops withdrawn images, but published ones accumulate; dropping firmware after a completed upgrade or adding a TTL would help low-memory hosts. The trusted zigpy-ota provider defers downloads, so default setups are mostly unaffected. (Would fold into the firmware-cache split described above.)
- **Share an `aiohttp.ClientSession`.** Every index load and image fetch creates a fresh session; pooling would be tidier, though the call frequency is low enough that it barely matters.

</details>






