### PR TITLE
Improve OTA provider index refresh resilience

### DIFF
--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -731,6 +731,57 @@ async def test_ota_provider_indexes_refreshed_concurrently(
     assert len(images.upgrades) == 1
 
 
+async def test_ota_index_download_failure_backoff(query_cmd, ota_image) -> None:
+    """Failed index downloads back off exponentially, capped at the index TTL."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    meta = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 1,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=ota_image.serialize(),
+    )
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    provider = SelfContainedProvider([meta])
+    ota.register_provider(provider)
+
+    with patch.object(
+        provider, "_load_index", side_effect=RuntimeError("offline")
+    ) as load_index:
+        # The first check attempts (and fails) a download
+        await ota.get_ota_images(device, query_cmd)
+        assert len(load_index.mock_calls) == 1
+        assert provider._index_failures == 1
+
+        # An immediate second check is backed off, no new attempt is made
+        await ota.get_ota_images(device, query_cmd)
+        assert len(load_index.mock_calls) == 1
+
+        # After the initial retry delay has passed, a new attempt is made
+        provider._index_last_failure -= 2 * provider.INDEX_RETRY_DELAY
+        await ota.get_ota_images(device, query_cmd)
+        assert len(load_index.mock_calls) == 2
+        assert provider._index_failures == 2
+
+        # The delay grows with each failure: the initial delay is no longer enough
+        provider._index_last_failure -= 1.5 * provider.INDEX_RETRY_DELAY
+        await ota.get_ota_images(device, query_cmd)
+        assert len(load_index.mock_calls) == 2
+
+        # The delay never exceeds the index expiration time
+        provider._index_failures = 100
+        provider._index_last_failure -= 2 * provider.INDEX_EXPIRATION_TIME
+        await ota.get_ota_images(device, query_cmd)
+        assert len(load_index.mock_calls) == 3
+
+    # A successful download resets the failure state
+    provider._index_last_failure = datetime.datetime.now(datetime.UTC)
+    provider.invalidate_index()  # the user can always force a retry
+    images = await ota.get_ota_images(device, query_cmd)
+    assert len(images.upgrades) == 1
+    assert provider._index_failures == 0
+
+
 async def test_invalidate_provider_caches(query_cmd) -> None:
     """invalidate_provider_caches resets all provider index timestamps."""
     ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -782,6 +782,44 @@ async def test_ota_index_download_failure_backoff(query_cmd, ota_image) -> None:
     assert provider._index_failures == 0
 
 
+async def test_ota_stale_provider_images_expire(query_cmd, ota_image, caplog) -> None:
+    """Images of a provider that is down for a prolonged time are dropped."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    meta = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 1,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=ota_image.serialize(),
+    )
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    provider = SelfContainedProvider([meta])
+    ota.register_provider(provider)
+
+    images1 = await ota.get_ota_images(device, query_cmd)
+    assert len(images1.upgrades) == 1
+
+    # The provider has been down for longer than the stale expiration time
+    stale = 2 * provider.STALE_INDEX_EXPIRATION_TIME
+    provider._index_last_updated -= stale
+    provider._index_last_success -= stale
+
+    with patch.object(provider, "_load_index", side_effect=RuntimeError("offline")):
+        images2 = await ota.get_ota_images(device, query_cmd)
+        assert len(images2.upgrades) == 0
+        assert caplog.text.count("dropping its 1 cached images") == 1
+
+        # The warning is not repeated on subsequent failing checks
+        provider._index_last_failure -= 2 * provider.INDEX_RETRY_DELAY
+        await ota.get_ota_images(device, query_cmd)
+        assert caplog.text.count("dropping its 1 cached images") == 1
+
+    # Once the provider recovers, its images are offered again
+    provider.invalidate_index()
+    images3 = await ota.get_ota_images(device, query_cmd)
+    assert images3 == images1
+
+
 async def test_invalidate_provider_caches(query_cmd) -> None:
     """invalidate_provider_caches resets all provider index timestamps."""
     ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -478,7 +478,11 @@ async def test_ota_trusted_provider_missing_sha3_256_checksum(
 
     # Image should be removed due to missing SHA3-256 checksum
     assert len(images.upgrades) == 0
-    assert "does not have SHA3-256 checksum" in caplog.text
+    assert caplog.text.count("does not have SHA3-256 checksum") == 1
+
+    # The warning is emitted once per index refresh, not once per device check
+    await ota.get_ota_images(device, query_cmd)
+    assert caplog.text.count("does not have SHA3-256 checksum") == 1
 
 
 def _make_device_with_ota_cluster(

--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -689,6 +689,48 @@ async def test_check_all_devices_for_ota_tolerates_failure(query_cmd) -> None:
     assert len(events2) == 1
 
 
+async def test_ota_provider_indexes_refreshed_concurrently(
+    query_cmd, ota_image
+) -> None:
+    """Provider indexes are refreshed concurrently, not sequentially."""
+    device = make_device(model="device model", manufacturer_id=0x1234)
+
+    meta = SelfContainedOtaImageMetadata(
+        file_version=query_cmd.current_file_version + 1,
+        manufacturer_id=query_cmd.manufacturer_code,
+        test_data=ota_image.serialize(),
+    )
+
+    second_provider_started = asyncio.get_running_loop().create_future()
+
+    class WaitingProvider(SelfContainedProvider):
+        """Provider that blocks until the second provider's refresh starts."""
+
+        async def _load_index(self, session):
+            await second_provider_started
+
+            for meta in self._index:
+                yield meta
+
+    class SignallingProvider(SelfContainedProvider):
+        """Provider that unblocks the first provider."""
+
+        async def _load_index(self, session):
+            second_provider_started.set_result(None)
+
+            for meta in self._index:
+                yield meta
+
+    ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)
+    # The waiting provider is registered (and so refreshed) first: a sequential
+    # refresh would stall here until the fetch timeout expires
+    ota.register_provider(WaitingProvider([meta]))
+    ota.register_provider(SignallingProvider([meta]))
+
+    images = await ota.get_ota_images(device, query_cmd)
+    assert len(images.upgrades) == 1
+
+
 async def test_invalidate_provider_caches(query_cmd) -> None:
     """invalidate_provider_caches resets all provider index timestamps."""
     ota = zigpy.ota.OTA(config={config.CONF_OTA_ENABLED: False}, application=None)

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -7,6 +7,7 @@ from asyncio import timeout as asyncio_timeout
 from collections import defaultdict
 import contextlib
 import dataclasses
+import datetime
 import hashlib
 import logging
 import typing
@@ -477,10 +478,11 @@ class OTA:
             async with asyncio_timeout(OTA_FETCH_TIMEOUT):
                 index = await provider.load_index()
         except Exception as exc:  # noqa: BLE001
-            # Keep the previously-cached images: a provider outage should not
-            # withdraw its images
+            # Keep the previously-cached images: a brief provider outage should
+            # not withdraw its images
             _LOGGER.debug("Failed to load provider %s", provider, exc_info=exc)
             provider.record_index_failure()
+            self._expire_stale_provider_images(provider)
             return
 
         # The cached index is still fresh
@@ -512,6 +514,33 @@ class OTA:
         # Replace the provider's images wholesale so images withdrawn from the
         # index are revoked
         self._image_cache[provider] = new_images
+
+    def _expire_stale_provider_images(
+        self, provider: zigpy.ota.providers.BaseOtaProvider
+    ) -> None:
+        """Drop a provider's cached images after a prolonged outage.
+
+        A provider that cannot be reached cannot withdraw images either, so
+        images from a provider whose index has not been successfully refreshed
+        for a long time are revoked instead of being offered indefinitely.
+        """
+        images = self._image_cache.get(provider)
+        if not images:
+            return
+
+        now = datetime.datetime.now(datetime.UTC)
+
+        if now - provider._index_last_success <= provider.STALE_INDEX_EXPIRATION_TIME:
+            return
+
+        _LOGGER.warning(
+            "Provider %s has been unreachable for over %s, dropping its"
+            " %d cached images",
+            provider,
+            provider.STALE_INDEX_EXPIRATION_TIME,
+            len(images),
+        )
+        del self._image_cache[provider]
 
     @zigpy.util.combine_concurrent_calls
     async def _fetch_image(self, image: OtaImageWithMetadata) -> OtaImageWithMetadata:

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -533,9 +533,11 @@ class OTA:
             p for p in self._providers if p.compatible_with_device(device)
         ]
 
