### PR TITLE
Add an `allow_downgrade` flag to OTA updates

### DIFF
--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -254,6 +254,129 @@ async def test_ota_manager_downgrade_rejected_without_flag(
     assert status == foundation.Status.NO_IMAGE_AVAILABLE
 
 
+@patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
+async def test_ota_manager_incompatible_image_rejected(
+    image_with_metadata: OtaImageWithMetadata,
+) -> None:
+    """An incompatible image is refused even when the version check would pass.
+
+    allow_downgrade only lifts the version check; compatibility is still enforced.
+    """
+    img = image_with_metadata
+
+    app = make_app({})
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77"))
+    dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+    dev.model = "model1"
+    dev.manufacturer = "manufacturer1"
+
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = zigpy.profiles.zha.DeviceType.PUMP
+
+    ota = ep.add_output_cluster(Ota.cluster_id)
+
+    async def send_packet(packet: t.ZigbeePacket):
+        assert img.firmware is not None
+
+        if packet.cluster_id == Ota.cluster_id:
+            hdr, cmd = ota.deserialize(packet.data.serialize())
+            if isinstance(cmd, Ota.ImageNotifyCommand):
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        ota,
+                        "query_next_image",
+                        field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                        manufacturer_code=img.firmware.header.manufacturer_id,
+                        # The image type does not match the image, so it is
+                        # incompatible regardless of the version
+                        image_type=img.firmware.header.image_type + 1,
+                        # A version the image's metadata would otherwise accept
+                        current_file_version=img.firmware.header.file_version - 5,
+                        hardware_version=1,
+                    )
+                )
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+
+    # Even with allow_downgrade, compatibility is still enforced
+    status = await dev.update_firmware(img, allow_downgrade=True)
+    assert status == foundation.Status.NO_IMAGE_AVAILABLE
+
+
+@patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
+async def test_ota_manager_force_skips_checks(
+    image_with_metadata: OtaImageWithMetadata,
+) -> None:
+    """force=True offers the image even when incompatible and not an upgrade."""
+    img = image_with_metadata
+
+    app = make_app({})
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77"))
+    dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+    dev.model = "model1"
+    dev.manufacturer = "manufacturer1"
+
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = zigpy.profiles.zha.DeviceType.PUMP
+
+    ota = ep.add_output_cluster(Ota.cluster_id)
+
+    # Stop the default cluster handler from also replying (NO_IMAGE_AVAILABLE)
+    dev.ota_in_progress = True
+
+    response_status = None
+
+    async def send_packet(packet: t.ZigbeePacket):
+        nonlocal response_status
+        assert img.firmware is not None
+
+        if packet.cluster_id == Ota.cluster_id:
+            hdr, cmd = ota.deserialize(packet.data.serialize())
+            if isinstance(cmd, Ota.ImageNotifyCommand):
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        ota,
+                        "query_next_image",
+                        field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                        # Both incompatible (wrong image type) and a downgrade
+                        manufacturer_code=img.firmware.header.manufacturer_id,
+                        image_type=img.firmware.header.image_type + 1,
+                        current_file_version=img.firmware.header.file_version + 10,
+                        hardware_version=1,
+                    )
+                )
+            elif isinstance(
+                cmd, Ota.ClientCommandDefs.query_next_image_response.schema
+            ):
+                # force makes the image be offered despite both checks failing
+                response_status = cmd.status
+
+                # Finish the update so it doesn't stall
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        ota,
+                        "upgrade_end",
+                        status=foundation.Status.SUCCESS,
+                        manufacturer_code=img.firmware.header.manufacturer_id,
+                        image_type=img.firmware.header.image_type,
+                        file_version=img.firmware.header.file_version,
+                    )
+                )
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+
+    status = await update_firmware(dev, img, force=True)
+    assert response_status == foundation.Status.SUCCESS
+    assert status == foundation.Status.SUCCESS
+
+
 async def test_ota_manager_allow_downgrade():
     """An explicitly selected older image installs when allow_downgrade is set."""
     # The device claims a newer running version than the image we want to install

