### PR TITLE
Confirm post-OTA reboot via announce/version-change instead of a fixed retry budget

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -719,7 +719,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
                 # post-OTA image_notify.
                 async def fire_announce() -> None:
                     await asyncio.sleep(0.05)
-                    dev.zdo.listener_event("device_announce", dev)
+                    dev.application.listener_event("device_joined", dev)
 
                 asyncio.create_task(fire_announce())  # noqa: RUF006
 
@@ -1087,7 +1087,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
                 # Simulate the device rebooting and announcing itself.
                 async def fire_announce() -> None:
                     await asyncio.sleep(0.05)
-                    dev.zdo.listener_event("device_announce", dev)
+                    dev.application.listener_event("device_joined", dev)
 
                 asyncio.create_task(fire_announce())  # noqa: RUF006
 
@@ -2154,16 +2154,36 @@ async def ota_dev(dev):
     return dev, cluster
 
 
-async def test_post_ota_confirmation_resolves_on_device_announce(ota_dev):
-    """A Device_annce on the device's ZDO resolves the wait."""
+async def test_post_ota_confirmation_resolves_on_device_joined(ota_dev):
+    """A `device_joined` event for this device resolves the wait."""
     dev, cluster = ota_dev
 
     wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
     # Give the wait function a chance to attach its listeners
     await asyncio.sleep(0)
 
-    dev.zdo.listener_event("device_announce", dev)
+    dev.application.listener_event("device_joined", dev)
     await asyncio.wait_for(wait_task, timeout=1.0)
+
+
+async def test_post_ota_confirmation_ignores_other_devices_joining(ota_dev):
+    """A `device_joined` event for a DIFFERENT device must NOT resolve the wait."""
+    dev, cluster = ota_dev
+
+    other = MagicMock()
+    other.ieee = t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11")
+    assert other.ieee != dev.ieee
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    await asyncio.sleep(0)
+
+    dev.application.listener_event("device_joined", other)
+    await asyncio.sleep(0)
+    assert not wait_task.done()
+
+    wait_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await wait_task
 
 
 async def test_post_ota_confirmation_resolves_on_version_change(ota_dev):
@@ -2259,7 +2279,7 @@ async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
     qni_listeners_before = len(
         cluster._event_listeners.get("ota_query_cache_updated", [])
     )
-    zdo_listeners_before = len(dev.zdo._listeners)
+    app_listeners_before = len(dev.application._listeners)
 
     wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
     await asyncio.sleep(0)
@@ -2268,7 +2288,7 @@ async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
         len(cluster._event_listeners.get("ota_query_cache_updated", []))
         == qni_listeners_before + 1
     )
-    assert len(dev.zdo._listeners) == zdo_listeners_before + 1
+    assert len(dev.application._listeners) == app_listeners_before + 1
 
     wait_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
@@ -2279,7 +2299,7 @@ async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
         len(cluster._event_listeners.get("ota_query_cache_updated", []))
         == qni_listeners_before
     )
-    assert len(dev.zdo._listeners) == zdo_listeners_before
+    assert len(dev.application._listeners) == app_listeners_before
 
 
 async def test_update_firmware_post_ota_timeout(monkeypatch, dev, caplog):