-        # Refresh the index of every provider whose cache expired
-        for provider in compatible_providers:
-            await self._refresh_provider_index(provider)
+        # Refresh the index of every provider whose cache expired, concurrently:
+        # one slow or unreachable provider should not delay the others
+        await asyncio.gather(
+            *(self._refresh_provider_index(p) for p in compatible_providers)
+        )
 
         # Merge the cached images of all compatible providers. The same metadata can
         # be served by multiple providers so prefer entries with downloaded firmware.

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -7,7 +7,6 @@ from asyncio import timeout as asyncio_timeout
 from collections import defaultdict
 import contextlib
 import dataclasses
-import datetime
 import hashlib
 import logging
 import typing
@@ -296,9 +295,7 @@ class OTA:
         is unchanged and is otherwise re-downloaded.
         """
         for provider in self._providers:
-            provider._index_last_updated = datetime.datetime.fromtimestamp(
-                0, tz=datetime.UTC
-            )
+            provider.invalidate_index()
 
     async def check_cluster_for_ota(self, cluster: Ota) -> None:
         """Check OTA image availability for a single OTA cluster.
@@ -483,6 +480,7 @@ class OTA:
             # Keep the previously-cached images: a provider outage should not
             # withdraw its images
             _LOGGER.debug("Failed to load provider %s", provider, exc_info=exc)