--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -208,6 +208,210 @@ async def test_ota_manger_device_reject(
     assert status == foundation.Status.NO_IMAGE_AVAILABLE
 
 
+@patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
+async def test_ota_manager_downgrade_rejected_without_flag(
+    image_with_metadata: OtaImageWithMetadata,
+) -> None:
+    """An explicitly selected older image is refused without allow_downgrade."""
+    img = image_with_metadata
+
+    app = make_app({})
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77"))
+    dev.node_desc = make_node_desc(logical_type=zdo_t.LogicalType.Router)
+    dev.model = "model1"
+    dev.manufacturer = "manufacturer1"
+
+    ep = dev.add_endpoint(1)
+    ep.status = zigpy.endpoint.Status.ZDO_INIT
+    ep.profile_id = 260
+    ep.device_type = zigpy.profiles.zha.DeviceType.PUMP
+
+    ota = ep.add_output_cluster(Ota.cluster_id)
+
+    async def send_packet(packet: t.ZigbeePacket):
+        assert img.firmware is not None
+
+        if packet.cluster_id == Ota.cluster_id:
+            hdr, cmd = ota.deserialize(packet.data.serialize())
+            if isinstance(cmd, Ota.ImageNotifyCommand):
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        ota,
+                        "query_next_image",
+                        field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                        manufacturer_code=img.firmware.header.manufacturer_id,
+                        image_type=img.firmware.header.image_type,
+                        # The device is running a newer version than the image
+                        current_file_version=img.firmware.header.file_version + 10,
+                        hardware_version=1,
+                    )
+                )
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+
+    status = await dev.update_firmware(img, allow_downgrade=False)
+    assert status == foundation.Status.NO_IMAGE_AVAILABLE
+
+
+async def test_ota_manager_allow_downgrade():
+    """An explicitly selected older image installs when allow_downgrade is set."""
+    # The device claims a newer running version than the image we want to install
+    device_file_version = FW_IMAGE.firmware.header.file_version + 10
+
+    app = make_app({})
+    dev = add_initialized_device(
+        app, nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77")
+    )
+    cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
+
+    with mock_attribute_reads(cluster, {"current_file_version": device_file_version}):
+        await dev.initialize()
+
+    # Stop the general cluster handler from interfering
+    dev.ota_in_progress = True
+
+    reconstructed_firmware = bytearray()
+
+    async def send_packet(packet: t.ZigbeePacket):
+        if packet.cluster_id != Ota.cluster_id:
+            return
+
+        hdr, cmd = cluster.deserialize(packet.data.serialize())
+        assert FW_IMAGE.firmware is not None
+
+        if isinstance(cmd, Ota.ImageNotifyCommand):
+            assert cmd.query_jitter == 100
+
+            # Ask for the next image, claiming a newer running version
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "query_next_image",
+                    field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    current_file_version=device_file_version,
+                    hardware_version=1,
+                )
+            )
+        elif isinstance(cmd, Ota.ClientCommandDefs.query_next_image_response.schema):
+            # The downgrade is accepted despite the older file version
+            assert cmd.status == foundation.Status.SUCCESS
+            assert cmd.file_version == FW_IMAGE.firmware.header.file_version
+
+            # Ask for the first block to get things started
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "image_block",
+                    field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    file_version=FW_IMAGE.firmware.header.file_version,
+                    file_offset=0,
+                    maximum_data_size=40,
+                    request_node_addr=dev.ieee,
+                )
+            )
+        elif isinstance(cmd, Ota.ClientCommandDefs.image_block_response.schema):
+            assert cmd.status == foundation.Status.SUCCESS
+
+            reconstructed_firmware[
+                cmd.file_offset : cmd.file_offset + len(cmd.image_data)
+            ] = cmd.image_data
+
+            if cmd.file_offset + len(cmd.image_data) == len(
+                FW_IMAGE.firmware.serialize()
+            ):
+                # End the upgrade
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        cluster,
+                        "upgrade_end",
+                        status=foundation.Status.SUCCESS,
+                        manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                        image_type=FW_IMAGE.firmware.header.image_type,
+                        file_version=FW_IMAGE.firmware.header.file_version,
+                    )
+                )
+            else:
+                # Keep going
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        cluster,
+                        "image_block",
+                        field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                        manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                        image_type=FW_IMAGE.firmware.header.image_type,
+                        file_version=FW_IMAGE.firmware.header.file_version,
+                        file_offset=cmd.file_offset + 40,
+                        maximum_data_size=40,
+                        request_node_addr=dev.ieee,
+                    )
+                )
+        elif isinstance(cmd, Ota.ClientCommandDefs.upgrade_end_response.schema):
+            pass
+        elif isinstance(
+            cmd,
+            foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Read_Attributes
+            ].schema,
+        ):
+            assert cmd.attribute_ids == [Ota.AttributeDefs.current_file_version.id]
+
+            req_hdr, req_cmd = cluster._create_request(
+                general=True,
+                command_id=foundation.GeneralCommand.Read_Attributes_rsp,
+                schema=foundation.GENERAL_COMMANDS[
+                    foundation.GeneralCommand.Read_Attributes_rsp
+                ].schema,
+                tsn=hdr.tsn,
+                disable_default_response=True,
+                direction=foundation.Direction.Server_to_Client,
+                args=(),
+                kwargs={
+                    "status_records": [
+                        foundation.ReadAttributeRecord(
+                            attrid=Ota.AttributeDefs.current_file_version.id,
+                            status=foundation.Status.SUCCESS,
+                            value=foundation.TypeValue(
+                                type=foundation.DATA_TYPES.pytype_to_datatype_id(
+                                    t.uint32_t
+                                ),
+                                value=FW_IMAGE.firmware.header.file_version,
+                            ),
+                        )
+                    ]
+                },
+            )
+
+            dev.application.packet_received(
+                t.ZigbeePacket(
+                    src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+                    src_ep=1,
+                    dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+                    dst_ep=1,
+                    tsn=hdr.tsn,
+                    profile_id=260,
+                    cluster_id=cluster.cluster_id,
+                    data=t.SerializableBytes(req_hdr.serialize() + req_cmd.serialize()),
+                    lqi=255,
+                    rssi=-30,
+                )
+            )
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    result = await update_firmware(dev, FW_IMAGE, allow_downgrade=True)
+
+    assert result == foundation.Status.SUCCESS
+    assert bytes(reconstructed_firmware) == FW_IMAGE.firmware.serialize()
+
+
 async def test_ota_manager():
     """Test that device firmware updates execute the expected calls."""
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -1013,8 +1013,20 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         image: OtaImageWithMetadata,
         progress_callback: Callable[[int, int, float], None] | None = None,
         force: bool = False,