@@ -2324,7 +2344,7 @@ async def test_update_firmware_post_ota_sends_image_notify_after_confirmation(
 
     async def fire_announce_soon():
         await asyncio.sleep(0.02)
-        dev.zdo.listener_event("device_announce", dev)
+        dev.application.listener_event("device_joined", dev)
 
     asyncio.create_task(fire_announce_soon())  # noqa: RUF006
 
@@ -2355,7 +2375,7 @@ async def test_update_firmware_post_ota_image_notify_failure_is_swallowed(
 
     async def fire_announce_soon():
         await asyncio.sleep(0.02)
-        dev.zdo.listener_event("device_announce", dev)
+        dev.application.listener_event("device_joined", dev)
 
     asyncio.create_task(fire_announce_soon())  # noqa: RUF006
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2302,6 +2302,30 @@ async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
     assert len(dev.application._listeners) == app_listeners_before
 
 
+async def test_post_ota_confirmation_unanswered_probe_is_swallowed(ota_dev, caplog):
+    """A probe read that fails outright neither confirms nor raises."""
+    dev, cluster = ota_dev
+
+    cluster.read_attributes = AsyncMock(
+        side_effect=zigpy.exceptions.DeliveryError("Device asleep")
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    # The probe failed, but the wait keeps waiting for the passive signals
+    cluster.read_attributes.assert_awaited_once()
+    assert "probe went unanswered" in caplog.text
+    assert not wait_task.done()
+
+    # Cleanup
+    wait_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await wait_task
+
+
 async def test_update_firmware_post_ota_timeout(monkeypatch, dev, caplog):
     """If neither confirmation signal arrives, timeout but still return SUCCESS."""
     ep = dev.add_endpoint(1)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 import logging
@@ -18,7 +19,7 @@ from zigpy.profiles import zha
 import zigpy.state
 import zigpy.types as t
 import zigpy.util
-from zigpy.zcl import ClusterType, OtaQueryCacheClearedEvent, foundation
+from zigpy.zcl import ClusterType, OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PollControl
 from zigpy.zdo import types as zdo_t
 
@@ -523,6 +524,7 @@ async def test_update_device_firmware_already_in_progress(dev, caplog):
 
 @patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
 @patch("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0.01)
+@patch("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
 async def test_update_device_firmware(monkeypatch, dev, caplog):
     """Test that device firmware updates execute the expected calls."""
     ep = dev.add_endpoint(1)
@@ -711,81 +713,30 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
                 assert cmd.file_version == active_fw_image.firmware.header.file_version
                 assert cmd.current_time == 0
                 assert cmd.upgrade_time == 0
-            elif isinstance(
-                cmd,
-                foundation.GENERAL_COMMANDS[
-                    foundation.GeneralCommand.Read_Attributes
-                ].schema,
-            ):
-                assert cmd.attribute_ids == [Ota.AttributeDefs.current_file_version.id]
 
-                req_hdr, req_cmd = cluster._create_request(
-                    general=True,
-                    command_id=foundation.GeneralCommand.Read_Attributes_rsp,
-                    schema=foundation.GENERAL_COMMANDS[
-                        foundation.GeneralCommand.Read_Attributes_rsp
-                    ].schema,
-                    tsn=hdr.tsn,
-                    disable_default_response=True,
-                    direction=foundation.Direction.Client_to_Server,
-                    args=(),
-                    kwargs={
-                        "status_records": [
-                            foundation.ReadAttributeRecord(
-                                attrid=Ota.AttributeDefs.current_file_version.id,
-                                status=foundation.Status.SUCCESS,
-                                value=foundation.TypeValue(
-                                    type=foundation.DataTypeId.uint32,
-                                    value=active_fw_image.firmware.header.file_version,
-                                ),
-                            )
-                        ]
-                    },
-                )
+                # Simulate the device rebooting and announcing itself.
+                # update_firmware() waits for this signal before sending the
+                # post-OTA image_notify.
+                async def fire_announce() -> None:
+                    await asyncio.sleep(0.05)
+                    dev.zdo.listener_event("device_announce", dev)
 
-                dev.application.packet_received(
-                    t.ZigbeePacket(
-                        src=t.AddrModeAddress(
-                            addr_mode=t.AddrMode.NWK, address=dev.nwk
-                        ),
-                        src_ep=1,
-                        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
-                        dst_ep=1,
-                        tsn=hdr.tsn,
-                        profile_id=260,
-                        cluster_id=cluster.cluster_id,
-                        data=t.SerializableBytes(
-                            req_hdr.serialize() + req_cmd.serialize()
-                        ),
-                        lqi=255,
-                        rssi=-30,
-                    )
-                )
+                asyncio.create_task(fire_announce())  # noqa: RUF006
 
     dev.application.send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
 
-    cleared_events = []
-    cluster.on_event(OtaQueryCacheClearedEvent.event_type, cleared_events.append)
-
     result = await dev.update_firmware(fw_image, progress_callback)
-    assert (
-        dev.endpoints[1]
-        .out_clusters[Ota.cluster_id]
-        ._attr_cache[Ota.AttributeDefs.current_file_version.id]
-        == 0x12345678
-    )
 
     # Wait for background tasks (post-OTA query_next_image handling)
     await asyncio.sleep(0)
-    # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
+    # 5 OTA + 1 probe read + 1 post-OTA image_notify + 1 post-OTA
+    # query_next_image_response
     assert dev.application.send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(40, 70, 57.142857142857146)
     assert progress_callback.call_args_list[1] == call(70, 70, 100.0)
     assert result == foundation.Status.SUCCESS
-    assert len(cleared_events) == 1
-    assert isinstance(cleared_events[0], OtaQueryCacheClearedEvent)
     # Post-OTA image_notify repopulated the query cache
     assert cluster.last_query_cmd is not None
 
@@ -796,7 +747,8 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     )
 
     await asyncio.sleep(0)
-    # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
+    # 5 OTA + 1 probe read + 1 post-OTA image_notify + 1 post-OTA
+    # query_next_image_response
     assert dev.application.send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(40, 70, 57.142857142857146)
@@ -943,6 +895,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
 
 @patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
 @patch("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0.01)
+@patch("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
 async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     """Legrand device (manufacturer_code == 4129) firmware update expects the "image_block" command "maximum_data_size" to be complied with."""
     ep = dev.add_endpoint(1)
@@ -1130,70 +1083,22 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
                 assert cmd.file_version == active_fw_image.firmware.header.file_version
                 assert cmd.current_time == 0
                 assert cmd.upgrade_time == 0
-            elif isinstance(
-                cmd,
-                foundation.GENERAL_COMMANDS[
-                    foundation.GeneralCommand.Read_Attributes
-                ].schema,
-            ):
-                assert cmd.attribute_ids == [Ota.AttributeDefs.current_file_version.id]
 
-                req_hdr, req_cmd = cluster._create_request(
-                    general=True,
-                    command_id=foundation.GeneralCommand.Read_Attributes_rsp,
-                    schema=foundation.GENERAL_COMMANDS[
-                        foundation.GeneralCommand.Read_Attributes_rsp
-                    ].schema,
-                    tsn=hdr.tsn,
-                    disable_default_response=True,
-                    direction=foundation.Direction.Client_to_Server,
-                    args=(),
-                    kwargs={
-                        "status_records": [
-                            foundation.ReadAttributeRecord(
-                                attrid=Ota.AttributeDefs.current_file_version.id,
-                                status=foundation.Status.SUCCESS,
-                                value=foundation.TypeValue(
-                                    type=foundation.DataTypeId.uint32,
-                                    value=active_fw_image.firmware.header.file_version,
-                                ),
-                            )
-                        ]
-                    },
-                )
+                # Simulate the device rebooting and announcing itself.
+                async def fire_announce() -> None:
+                    await asyncio.sleep(0.05)
+                    dev.zdo.listener_event("device_announce", dev)
 
-                dev.application.packet_received(
-                    t.ZigbeePacket(
-                        src=t.AddrModeAddress(
-                            addr_mode=t.AddrMode.NWK, address=dev.nwk
-                        ),
-                        src_ep=1,
-                        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
-                        dst_ep=1,
-                        tsn=hdr.tsn,
-                        profile_id=260,
-                        cluster_id=cluster.cluster_id,
-                        data=t.SerializableBytes(
-                            req_hdr.serialize() + req_cmd.serialize()
-                        ),
-                        lqi=255,
-                        rssi=-30,
-                    )
-                )
+                asyncio.create_task(fire_announce())  # noqa: RUF006
 
     dev.application.send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
     result = await dev.update_firmware(fw_image, progress_callback)
-    assert (
-        dev.endpoints[1]
-        .out_clusters[Ota.cluster_id]
-        ._attr_cache[Ota.AttributeDefs.current_file_version.id]
-        == 0x12345678
-    )
 
     # Wait for background tasks (post-OTA query_next_image handling)
     await asyncio.sleep(0)
-    # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
+    # 5 OTA + 1 probe read + 1 post-OTA image_notify + 1 post-OTA
+    # query_next_image_response
     assert dev.application.send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(64, 70, 91.42857142857143)
@@ -1207,7 +1112,8 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     )
 
     await asyncio.sleep(0)
-    # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
+    # 5 OTA + 1 probe read + 1 post-OTA image_notify + 1 post-OTA
+    # query_next_image_response
     assert dev.application.send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(64, 70, 91.42857142857143)
@@ -2179,8 +2085,288 @@ async def test_reinterview_during_ota(dev):
     dev._application._device_reinterviewed.assert_not_called()
 
 
+async def test_update_firmware_no_reinterview_on_confirmation_timeout(monkeypatch, dev):
+    """update_firmware() does not invoke reinterview() when confirmation times
+    out — recovery is deferred to the version-change listener instead.
+    """
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    async def mockrequest(nwk, tries=None, delay=None):
+        return [0, None, [0, 1]]
+
+    async def mockepinit(self, *args, **kwargs):
+        self.status = endpoint.Status.ZDO_INIT
+        self.add_input_cluster(Basic.cluster_id)
+
+    async def mock_ep_get_model_info(self):
+        return "Model", "Manufacturer"
+
+    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
+    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
+    dev.zdo.Active_EP_req = mockrequest
+
+    with mock_attribute_reads(cluster, {"current_file_version": 0x00000001}):
+        await dev.initialize()
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 0.1)
+
+    dev.reinterview = AsyncMock()
+
+    result = await dev.update_firmware(
+        MagicMock(),
+        progress_callback=MagicMock(),
+    )
+
+    assert result == foundation.Status.SUCCESS
+    dev.reinterview.assert_not_called()
+
+
+def _make_post_ota_qni_event(
+    cluster: Ota,
+    current_file_version: int,
+) -> OtaQueryCacheUpdatedEvent:
+    """Build an OtaQueryCacheUpdatedEvent for a cluster with the given version."""
+    return OtaQueryCacheUpdatedEvent(
+        device_ieee=str(cluster.endpoint.device.ieee),
+        endpoint_id=cluster.endpoint.endpoint_id,
+        cluster_type=cluster.cluster_type,
+        cluster_id=cluster.cluster_id,
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=current_file_version,
+        hardware_version=None,
+    )
+
+
+@pytest.fixture
+async def ota_dev(dev):
+    """A device with an OTA out_cluster ready for post-OTA tests."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+    return dev, cluster
+
+
+async def test_post_ota_confirmation_resolves_on_device_announce(ota_dev):
+    """A Device_annce on the device's ZDO resolves the wait."""
+    dev, cluster = ota_dev
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    # Give the wait function a chance to attach its listeners
+    await asyncio.sleep(0)
+
+    dev.zdo.listener_event("device_announce", dev)
+    await asyncio.wait_for(wait_task, timeout=1.0)
+
+
+async def test_post_ota_confirmation_resolves_on_version_change(ota_dev):
+    """A version-change OtaQueryCacheUpdatedEvent resolves the wait."""
+    dev, cluster = ota_dev
+
+    # Establish a baseline so the snapshot is non-None
+    cluster.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=0x00000001,
+    )
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    await asyncio.sleep(0)
+
+    cluster.emit(
+        "ota_query_cache_updated",
+        _make_post_ota_qni_event(cluster, current_file_version=0x00000002),
+    )
+    await asyncio.wait_for(wait_task, timeout=1.0)
+
+
+async def test_post_ota_confirmation_ignores_same_version(ota_dev):
+    """An OtaQueryCacheUpdatedEvent with the same version does NOT resolve."""
+    dev, cluster = ota_dev
+
+    cluster.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=0x00000001,
+    )
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    await asyncio.sleep(0)
+
+    cluster.emit(
+        "ota_query_cache_updated",
+        _make_post_ota_qni_event(cluster, current_file_version=0x00000001),
+    )
+    await asyncio.sleep(0)
+    assert not wait_task.done()
+
+    # Cleanup
+    wait_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await wait_task
+
+
+async def test_post_ota_confirmation_resolves_immediately_on_pre_attach_change(
+    ota_dev,
+):
+    """If the version already changed before the wait started, resolve immediately."""
+    dev, cluster = ota_dev
+
+    cluster.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=0x00000001,
+    )
+
+    # Trigger the version change AFTER snapshot but BEFORE the listeners are
+    # attached: monkey-patch on_event to swap last_query_cmd at attach time.
+    real_on_event = cluster.on_event
+
+    def patched_on_event(event_name, callback, with_context=False):
+        unsub = real_on_event(event_name, callback, with_context=with_context)
+        # Simulate a version change right after listener attach (still before
+        # the wait re-checks the snapshot)
+        cluster.last_query_cmd = Ota.QueryNextImageCommand(
+            field_control=Ota.QueryNextImageCommand.FieldControl(0),
+            manufacturer_code=0x1234,
+            image_type=0x90,
+            current_file_version=0x00000002,
+        )
+        return unsub
+
+    cluster.on_event = patched_on_event
+
+    await asyncio.wait_for(
+        dev._wait_for_post_ota_confirmation(cluster),
+        timeout=1.0,
+    )
+
+
+async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
+    """Cancellation should remove both listeners."""
+    dev, cluster = ota_dev
+
+    qni_listeners_before = len(
+        cluster._event_listeners.get("ota_query_cache_updated", [])
+    )
+    zdo_listeners_before = len(dev.zdo._listeners)
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    await asyncio.sleep(0)
+    # Listeners are attached
+    assert (
+        len(cluster._event_listeners.get("ota_query_cache_updated", []))
+        == qni_listeners_before + 1
+    )
+    assert len(dev.zdo._listeners) == zdo_listeners_before + 1
+
+    wait_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await wait_task
+
+    # And cleaned up after cancellation
+    assert (
+        len(cluster._event_listeners.get("ota_query_cache_updated", []))
+        == qni_listeners_before
+    )
+    assert len(dev.zdo._listeners) == zdo_listeners_before
+
+
+async def test_update_firmware_post_ota_timeout(monkeypatch, dev, caplog):
+    """If neither confirmation signal arrives, timeout but still return SUCCESS."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 0.05)
+
+    cluster.image_notify = AsyncMock()
+
+    result = await dev.update_firmware(MagicMock(), progress_callback=MagicMock())
+
+    assert result == foundation.Status.SUCCESS
+    assert "Device did not confirm new firmware" in caplog.text
+    # image_notify must NOT be sent on timeout
+    cluster.image_notify.assert_not_called()
+
+
+async def test_update_firmware_post_ota_sends_image_notify_after_confirmation(
+    monkeypatch, dev
+):
+    """After confirmation, update_firmware sends image_notify."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
+
+    cluster.image_notify = AsyncMock()
+
+    async def fire_announce_soon():
+        await asyncio.sleep(0.02)
+        dev.zdo.listener_event("device_announce", dev)
+
+    asyncio.create_task(fire_announce_soon())  # noqa: RUF006
+
+    result = await dev.update_firmware(MagicMock(), progress_callback=MagicMock())
+
+    assert result == foundation.Status.SUCCESS
+    cluster.image_notify.assert_awaited_once()
+
+
+async def test_update_firmware_post_ota_image_notify_failure_is_swallowed(
+    monkeypatch, dev, caplog
+):
+    """A failing post-OTA image_notify still results in a SUCCESS return."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
+
+    cluster.image_notify = AsyncMock(
+        side_effect=zigpy.exceptions.DeliveryError("Device asleep")
+    )
+
+    async def fire_announce_soon():
+        await asyncio.sleep(0.02)
+        dev.zdo.listener_event("device_announce", dev)
+
+    asyncio.create_task(fire_announce_soon())  # noqa: RUF006
+
+    result = await dev.update_firmware(MagicMock(), progress_callback=MagicMock())
+
+    assert result == foundation.Status.SUCCESS
+    assert "Post-OTA image_notify failed" in caplog.text
+
+
 async def test_update_firmware_triggers_reinterview(monkeypatch, dev):
-    """Test that successful OTA triggers reinterview."""
+    """Test that successful OTA triggers reinterview (probe-read confirmation)."""
     ep = dev.add_endpoint(1)
     cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
     ep.add_output_cluster(Ota.cluster_id, cluster)
@@ -2208,9 +2394,12 @@ async def test_update_firmware_triggers_reinterview(monkeypatch, dev):
         "zigpy.device.update_firmware",
         AsyncMock(return_value=foundation.Status.SUCCESS),
     )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
 
     dev.reinterview = AsyncMock()
 
+    # The active probe read succeeds and confirms the new firmware
     with mock_attribute_reads(cluster, {"current_file_version": 0x00000002}):
         result = await dev.update_firmware(
             MagicMock(),

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -396,6 +396,162 @@ async def test_ota_handle_query_next_image(ota_cluster):
     assert image_events[0].query_cmd is cmd
 
 
+def _make_qni_cmd(version: int) -> Ota.QueryNextImageCommand:
+    """Build a real QueryNextImageCommand with the given current_file_version."""
+    return Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=version,
+    )
+
+
+@pytest.fixture
+def ota_cluster_for_reinterview(ota_cluster):
+    """ota_cluster fixture with reinterview-relevant defaults set up."""
+    dev = ota_cluster.endpoint.device
+    dev.ota_in_progress = False
+    dev._reinterview_in_progress = False
+    dev.reinterview = AsyncMock()
+    ota_cluster.query_next_image_response = AsyncMock()
+
+    # Stub OTA image lookup so the handler doesn't try to fetch images
+    dev.application.ota.check_cluster_for_ota = AsyncMock()
+
+    return ota_cluster
+
+
+async def test_qni_reinterview_on_version_change(ota_cluster_for_reinterview):
+    """A new current_file_version triggers a scheduled re-interview."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    # First observation: should NOT trigger reinterview (no prior baseline)
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+    await asyncio.sleep(0)
+    assert dev.reinterview.call_count == 0
+
+    # Second observation with a different version: SHOULD trigger reinterview
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
+    await asyncio.sleep(0)
+    assert dev.reinterview.call_count == 1
+
+
+async def test_qni_no_reinterview_when_version_unchanged(ota_cluster_for_reinterview):
+    """Same version reported twice does not trigger a re-interview."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+    await asyncio.sleep(0)
+
+    assert dev.reinterview.call_count == 0
+
+
+async def test_qni_no_reinterview_for_coordinator(ota_cluster_for_reinterview):
+    """The active coordinator is never re-interviewed via this path."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    # Make this device the active coordinator
+    dev.application.state.node_info.ieee = dev.ieee
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
+    await asyncio.sleep(0)
+
+    assert dev.reinterview.call_count == 0
+
+
+async def test_qni_no_reinterview_during_ota(ota_cluster_for_reinterview):
+    """A version change during an in-progress OTA defers to update_firmware()."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+
+    # An OTA is now running for this device
+    dev.ota_in_progress = True
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
+    await asyncio.sleep(0)
+
+    assert dev.reinterview.call_count == 0
+
+
+async def test_qni_no_reinterview_when_already_reinterviewing(
+    ota_cluster_for_reinterview,
+):
+    """Skip if a re-interview is already running for this device."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+
+    dev._reinterview_in_progress = True
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
+    await asyncio.sleep(0)
+
+    assert dev.reinterview.call_count == 0
+
+
+async def test_qni_reinterview_is_scheduled_not_awaited(ota_cluster_for_reinterview):
+    """Reinterview must be scheduled as a task so it doesn't block the receive path."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    # Make reinterview hang forever — if the handler awaits it inline,
+    # _handle_query_next_image will never return.
+    blocker = asyncio.Event()
+
+    async def hanging_reinterview():
+        await blocker.wait()
+
+    dev.reinterview = AsyncMock(side_effect=hanging_reinterview)
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    # First, establish a baseline version
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+
+    # Second, with a changed version. Must complete promptly even while the
+    # reinterview task is hanging.
+    await asyncio.wait_for(
+        ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002)),
+        timeout=1.0,
+    )
+
+    # Let the scheduled task start and hit the blocker
+    await asyncio.sleep(0)
+    assert dev.reinterview.call_count == 1
+
+    # Release the hanging reinterview so verify_cleanup doesn't see a lingering task
+    blocker.set()
+    await asyncio.sleep(0)
+
+
 async def test_ota_handle_image_block_req(ota_cluster):
     dev = ota_cluster.endpoint.device
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -1098,7 +1098,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
           that reboot without sending any traffic of their own).
         - A new `QueryNextImageCommand` whose `current_file_version` differs
           from the value cached on the OTA cluster before this wait began.
-        - A `Device_annce` from this device.
+        - A `device_joined` event for this device on the Application (fires
+          on TC-join and on the Device_annce path when the device's NWK
+          changes or it was unknown).
+
+        Listeners are attached only at the start of this wait and torn down
+        on resolution, timeout, or cancellation, so unrelated joins from
+        before the OTA do not get counted.
         """
         snapshot = (
             ota.last_query_cmd.current_file_version
@@ -1107,6 +1113,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         )
 
         confirmed = asyncio.Event()
+        device_ieee = self.ieee
 
         def on_qni_update(event: OtaQueryCacheUpdatedEvent) -> None:
             if (
@@ -1117,12 +1124,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         unsub_qni = ota.on_event(OtaQueryCacheUpdatedEvent.event_type, on_qni_update)
 
-        class _DeviceAnnounceListener:
-            def device_announce(self, _device: Device) -> None:
-                confirmed.set()
+        class _PostOtaJoinListener:
+            def device_joined(self, joined_dev: Device) -> None:
+                if joined_dev.ieee == device_ieee:
+                    confirmed.set()
 
-        annce_listener = _DeviceAnnounceListener()
-        self.zdo.add_listener(annce_listener)
+        join_listener = _PostOtaJoinListener()
+        self._application.add_listener(join_listener)
 
         async def probe_version() -> None:
             # Actively poll the firmware version: sleepy devices won't answer,
@@ -1161,7 +1169,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             with contextlib.suppress(asyncio.CancelledError):
                 await probe_task
             unsub_qni()
-            self.zdo.remove_listener(annce_listener)
+            self._application.remove_listener(join_listener)
 
     def get_last_ota_query_cmd(self) -> QueryNextImageCommand | None:
         """Return the last cached QueryNextImageCommand, preferring client clusters."""

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -37,7 +37,7 @@ from zigpy.ota.manager import update_firmware
 from zigpy.profiles import zha, zll
 import zigpy.types as t
 import zigpy.util
-from zigpy.zcl import Cluster, ClusterType, OtaQueryCacheClearedEvent, foundation
+from zigpy.zcl import Cluster, ClusterType, OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import Ota, PollControl, QueryNextImageCommand
 import zigpy.zdo.types as zdo_t
 
@@ -57,6 +57,8 @@ DEFAULT_REQUEST_RETRIES = 2
 DEFAULT_REQUEST_RETRY_DELAY = 0.1
 
 AFTER_OTA_ATTR_READ_DELAY = 10
+POST_OTA_PROBE_ATTEMPTS = 10
+POST_OTA_CONFIRMATION_TIMEOUT = 300
 
 
 @dataclass(frozen=True, slots=True)
@@ -1037,28 +1039,37 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         if result != foundation.Status.SUCCESS:
             return result
 
-        # Clear the current file version when the update succeeds
         ota = self.find_cluster(
             cluster_id=Ota.cluster_id, cluster_type=ClusterType.Client
         )
-        ota.update_attribute(Ota.AttributeDefs.current_file_version.id, None)
-        ota.last_query_cmd = None
-        ota.emit(
-            OtaQueryCacheClearedEvent.event_type,
-            OtaQueryCacheClearedEvent(
-                device_ieee=str(self.ieee),
-                endpoint_id=ota.endpoint.endpoint_id,
-            ),
-        )
 
+        # Devices need a moment after the final block before they're worth
+        # talking to again.
         await asyncio.sleep(AFTER_OTA_ATTR_READ_DELAY)
-        await ota.read_attributes(
-            [Ota.AttributeDefs.current_file_version.name],
-            retries=10,
-            retry_delay=AFTER_OTA_ATTR_READ_DELAY,
-        )
 
-        # Prompt device to send QueryNextImage with updated version for query cache
+        # Wait for the device to confirm it booted into the new firmware,
+        # whichever signal arrives first:
+        #   - a successful active read of `current_file_version` (a quietly
+        #     rebooted mains device that sends no traffic on its own),
+        #   - QueryNextImage with a `current_file_version` that differs from
+        #     the value we cached pre-flash (the OTA cluster's listener will
+        #     also schedule a re-interview when this happens), or
+        #   - Device_annce after the post-flash reboot.
+        try:
+            await asyncio.wait_for(
+                self._wait_for_post_ota_confirmation(ota),
+                timeout=POST_OTA_CONFIRMATION_TIMEOUT,
+            )
+        except TimeoutError:
+            self.warning(
+                "Device did not confirm new firmware within %ds; reinterview "
+                "will run if/when the device next reports a version change",
+                POST_OTA_CONFIRMATION_TIMEOUT,
+            )
+            return result
+
+        # The device responded. Best-effort: tell it to refresh its OTA query
+        # cache so it learns we don't have a newer image for it right now.
         try:
             await ota.image_notify(
                 payload_type=Ota.ImageNotifyCommand.PayloadType.QueryJitter,
@@ -1067,12 +1078,90 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         except Exception:  # noqa: BLE001
             self.debug("Post-OTA image_notify failed", exc_info=True)
 
-        # Re-interview the device after successful OTA to pick up
-        # any changes in clusters/endpoints/model and re-apply quirks.
+        # Re-interview the device after successful OTA to pick up any changes
+        # in clusters/endpoints/model and re-apply quirks. The OTA cluster's
+        # version-change listener may have already driven a re-interview when a
+        # post-flash QueryNextImage arrived: an in-flight one leaves the shadow
+        # device registered (and the `reinterviewing` guard set), a completed
+        # one has replaced this device in `application.devices` — skip both.
         # reinterview() handles its own errors internally.
-        await self.reinterview()
+        if self._application.devices.get(self.ieee, self) is self:
+            await self.reinterview()
 
         return result
+
+    async def _wait_for_post_ota_confirmation(self, ota: Ota) -> None:
+        """Wait until the device confirms a successful boot into new firmware.
+
+        Resolves on whichever signal arrives first:
+        - A successful active read of `current_file_version` (probes devices
+          that reboot without sending any traffic of their own).
+        - A new `QueryNextImageCommand` whose `current_file_version` differs
+          from the value cached on the OTA cluster before this wait began.
+        - A `Device_annce` from this device.
+        """
+        snapshot = (
+            ota.last_query_cmd.current_file_version
+            if ota.last_query_cmd is not None
+            else None
+        )
+
+        confirmed = asyncio.Event()
+
+        def on_qni_update(event: OtaQueryCacheUpdatedEvent) -> None:
+            if (
+                event.current_file_version is not None
+                and event.current_file_version != snapshot
+            ):
+                confirmed.set()
+
+        unsub_qni = ota.on_event(OtaQueryCacheUpdatedEvent.event_type, on_qni_update)
+
+        class _DeviceAnnounceListener:
+            def device_announce(self, _device: Device) -> None:
+                confirmed.set()
+
+        annce_listener = _DeviceAnnounceListener()
+        self.zdo.add_listener(annce_listener)
+
+        async def probe_version() -> None:
+            # Actively poll the firmware version: sleepy devices won't answer,
+            # but a rebooted-and-quiet mains device will. Any response means
+            # the device survived the flash (and a read also refreshes the
+            # attribute cache with the running version).
+            try:
+                await ota.read_attributes(
+                    [Ota.AttributeDefs.current_file_version.name],
+                    retries=POST_OTA_PROBE_ATTEMPTS,
+                    retry_delay=AFTER_OTA_ATTR_READ_DELAY,
+                )
+            except Exception:  # noqa: BLE001
+                self.debug("Post-OTA firmware version probe went unanswered")
+                return
+
+            confirmed.set()
+
+        probe_task = asyncio.ensure_future(probe_version())
+
+        try:
+            # Race-safe re-check after attaching listeners: if a confirming
+            # QueryNextImage arrived between snapshot and listener attach,
+            # `last_query_cmd` will already reflect the new version.
+            current = (
+                ota.last_query_cmd.current_file_version
+                if ota.last_query_cmd is not None
+                else None
+            )
+            if current is not None and current != snapshot:
+                return
+
+            await confirmed.wait()
+        finally:
+            probe_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await probe_task
+            unsub_qni()
+            self.zdo.remove_listener(annce_listener)
 
     def get_last_ota_query_cmd(self) -> QueryNextImageCommand | None:
         """Return the last cached QueryNextImageCommand, preferring client clusters."""

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -57,7 +57,7 @@ DEFAULT_REQUEST_RETRIES = 2
 DEFAULT_REQUEST_RETRY_DELAY = 0.1
 
 AFTER_OTA_ATTR_READ_DELAY = 10
-POST_OTA_PROBE_ATTEMPTS = 10
+POST_OTA_PROBE_RETRIES = 10
 POST_OTA_CONFIRMATION_TIMEOUT = 300
 
 
@@ -1098,6 +1098,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
           that reboot without sending any traffic of their own).
         - A new `QueryNextImageCommand` whose `current_file_version` differs
           from the value cached on the OTA cluster before this wait began.
+          When no baseline was cached, any query counts: the device is alive
+          and talking after the flash, which is all this wait establishes.
         - A `device_joined` event for this device on the Application (fires
           on TC-join and on the Device_annce path when the device's NWK
           changes or it was unknown).
@@ -1140,7 +1142,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             try:
                 await ota.read_attributes(
                     [Ota.AttributeDefs.current_file_version.name],
-                    retries=POST_OTA_PROBE_ATTEMPTS,
+                    retries=POST_OTA_PROBE_RETRIES,
                     retry_delay=AFTER_OTA_ATTR_READ_DELAY,
                 )
             except Exception:  # noqa: BLE001
@@ -1149,7 +1151,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
             confirmed.set()
 
-        probe_task = asyncio.ensure_future(probe_version())
+        probe_task = asyncio.create_task(probe_version())
 
         try:
             # Race-safe re-check after attaching listeners: if a confirming

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2159,6 +2159,8 @@ class Ota(Cluster):
             )
 
     async def _handle_query_next_image(self, hdr, cmd):
+        old_query_cmd = self.last_query_cmd
+
         # Cache the query command fields for proactive OTA lookups
         self.last_query_cmd = cmd
         self.emit(
@@ -2175,12 +2177,64 @@ class Ota(Cluster):
             ),
         )
 