+            provider.record_index_failure()
             return
 
         # The cached index is still fresh

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -501,6 +501,17 @@ class OTA:
             if provider.TRUSTED and not meta.trusted:
                 meta = meta.replace(trusted=True)
 
+            # Trusted images are not downloaded before installation, so their
+            # content cannot be verified without a SHA3-256 checksum
+            if meta.trusted and (
+                meta.checksum is None or not meta.checksum.startswith("sha3-256:")
+            ):
+                _LOGGER.warning(
+                    "Trusted image %s does not have SHA3-256 checksum, ignoring",
+                    meta,
+                )
+                continue
+
             if meta in new_images:
                 continue
 
@@ -671,33 +682,16 @@ class OTA:
         self,
         upgrades: dict[zigpy.ota.providers.BaseOtaImageMetadata, OtaImageWithMetadata],
     ) -> None:
-        """Remove images with identical versions and specificity but differing contents.
-
-        Also removes trusted images that lack a SHA3-256 checksum, since their content
-        cannot be verified for collision detection.
-        """
+        """Remove images with identical versions and specificity but differing contents."""
         # Structure: {(version, specificity): {content_hash: [images]}}
         collisions: defaultdict[
             tuple[int, int], defaultdict[str, list[OtaImageWithMetadata]]
         ] = defaultdict(lambda: defaultdict(list))
 
-        images_to_remove: list[zigpy.ota.providers.BaseOtaImageMetadata] = []
-
         for img in upgrades.values():
             # Untrusted images are always downloaded above and ones that failed
             # to download were already removed; this should never happen.
             assert img.firmware is not None or img.metadata.trusted
-
-            # Ignore trusted image without SHA3-256 checksum
-            if img.firmware is None and (
-                img.metadata.checksum is None
-                or not img.metadata.checksum.startswith("sha3-256:")
-            ):
-                _LOGGER.warning(
-                    "Trusted image %s does not have SHA3-256 checksum, ignoring", img
-                )
-                images_to_remove.append(img.metadata)
-                continue
 
             # Calculate content hash from firmware if available, otherwise use metadata
             if img.firmware is not None:
@@ -707,13 +701,12 @@ class OTA:
                 )
                 content_hash = "sha3-256:" + hasher.hexdigest()
             else:
-                assert img.metadata.checksum is not None  # Checked above
+                # Trusted images without a SHA3-256 checksum are dropped when
+                # the provider's index is refreshed
+                assert img.metadata.checksum is not None
                 content_hash = img.metadata.checksum
 
             collisions[img.version, img.specificity][content_hash].append(img)
-
-        for meta in images_to_remove:
-            upgrades.pop(meta)
 
         for (version, specificity), buckets in collisions.items():
             # If there are multiple unique hashes, we have a collision

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -197,6 +197,9 @@ class BaseOtaProvider:
     VOL_SCHEMA: vol.Schema
     JSON_SCHEMA: dict | None = None
     INDEX_EXPIRATION_TIME = datetime.timedelta(hours=24)
+    # Base delay for retrying after a failed index download, doubled with every
+    # consecutive failure and capped at INDEX_EXPIRATION_TIME
+    INDEX_RETRY_DELAY = datetime.timedelta(minutes=30)
     TRUSTED: bool = False
 
     def __init__(
@@ -207,7 +210,14 @@ class BaseOtaProvider:
         override_previous: bool = False,
     ) -> None:
         self.url = self.DEFAULT_URL if url in (True, None) else url
-        self._index_last_updated = datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
+
+        epoch = datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
+        self._index_last_updated = epoch
+        # Unlike `_index_last_updated`, this is not reset by `invalidate_index()`
+        # so it tracks how stale the provider's cached images really are
+        self._index_last_success = epoch
+        self._index_failures = 0
+        self._index_last_failure = epoch
 
         if manufacturer_ids is not None:
             self.manufacturer_ids = tuple(manufacturer_ids)
@@ -222,21 +232,55 @@ class BaseOtaProvider:
 
         return device.manufacturer_id in self.manufacturer_ids
 
