### PR TITLE
Skip registering duplicate OTA providers

### DIFF
--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -790,3 +790,20 @@ async def test_ota_provider_hash_includes_type(tmp_path) -> None:
     assert LocalZigpyProvider(index_file=other_index_file) not in buckets
     assert LocalZ2MProvider(index_file=other_index_file) not in buckets
     assert AdvancedFileProvider(path=tmp_path / "other") not in buckets
+
+
+async def test_register_provider_skips_duplicates() -> None:
+    """Registering a provider equal to an already-registered one is a no-op."""
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+
+    provider = SelfContainedProvider([])
+    ota.register_provider(provider)
+    ota.register_provider(SelfContainedProvider([]))
+
+    assert ota._providers == [provider]
+
+    # A provider of a different type with the same fields is not a duplicate
+    trusted = TrustedSelfContainedProvider([])
+    ota.register_provider(trusted)
+
+    assert ota._providers == [provider, trusted]

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -792,7 +792,7 @@ async def test_ota_provider_hash_includes_type(tmp_path) -> None:
     assert AdvancedFileProvider(path=tmp_path / "other") not in buckets
 
 
-async def test_register_provider_skips_duplicates() -> None:
+async def test_register_provider_skips_duplicates(caplog) -> None:
     """Registering a provider equal to an already-registered one is a no-op."""
     ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
 
@@ -801,6 +801,7 @@ async def test_register_provider_skips_duplicates() -> None:
     ota.register_provider(SelfContainedProvider([]))
 
     assert ota._providers == [provider]
+    assert "Ignoring duplicate OTA provider" in caplog.text
 
     # A provider of a different type with the same fields is not a duplicate
     trusted = TrustedSelfContainedProvider([])

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -462,7 +462,7 @@ class OTA:
     def register_provider(self, provider: zigpy.ota.providers.BaseOtaProvider) -> None:
         """Register a new OTA provider."""
         if provider in self._providers:
-            _LOGGER.debug("Ignoring duplicate OTA provider: %s", provider)
+            _LOGGER.warning("Ignoring duplicate OTA provider: %s", provider)
             return
 
         _LOGGER.debug("Registering new OTA provider: %s", provider)

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -461,6 +461,10 @@ class OTA:
 
     def register_provider(self, provider: zigpy.ota.providers.BaseOtaProvider) -> None:
         """Register a new OTA provider."""
+        if provider in self._providers:
+            _LOGGER.debug("Ignoring duplicate OTA provider: %s", provider)
+            return
+
         _LOGGER.debug("Registering new OTA provider: %s", provider)
         self._providers.append(provider)
 


### PR DESCRIPTION
Follow-up promised in https://github.com/zigpy/zigpy/pull/1837#discussion_r3392829381 (raised by Copilot review).

## Problem

The same logical provider can be registered multiple times — e.g. listed in both `providers` and `extra_providers`, or once via a deprecated config option and once explicitly. Nothing deduplicates them: `_register_providers()` only filters by `override_previous` and disabled types.

Each duplicate instance keeps its own `_index_last_updated`, and the refresh calls in `get_ota_images()` are sequential awaits, so `combine_concurrent_calls` never merges them. The result is one redundant index download per duplicate instance per 24 h expiration cycle. (Correctness is unaffected: equal providers share a single image cache bucket.)

## Changes

`register_provider()` now ignores a provider that compares equal to an already-registered one, with a warning (a duplicate is always an actionable misconfiguration, registration happens once at startup, and the deprecated config options already warn). Equal providers are interchangeable — equality requires the exact type plus identical URL/manufacturer IDs since #1838 — so dropping the duplicate is safe for both explicit registrations and merged config intents.

## Testing

- Registering an equal provider twice keeps a single instance; a provider of a different type with identical fields is still registered.
- The existing `test_ota_matching_priority` exercises the dedup implicitly: it registers two equal `BrokenProvider` instances, and its assertions are unaffected by the second one now being skipped.

