### PR TITLE
Queue a pending re-interview for a device's next check-in

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -719,7 +719,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
                 # post-OTA image_notify.
                 async def fire_announce() -> None:
                     await asyncio.sleep(0.05)
-                    dev.zdo.listener_event("device_announce", dev)
+                    dev.application.listener_event("device_joined", dev)
 
                 asyncio.create_task(fire_announce())  # noqa: RUF006
 
@@ -1087,7 +1087,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
                 # Simulate the device rebooting and announcing itself.
                 async def fire_announce() -> None:
                     await asyncio.sleep(0.05)
-                    dev.zdo.listener_event("device_announce", dev)
+                    dev.application.listener_event("device_joined", dev)
 
                 asyncio.create_task(fire_announce())  # noqa: RUF006
 
@@ -2154,16 +2154,36 @@ async def ota_dev(dev):
     return dev, cluster
 
 
-async def test_post_ota_confirmation_resolves_on_device_announce(ota_dev):
-    """A Device_annce on the device's ZDO resolves the wait."""
+async def test_post_ota_confirmation_resolves_on_device_joined(ota_dev):
+    """A `device_joined` event for this device resolves the wait."""
     dev, cluster = ota_dev
 
     wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
     # Give the wait function a chance to attach its listeners
     await asyncio.sleep(0)
 
-    dev.zdo.listener_event("device_announce", dev)
+    dev.application.listener_event("device_joined", dev)
     await asyncio.wait_for(wait_task, timeout=1.0)
+
+
+async def test_post_ota_confirmation_ignores_other_devices_joining(ota_dev):
+    """A `device_joined` event for a DIFFERENT device must NOT resolve the wait."""
+    dev, cluster = ota_dev
+
+    other = MagicMock()
+    other.ieee = t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11")
+    assert other.ieee != dev.ieee
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    await asyncio.sleep(0)
+
+    dev.application.listener_event("device_joined", other)
+    await asyncio.sleep(0)
+    assert not wait_task.done()
+
+    wait_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await wait_task
 
 
 async def test_post_ota_confirmation_resolves_on_version_change(ota_dev):
@@ -2259,7 +2279,7 @@ async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
     qni_listeners_before = len(
         cluster._event_listeners.get("ota_query_cache_updated", [])
     )
-    zdo_listeners_before = len(dev.zdo._listeners)
+    app_listeners_before = len(dev.application._listeners)
 
     wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
     await asyncio.sleep(0)
@@ -2268,7 +2288,7 @@ async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
         len(cluster._event_listeners.get("ota_query_cache_updated", []))
         == qni_listeners_before + 1
     )
-    assert len(dev.zdo._listeners) == zdo_listeners_before + 1
+    assert len(dev.application._listeners) == app_listeners_before + 1
 
     wait_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
@@ -2279,7 +2299,7 @@ async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
         len(cluster._event_listeners.get("ota_query_cache_updated", []))
         == qni_listeners_before
     )
-    assert len(dev.zdo._listeners) == zdo_listeners_before
+    assert len(dev.application._listeners) == app_listeners_before
 
 
 async def test_update_firmware_post_ota_timeout(monkeypatch, dev, caplog):
