### PR TITLE
Compare OTA providers by exact type in equality and hash

### DIFF
--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -740,3 +740,13 @@ async def test_invalidate_provider_caches_clears_image_cache(
     # Second check should find no upgrades
     result2 = await ota.get_ota_images(device, query_cmd)
     assert len(result2.upgrades) == 0
+
+
+async def test_ota_provider_equality_requires_exact_type() -> None:
+    """Providers of different types with the same URL do not compare equal."""
+    untrusted = SelfContainedProvider([])
+    trusted = TrustedSelfContainedProvider([])
+
+    assert untrusted == SelfContainedProvider([])
+    assert untrusted != trusted
+    assert trusted != untrusted

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -780,3 +780,9 @@ async def test_ota_provider_hash_includes_type(tmp_path) -> None:
     assert buckets[LocalZigpyProvider(index_file=index_file)] == 1
     assert buckets[LocalZ2MProvider(index_file=index_file)] == 2
     assert buckets[AdvancedFileProvider(path=tmp_path)] == 3
+
+    # Same type but different fields is not equal
+    other_index_file = tmp_path / "other_index.json"
+    assert LocalZigpyProvider(index_file=other_index_file) not in buckets
+    assert LocalZ2MProvider(index_file=other_index_file) not in buckets
+    assert AdvancedFileProvider(path=tmp_path / "other") not in buckets

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -4,7 +4,7 @@ import asyncio
 import datetime
 import hashlib
 import typing
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 import aiohttp
 import attrs
@@ -759,6 +759,10 @@ async def test_ota_provider_equality_requires_exact_type() -> None:
 
     # Comparing against a non-provider falls back to the reflected comparison
     assert untrusted != "not a provider"
+
+    # Only true if __eq__ returns NotImplemented for non-providers, so Python
+    # falls back to ANY's own __eq__
+    assert untrusted == ANY
 
     # Distinct provider types occupy distinct dict keys, equal providers share one
     buckets = {untrusted: 1, trusted: 2}

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -750,3 +750,9 @@ async def test_ota_provider_equality_requires_exact_type() -> None:
     assert untrusted == SelfContainedProvider([])
     assert untrusted != trusted
     assert trusted != untrusted
+
+    # Distinct provider types occupy distinct dict keys, equal providers share one
+    buckets = {untrusted: 1, trusted: 2}
+    assert len(buckets) == 2
+    assert buckets[SelfContainedProvider([])] == 1
+    assert buckets[TrustedSelfContainedProvider([])] == 2

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -16,7 +16,13 @@ from zigpy import config
 import zigpy.device
 import zigpy.ota
 from zigpy.ota.image import FieldControl
-from zigpy.ota.providers import BaseOtaImageMetadata, BaseOtaProvider
+from zigpy.ota.providers import (
+    AdvancedFileProvider,
+    BaseOtaImageMetadata,
+    BaseOtaProvider,
+    LocalZ2MProvider,
+    LocalZigpyProvider,
+)
 import zigpy.types
 from zigpy.zcl import ClusterType, OtaImageAvailableEvent
 from zigpy.zcl.clusters.general import Ota
@@ -751,8 +757,26 @@ async def test_ota_provider_equality_requires_exact_type() -> None:
     assert untrusted != trusted
     assert trusted != untrusted
 
+    # Comparing against a non-provider falls back to the reflected comparison
+    assert untrusted != "not a provider"
+
     # Distinct provider types occupy distinct dict keys, equal providers share one
     buckets = {untrusted: 1, trusted: 2}
     assert len(buckets) == 2
     assert buckets[SelfContainedProvider([])] == 1
     assert buckets[TrustedSelfContainedProvider([])] == 2
+
+
+async def test_ota_provider_hash_includes_type(tmp_path) -> None:
+    """Distinct provider types hashing over the same fields do not collide."""
+    index_file = tmp_path / "index.json"
+
+    local_zigpy = LocalZigpyProvider(index_file=index_file)
+    local_z2m = LocalZ2MProvider(index_file=index_file)
+    advanced = AdvancedFileProvider(path=tmp_path)
+
+    buckets = {local_zigpy: 1, local_z2m: 2, advanced: 3}
+    assert len(buckets) == 3
+    assert buckets[LocalZigpyProvider(index_file=index_file)] == 1
+    assert buckets[LocalZ2MProvider(index_file=index_file)] == 2
+    assert buckets[AdvancedFileProvider(path=tmp_path)] == 3

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -505,7 +505,7 @@ class LocalZigpyProvider(BaseZigpyProvider):
         return super().__eq__(other) and self.index_file == other.index_file
 
     def __hash__(self) -> int:
-        return hash((self.index_file, self.manufacturer_ids))
+        return hash((type(self), self.index_file, self.manufacturer_ids))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(index_file={self.index_file!r}, manufacturer_ids={self.manufacturer_ids!r})"
@@ -598,7 +598,7 @@ class LocalZ2MProvider(BaseZ2MProvider):
         return super().__eq__(other) and self.index_file == other.index_file
 
     def __hash__(self) -> int:
-        return hash((self.index_file, self.manufacturer_ids))
+        return hash((type(self), self.index_file, self.manufacturer_ids))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(index_file={self.index_file!r}, manufacturer_ids={self.manufacturer_ids!r})"
@@ -703,7 +703,7 @@ class ZigpyOtaProvider(BaseZigpyProvider):
         return super().__eq__(other) and self.channel == other.channel
 
     def __hash__(self) -> int:
-        return hash((self.url, self.channel, self.manufacturer_ids))
+        return hash((type(self), self.url, self.channel, self.manufacturer_ids))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(url={self.url!r}, channel={self.channel!r}, manufacturer_ids={self.manufacturer_ids!r})"
@@ -766,7 +766,7 @@ class AdvancedFileProvider(BaseOtaProvider):
         return super().__eq__(other) and self.path == other.path
 
     def __hash__(self) -> int:
-        return hash((self.path, self.manufacturer_ids))
+        return hash((type(self), self.path, self.manufacturer_ids))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(path={self.path!r}, manufacturer_ids={self.manufacturer_ids!r})"

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -247,8 +247,12 @@ class BaseOtaProvider:
         raise NotImplementedError
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, BaseOtaProvider) or type(self) is not type(other):
+        if not isinstance(other, BaseOtaProvider):
             return NotImplemented
