### PR TITLE
Add OTA update check method with rate-limited index refresh

### DIFF
--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -5,7 +5,7 @@ import datetime
 import hashlib
 import logging
 import typing
-from unittest.mock import ANY, AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import aiohttp
 import attrs
@@ -687,6 +687,34 @@ async def test_check_all_devices_for_ota_tolerates_failure(query_cmd) -> None:
 
     # device2 should still get checked even though device1 failed
     assert len(events2) == 1
+
+
+async def test_check_for_updates_rate_limits_invalidation() -> None:
+    """check_for_updates invalidates indexes at most once per rate limit."""
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    ota.invalidate_provider_caches = MagicMock(wraps=ota.invalidate_provider_caches)
+    ota.check_all_devices_for_ota = AsyncMock()
+
+    # The first check invalidates the caches
+    await ota.check_for_updates()
+    assert len(ota.invalidate_provider_caches.mock_calls) == 1
+    assert len(ota.check_all_devices_for_ota.mock_calls) == 1
+
+    # A second check within the rate limit does not, but still checks devices
+    await ota.check_for_updates()
+    assert len(ota.invalidate_provider_caches.mock_calls) == 1
+    assert len(ota.check_all_devices_for_ota.mock_calls) == 2
+
+    # Unless it is forced
+    await ota.check_for_updates(force=True)
+    assert len(ota.invalidate_provider_caches.mock_calls) == 2
+    assert len(ota.check_all_devices_for_ota.mock_calls) == 3
+
+    # After the rate limit has passed, the caches are invalidated again
+    ota._last_user_refresh -= 2 * zigpy.ota.USER_REFRESH_RATE_LIMIT
+    await ota.check_for_updates()
+    assert len(ota.invalidate_provider_caches.mock_calls) == 3
+    assert len(ota.check_all_devices_for_ota.mock_calls) == 4
 
 
 async def test_invalidate_provider_caches(query_cmd) -> None:

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -47,6 +47,10 @@ OTA_FETCH_TIMEOUT = 20
 MAX_DEVICES_CHECKING_IN_PER_BROADCAST = 15
 BROADCAST_SETTLE_DELAY = 60
 
+# Rate limit for user-initiated index refreshes, to avoid hammering the OTA
+# providers when the user repeatedly checks for updates
+USER_REFRESH_RATE_LIMIT = datetime.timedelta(minutes=10)
+
 
 @dataclasses.dataclass(frozen=True)
 class OtaImagesResult(t.BaseDataclassMixin):
@@ -246,6 +250,7 @@ class OTA:
         ] = {}
 
         self._broadcast_loop_task = None
+        self._last_user_refresh = datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
 
         if config[CONF_OTA_ENABLED]:
             self._register_providers(self._config)
@@ -299,6 +304,24 @@ class OTA:
             provider._index_last_updated = datetime.datetime.fromtimestamp(
                 0, tz=datetime.UTC
             )