@@ -2324,7 +2344,7 @@ async def test_update_firmware_post_ota_sends_image_notify_after_confirmation(
 
     async def fire_announce_soon():
         await asyncio.sleep(0.02)
-        dev.zdo.listener_event("device_announce", dev)
+        dev.application.listener_event("device_joined", dev)
 
     asyncio.create_task(fire_announce_soon())  # noqa: RUF006
 
@@ -2355,7 +2375,7 @@ async def test_update_firmware_post_ota_image_notify_failure_is_swallowed(
 
     async def fire_announce_soon():
         await asyncio.sleep(0.02)
-        dev.zdo.listener_event("device_announce", dev)
+        dev.application.listener_event("device_joined", dev)
 
     asyncio.create_task(fire_announce_soon())  # noqa: RUF006
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,6 +4,7 @@ from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 import logging
 import math
+import time
 from unittest.mock import call
 
 import pytest
@@ -1642,6 +1643,218 @@ async def test_fast_poll_mode_cancel_old_timer(dev: device.Device) -> None:
     # It would have happened by now
     await asyncio.sleep(0.3)
     assert dev._fast_polling
+
+
+def make_wake_packet(dev, tsn: int = 0x12) -> t.ZigbeePacket:
+    """Build a minimal inbound packet signalling that the device is awake."""
+    return t.ZigbeePacket(
+        profile_id=260,
+        cluster_id=Basic.cluster_id,
+        src_ep=1,
+        dst_ep=1,
+        data=t.SerializableBytes(
+            foundation.ZCLHeader(
+                frame_control=foundation.FrameControl(
+                    frame_type=foundation.FrameType.GLOBAL_COMMAND,
+                    is_manufacturer_specific=False,
+                    direction=foundation.Direction.Server_to_Client,
+                    disable_default_response=True,
+                    reserved=0,
+                ),
+                tsn=tsn,
+                command_id=foundation.GeneralCommand.Default_Response,
+                manufacturer=None,
+            ).serialize()
+            + (
+                foundation.GENERAL_COMMANDS[foundation.GeneralCommand.Default_Response]
+                .schema(
+                    command_id=Basic.ServerCommandDefs.reset_fact_default.id,
+                    status=foundation.Status.SUCCESS,
+                )
+                .serialize()
+            )
+        ),
+        src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+    )
+
+
+async def test_checkin_action_runs_and_unregisters(dev: device.Device) -> None:
+    """A completed (True) check-in action runs once and is unregistered."""
+    action = AsyncMock(return_value=True)
+    dev.register_checkin_action("test", action)
+    assert dev.has_pending_checkin_actions
+
+    dev.packet_received(make_wake_packet(dev))
+    await asyncio.sleep(0)
+
+    action.assert_awaited_once()
+    assert not dev.has_pending_checkin_actions
+
+    # Further packets do not run it again
+    dev.packet_received(make_wake_packet(dev, tsn=0x13))
+    await asyncio.sleep(0)
+    action.assert_awaited_once()
+
+
+async def test_checkin_action_cooldown(dev: device.Device) -> None:
+    """An incomplete (False) action is retried, but not within its cooldown."""
+    action = AsyncMock(return_value=False)
+    dev.register_checkin_action("test", action, cooldown=60)
+
+    dev.packet_received(make_wake_packet(dev))
+    await asyncio.sleep(0)
+    action.assert_awaited_once()
+    assert dev.has_pending_checkin_actions
+
+    # A packet within the cooldown does not retrigger the action
+    dev.packet_received(make_wake_packet(dev, tsn=0x13))
+    await asyncio.sleep(0)
+    action.assert_awaited_once()
+
+    # After the cooldown expires, the action is retried
+    dev._checkin_actions["test"].last_attempt -= 61
+    dev.packet_received(make_wake_packet(dev, tsn=0x14))
+    await asyncio.sleep(0)
+    assert action.await_count == 2
+
+
+async def test_checkin_action_exception_keeps_registered(
+    dev: device.Device, caplog
+) -> None:
+    """A raising action is logged and stays registered."""
+    action = AsyncMock(side_effect=RuntimeError("Oops"))
+    dev.register_checkin_action("test", action, cooldown=0)
+
+    dev.packet_received(make_wake_packet(dev))
+    await asyncio.sleep(0)
+
+    action.assert_awaited_once()
+    assert "Check-in action 'test' failed" in caplog.text
+    assert dev.has_pending_checkin_actions
+
+    # It is retried on a later check-in
+    dev.packet_received(make_wake_packet(dev, tsn=0x13))
+    await asyncio.sleep(0)
+    assert action.await_count == 2
+
+
+async def test_checkin_action_not_retriggered_while_running(
+    dev: device.Device,
+) -> None:
+    """An in-flight action is not started a second time by its own traffic."""
+    started = 0
+    finish = asyncio.Event()
+
+    async def action() -> bool:
+        nonlocal started
+        started += 1
+        await finish.wait()
+        return True
+
+    dev.register_checkin_action("test", action, cooldown=0)
+
+    dev.packet_received(make_wake_packet(dev))
+    await asyncio.sleep(0)
+    assert started == 1
+
+    # Traffic while the action is running (e.g. its own responses) is ignored
+    dev.packet_received(make_wake_packet(dev, tsn=0x13))
+    await asyncio.sleep(0)
+    assert started == 1
+
+    finish.set()
+    await asyncio.sleep(0)
+    assert not dev.has_pending_checkin_actions
+
+
+async def test_checkin_action_duplicate_packet_still_triggers(
+    dev: device.Device,
+) -> None:
+    """A duplicate (debounced) packet is still a wake signal."""
+    action = AsyncMock(return_value=False)
+    dev.register_checkin_action("test", action, cooldown=0)
+
+    packet = make_wake_packet(dev)
+    dev.packet_received(packet)
+    await asyncio.sleep(0)
+    dev.packet_received(packet)  # filtered by the debouncer
+    await asyncio.sleep(0)
+
+    assert action.await_count == 2
+
+
+async def test_checkin_action_cleared_on_remove(dev: device.Device) -> None:
+    """Removing the device clears its pending check-in actions."""
+    dev.register_checkin_action("test", AsyncMock(return_value=True))
+    assert dev.has_pending_checkin_actions
+
+    dev.on_remove()
+    assert not dev.has_pending_checkin_actions
+
+
+async def test_checkin_action_remove_is_idempotent(dev: device.Device) -> None:
+    """Removing a missing action is a no-op."""
+    dev.remove_checkin_action("missing")
+
+    dev.register_checkin_action("test", AsyncMock(return_value=True))
+    dev.remove_checkin_action("test")
+    assert not dev.has_pending_checkin_actions
+
+
+async def test_checkin_action_triggered_by_handle_join(app) -> None:
+    """A stack-reported join/announce triggers pending check-in actions."""
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
+    dev.node_desc = make_node_desc()
+
+    action = AsyncMock(return_value=True)
+    dev.register_checkin_action("test", action)
+
+    app.handle_join(nwk=dev.nwk, ieee=dev.ieee, parent_nwk=0x0000)
+    await asyncio.sleep(0)
+
+    action.assert_awaited_once()
+    assert not dev.has_pending_checkin_actions
+
+
+async def test_poll_control_checkin_fast_polls_with_pending_actions(
+    dev: device.Device,
+) -> None:
+    """A Poll Control check-in starts fast polling when actions are pending."""
+    ep = dev.add_endpoint(1)
+    poll_control = ep.add_input_cluster(PollControl.cluster_id)
+    poll_control.checkin_response = AsyncMock()
+
+    # Prevent the action from running (and completing) via the trigger, so the
+    # response decision is made while the action is still pending
+    dev.register_checkin_action("test", AsyncMock(return_value=True), cooldown=0)
+    dev._checkin_actions["test"].last_attempt = time.monotonic()
+    dev._checkin_actions["test"].cooldown = 60
+
+    zcl_hdr = foundation.ZCLHeader(
+        frame_control=foundation.FrameControl(
+            frame_type=foundation.FrameType.CLUSTER_COMMAND,
+            is_manufacturer_specific=False,
+            direction=foundation.Direction.Server_to_Client,
+            disable_default_response=1,
+            reserved=0,
+        ),
+        tsn=0x12,
+        command_id=PollControl.ClientCommandDefs.checkin.id,
+    )
+    command = PollControl.ClientCommandDefs.checkin.schema()
+
+    await dev.poll_control_checkin_callback(zcl_hdr, command)
+
+    assert poll_control.checkin_response.mock_calls == [
+        call(
+            start_fast_polling=True,
+            fast_poll_timeout=int(device.DEFAULT_FAST_POLL_TIMEOUT * 4),
+            tsn=0x12,
+            expect_reply=False,
+            disable_default_response=True,
+        )
+    ]
 
     # The second one resets it
     await asyncio.sleep(0.3)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1768,6 +1768,33 @@ async def test_checkin_action_not_retriggered_while_running(
     assert not dev.has_pending_checkin_actions
 
 
+async def test_checkin_action_reregistered_while_running(
+    dev: device.Device,
+) -> None:
+    """Re-registering an in-flight action must not orphan its completion."""
+    finish = asyncio.Event()
+
+    async def action() -> bool:
+        await finish.wait()
+        return True
+
+    dev.register_checkin_action("test", action, cooldown=0)
+
+    dev.packet_received(make_wake_packet(dev))
+    await asyncio.sleep(0)
+
+    # Re-register while the first attempt is still running: the entry must be
+    # updated in place so the running attempt can still unregister on success
+    replacement = AsyncMock(return_value=True)
+    dev.register_checkin_action("test", replacement, cooldown=30)
+
+    finish.set()
+    await asyncio.sleep(0)
+
+    assert not dev.has_pending_checkin_actions
+    replacement.assert_not_called()
+
+
 async def test_checkin_action_duplicate_packet_still_triggers(
     dev: device.Device,
 ) -> None:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2348,6 +2348,17 @@ async def test_schedule_reinterview_on_checkin(dev: device.Device) -> None:
     listener.device_reinterview_pending_updated.assert_called_with(None)
 
 
+async def test_reinterview_pending_accepts_timestamps(dev: device.Device) -> None:
+    """The setter accepts numeric timestamps, as restored from the database."""
+    timestamp = datetime(2026, 7, 3, tzinfo=UTC).timestamp()
+
+    dev.reinterview_pending = timestamp
+
+    assert dev.reinterview_pending == timestamp
+    assert dev._reinterview_pending == datetime.fromtimestamp(timestamp, UTC)
+    assert device.REINTERVIEW_CHECKIN_ACTION in dev._checkin_actions
+
+
 async def test_schedule_reinterview_on_checkin_coordinator(app) -> None:
     """The coordinator itself is never queued for a re-interview."""
     coordinator = app.add_device(nwk=0x0000, ieee=NCP_IEEE)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2302,6 +2302,30 @@ async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
     assert len(dev.application._listeners) == app_listeners_before
 
 
+async def test_post_ota_confirmation_unanswered_probe_is_swallowed(ota_dev, caplog):
+    """A probe read that fails outright neither confirms nor raises."""
+    dev, cluster = ota_dev
+
+    cluster.read_attributes = AsyncMock(
+        side_effect=zigpy.exceptions.DeliveryError("Device asleep")
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    # The probe failed, but the wait keeps waiting for the passive signals
+    cluster.read_attributes.assert_awaited_once()
+    assert "probe went unanswered" in caplog.text
+    assert not wait_task.done()
+
+    # Cleanup
+    wait_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await wait_task
+
+
 async def test_update_firmware_post_ota_timeout(monkeypatch, dev, caplog):
     """If neither confirmation signal arrives, timeout but still return SUCCESS."""
     ep = dev.add_endpoint(1)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 import logging
@@ -18,7 +19,7 @@ from zigpy.profiles import zha
 import zigpy.state
 import zigpy.types as t
 import zigpy.util
-from zigpy.zcl import ClusterType, OtaQueryCacheClearedEvent, foundation
+from zigpy.zcl import ClusterType, OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PollControl
 from zigpy.zdo import types as zdo_t
 
@@ -523,6 +524,7 @@ async def test_update_device_firmware_already_in_progress(dev, caplog):
 
 @patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
 @patch("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0.01)
+@patch("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
 async def test_update_device_firmware(monkeypatch, dev, caplog):
     """Test that device firmware updates execute the expected calls."""
     ep = dev.add_endpoint(1)
@@ -711,81 +713,30 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
                 assert cmd.file_version == active_fw_image.firmware.header.file_version
                 assert cmd.current_time == 0
                 assert cmd.upgrade_time == 0
-            elif isinstance(
-                cmd,
-                foundation.GENERAL_COMMANDS[
-                    foundation.GeneralCommand.Read_Attributes
-                ].schema,
-            ):
-                assert cmd.attribute_ids == [Ota.AttributeDefs.current_file_version.id]
 
-                req_hdr, req_cmd = cluster._create_request(
-                    general=True,
-                    command_id=foundation.GeneralCommand.Read_Attributes_rsp,
-                    schema=foundation.GENERAL_COMMANDS[
-                        foundation.GeneralCommand.Read_Attributes_rsp
-                    ].schema,
-                    tsn=hdr.tsn,
-                    disable_default_response=True,
-                    direction=foundation.Direction.Client_to_Server,
-                    args=(),
-                    kwargs={
-                        "status_records": [
-                            foundation.ReadAttributeRecord(
-                                attrid=Ota.AttributeDefs.current_file_version.id,
-                                status=foundation.Status.SUCCESS,
-                                value=foundation.TypeValue(
-                                    type=foundation.DataTypeId.uint32,
-                                    value=active_fw_image.firmware.header.file_version,
-                                ),
-                            )
-                        ]
-                    },
-                )
+                # Simulate the device rebooting and announcing itself.
+                # update_firmware() waits for this signal before sending the
+                # post-OTA image_notify.
+                async def fire_announce() -> None:
+                    await asyncio.sleep(0.05)
+                    dev.zdo.listener_event("device_announce", dev)
 
-                dev.application.packet_received(
-                    t.ZigbeePacket(
-                        src=t.AddrModeAddress(
-                            addr_mode=t.AddrMode.NWK, address=dev.nwk
-                        ),
-                        src_ep=1,
-                        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
-                        dst_ep=1,
-                        tsn=hdr.tsn,
-                        profile_id=260,
-                        cluster_id=cluster.cluster_id,
-                        data=t.SerializableBytes(
-                            req_hdr.serialize() + req_cmd.serialize()
-                        ),
-                        lqi=255,
-                        rssi=-30,
-                    )
-                )
+                asyncio.create_task(fire_announce())  # noqa: RUF006
 
     dev.application.send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
 
-    cleared_events = []
-    cluster.on_event(OtaQueryCacheClearedEvent.event_type, cleared_events.append)
-
     result = await dev.update_firmware(fw_image, progress_callback)
-    assert (
-        dev.endpoints[1]
-        .out_clusters[Ota.cluster_id]
-        ._attr_cache[Ota.AttributeDefs.current_file_version.id]
-        == 0x12345678
-    )
 
     # Wait for background tasks (post-OTA query_next_image handling)
     await asyncio.sleep(0)
-    # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
+    # 5 OTA + 1 probe read + 1 post-OTA image_notify + 1 post-OTA
+    # query_next_image_response
     assert dev.application.send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(40, 70, 57.142857142857146)
     assert progress_callback.call_args_list[1] == call(70, 70, 100.0)
     assert result == foundation.Status.SUCCESS
-    assert len(cleared_events) == 1
-    assert isinstance(cleared_events[0], OtaQueryCacheClearedEvent)
     # Post-OTA image_notify repopulated the query cache
     assert cluster.last_query_cmd is not None
 
@@ -796,7 +747,8 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     )
 
     await asyncio.sleep(0)
-    # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
+    # 5 OTA + 1 probe read + 1 post-OTA image_notify + 1 post-OTA
+    # query_next_image_response
     assert dev.application.send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(40, 70, 57.142857142857146)
@@ -943,6 +895,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
 
 @patch("zigpy.ota.manager.MAX_TIME_WITHOUT_PROGRESS", 0.1)
 @patch("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0.01)
+@patch("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
 async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     """Legrand device (manufacturer_code == 4129) firmware update expects the "image_block" command "maximum_data_size" to be complied with."""
     ep = dev.add_endpoint(1)
@@ -1130,70 +1083,22 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
                 assert cmd.file_version == active_fw_image.firmware.header.file_version
                 assert cmd.current_time == 0
                 assert cmd.upgrade_time == 0
-            elif isinstance(
-                cmd,
-                foundation.GENERAL_COMMANDS[
-                    foundation.GeneralCommand.Read_Attributes
-                ].schema,
-            ):
-                assert cmd.attribute_ids == [Ota.AttributeDefs.current_file_version.id]
 
-                req_hdr, req_cmd = cluster._create_request(
-                    general=True,
-                    command_id=foundation.GeneralCommand.Read_Attributes_rsp,
-                    schema=foundation.GENERAL_COMMANDS[
-                        foundation.GeneralCommand.Read_Attributes_rsp
-                    ].schema,
-                    tsn=hdr.tsn,
-                    disable_default_response=True,
-                    direction=foundation.Direction.Client_to_Server,
-                    args=(),
-                    kwargs={
-                        "status_records": [
-                            foundation.ReadAttributeRecord(
-                                attrid=Ota.AttributeDefs.current_file_version.id,
-                                status=foundation.Status.SUCCESS,
-                                value=foundation.TypeValue(
-                                    type=foundation.DataTypeId.uint32,
-                                    value=active_fw_image.firmware.header.file_version,
-                                ),
-                            )
-                        ]
-                    },
-                )
+                # Simulate the device rebooting and announcing itself.
+                async def fire_announce() -> None:
+                    await asyncio.sleep(0.05)
+                    dev.zdo.listener_event("device_announce", dev)
 
-                dev.application.packet_received(
-                    t.ZigbeePacket(
-                        src=t.AddrModeAddress(
-                            addr_mode=t.AddrMode.NWK, address=dev.nwk
-                        ),
-                        src_ep=1,
-                        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
-                        dst_ep=1,
-                        tsn=hdr.tsn,
-                        profile_id=260,
-                        cluster_id=cluster.cluster_id,
-                        data=t.SerializableBytes(
-                            req_hdr.serialize() + req_cmd.serialize()
-                        ),
-                        lqi=255,
-                        rssi=-30,
-                    )
-                )
+                asyncio.create_task(fire_announce())  # noqa: RUF006
 
     dev.application.send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
     result = await dev.update_firmware(fw_image, progress_callback)
-    assert (
-        dev.endpoints[1]
-        .out_clusters[Ota.cluster_id]
-        ._attr_cache[Ota.AttributeDefs.current_file_version.id]
-        == 0x12345678
-    )
 
     # Wait for background tasks (post-OTA query_next_image handling)
     await asyncio.sleep(0)
-    # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
+    # 5 OTA + 1 probe read + 1 post-OTA image_notify + 1 post-OTA
+    # query_next_image_response
     assert dev.application.send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(64, 70, 91.42857142857143)
@@ -1207,7 +1112,8 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     )
 
     await asyncio.sleep(0)
-    # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
+    # 5 OTA + 1 probe read + 1 post-OTA image_notify + 1 post-OTA
+    # query_next_image_response
     assert dev.application.send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(64, 70, 91.42857142857143)
@@ -2179,8 +2085,288 @@ async def test_reinterview_during_ota(dev):
     dev._application._device_reinterviewed.assert_not_called()
 
 
+async def test_update_firmware_no_reinterview_on_confirmation_timeout(monkeypatch, dev):
+    """update_firmware() does not invoke reinterview() when confirmation times
+    out — recovery is deferred to the version-change listener instead.
+    """
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    async def mockrequest(nwk, tries=None, delay=None):
+        return [0, None, [0, 1]]
+
+    async def mockepinit(self, *args, **kwargs):
+        self.status = endpoint.Status.ZDO_INIT
+        self.add_input_cluster(Basic.cluster_id)
+
+    async def mock_ep_get_model_info(self):
+        return "Model", "Manufacturer"
+
+    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
+    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
+    dev.zdo.Active_EP_req = mockrequest
+
+    with mock_attribute_reads(cluster, {"current_file_version": 0x00000001}):
+        await dev.initialize()
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 0.1)
+
+    dev.reinterview = AsyncMock()
+
+    result = await dev.update_firmware(
+        MagicMock(),
+        progress_callback=MagicMock(),
+    )
+
+    assert result == foundation.Status.SUCCESS
+    dev.reinterview.assert_not_called()
+
+
+def _make_post_ota_qni_event(
+    cluster: Ota,
+    current_file_version: int,
+) -> OtaQueryCacheUpdatedEvent:
+    """Build an OtaQueryCacheUpdatedEvent for a cluster with the given version."""
+    return OtaQueryCacheUpdatedEvent(
+        device_ieee=str(cluster.endpoint.device.ieee),
+        endpoint_id=cluster.endpoint.endpoint_id,
+        cluster_type=cluster.cluster_type,
+        cluster_id=cluster.cluster_id,
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=current_file_version,
+        hardware_version=None,
+    )
+
+
+@pytest.fixture
+async def ota_dev(dev):
+    """A device with an OTA out_cluster ready for post-OTA tests."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+    return dev, cluster
+
+
+async def test_post_ota_confirmation_resolves_on_device_announce(ota_dev):
+    """A Device_annce on the device's ZDO resolves the wait."""
+    dev, cluster = ota_dev
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    # Give the wait function a chance to attach its listeners
+    await asyncio.sleep(0)
+
+    dev.zdo.listener_event("device_announce", dev)
+    await asyncio.wait_for(wait_task, timeout=1.0)
+
+
+async def test_post_ota_confirmation_resolves_on_version_change(ota_dev):
+    """A version-change OtaQueryCacheUpdatedEvent resolves the wait."""
+    dev, cluster = ota_dev
+
+    # Establish a baseline so the snapshot is non-None
+    cluster.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=0x00000001,
+    )
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    await asyncio.sleep(0)
+
+    cluster.emit(
+        "ota_query_cache_updated",
+        _make_post_ota_qni_event(cluster, current_file_version=0x00000002),
+    )
+    await asyncio.wait_for(wait_task, timeout=1.0)
+
+
+async def test_post_ota_confirmation_ignores_same_version(ota_dev):
+    """An OtaQueryCacheUpdatedEvent with the same version does NOT resolve."""
+    dev, cluster = ota_dev
+
+    cluster.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=0x00000001,
+    )
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    await asyncio.sleep(0)
+
+    cluster.emit(
+        "ota_query_cache_updated",
+        _make_post_ota_qni_event(cluster, current_file_version=0x00000001),
+    )
+    await asyncio.sleep(0)
+    assert not wait_task.done()
+
+    # Cleanup
+    wait_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await wait_task
+
+
+async def test_post_ota_confirmation_resolves_immediately_on_pre_attach_change(
+    ota_dev,
+):
+    """If the version already changed before the wait started, resolve immediately."""
+    dev, cluster = ota_dev
+
+    cluster.last_query_cmd = Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=0x00000001,
+    )
+
+    # Trigger the version change AFTER snapshot but BEFORE the listeners are
+    # attached: monkey-patch on_event to swap last_query_cmd at attach time.
+    real_on_event = cluster.on_event
+
+    def patched_on_event(event_name, callback, with_context=False):
+        unsub = real_on_event(event_name, callback, with_context=with_context)
+        # Simulate a version change right after listener attach (still before
+        # the wait re-checks the snapshot)
+        cluster.last_query_cmd = Ota.QueryNextImageCommand(
+            field_control=Ota.QueryNextImageCommand.FieldControl(0),
+            manufacturer_code=0x1234,
+            image_type=0x90,
+            current_file_version=0x00000002,
+        )
+        return unsub
+
+    cluster.on_event = patched_on_event
+
+    await asyncio.wait_for(
+        dev._wait_for_post_ota_confirmation(cluster),
+        timeout=1.0,
+    )
+
+
+async def test_post_ota_confirmation_cleans_up_listeners_on_cancel(ota_dev):
+    """Cancellation should remove both listeners."""
+    dev, cluster = ota_dev
+
+    qni_listeners_before = len(
+        cluster._event_listeners.get("ota_query_cache_updated", [])
+    )
+    zdo_listeners_before = len(dev.zdo._listeners)
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    await asyncio.sleep(0)
+    # Listeners are attached
+    assert (
+        len(cluster._event_listeners.get("ota_query_cache_updated", []))
+        == qni_listeners_before + 1
+    )
+    assert len(dev.zdo._listeners) == zdo_listeners_before + 1
+
+    wait_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await wait_task
+
+    # And cleaned up after cancellation
+    assert (
+        len(cluster._event_listeners.get("ota_query_cache_updated", []))
+        == qni_listeners_before
+    )
+    assert len(dev.zdo._listeners) == zdo_listeners_before
+
+
+async def test_update_firmware_post_ota_timeout(monkeypatch, dev, caplog):
+    """If neither confirmation signal arrives, timeout but still return SUCCESS."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 0.05)
+
+    cluster.image_notify = AsyncMock()
+
+    result = await dev.update_firmware(MagicMock(), progress_callback=MagicMock())
+
+    assert result == foundation.Status.SUCCESS
+    assert "Device did not confirm new firmware" in caplog.text
+    # image_notify must NOT be sent on timeout
+    cluster.image_notify.assert_not_called()
+
+
+async def test_update_firmware_post_ota_sends_image_notify_after_confirmation(
+    monkeypatch, dev
+):
+    """After confirmation, update_firmware sends image_notify."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
+
+    cluster.image_notify = AsyncMock()
+
+    async def fire_announce_soon():
+        await asyncio.sleep(0.02)
+        dev.zdo.listener_event("device_announce", dev)
+
+    asyncio.create_task(fire_announce_soon())  # noqa: RUF006
+
+    result = await dev.update_firmware(MagicMock(), progress_callback=MagicMock())
+
+    assert result == foundation.Status.SUCCESS
+    cluster.image_notify.assert_awaited_once()
+
+
+async def test_update_firmware_post_ota_image_notify_failure_is_swallowed(
+    monkeypatch, dev, caplog
+):
+    """A failing post-OTA image_notify still results in a SUCCESS return."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
+
+    cluster.image_notify = AsyncMock(
+        side_effect=zigpy.exceptions.DeliveryError("Device asleep")
+    )
+
+    async def fire_announce_soon():
+        await asyncio.sleep(0.02)
+        dev.zdo.listener_event("device_announce", dev)
+
+    asyncio.create_task(fire_announce_soon())  # noqa: RUF006
+
+    result = await dev.update_firmware(MagicMock(), progress_callback=MagicMock())
+
+    assert result == foundation.Status.SUCCESS
+    assert "Post-OTA image_notify failed" in caplog.text
+
+
 async def test_update_firmware_triggers_reinterview(monkeypatch, dev):
-    """Test that successful OTA triggers reinterview."""
+    """Test that successful OTA triggers reinterview (probe-read confirmation)."""
     ep = dev.add_endpoint(1)
     cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
     ep.add_output_cluster(Ota.cluster_id, cluster)
@@ -2208,9 +2394,12 @@ async def test_update_firmware_triggers_reinterview(monkeypatch, dev):
         "zigpy.device.update_firmware",
         AsyncMock(return_value=foundation.Status.SUCCESS),
     )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 1)
 
     dev.reinterview = AsyncMock()
 
+    # The active probe read succeeds and confirms the new firmware
     with mock_attribute_reads(cluster, {"current_file_version": 0x00000002}):
         result = await dev.update_firmware(
             MagicMock(),

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -9,7 +9,7 @@ from unittest.mock import call
 
 import pytest
 
-from tests.conftest import make_node_desc, mock_attribute_reads
+from tests.conftest import NCP_IEEE, make_node_desc, mock_attribute_reads
 from zigpy import device, endpoint
 import zigpy.application
 from zigpy.datastructures import RequestLimiter
@@ -2325,6 +2325,166 @@ async def test_reinterview_during_ota(dev):
     dev._application._device_reinterviewed.assert_not_called()
 
 
+async def test_schedule_reinterview_on_checkin(dev: device.Device) -> None:
+    """Scheduling sets the pending flag, fires an event, and arms the action."""
+    listener = MagicMock()
+    dev.add_listener(listener)
+
+    assert dev.reinterview_pending is None
+    dev.schedule_reinterview_on_checkin()
+
+    assert dev.reinterview_pending is not None
+    assert device.REINTERVIEW_CHECKIN_ACTION in dev._checkin_actions
+    listener.device_reinterview_pending_updated.assert_called_once()
+
+    # Scheduling again keeps the original request timestamp
+    pending = dev.reinterview_pending
+    dev.schedule_reinterview_on_checkin()
+    assert dev.reinterview_pending == pending
+
+    # Clearing the flag disarms the check-in action
+    dev.reinterview_pending = None
+    assert not dev.has_pending_checkin_actions
+    listener.device_reinterview_pending_updated.assert_called_with(None)
+
+
+async def test_schedule_reinterview_on_checkin_coordinator(app) -> None:
+    """The coordinator itself is never queued for a re-interview."""
+    coordinator = app.add_device(nwk=0x0000, ieee=NCP_IEEE)
+
+    coordinator.schedule_reinterview_on_checkin()
+
+    assert coordinator.reinterview_pending is None
+    assert not coordinator.has_pending_checkin_actions
+
+
+async def test_reinterview_checkin_action_bails_when_busy(dev: device.Device) -> None:
+    """The re-interview action defers while the device is otherwise busy."""
+    dev.reinterview = AsyncMock()
+
+    dev.ota_in_progress = True
+    assert await dev._reinterview_checkin_action() is False
+    dev.ota_in_progress = False
+
+    dev._reinterview_in_progress = True
+    assert await dev._reinterview_checkin_action() is False
+    dev._reinterview_in_progress = False
+
+    mock_task = MagicMock()
+    mock_task.done.return_value = False
+    dev._initialize_task = mock_task
+    assert await dev._reinterview_checkin_action() is False
+    dev._initialize_task = None
+
+    dev.reinterview.assert_not_called()
+
+
+async def test_reinterview_checkin_action_success_is_the_swap(app) -> None:
+    """The action reports success only when the device object was replaced."""
+    dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
+    dev.node_desc = make_node_desc()
+
+    # A failed re-interview leaves the old device registered: not done yet
+    dev.reinterview = AsyncMock()
+    assert await dev._reinterview_checkin_action() is False
+
+    # A successful one replaces the device object: done
+    def swap() -> None:
+        app.devices[dev.ieee] = MagicMock()
+
+    dev.reinterview = AsyncMock(side_effect=swap)
+    assert await dev._reinterview_checkin_action() is True
+
+
+async def test_reinterview_on_checkin_end_to_end(
+    monkeypatch,
+    app: zigpy.application.ControllerApplication,
+) -> None:
+    """A queued re-interview runs off an inbound packet and clears itself."""
+    ieee = t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11")
+    node_desc = make_node_desc()
+
+    async def mock_get_node_descriptor(self):
+        self.node_desc = node_desc
+        return node_desc
+
+    async def mockrequest(*args, **kwargs):
+        return [0, None, [0, 1]]
+
+    async def mockepinit(self, *args, **kwargs):
+        self.status = endpoint.Status.ZDO_INIT
+        self.add_input_cluster(Basic.cluster_id)
+
+    async def mock_ep_get_model_info(self):
+        return "Model", "Manufacturer"
+
+    monkeypatch.setattr(device.Device, "get_node_descriptor", mock_get_node_descriptor)
+    monkeypatch.setattr(endpoint.Endpoint, "initialize", mockepinit)
+    monkeypatch.setattr(endpoint.Endpoint, "get_model_info", mock_ep_get_model_info)
+
+    dev = app.add_device(ieee=ieee, nwk=t.NWK(0x1234))
+    dev.zdo.Active_EP_req = mockrequest
+    await dev.initialize()
+    old_dev = app.devices[ieee]
+
+    # Patch Device.__init__ so the shadow also gets Active_EP_req mocked
+    original_init = device.Device.__init__
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.zdo.Active_EP_req = mockrequest
+
+    monkeypatch.setattr(device.Device, "__init__", patched_init)
+
+    old_dev.schedule_reinterview_on_checkin()
+    assert old_dev.reinterview_pending is not None
+
+    # The device checks in: any inbound packet triggers the re-interview
+    old_dev.packet_received(make_wake_packet(old_dev))
+
+    async with asyncio.timeout(1):
+        while app.devices[ieee] is old_dev:
+            await asyncio.sleep(0)
+
+    new_dev = app.devices[ieee]
+    assert new_dev.is_initialized
+    assert new_dev.reinterview_pending is None
+    assert not new_dev.has_pending_checkin_actions
+
+
+async def test_update_firmware_queues_reinterview_before_confirmation(
+    monkeypatch, dev, caplog
+):
+    """update_firmware() queues a re-interview even when confirmation times out."""
+    ep = dev.add_endpoint(1)
+    cluster = zigpy.zcl.Cluster.from_id(ep, Ota.cluster_id, is_server=False)
+    ep.add_output_cluster(Ota.cluster_id, cluster)
+
+    monkeypatch.setattr(
+        "zigpy.device.update_firmware",
+        AsyncMock(return_value=foundation.Status.SUCCESS),
+    )
+    monkeypatch.setattr("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0)
+    monkeypatch.setattr("zigpy.device.POST_OTA_CONFIRMATION_TIMEOUT", 0.05)
+
+    result = await dev.update_firmware(MagicMock(), progress_callback=MagicMock())
+
+    assert result == foundation.Status.SUCCESS
+    assert dev.reinterview_pending is not None
+    assert device.REINTERVIEW_CHECKIN_ACTION in dev._checkin_actions
+    assert "re-interview stays queued" in caplog.text
+
+
+async def test_clone_copies_reinterview_pending_silently(dev: device.Device) -> None:
+    """clone() carries the pending flag without arming actions on the clone."""
+    dev.reinterview_pending = datetime(2026, 1, 1, tzinfo=UTC)
+
+    clone = dev.clone()
+
+    assert clone._reinterview_pending == dev._reinterview_pending
+    assert not clone.has_pending_checkin_actions
+
+
 async def test_update_firmware_no_reinterview_on_confirmation_timeout(monkeypatch, dev):
     """update_firmware() does not invoke reinterview() when confirmation times
     out — recovery is deferred to the version-change listener instead.
@@ -2445,6 +2605,17 @@ async def test_post_ota_confirmation_resolves_on_version_change(ota_dev):
         "ota_query_cache_updated",
         _make_post_ota_qni_event(cluster, current_file_version=0x00000002),
     )
+    await asyncio.wait_for(wait_task, timeout=1.0)
+
+
+async def test_post_ota_confirmation_resolves_on_reinterview(ota_dev):
+    """A completed re-interview for this device resolves the wait."""
+    dev, cluster = ota_dev
+
+    wait_task = asyncio.create_task(dev._wait_for_post_ota_confirmation(cluster))
+    await asyncio.sleep(0)
+
+    dev.application.listener_event("device_reinterviewed", dev)
     await asyncio.wait_for(wait_task, timeout=1.0)
 
 

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -396,6 +396,162 @@ async def test_ota_handle_query_next_image(ota_cluster):
     assert image_events[0].query_cmd is cmd
 
 
+def _make_qni_cmd(version: int) -> Ota.QueryNextImageCommand:
+    """Build a real QueryNextImageCommand with the given current_file_version."""
+    return Ota.QueryNextImageCommand(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x1234,
+        image_type=0x90,
+        current_file_version=version,
+    )
+
+
+@pytest.fixture
+def ota_cluster_for_reinterview(ota_cluster):
+    """ota_cluster fixture with reinterview-relevant defaults set up."""
+    dev = ota_cluster.endpoint.device
+    dev.ota_in_progress = False
+    dev._reinterview_in_progress = False
+    dev.reinterview = AsyncMock()
+    ota_cluster.query_next_image_response = AsyncMock()
+
+    # Stub OTA image lookup so the handler doesn't try to fetch images
+    dev.application.ota.check_cluster_for_ota = AsyncMock()
+
+    return ota_cluster
+
+
+async def test_qni_reinterview_on_version_change(ota_cluster_for_reinterview):
+    """A new current_file_version triggers a scheduled re-interview."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    # First observation: should NOT trigger reinterview (no prior baseline)
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+    await asyncio.sleep(0)
+    assert dev.reinterview.call_count == 0
+
+    # Second observation with a different version: SHOULD trigger reinterview
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
+    await asyncio.sleep(0)
+    assert dev.reinterview.call_count == 1
+
+
+async def test_qni_no_reinterview_when_version_unchanged(ota_cluster_for_reinterview):
+    """Same version reported twice does not trigger a re-interview."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+    await asyncio.sleep(0)
+
+    assert dev.reinterview.call_count == 0
+
+
+async def test_qni_no_reinterview_for_coordinator(ota_cluster_for_reinterview):
+    """The active coordinator is never re-interviewed via this path."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    # Make this device the active coordinator
+    dev.application.state.node_info.ieee = dev.ieee
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
+    await asyncio.sleep(0)
+
+    assert dev.reinterview.call_count == 0
+
+
+async def test_qni_no_reinterview_during_ota(ota_cluster_for_reinterview):
+    """A version change during an in-progress OTA defers to update_firmware()."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+
+    # An OTA is now running for this device
+    dev.ota_in_progress = True
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
+    await asyncio.sleep(0)
+
+    assert dev.reinterview.call_count == 0
+
+
+async def test_qni_no_reinterview_when_already_reinterviewing(
+    ota_cluster_for_reinterview,
+):
+    """Skip if a re-interview is already running for this device."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+
+    dev._reinterview_in_progress = True
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
+    await asyncio.sleep(0)
+
+    assert dev.reinterview.call_count == 0
+
+
+async def test_qni_reinterview_is_scheduled_not_awaited(ota_cluster_for_reinterview):
+    """Reinterview must be scheduled as a task so it doesn't block the receive path."""
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    # Make reinterview hang forever — if the handler awaits it inline,
+    # _handle_query_next_image will never return.
+    blocker = asyncio.Event()
+
+    async def hanging_reinterview():
+        await blocker.wait()
+
+    dev.reinterview = AsyncMock(side_effect=hanging_reinterview)
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    # First, establish a baseline version
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+
+    # Second, with a changed version. Must complete promptly even while the
+    # reinterview task is hanging.
+    await asyncio.wait_for(
+        ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002)),
+        timeout=1.0,
+    )
+
+    # Let the scheduled task start and hit the blocker
+    await asyncio.sleep(0)
+    assert dev.reinterview.call_count == 1
+
+    # Release the hanging reinterview so verify_cleanup doesn't see a lingering task
+    blocker.set()
+    await asyncio.sleep(0)
+
+
 async def test_ota_handle_image_block_req(ota_cluster):
     dev = ota_cluster.endpoint.device
 

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from zigpy import device, types, zcl
+import zigpy.device
 import zigpy.endpoint
 from zigpy.ota import OTA, OtaImagesResult
 from zigpy.zcl import OtaImageAvailableEvent, OtaQueryCacheUpdatedEvent, foundation