+        self._maybe_schedule_post_ota_reinterview(
+            old_version=(
+                old_query_cmd.current_file_version
+                if old_query_cmd is not None
+                else None
+            ),
+            new_version=cmd.current_file_version,
+        )
+
         # Always send no image available response so that the device stops asking
         await self.query_next_image_response(
             foundation.Status.NO_IMAGE_AVAILABLE, tsn=hdr.tsn
         )
 
         await self.endpoint.device.application.ota.check_cluster_for_ota(self)
+
+    def _maybe_schedule_post_ota_reinterview(
+        self,
+        old_version: int | None,
+        new_version: int | None,
+    ) -> None:
+        """Schedule a reinterview if the device reports a new running firmware.
+
+        A QueryNextImage with a `current_file_version` different from the value
+        we previously cached for this device is a strong signal that the device
+        rebooted into new firmware (e.g. after an OTA, including OTAs done
+        outside of `update_firmware()`). Re-interviewing rebuilds endpoints,
+        clusters, and quirks to match the new firmware.
+
+        Skipped when the previous value is unknown (first observation), when
+        the value is unchanged, when an OTA is in progress (the OTA flow drives
+        its own reinterview), when a reinterview is already running, or for
+        the active coordinator.
+        """
+        if old_version is None or new_version is None:
+            return
+        if old_version == new_version:
+            return
+
+        device = self.endpoint.device
+        app = device.application
+
+        if device.ieee == app.state.node_info.ieee:
+            return
+        if device.ota_in_progress:
+            return
+        if device.reinterviewing:
+            return
+
+        device.info(
+            "Firmware version changed (0x%08X -> 0x%08X), scheduling re-interview",
+            old_version,
+            new_version,
+        )
+        app.create_task(
+            device.reinterview(),
+            name=f"reinterview_after_fw_change-{device.ieee}",
+        )
 
     async def _handle_image_block_req(self, hdr, cmd):
         # Abort any running firmware update (i.e. the integration is reloaded midway)