+    def _should_load_index(self, now: datetime.datetime) -> bool:
+        # Don't hammer the OTA indexes too frequently
+        if now - self._index_last_updated < self.INDEX_EXPIRATION_TIME:
+            return False
+
+        # Back off exponentially after repeated failures. The exponent is capped
+        # to avoid a timedelta overflow; the delay itself caps far earlier.
+        if self._index_failures > 0:
+            retry_delay = min(
+                self.INDEX_RETRY_DELAY * 2 ** min(self._index_failures - 1, 16),
+                self.INDEX_EXPIRATION_TIME,
+            )
+
+            if now - self._index_last_failure < retry_delay:
+                return False
+
+        return True
+
+    def record_index_failure(self) -> None:
+        """Record a failed index download, growing the retry backoff."""
+        self._index_failures += 1
+        self._index_last_failure = datetime.datetime.now(datetime.UTC)
+
+    def invalidate_index(self) -> None:
+        """Allow the next `load_index()` call to download the index immediately."""
+        epoch = datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
+        self._index_last_updated = epoch
+        self._index_failures = 0
+        self._index_last_failure = epoch
+
     async def load_index(self) -> list[BaseOtaImageMetadata] | None:
         now = datetime.datetime.now(datetime.UTC)
 
-        # Don't hammer the OTA indexes too frequently
-        if now - self._index_last_updated < self.INDEX_EXPIRATION_TIME:
+        if not self._should_load_index(now):
             return None
 
-        try:
-            async with aiohttp.ClientSession(
-                headers={"accept": "application/json"},
-                raise_for_status=True,
-            ) as session:
-                return [meta async for meta in self._load_index(session)]
-        finally:
-            self._index_last_updated = now
+        async with aiohttp.ClientSession(
+            headers={"accept": "application/json"},
+            raise_for_status=True,
+        ) as session:
+            index = [meta async for meta in self._load_index(session)]
+
+        # Failures are recorded by the OTA manager via `record_index_failure()`,
+        # since it also enforces the download timeout
+        self._index_last_updated = now
+        self._index_last_success = now
+        self._index_failures = 0
+
+        return index
 
     async def _load_index(
         self, session: aiohttp.ClientSession

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -200,6 +200,9 @@ class BaseOtaProvider:
     # Base delay for retrying after a failed index download, doubled with every
     # consecutive failure and capped at INDEX_EXPIRATION_TIME
     INDEX_RETRY_DELAY = datetime.timedelta(minutes=30)
+    # How long a provider's index may fail to refresh before its cached images
+    # are dropped: an unreachable provider cannot withdraw images either
+    STALE_INDEX_EXPIRATION_TIME = datetime.timedelta(days=3)
     TRUSTED: bool = False
 
     def __init__(


### PR DESCRIPTION
DRAFT. Maybe this should be split up into three PRs. When reviewing, review the individual commits.

Follow-up to #1837. Makes the per-provider index refresh handle slow, failing, and permanently-dead providers gracefully. Branch: `tjj/ota-provider-health`.

## Changes

- **Refresh provider indexes concurrently.** `get_ota_images()` previously refreshed each compatible provider's index sequentially, so one slow or unreachable provider delayed every other by up to the 20 s fetch timeout — and dead providers are real (the ThirdReality and Inovelli servers shut down permanently), so the stalls stack up. Refreshes are now gathered concurrently; safe because each refresh only rebinds its own provider's cache bucket and swallows its own exceptions.
- **Exponential backoff for failed index downloads.** A failed download previously set `_index_last_updated` in a `finally` block, locking the provider out for the full 24 h expiration: a transient network blip at startup meant no OTA images from that provider for a day. Failures now retry after an exponentially growing delay (30 min base, doubling per consecutive failure, capped at the 24 h TTL), tracked separately from the success timestamp. `invalidate_provider_caches()` clears the failure state via the new `provider.invalidate_index()`, so a user-initiated re-check can always retry immediately.
- **Expire images of providers down for a prolonged time.** A provider that cannot be reached cannot withdraw images either, so a permanently dead provider would keep offering its last-known images until restart. When a refresh fails and the last *successful* refresh is older than `STALE_INDEX_EXPIRATION_TIME` (3 days), the provider's cached images are dropped with a single warning. Age-based (not failure-count-based) to avoid flapping update entities on intermittent connectivity; recovery repopulates on the next check.
- **Warn about unverifiable trusted images once per refresh.** The "trusted image lacks a SHA3-256 checksum" warning lived in the per-device matching path, so it fired for every device on every check cycle. The check now runs when a provider's index is refreshed: unverifiable trusted images are excluded from the cache up front (so they no longer appear in downgrades either) and the warning fires once per refresh, re-arming naturally on invalidation.

## Notes

- New provider state: `_index_last_success` (monotone, **not** reset by invalidation, so it tracks true staleness), plus failure count/timestamp. New constants `INDEX_RETRY_DELAY` (30 min) and `STALE_INDEX_EXPIRATION_TIME` (3 days).
- The backoff exponent is capped (`min(failures-1, 16)`) to avoid a `timedelta` overflow.

## Testing

New tests for concurrent refresh (a provider whose index load blocks until a second provider's load starts — a sequential refresh would stall), exponential backoff lifecycle, stale-provider expiry + recovery, and the once-per-refresh warning. Full suite passes; `zigpy/ota/` at 99% coverage.