@@ -439,6 +440,31 @@ async def test_qni_reinterview_on_version_change(ota_cluster_for_reinterview):
     await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
     await asyncio.sleep(0)
     assert dev.reinterview.call_count == 1
+
+
+async def test_qni_version_change_queues_reinterview_for_checkin(
+    ota_cluster_for_reinterview,
+):
+    """A version change also queues a re-interview for the next check-in.
+
+    If the immediate re-interview attempt fails (e.g. a sleepy device going
+    back to sleep), it is retried whenever the device is next heard from.
+    """
+    ota_cluster = ota_cluster_for_reinterview
+    dev = ota_cluster.endpoint.device
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000001))
+    assert dev.reinterview_pending is None
+
+    await ota_cluster._handle_query_next_image(hdr, _make_qni_cmd(0x00000002))
+    await asyncio.sleep(0)
+
+    assert dev.reinterview_pending is not None
+    assert zigpy.device.REINTERVIEW_CHECKIN_ACTION in dev._checkin_actions
 
 
 async def test_qni_no_reinterview_when_version_unchanged(ota_cluster_for_reinterview):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -842,6 +842,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # be updated
         dev.last_seen = datetime.now(UTC)
 
+        # Joins/announces reported by the radio stack without a ZDO packet also
+        # mean the device is awake
+        dev._trigger_checkin_actions()
+
         # Cancel all pending requests for the device
         dev._concurrent_requests_semaphore.cancel_waiting(
             zigpy.exceptions.DeliveryError("Device has re-joined the network")

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -710,6 +710,11 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # (relevant when no quirk is applied and new_device is the shadow itself)
         new_device._reinterview_in_progress = False
 
+        # The re-interview satisfies any pending re-interview request. Clear it
+        # through the setter on the new device: some quirk constructors copy
+        # arbitrary attributes from the device they replace.
+        new_device.reinterview_pending = None
+
         # Restore group memberships on the new device's matching endpoints.
         # A group may have been removed while we were awaiting `_remove_device`,
         # so guard against missing entries rather than aborting the reinterview.

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -60,6 +60,8 @@ AFTER_OTA_ATTR_READ_DELAY = 10
 POST_OTA_PROBE_RETRIES = 10
 POST_OTA_CONFIRMATION_TIMEOUT = 300
 
+CHECKIN_ACTION_RETRY_COOLDOWN = 300
+
 
 @dataclass(frozen=True, slots=True)
 class ResponseKey:
@@ -69,6 +71,17 @@ class ResponseKey:
     cluster_id: int
     direction: foundation.Direction | None
     tsn: int
+
+
+@dataclass
+class _CheckinAction:
+    """A pending action to run when the device is next seen awake."""
+
+    name: str
+    coro_factory: Callable[[], Coroutine[Any, Any, bool]]
+    cooldown: float
+    task: asyncio.Task | None = None
+    last_attempt: float | None = None
 
 
 class Status(enum.IntEnum):
@@ -120,6 +133,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._on_remove_callbacks: list[typing.Callable[[], None]] = []
         self._tasks: set[asyncio.Future[Any]] = set()
 
+        self._checkin_actions: dict[str, _CheckinAction] = {}
+
         self._packet_debouncer = zigpy.datastructures.Debouncer()
         self._concurrent_requests_semaphore = zigpy.datastructures.RequestLimiter(
             max_concurrency=MAX_DEVICE_CONCURRENCY,
@@ -159,6 +174,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             callback()
 
         self._on_remove_callbacks.clear()
+        self._checkin_actions.clear()
 
         for task in self._tasks:
             task.cancel()
@@ -413,6 +429,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             if (
                 self.initializing
                 or self.reinterviewing
+                or self.has_pending_checkin_actions
                 or self._concurrent_requests_semaphore.active_requests > 0
                 or self._fast_polling
             ):
@@ -433,6 +450,82 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     expect_reply=False,
                     disable_default_response=True,
                 )
+
+    def register_checkin_action(
+        self,
+        name: str,
+        coro_factory: Callable[[], Coroutine[Any, Any, bool]],
+        *,
+        cooldown: float = CHECKIN_ACTION_RETRY_COOLDOWN,
+    ) -> None:
+        """Run an action the next time the device shows signs of being awake.
+
+        Sleepy end devices can only receive requests for a short moment after
+        they send something themselves. `coro_factory` is called (and the
+        coroutine awaited) when a packet is received from the device. The
+        coroutine must return `True` when the action is complete, which
+        unregisters it, or `False` to retry on a later check-in, no sooner
+        than `cooldown` seconds after the last attempt started. A raised
+        exception is logged and keeps the action registered, like `False`.
+
+        Registering an action with an existing name replaces its coroutine
+        factory but keeps the running attempt and cooldown state.
+        """
+        existing = self._checkin_actions.get(name)
+        self._checkin_actions[name] = _CheckinAction(
+            name=name,
+            coro_factory=coro_factory,
+            cooldown=cooldown,
+            task=existing.task if existing is not None else None,
+            last_attempt=existing.last_attempt if existing is not None else None,
+        )
+
+    def remove_checkin_action(self, name: str) -> None:
+        """Remove a previously registered check-in action, if present."""
+        self._checkin_actions.pop(name, None)
+
+    @property
+    def has_pending_checkin_actions(self) -> bool:
+        """Return True if any check-in actions are waiting to run."""
+        return bool(self._checkin_actions)
+
+    def _trigger_checkin_actions(self) -> None:
+        """Start all due check-in actions: the device appears to be awake."""
+        now = time.monotonic()
+
+        for action in list(self._checkin_actions.values()):
+            if action.task is not None and not action.task.done():
+                # Already running: ignore traffic caused by the action itself
+                continue
+
+            if (
+                action.last_attempt is not None
+                and now - action.last_attempt < action.cooldown
+            ):
+                continue
+
+            action.last_attempt = now
+            # Run on the application, not the device: device-owned tasks are
+            # cancelled when a re-interview swaps the device object, which
+            # would cancel an action that is itself driving the re-interview.
+            action.task = self._application.create_task(
+                self._run_checkin_action(action),
+                name=f"checkin_action_{action.name}-{self.ieee}",
+            )
+
+    async def _run_checkin_action(self, action: _CheckinAction) -> None:
+        try:
+            done = await action.coro_factory()
+        except Exception:  # noqa: BLE001
+            self.warning(
+                "Check-in action %r failed, will retry on a later check-in",
+                action.name,
+                exc_info=True,
+            )
+            return
+
+        if done and self._checkin_actions.get(action.name) is action:
+            del self._checkin_actions[action.name]
 
     async def begin_fast_polling(
         self, timeout: float = DEFAULT_FAST_POLL_TIMEOUT, *, reset_after: bool = True
@@ -926,6 +1019,12 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         if packet.rssi is not None:
             self.rssi = packet.rssi
+
+        # The device just sent traffic, so it is likely briefly awake and able
+        # to receive queued requests. Duplicate packets are a wake signal too,
+        # so trigger before the debouncer filters them out.
+        if self._checkin_actions:
+            self._trigger_checkin_actions()
 
         # Filter duplicate packets
         if self._should_filter_packet(packet):

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -61,6 +61,7 @@ POST_OTA_PROBE_RETRIES = 10
 POST_OTA_CONFIRMATION_TIMEOUT = 300
 
 CHECKIN_ACTION_RETRY_COOLDOWN = 300
+REINTERVIEW_CHECKIN_ACTION = "reinterview"
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,6 +115,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self.rssi: int | None = None
         self.ota_in_progress: bool = False
         self._last_seen: datetime | None = None
+        self._reinterview_pending: datetime | None = None
 
         self._initialize_task: asyncio.Task | None = None
         self._reinterview_in_progress: bool = False
@@ -253,6 +255,63 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         self._last_seen = value
         self.listener_event("device_last_seen_updated", self._last_seen)
+
+    @property
+    def reinterview_pending(self) -> float | None:
+        """Timestamp of a pending re-interview request, or None."""
+        if self._reinterview_pending is None:
+            return None
+
+        return self._reinterview_pending.timestamp()
+
+    @reinterview_pending.setter
+    def reinterview_pending(self, value: datetime | float | None) -> None:
+        if isinstance(value, int | float):
+            value = datetime.fromtimestamp(value, UTC)
+
+        self._reinterview_pending = value
+        self.listener_event("device_reinterview_pending_updated", value)
+
+        # Keep the invariant: the flag is set exactly when the re-interview
+        # check-in action is armed
+        if value is not None:
+            self.register_checkin_action(
+                REINTERVIEW_CHECKIN_ACTION, self._reinterview_checkin_action
+            )
+        else:
+            self.remove_checkin_action(REINTERVIEW_CHECKIN_ACTION)
+
+    def schedule_reinterview_on_checkin(self) -> None:
+        """Re-interview this device the next time it is seen awake.
+
+        Unlike `reinterview()`, this is safe for sleepy end devices that are
+        currently unreachable: the re-interview is deferred until the device
+        next checks in and is retried until it succeeds.
+        """
+        if self.ieee == self._application.state.node_info.ieee:
+            self.debug("Not scheduling a re-interview for the coordinator")
+            return
+
+        if self._reinterview_pending is None:
+            self.reinterview_pending = datetime.now(UTC)
+        else:
+            # Keep the original request timestamp but make sure the check-in
+            # action is armed
+            self.register_checkin_action(
+                REINTERVIEW_CHECKIN_ACTION, self._reinterview_checkin_action
+            )
+
+    async def _reinterview_checkin_action(self) -> bool:
+        """Check-in action driving a pending re-interview."""
+        if self.ota_in_progress or self.initializing or self.reinterviewing:
+            return False
+
+        await self.reinterview()
+
+        # reinterview() handles its own errors: success means this device
+        # object was replaced by the re-interviewed one. A device that is no
+        # longer registered at all was removed, so stop retrying then too.
+        return self._application.devices.get(self.ieee) is not self
 
     @property
     def non_zdo_endpoints(self) -> list[zigpy.endpoint.Endpoint]:
@@ -1155,6 +1214,11 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         if result != foundation.Status.SUCCESS:
             return result
 
+        # Queue a re-interview for the device's next check-in first: if the
+        # confirmation below times out (e.g. for sleepy end devices), the
+        # re-interview still happens once the device is next heard from.
+        self.schedule_reinterview_on_checkin()
+
         ota = self.find_cluster(
             cluster_id=Ota.cluster_id, cluster_type=ClusterType.Client
         )
@@ -1178,8 +1242,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             )
         except TimeoutError:
             self.warning(
-                "Device did not confirm new firmware within %ds; reinterview "
-                "will run if/when the device next reports a version change",
+                "Device did not confirm new firmware within %ds; a "
+                "re-interview stays queued for the device's next check-in",
                 POST_OTA_CONFIRMATION_TIMEOUT,
             )
             return result
@@ -1245,6 +1309,12 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         class _PostOtaJoinListener:
             def device_joined(self, joined_dev: Device) -> None:
                 if joined_dev.ieee == device_ieee:
+                    confirmed.set()
+
+            def device_reinterviewed(self, new_device: Device) -> None:
+                # The queued re-interview already ran (e.g. driven by a
+                # check-in), which is the strongest possible confirmation
+                if new_device.ieee == device_ieee:
                     confirmed.set()
 
         join_listener = _PostOtaJoinListener()
@@ -1393,6 +1463,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         new.lqi = self.lqi
         new.rssi = self.rssi
         new.last_seen = self.last_seen
+        # Copied without the setter: a detached clone must not fire events or
+        # arm check-in actions
+        new._reinterview_pending = self._reinterview_pending
         new.relays = self.relays
         new.original_signature = self.original_signature
         new.status = self.status

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -1098,7 +1098,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
           that reboot without sending any traffic of their own).
         - A new `QueryNextImageCommand` whose `current_file_version` differs
           from the value cached on the OTA cluster before this wait began.