+
+        # Providers of a different concrete type are never equal
+        if type(self) is not type(other):
+            return False
 
         return self.url == other.url and self.manufacturer_ids == other.manufacturer_ids
 

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -247,13 +247,13 @@ class BaseOtaProvider:
         raise NotImplementedError
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, BaseOtaProvider) or type(self) is not type(other):
             return NotImplemented
 
         return self.url == other.url and self.manufacturer_ids == other.manufacturer_ids
 
     def __hash__(self) -> int:
-        return hash((self.url, self.manufacturer_ids))
+        return hash((type(self), self.url, self.manufacturer_ids))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(url={self.url!r}, manufacturer_ids={self.manufacturer_ids!r})"


### PR DESCRIPTION
Split out prerequisite from:
- https://github.com/zigpy/zigpy/pull/1837

This fixes an issue where comparing different provider types with the same URL/file could result in a false-positive.

Existing `hash` methods of some providers were also uncovered. Since those lines were modified, we also add small tests here.

## AI summary

`BaseOtaProvider.__eq__` used an `isinstance` check, so a provider subclass compared equal to its parent class when the shared fields matched — even though the subclass may change behavior entirely (different `_load_index()`, `TRUSTED` flag, etc.). `__hash__` also ignored the type, so such providers collided as dict/set keys.

### Example

A subclass that only changes behavior, with no extra fields:

```python
class Tradfri(BaseOtaProvider): ...
class TrustedTradfri(Tradfri):
    TRUSTED = True

Tradfri() == TrustedTradfri()  # True — two different providers, one dict key
```

(`TrustedTradfri().__eq__(Tradfri())` returns `NotImplemented`, but Python's reflected lookup falls back to the parent's `isinstance`-based `__eq__`, so `==` is `True` in both directions.)

Similarly for hashing: `LocalZigpyProvider` and `LocalZ2MProvider` both hash over `(index_file, manufacturer_ids)`, so the two *different* providers configured with the same local index file always hash-collided:

```python
hash(LocalZigpyProvider(index_file="index.json"))  # identical
hash(LocalZ2MProvider(index_file="index.json"))    # identical
```

Mostly harmless today, but providers are about to be used as dict keys for per-provider image caching (#1837), where well-defined identity matters.

### Changes

- `__eq__` requires the exact same type in the base class: providers of a different concrete type compare definitively `False`, while non-provider types still get `NotImplemented` (preserving reflected comparisons, e.g. `mock.ANY`). Subclass `__eq__` implementations inherit this via their `super().__eq__()` delegation.
- All `__hash__` implementations (base class, `LocalZigpyProvider`, `LocalZ2MProvider`, `ZigpyOtaProvider`, `AdvancedFileProvider`) now include `type(self)`.

## Testing

- Distinct provider types with identical fields compare unequal and occupy distinct dict keys, while equal providers share one key.
- The changed subclass `__hash__` implementations are exercised via dict lookups (`LocalZigpyProvider`/`LocalZ2MProvider` with the same index file, `AdvancedFileProvider`), and same-type providers with differing fields compare unequal.
- Comparing a provider against a non-provider still falls back to the reflected comparison (`NotImplemented`).