### PR DESCRIPTION
**DRAFT / EXPERIMENTAL.**

> [!NOTE]
> Part of a four-PR series making post-OTA re-interviews reliable for sleepy end devices. Merge order (first to last):
> 1. #1849 — Confirm post-OTA reboot via announce/version-change instead of a fixed retry budget **(this PR)**
> 2. #1850 — Add generic per-device check-in action mechanism
> 3. #1851 — Queue a pending re-interview for a device's next check-in
> 4. #1852 — Persist pending re-interview requests in the application database

Reworks the post-OTA recovery flow in `update_firmware()` so it no longer depends on the device answering a fixed read-attributes retry window. Branch: `tjj/reinterview_ota_announcement`. First of a series ending in queued re-interviews for sleepy devices (`tjj/checkin-actions` → `tjj/reinterview-on-checkin` → `tjj/reinterview-pending-persistence`).

## Problem

After a successful flash, `update_firmware()` read `current_file_version` with a fixed retry budget (#1818 bumped it from ~40 s to ~110 s), then sent `image_notify` and re-interviewed. Devices that reboot slower than the budget — and sleepy end devices that never answer reads at all — threw, skipping both `image_notify` and the re-interview. OTAs done outside of `update_firmware()` (another coordinator, factory pre-staging) never triggered a re-interview at all.

## Changes

- **Stateless version-change fallback.** When a device sends a `QueryNextImageCommand` whose `current_file_version` differs from the previously cached value, `Ota._maybe_schedule_post_ota_reinterview()` schedules a re-interview. This works regardless of how or when the device was flashed and survives restarts of zigpy itself. Guarded: skipped on first observation (no baseline), unchanged version, `ota_in_progress`, an already-running re-interview, and the coordinator.
- **Post-OTA confirmation wait.** The fixed read/notify/reinterview sequence is replaced by a wait (`POST_OTA_CONFIRMATION_TIMEOUT` = 5 min) that resolves on whichever arrives first:
  - a successful **active probe** read of `current_file_version` (kept from the old flow, but now best-effort — exhausted retries no longer abort anything; this covers rebooted mains devices that stay quiet),
  - a **version-changed `QueryNextImage`** (via the `OtaQueryCacheUpdatedEvent` listener, with a race-safe re-check around listener attach),
  - a **`device_joined`** event for this device (the Device_annce path after the post-flash reboot).
- After confirmation: best-effort `image_notify` (so the device re-queries and repopulates the OTA query cache), then a direct re-interview — skipped if the version-change listener already replaced this device with a re-interviewed one (staleness check on `application.devices`).
- On timeout, `update_firmware()` logs a warning and still returns `SUCCESS`; recovery is deferred to the version-change fallback.
- The pre-flash OTA query cache is deliberately **no longer cleared** on success: the cached version is the baseline the version-change comparison needs.

## Notes

- A same-NWK `Device_annce` does not fire `device_joined` (`handle_join` treats it as a non-join); those devices are covered by the probe and the QNI signal — and by the check-in trigger in the follow-up branches.
- New constants: `POST_OTA_PROBE_RETRIES` (10 retries after the initial read, 10 s apart, matching `read_attributes()` semantics), `POST_OTA_CONFIRMATION_TIMEOUT` (300 s).

## Testing

New tests for the version-change fallback (baseline/unchanged/coordinator/during-OTA/already-reinterviewing guards, scheduled-not-awaited) and the confirmation wait (resolves on `device_joined`, on version change, on probe read; ignores other devices and unchanged versions; race-safe pre-attach change; listener cleanup on cancel; timeout still returns `SUCCESS` and skips `image_notify`). Existing OTA tests updated for the new flow. Full suite passes.