-        - A `Device_annce` from this device.
+        - A `device_joined` event for this device on the Application (fires
+          on TC-join and on the Device_annce path when the device's NWK
+          changes or it was unknown).
+
+        Listeners are attached only at the start of this wait and torn down
+        on resolution, timeout, or cancellation, so unrelated joins from
+        before the OTA do not get counted.
         """
         snapshot = (
             ota.last_query_cmd.current_file_version
@@ -1107,6 +1113,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         )
 
         confirmed = asyncio.Event()
+        device_ieee = self.ieee
 
         def on_qni_update(event: OtaQueryCacheUpdatedEvent) -> None:
             if (
@@ -1117,12 +1124,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         unsub_qni = ota.on_event(OtaQueryCacheUpdatedEvent.event_type, on_qni_update)
 
-        class _DeviceAnnounceListener:
-            def device_announce(self, _device: Device) -> None:
-                confirmed.set()
+        class _PostOtaJoinListener:
+            def device_joined(self, joined_dev: Device) -> None:
+                if joined_dev.ieee == device_ieee:
+                    confirmed.set()
 
-        annce_listener = _DeviceAnnounceListener()
-        self.zdo.add_listener(annce_listener)
+        join_listener = _PostOtaJoinListener()
+        self._application.add_listener(join_listener)
 
         async def probe_version() -> None:
             # Actively poll the firmware version: sleepy devices won't answer,
@@ -1161,7 +1169,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             with contextlib.suppress(asyncio.CancelledError):
                 await probe_task
             unsub_qni()
-            self.zdo.remove_listener(annce_listener)
+            self._application.remove_listener(join_listener)
 
     def get_last_ota_query_cmd(self) -> QueryNextImageCommand | None:
         """Return the last cached QueryNextImageCommand, preferring client clusters."""

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -37,7 +37,7 @@ from zigpy.ota.manager import update_firmware
 from zigpy.profiles import zha, zll
 import zigpy.types as t
 import zigpy.util
-from zigpy.zcl import Cluster, ClusterType, OtaQueryCacheClearedEvent, foundation
+from zigpy.zcl import Cluster, ClusterType, OtaQueryCacheUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import Ota, PollControl, QueryNextImageCommand
 import zigpy.zdo.types as zdo_t
 
@@ -57,6 +57,8 @@ DEFAULT_REQUEST_RETRIES = 2
 DEFAULT_REQUEST_RETRY_DELAY = 0.1
 
 AFTER_OTA_ATTR_READ_DELAY = 10
+POST_OTA_PROBE_ATTEMPTS = 10
+POST_OTA_CONFIRMATION_TIMEOUT = 300
 
 
 @dataclass(frozen=True, slots=True)
@@ -1037,28 +1039,37 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         if result != foundation.Status.SUCCESS:
             return result
 
-        # Clear the current file version when the update succeeds
         ota = self.find_cluster(
             cluster_id=Ota.cluster_id, cluster_type=ClusterType.Client
         )
-        ota.update_attribute(Ota.AttributeDefs.current_file_version.id, None)
-        ota.last_query_cmd = None
-        ota.emit(
-            OtaQueryCacheClearedEvent.event_type,
-            OtaQueryCacheClearedEvent(
-                device_ieee=str(self.ieee),
-                endpoint_id=ota.endpoint.endpoint_id,
-            ),
-        )
 
+        # Devices need a moment after the final block before they're worth
+        # talking to again.
         await asyncio.sleep(AFTER_OTA_ATTR_READ_DELAY)
-        await ota.read_attributes(
-            [Ota.AttributeDefs.current_file_version.name],
-            retries=10,
-            retry_delay=AFTER_OTA_ATTR_READ_DELAY,
-        )
 
-        # Prompt device to send QueryNextImage with updated version for query cache
+        # Wait for the device to confirm it booted into the new firmware,
+        # whichever signal arrives first:
+        #   - a successful active read of `current_file_version` (a quietly
+        #     rebooted mains device that sends no traffic on its own),
+        #   - QueryNextImage with a `current_file_version` that differs from
+        #     the value we cached pre-flash (the OTA cluster's listener will
+        #     also schedule a re-interview when this happens), or
+        #   - Device_annce after the post-flash reboot.
+        try:
+            await asyncio.wait_for(
+                self._wait_for_post_ota_confirmation(ota),
+                timeout=POST_OTA_CONFIRMATION_TIMEOUT,
+            )
+        except TimeoutError:
+            self.warning(
+                "Device did not confirm new firmware within %ds; reinterview "
+                "will run if/when the device next reports a version change",
+                POST_OTA_CONFIRMATION_TIMEOUT,
+            )
+            return result
+
+        # The device responded. Best-effort: tell it to refresh its OTA query
+        # cache so it learns we don't have a newer image for it right now.
         try:
             await ota.image_notify(
                 payload_type=Ota.ImageNotifyCommand.PayloadType.QueryJitter,
@@ -1067,12 +1078,90 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         except Exception:  # noqa: BLE001
             self.debug("Post-OTA image_notify failed", exc_info=True)
 
-        # Re-interview the device after successful OTA to pick up
-        # any changes in clusters/endpoints/model and re-apply quirks.
+        # Re-interview the device after successful OTA to pick up any changes
+        # in clusters/endpoints/model and re-apply quirks. The OTA cluster's
+        # version-change listener may have already driven a re-interview when a
+        # post-flash QueryNextImage arrived: an in-flight one leaves the shadow
+        # device registered (and the `reinterviewing` guard set), a completed
+        # one has replaced this device in `application.devices` — skip both.
         # reinterview() handles its own errors internally.
-        await self.reinterview()
+        if self._application.devices.get(self.ieee, self) is self:
+            await self.reinterview()
 
         return result
+
+    async def _wait_for_post_ota_confirmation(self, ota: Ota) -> None:
+        """Wait until the device confirms a successful boot into new firmware.
+
+        Resolves on whichever signal arrives first:
+        - A successful active read of `current_file_version` (probes devices
+          that reboot without sending any traffic of their own).
+        - A new `QueryNextImageCommand` whose `current_file_version` differs
+          from the value cached on the OTA cluster before this wait began.
+        - A `Device_annce` from this device.
+        """
+        snapshot = (
+            ota.last_query_cmd.current_file_version
+            if ota.last_query_cmd is not None
+            else None
+        )
+
+        confirmed = asyncio.Event()
+
+        def on_qni_update(event: OtaQueryCacheUpdatedEvent) -> None:
+            if (
+                event.current_file_version is not None
+                and event.current_file_version != snapshot
+            ):
+                confirmed.set()
+
+        unsub_qni = ota.on_event(OtaQueryCacheUpdatedEvent.event_type, on_qni_update)
+
+        class _DeviceAnnounceListener:
+            def device_announce(self, _device: Device) -> None:
+                confirmed.set()
+
+        annce_listener = _DeviceAnnounceListener()
+        self.zdo.add_listener(annce_listener)
+
+        async def probe_version() -> None:
+            # Actively poll the firmware version: sleepy devices won't answer,
+            # but a rebooted-and-quiet mains device will. Any response means
+            # the device survived the flash (and a read also refreshes the
+            # attribute cache with the running version).
+            try:
+                await ota.read_attributes(
+                    [Ota.AttributeDefs.current_file_version.name],
+                    retries=POST_OTA_PROBE_ATTEMPTS,
+                    retry_delay=AFTER_OTA_ATTR_READ_DELAY,
+                )
+            except Exception:  # noqa: BLE001
+                self.debug("Post-OTA firmware version probe went unanswered")
+                return
+
+            confirmed.set()
+
+        probe_task = asyncio.ensure_future(probe_version())
+
+        try:
+            # Race-safe re-check after attaching listeners: if a confirming
+            # QueryNextImage arrived between snapshot and listener attach,
+            # `last_query_cmd` will already reflect the new version.
+            current = (
+                ota.last_query_cmd.current_file_version
+                if ota.last_query_cmd is not None
+                else None
+            )
+            if current is not None and current != snapshot:
+                return
+
+            await confirmed.wait()
+        finally:
+            probe_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await probe_task
+            unsub_qni()
+            self.zdo.remove_listener(annce_listener)
 
     def get_last_ota_query_cmd(self) -> QueryNextImageCommand | None:
         """Return the last cached QueryNextImageCommand, preferring client clusters."""

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -174,6 +174,12 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             callback()
 
         self._on_remove_callbacks.clear()
+
+        # Check-in action tasks run on the application and are deliberately
+        # not cancelled here: `_device_reinterviewed()` calls the old device's
+        # `on_remove()` mid-swap, and an action driving that very re-interview
+        # must not cancel its own call stack. Orphaned tasks fail their device
+        # I/O and are never retriggered.
         self._checkin_actions.clear()
 
         for task in self._tasks:
@@ -472,16 +478,27 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         factory but keeps the running attempt and cooldown state.
         """
         existing = self._checkin_actions.get(name)