+
+    async def check_for_updates(self, *, force: bool = False) -> None:
+        """Check all devices for new firmware with refreshed provider indexes.
+
+        Intended for user-initiated "check for updates" actions: invalidates
+        the provider index caches (rate-limited to once per
+        USER_REFRESH_RATE_LIMIT unless `force`) and re-checks every device
+        with a cached query command against the refreshed indexes. Devices
+        without a cached query command are covered by the periodic broadcasts
+        or an explicit `broadcast_notify()`.
+        """
+        now = datetime.datetime.now(datetime.UTC)
+
+        if force or now - self._last_user_refresh >= USER_REFRESH_RATE_LIMIT:
+            self._last_user_refresh = now
+            self.invalidate_provider_caches()
+
+        await self.check_all_devices_for_ota()
 
     async def check_cluster_for_ota(self, cluster: Ota) -> None:
         """Check OTA image availability for a single OTA cluster.

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -49,7 +49,7 @@ BROADCAST_SETTLE_DELAY = 60
 
 # Rate limit for user-initiated index refreshes, to avoid hammering the OTA
 # providers when the user repeatedly checks for updates
-USER_REFRESH_RATE_LIMIT = datetime.timedelta(minutes=10)
+USER_REFRESH_RATE_LIMIT = datetime.timedelta(minutes=2)
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Made possible by:
- https://github.com/zigpy/zigpy/pull/1837/

### Description

This PR adds a method that'll be used by HA's "Check for updates" button, so that it'll actually refresh the OTA indexes and check for new updates available there.

As the user can spam that button, zigpy currently implements a 2 minute rate-limit. I think this is good to just not hit existing provider indexes excessively if the user spams that button. Though we can probably also drop this completely if we don't want to keep this in zigpy? Or maybe even lengthen to 5 minutes (or maybe even 10 minutes).

### AI description

This PR adds a `check_for_updates()` method which invalidates the provider index caches, rate-limited to once per 2 minutes unless forced, and re-checks every device with a cached query command against the refreshed indexes. This gives
consumers (e.g. (Z)HA's "Check for updates" button) a single entry point that actually refreshes the indexes without re-implementing the rate limiting, and gives `invalidate_provider_caches()` its first caller.

Devices without a cached query command remain covered by the periodic broadcasts or an explicit `broadcast_notify()`.


----

See below for some more "thoughts" on everything OTA in general. TL;DR there's still more stuff I wanna improve a bit.


### Current ZHA/HA implementation

Currently, the [HA implementation (only) sends a broadcast notify command](https://github.com/home-assistant/core/blob/7074c291a0d22ef9e973d361bad3690305fdf895/homeassistant/components/zha/update.py#L98) to refresh the last query commands but doesn't actually refresh the indexes for new images, unless 24 hours have passed after the last check (assuming the device isn't asleep and responds to the image notify with a query img cmd).

Also, we don't really need to (or want to) send broadcast notify commands when the user checks for updates manually. So we can probably drop HA from doing that entirely.

Ideally, we'd just do this when a user calls `homeassistant.update_entity` for a single update entity, yet not when using the general "Check for updates" button but the current implementation with the HA coordinator is already not great IMO and that would become even worse trying to hack that differentiation together.

After this PR, we can just call this method from HA, as seen below (but likely also drop the image notify command afterwards – not in the branch): https://github.com/home-assistant/core/compare/dev...TheJulianJES:core:tjj/zha-ota-check-for-updates


### Advantage of this with the above merged zigpy PR (#1837)

With the above caching PR (https://github.com/zigpy/zigpy/pull/1837/), calling `invalidate_provider_caches()` (and then refreshing the indexes) no longer redownloads existing images from non-trusted providers if the metadata stays the same. So with that, we can actually hook this up to a user-initiated action, without worrying about downloading non-trusted OTA providers images every time the user checks for updates (manually).

With that PR, withdrawn images will also no longer be offered for installation after the user checked for updates.


### Note on zigpy index auto-background refresh

Note that zigpy also checks the provider indexes for updates in the background every 24 hours after the OTA broadcast:
https://github.com/zigpy/zigpy/blob/43dea44d371938db6d9c37d1dd4f66b062256e29/zigpy/ota/__init__.py#L261-L273
This was introduced with:
- https://github.com/zigpy/zigpy/pull/1799

There, the broadcast notify command is sent first. Then we wait a minute to check for new images for all devices, so 

Writing this description (that's already gotten way too long), we should maybe think about swapping that order?
I guess it won't really make a huge difference though. Whether we:
1. send the OTA broadcast first to cache the latest "query next image" commands + emit OTA image events for possibly outdated indexes AND only then refresh the indexes to emit (new) events again,
or
2. read the latest index + emit events for possibly outdated query commands (which are unlikely to be outdated in the first place) AND only then send the OTA broadcast to cache the latest "query next image" commands + emit OTA image events (again)

Currently, we do option 1 but 2 may be (slightly) better, as OTA indexes generally get refreshed more often than a device randomly changing its image query command (i.e. `manufacturer_id`, `image_type`, ...).

I guess I'm not a huge fan of emitting the `OtaImageAvailableEvent` (possibly) twice per image in such a short amount of time but it also doesn't really matter... Trying to avoid this would only have more downsides IMO and it's not really an issue.

### Thoughts on OTA broadcast loop + index refresh loop

I've thought about having a separate OTA broadcast loop and one for index refreshing when adding the index refreshing to the OTA broadcast loop in #1799 but it probably doesn't make a lot of sense. The index refreshing won't happen every time the OTA broadcast command is sent (24 hour rate limit for index refreshing).

I guess the only reason to have them separate would be for separate config options.


### Thought on OTA broadcast (loop) at all

We *should* also always have the latest OTA query command cached when a device is first paired (with recent zigpy versions) or when it's re-interviewed. But for everything else (e.g. devices paired on older zigpy versions and also to catch devices that are removed + re-added to the network without being removed + re-paired* (or re-interviewed)), we need the OTA broadcast loop.

*: We also need better logic in zigpy to determine when a device has been re-paired by the user and when it's just re-joining on its own. In the first case, we always want to re-interview I guess. (And maybe some (re-)interviewing improvements + DB ones as well:9