+        allow_downgrade: bool = False,
     ) -> foundation.Status | None:
-        """Update device firmware."""
+        """Update device firmware.
+
+        :param image: the OTA image to install on the device.
+        :param progress_callback: optional callback invoked with progress updates.
+        :param force: skip both the compatibility and version checks, and rewrite the
+            advertised file version so the device always accepts the image. Use only
+            as a last resort.
+        :param allow_downgrade: skip only the version check so an explicitly selected
+            image that is older than (or equal to) the running firmware can be
+            installed. Compatibility is still enforced. Has no effect when ``force``
+            is set.
+        """
         if self.ota_in_progress:
             self.debug("OTA already in progress")
             return None
@@ -1027,6 +1039,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 image=image,
                 progress_callback=progress_callback,
                 force=force,
+                allow_downgrade=allow_downgrade,
             )
         except Exception as exc:  # noqa: BLE001
             self.debug("OTA failed!", exc_info=exc)

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -54,6 +54,7 @@ class OTAManager:
         image: OtaImageWithMetadata,
         progress_callback=None,
         force: bool = False,
+        allow_downgrade: bool = False,
     ) -> None:
         self.device = device
         self.ota_cluster = device.find_cluster(
@@ -64,6 +65,7 @@ class OTAManager:
         self._image_data = image.firmware.serialize()
         self.progress_callback = progress_callback
         self.force = force
+        self.allow_downgrade = allow_downgrade
 
         self._upgrade_end_future = asyncio.get_running_loop().create_future()
         self._stall_timer = zigpy.datastructures.ReschedulableTimeout(
@@ -134,11 +136,29 @@ class OTAManager:
     ) -> None:
         """Handle image query request."""
 
-        # If we try to send a device an old image (e.g. cache issue), don't bother
-        if not self.force and (
-            not self.image.check_compatibility(self.device, command)
-            or not self.image.check_version(command.current_file_version)
+        # If we try to send a device an old image (e.g. cache issue), don't bother.
+        # `force` skips both the compatibility and version checks. `allow_downgrade`
+        # skips only the version check, still honoring compatibility, so a caller can
+        # deliberately install an older but compatible image.
+        if self.force:
+            status = foundation.Status.SUCCESS
+        elif not self.image.check_compatibility(self.device, command):
+            self.device.warning(
+                "OTA image %s is not compatible with the device, replying with"
+                " NO_IMAGE_AVAILABLE",
+                self.image,
+            )
+            status = foundation.Status.NO_IMAGE_AVAILABLE
+        elif not self.allow_downgrade and not self.image.check_version(
+            command.current_file_version
         ):
+            self.device.warning(
+                "OTA image %s does not pass the version check (current file version"
+                " 0x%08X); pass allow_downgrade=True to install it anyway. Replying"
+                " with NO_IMAGE_AVAILABLE",
+                self.image,
+                command.current_file_version,
+            )
             status = foundation.Status.NO_IMAGE_AVAILABLE
         else:
             status = foundation.Status.SUCCESS
@@ -321,6 +341,7 @@ async def update_firmware(
     image: OtaImageWithMetadata,
     progress_callback: Callable[[int, int, float], None] | None = None,
     force: bool = False,
+    allow_downgrade: bool = False,
 ) -> foundation.Status:
     """Update the firmware on a Zigbee device."""
     # Fetch firmware if not already downloaded (deferred download for trusted providers)
@@ -350,6 +371,12 @@ async def update_firmware(
 
     # Ask the device to start fast polling before we send the OTA image
     async with device.fast_poll_mode():
-        with OTAManager(device, image, progress_callback=progress, force=force) as ota:
+        with OTAManager(
+            device,
+            image,
+            progress_callback=progress,
+            force=force,
+            allow_downgrade=allow_downgrade,
+        ) as ota:
             await ota.notify()
             return await ota.wait()


### PR DESCRIPTION
## Proposed change

This adds an `allow_downgrade` flag, allowing for a ZHA PR, so you can use the native `update.install` service in HA to just choose an older version to downgrade to. For that, we need to relax some checks in ZHA, so that if a manual version is provided (from ZHA/HA), the "newer version check" is ignored in zigpy.

There's going to be a (small) corresponding ZHA PR for this.

In the future, I also wanna look if we can trigger the `force` option from HA, as we need this for some devices (but other devices also do not support it at all and only need the `allow_downgrade from this PR). Maybe we can just have `force` at the start or end of the firmware version...? 😄 

Related ZHA PR:
- https://github.com/zigpy/zha/pull/793

## AI summary – Problem

A caller of `Device.update_firmware(image=...)` that hands in a specific image **older** than the device's running firmware cannot install it without also passing `force=True`.

This is because `OTAManager._image_query_req` replies with `NO_IMAGE_AVAILABLE` whenever `not self.force and not self.image.check_version(command.current_file_version)`, and `check_version` returns `False` for any image whose version is `<=` the device's current version.

`force` is the only escape hatch today, but it conflates two unrelated things: it skips the version check **and** the compatibility check, and it rewrites the advertised file version to `0xFFFFFFFE` so the device always accepts the image. That's far too blunt for "the user deliberately picked an older but otherwise compatible firmware."

Downstream (e.g. ZHA's update entity) the user picks a specific firmware from a list and has no way to know a downgrade needs `force=True`. The device just gets `NO_IMAGE_AVAILABLE`, surfaced as:

> Update was not successful: `<Status.NO_IMAGE_AVAILABLE: 152>`

Real example: a frient WISZB-131 at `current_file_version=131079`, user selected `131078`, log shows the silent `NO_IMAGE_AVAILABLE` reply.

## Change

- Add an explicit `allow_downgrade: bool = False` parameter to `Device.update_firmware`, `zigpy.ota.manager.update_firmware`, and `OTAManager`, separate from `force`. When set, `_image_query_req` skips **only** the version check; compatibility (`check_compatibility`) is still enforced, and the real file version is still advertised (no `force`-style version rewrite).
- When `_image_query_req` is about to reply `NO_IMAGE_AVAILABLE`, log at `WARNING` which guard failed — compatibility vs. version — including the device's current file version and a hint to pass `allow_downgrade=True`. The cause is now debuggable from logs alone.
- Add unit tests covering an explicitly selected older image: it installs when `allow_downgrade=True` (full block-transfer path to `SUCCESS`) and is refused with `NO_IMAGE_AVAILABLE` when `allow_downgrade=False`.

The default behavior is unchanged: implicit updates still refuse downgrades, and `force=True` keeps skipping both checks for backward compatibility.

## Downstream (ZHA)

ZHA's `async_install(version)` already carries the user-intent signal:

- `version is None` → auto-install the newest upgrade (can never be a downgrade).
- `version is not None` → the user explicitly named a version, resolved against both upgrades and downgrades.

So the ZHA call becomes:

```python
result = await self.device.device.update_firmware(
    image=firmware,
    progress_callback=self._update_progress,
    allow_downgrade=(version is not None),
)
```

This keeps the version guard on for the automatic "install latest" path (where it also protects against acting on a stale cached image) and lifts it only when the user explicitly chose a version. (Separate ZHA PR.)

## Note on device behavior

`allow_downgrade` lets zigpy *offer* a downgrade; whether the device *accepts* it is up to the device firmware. Many devices hard-refuse downgrades at the bootloader. For example, a Sonoff S60ZBTPF running `0x2003` offered `0x2002` replies `query_next_image_response(status=SUCCESS, file_version=8194)` (the offer goes out correctly) but immediately responds `upgrade_end(INVALID_IMAGE)` without requesting a single block. In that case the user now sees the device's honest `INVALID_IMAGE` instead of zigpy's silent `NO_IMAGE_AVAILABLE`.