+
+        if existing is not None:
+            # Mutate in place instead of replacing: a running attempt holds a
+            # reference to this object and unregisters by identity on success
+            existing.coro_factory = coro_factory
+            existing.cooldown = cooldown
+            return
+
         self._checkin_actions[name] = _CheckinAction(
             name=name,
             coro_factory=coro_factory,
             cooldown=cooldown,
-            task=existing.task if existing is not None else None,
-            last_attempt=existing.last_attempt if existing is not None else None,
         )
 
     def remove_checkin_action(self, name: str) -> None:
-        """Remove a previously registered check-in action, if present."""
+        """Remove a previously registered check-in action, if present.
+
+        A currently running attempt is deliberately not cancelled — it may be
+        mid-request (or mid-re-interview) and aborting it is riskier than
+        letting it finish; it just will not be retried afterwards.
+        """
         self._checkin_actions.pop(name, None)
 
     @property

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -57,7 +57,7 @@ DEFAULT_REQUEST_RETRIES = 2
 DEFAULT_REQUEST_RETRY_DELAY = 0.1
 
 AFTER_OTA_ATTR_READ_DELAY = 10
-POST_OTA_PROBE_ATTEMPTS = 10
+POST_OTA_PROBE_RETRIES = 10
 POST_OTA_CONFIRMATION_TIMEOUT = 300
 
 
@@ -1098,6 +1098,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
           that reboot without sending any traffic of their own).
         - A new `QueryNextImageCommand` whose `current_file_version` differs
           from the value cached on the OTA cluster before this wait began.
+          When no baseline was cached, any query counts: the device is alive
+          and talking after the flash, which is all this wait establishes.
         - A `device_joined` event for this device on the Application (fires
           on TC-join and on the Device_annce path when the device's NWK
           changes or it was unknown).
@@ -1140,7 +1142,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             try:
                 await ota.read_attributes(
                     [Ota.AttributeDefs.current_file_version.name],
-                    retries=POST_OTA_PROBE_ATTEMPTS,
+                    retries=POST_OTA_PROBE_RETRIES,
                     retry_delay=AFTER_OTA_ATTR_READ_DELAY,
                 )
             except Exception:  # noqa: BLE001
@@ -1149,7 +1151,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
             confirmed.set()
 
-        probe_task = asyncio.ensure_future(probe_version())
+        probe_task = asyncio.create_task(probe_version())
 
         try:
             # Race-safe re-check after attaching listeners: if a confirming

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2159,6 +2159,8 @@ class Ota(Cluster):
             )
 
     async def _handle_query_next_image(self, hdr, cmd):
+        old_query_cmd = self.last_query_cmd
+
         # Cache the query command fields for proactive OTA lookups
         self.last_query_cmd = cmd
         self.emit(
@@ -2175,12 +2177,64 @@ class Ota(Cluster):
             ),
         )
 
+        self._maybe_schedule_post_ota_reinterview(
+            old_version=(
+                old_query_cmd.current_file_version
+                if old_query_cmd is not None
+                else None
+            ),
+            new_version=cmd.current_file_version,
+        )
+
         # Always send no image available response so that the device stops asking
         await self.query_next_image_response(
             foundation.Status.NO_IMAGE_AVAILABLE, tsn=hdr.tsn
         )
 
         await self.endpoint.device.application.ota.check_cluster_for_ota(self)
+
+    def _maybe_schedule_post_ota_reinterview(
+        self,
+        old_version: int | None,
+        new_version: int | None,
+    ) -> None:
+        """Schedule a reinterview if the device reports a new running firmware.
+
+        A QueryNextImage with a `current_file_version` different from the value
+        we previously cached for this device is a strong signal that the device
+        rebooted into new firmware (e.g. after an OTA, including OTAs done
+        outside of `update_firmware()`). Re-interviewing rebuilds endpoints,
+        clusters, and quirks to match the new firmware.
+
+        Skipped when the previous value is unknown (first observation), when
+        the value is unchanged, when an OTA is in progress (the OTA flow drives
+        its own reinterview), when a reinterview is already running, or for
+        the active coordinator.
+        """
+        if old_version is None or new_version is None:
+            return
+        if old_version == new_version:
+            return
+
+        device = self.endpoint.device
+        app = device.application
+
+        if device.ieee == app.state.node_info.ieee:
+            return
+        if device.ota_in_progress:
+            return
+        if device.reinterviewing:
+            return
+
+        device.info(
+            "Firmware version changed (0x%08X -> 0x%08X), scheduling re-interview",
+            old_version,
+            new_version,
+        )
+        app.create_task(
+            device.reinterview(),
+            name=f"reinterview_after_fw_change-{device.ieee}",
+        )
 
     async def _handle_image_block_req(self, hdr, cmd):
         # Abort any running firmware update (i.e. the integration is reloaded midway)

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2231,6 +2231,13 @@ class Ota(Cluster):
             old_version,
             new_version,
         )
+
+        # Queue the re-interview so it is retried on a later check-in if the
+        # attempt below fails (e.g. a sleepy device going back to sleep)
+        device.schedule_reinterview_on_checkin()
+
+        # The device is awake right now (it just sent a QueryNextImage), so
+        # also attempt the re-interview immediately
         app.create_task(
             device.reinterview(),
             name=f"reinterview_after_fw_change-{device.ieee}",


### PR DESCRIPTION
**DRAFT / EXPERIMENTAL.**

> [!NOTE]
> Part of a four-PR series making post-OTA re-interviews reliable for sleepy end devices. Merge order (first to last):
> 1. #1849 — Confirm post-OTA reboot via announce/version-change instead of a fixed retry budget
> 2. #1850 — Add generic per-device check-in action mechanism
> 3. #1851 — Queue a pending re-interview for a device's next check-in **(this PR)**
> 4. #1852 — Persist pending re-interview requests in the application database

Makes post-OTA re-interviews reliable for sleepy end devices by deferring them to the device's next check-in. Branch: `tjj/reinterview-on-checkin`, stacked on `tjj/checkin-actions`. Persistence of the flag follows in `tjj/reinterview-pending-persistence`.

## Problem

Even with the post-OTA confirmation wait, a sleepy end device can sleep through the whole 5-minute window and through the version-change listener's immediate re-interview attempt (it may doze off again mid-interview). The device then keeps stale endpoints/clusters/quirks until it happens to send another OTA query — often a day later — or is manually re-paired.

## Changes

- **`Device.reinterview_pending`** — a request timestamp mirroring `last_seen` (`None` = not pending). The setter fires `device_reinterview_pending_updated` (for DB persistence in the follow-up) and maintains the invariant *flag set ⇔ re-interview check-in action armed*, so every writer (OTA, future ZHA use, DB restore) gets arming for free.
- **`Device.schedule_reinterview_on_checkin()`** — public entry point; refuses the coordinator; keeps the original request timestamp on repeat calls. Also usable by ZHA later, e.g. "Reconfigure device" on a sleeping device could queue instead of failing.
- **The check-in action** defers (`False`) while `ota_in_progress`/`initializing`/`reinterviewing`, otherwise drives `reinterview()`. Success is detected as "this device object was swapped out of `application.devices`" — necessary because `reinterview()` swallows its own errors. Retries on later check-ins with the standard cooldown until the swap happens.
- **OTA wiring.** `update_firmware()` queues the re-interview immediately after a successful flash, *before* the confirmation wait — the timeout path is now fully covered. The confirmation wait also resolves on a `device_reinterviewed` event (the check-in path may complete the re-interview mid-wait). The version-change listener queues the flag too before its immediate attempt, so that attempt failing (device back asleep) is no longer a dead end.
- **Clearing.** A successful re-interview clears the flag on the *new* device object (defensively, via the setter — quirk constructors may copy attributes from the device they replace); the flag is deliberately not copied to the re-interview shadow. On failure the old device stays registered with flag and action intact. `clone()` copies the raw field without firing events or arming actions (needed for the DB snapshot clone in the follow-up).

## Notes

Re-interview traffic cannot retrigger the action: during a re-interview the shadow device owns `application.devices[ieee]`, so inbound packets route to the shadow's (empty) registry; outside of it, the running-task guard applies.

## Testing

New tests: flag/event/arming semantics, coordinator refusal, busy-guard deferral, swap-based success detection, an end-to-end queued re-interview driven by an inbound packet (flag and action gone on the new device), `update_firmware()` queueing before a timed-out confirmation, silent `clone()` copy, confirmation-wait resolution on `device_reinterviewed`, and the version-change listener queueing the flag. Full suite passes.
