### PR TITLE
Expand network backups JSON blob into separate tables

### DIFF
--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1152,9 +1152,10 @@ async def test_appdb_network_state_reactive_updates(tmp_path, backup_factory):  
     app2.state.network_info = reloaded.network_info
     app2.state.node_info = reloaded.node_info
 
-    reloaded.network_info.network_key.tx_counter += 1000
-    reloaded.network_info.tc_link_key.tx_counter += 2000
-    app2.network_state_updated()
+    app2.network_frame_counter_updated(
+        reloaded.network_info.network_key.tx_counter + 1000
+    )
+    app2.aps_frame_counter_updated(reloaded.network_info.tc_link_key.tx_counter + 2000)
 
     app2.network_route_updated(t.NWK(0x1234), t.NWK(0x5678))
     await app2.shutdown()

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -35,6 +35,7 @@ from zigpy.const import (
 from zigpy.device import Device, Status
 import zigpy.endpoint
 import zigpy.ota
+import zigpy.state
 import zigpy.types as t
 import zigpy.zcl
 from zigpy.zcl import (
@@ -1157,7 +1158,7 @@ async def test_appdb_network_state_reactive_updates(tmp_path, backup_factory):  
     )
     app2.aps_frame_counter_updated(reloaded.network_info.tc_link_key.tx_counter + 2000)
 
-    app2.network_route_updated(t.NWK(0x1234), t.NWK(0x5678))
+    app2.network_route_updated(t.NWK(0x1234), t.NWK(0x5678), t.uint8_t(7))
     await app2.shutdown()
 
     # Phase 3: the granular writes landed on the current backup row
@@ -1165,7 +1166,9 @@ async def test_appdb_network_state_reactive_updates(tmp_path, backup_factory):  
     net = app3.backups.backups[0].network_info
     assert net.network_key.tx_counter == reloaded.network_info.network_key.tx_counter
     assert net.tc_link_key.tx_counter == reloaded.network_info.tc_link_key.tx_counter
-    assert net.route_table[t.NWK(0x1234)] == t.NWK(0x5678)
+    assert net.route_table[t.NWK(0x1234)] == zigpy.state.Route(
+        next_hop=t.NWK(0x5678), path_cost=t.uint8_t(7)
+    )
 
     # Phase 4: removing the route deletes it
     app3.state.network_info = net

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -1138,6 +1138,44 @@ async def test_appdb_network_backups_format_change(tmp_path, backup_factory):  #
     assert mock_add_backup.mock_calls == [call(new_backup, suppress_event=True)]
 
 
+async def test_appdb_network_state_reactive_updates(tmp_path, backup_factory):  # noqa: F811
+    db = tmp_path / "test.db"
+
+    # Phase 1: persist a baseline backup
+    app1 = await make_app_with_db(db)
+    app1.backups.add_backup(backup_factory())
+    await app1.shutdown()
+
+    # Phase 2: only granular reactive updates, no new backup
+    app2 = await make_app_with_db(db)
+    reloaded = app2.backups.backups[0]
+    app2.state.network_info = reloaded.network_info
+    app2.state.node_info = reloaded.node_info
+
+    reloaded.network_info.network_key.tx_counter += 1000
+    reloaded.network_info.tc_link_key.tx_counter += 2000
+    app2.network_state_updated()
+
+    app2.network_route_updated(t.NWK(0x1234), t.NWK(0x5678))
+    await app2.shutdown()
+
+    # Phase 3: the granular writes landed on the current backup row
+    app3 = await make_app_with_db(db)
+    net = app3.backups.backups[0].network_info
+    assert net.network_key.tx_counter == reloaded.network_info.network_key.tx_counter
+    assert net.tc_link_key.tx_counter == reloaded.network_info.tc_link_key.tx_counter
+    assert net.route_table[t.NWK(0x1234)] == t.NWK(0x5678)
+
+    # Phase 4: removing the route deletes it
+    app3.state.network_info = net
+    app3.network_route_updated(t.NWK(0x1234), t.NWK(0x5678), removed=True)
+    await app3.shutdown()
+
+    app4 = await make_app_with_db(db)
+    assert t.NWK(0x1234) not in app4.backups.backups[0].network_info.route_table
+    await app4.shutdown()
+
+
 async def test_appdb_persist_coordinator_info(tmp_path):  # noqa: F811
     db = tmp_path / "test.db"
 

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -86,8 +86,12 @@ def backup_factory():
                     t.EUI64.convert("AA:BB:CC:DD:11:22:33:44"): t.NWK(0x0ABC),
                 },
                 route_table={
-                    t.NWK(0x16B5): t.NWK(0xBFB9),
-                    t.NWK(0x1AF6): t.NWK(0x0ABC),
+                    t.NWK(0x16B5): app_state.Route(
+                        next_hop=t.NWK(0xBFB9), path_cost=t.uint8_t(5)
+                    ),
+                    t.NWK(0x1AF6): app_state.Route(
+                        next_hop=t.NWK(0x0ABC), path_cost=t.uint8_t(9)
+                    ),
                 },
                 stack_specific={
                     "zstack": {"tclk_seed": "71e31105bb92a2d15747a0d0a042dbfd"}
@@ -287,6 +291,25 @@ def test_from_dict_future_version(backup: zigpy.backups.NetworkBackup, caplog) -
 
     # Verify version was downgraded to current BACKUP_FORMAT_VERSION
     assert backup.version == zigpy.backups.BACKUP_FORMAT_VERSION
+
+
+def test_from_dict_v1_route_table(backup: zigpy.backups.NetworkBackup) -> None:
+    """A v1 backup stored the bare next hop; it upgrades to a Route with unknown cost."""
+    obj = backup.as_dict()
+    obj["version"] = 1
+    obj["network_info"]["route_table"] = {"16b5": "bfb9", "1af6": "0abc"}
+
+    restored = zigpy.backups.NetworkBackup.from_dict(obj)
+
+    assert restored.version == zigpy.backups.BACKUP_FORMAT_VERSION
+    assert restored.network_info.route_table == {
+        t.NWK(0x16B5): app_state.Route(
+            next_hop=t.NWK(0xBFB9), path_cost=t.uint8_t(0xFF)
+        ),
+        t.NWK(0x1AF6): app_state.Route(
+            next_hop=t.NWK(0x0ABC), path_cost=t.uint8_t(0xFF)
+        ),
+    }
 
 
 def test_backup_compatibility(backup_factory):

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -744,6 +744,65 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         )
         await self._db.commit()
 
+    def on_network_state_updated(
+        self, event: zigpy.backups.NetworkStateUpdatedEvent
+    ) -> None:
+        self.enqueue("_save_network_state_fields", event.network_info)
+
+    async def _save_network_state_fields(
+        self, network_info: zigpy.state.NetworkInfo
+    ) -> None:
+        # Update just the volatile frame counters on the current (most recent) backup,
+        # rather than rewriting the whole decomposed snapshot.
+        await self.execute(
+            f"""UPDATE network_info{DB_V}
+                    SET network_key_tx_counter=?, tc_link_key_tx_counter=?
+                    WHERE id=(SELECT id FROM network_info{DB_V}
+                                  ORDER BY backup_time DESC LIMIT 1)""",
+            (
+                int(network_info.network_key.tx_counter),
+                int(network_info.tc_link_key.tx_counter),
+            ),
+        )
+        await self._db.commit()
+
+    def on_network_route_updated(
+        self, event: zigpy.backups.NetworkRouteUpdatedEvent
+    ) -> None:
+        self.enqueue(
+            "_save_network_route", event.destination, event.next_hop, event.removed
+        )
+
+    async def _save_network_route(
+        self, destination: t.NWK, next_hop: t.NWK, removed: bool
+    ) -> None:
+        async with self.execute(
+            f"SELECT id FROM network_info{DB_V} ORDER BY backup_time DESC LIMIT 1"
+        ) as cursor:
+            row = await cursor.fetchone()
+
+        if row is None:
+            return
+
+        (backup_id,) = row
+
+        if removed:
+            await self.execute(
+                f"DELETE FROM network_routes{DB_V} WHERE backup_id=? AND destination=?",
+                (backup_id, int(destination)),
+            )
+        else:
+            await self.execute(
+                f"""INSERT INTO network_routes{DB_V} (backup_id, destination, next_hop)
+                        VALUES (?, ?, ?)
+                        ON CONFLICT (backup_id, destination)
+                        DO UPDATE SET next_hop=excluded.next_hop
+                            WHERE next_hop != excluded.next_hop""",
+                (backup_id, int(destination), int(next_hop)),
+            )
+
+        await self._db.commit()
+
     async def _write_network_backup(self, backup: zigpy.backups.NetworkBackup) -> None:
         """Decompose a `NetworkBackup` into the granular network-state tables."""
         net = backup.network_info

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -55,7 +55,7 @@ if sqlite3.sqlite_version_info < MIN_SQLITE_VERSION:
 
 LOGGER = logging.getLogger(__name__)
 
-DB_VERSION = 15
+DB_VERSION = 16
 DB_V = f"_v{DB_VERSION}"
 
 UNIX_EPOCH = datetime.fromtimestamp(0, tz=UTC)
@@ -726,26 +726,252 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         await self._db.commit()
 
     def network_backup_created(self, backup: zigpy.backups.NetworkBackup) -> None:
-        self.enqueue("_network_backup_created", json.dumps(backup.as_dict()))
+        self.enqueue("_network_backup_created", backup)
 
-    async def _network_backup_created(self, backup_json: str) -> None:
-        q = f"""INSERT INTO network_backups{DB_V} VALUES (?, ?)
-                    ON CONFLICT (id)
-                    DO UPDATE SET
-                        backup_json=excluded.backup_json"""
-
-        await self.execute(q, (None, backup_json))
+    async def _network_backup_created(
+        self, backup: zigpy.backups.NetworkBackup
+    ) -> None:
+        await self._write_network_backup(backup)
         await self._db.commit()
 
     def network_backup_removed(self, backup: zigpy.backups.NetworkBackup) -> None:
         self.enqueue("_network_backup_removed", backup.backup_time)
 
     async def _network_backup_removed(self, backup_time: datetime) -> None:
-        q = f"""DELETE FROM network_backups{DB_V}
-                    WHERE json_extract(backup_json, '$.backup_time')=?"""
-
-        await self.execute(q, (backup_time.isoformat(),))
+        await self.execute(
+            f"DELETE FROM network_info{DB_V} WHERE backup_time=?",
+            (backup_time.timestamp(),),
+        )
         await self._db.commit()
+
+    async def _write_network_backup(self, backup: zigpy.backups.NetworkBackup) -> None:
+        """Decompose a `NetworkBackup` into the granular network-state tables."""
+        net = backup.network_info
+        node = backup.node_info
+
+        async with self.execute(
+            f"""INSERT INTO network_info{DB_V} (
+                backup_time,
+                node_ieee, node_nwk, node_logical_type,
+                node_model, node_manufacturer, node_version,
+                extended_pan_id, pan_id, nwk_update_id, nwk_manager_id,
+                channel, channel_mask, security_level, tx_power,
+                network_key, network_key_seq,
+                network_key_tx_counter, network_key_rx_counter,
+                tc_link_key, tc_link_key_partner_ieee, tc_link_key_seq,
+                tc_link_key_tx_counter, tc_link_key_rx_counter,
+                stack_specific, metadata, source
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                backup.backup_time.timestamp(),
+                node.ieee,
+                int(node.nwk),
+                int(node.logical_type),
+                node.model,
+                node.manufacturer,
+                node.version,
+                net.extended_pan_id,
+                int(net.pan_id),
+                int(net.nwk_update_id),
+                int(net.nwk_manager_id),
+                int(net.channel),
+                int(net.channel_mask),
+                int(net.security_level),
+                (None if net.tx_power is None else int(net.tx_power)),
+                net.network_key.key.serialize(),
+                int(net.network_key.seq),
+                int(net.network_key.tx_counter),
+                int(net.network_key.rx_counter),
+                net.tc_link_key.key.serialize(),
+                net.tc_link_key.partner_ieee,
+                int(net.tc_link_key.seq),
+                int(net.tc_link_key.tx_counter),
+                int(net.tc_link_key.rx_counter),
+                json.dumps(net.stack_specific),
+                json.dumps(net.metadata),
+                net.source,
+            ),
+        ) as cursor:
+            backup_id = cursor.lastrowid
+
+        await self._db.executemany(
+            f"""INSERT INTO network_link_keys{DB_V}
+                    (backup_id, partner_ieee, key, tx_counter, rx_counter, seq)
+                    VALUES (?,?,?,?,?,?)""",
+            [
+                (
+                    backup_id,
+                    key.partner_ieee,
+                    key.key.serialize(),
+                    int(key.tx_counter),
+                    int(key.rx_counter),
+                    int(key.seq),
+                )
+                for key in net.key_table
+            ],
+        )
+
+        await self._db.executemany(
+            f"INSERT INTO network_children{DB_V} (backup_id, ieee) VALUES (?,?)",
+            [(backup_id, ieee) for ieee in net.children],
+        )
+
+        await self._db.executemany(
+            f"INSERT INTO network_addresses{DB_V} (backup_id, ieee, nwk) VALUES (?,?,?)",
+            [(backup_id, ieee, int(nwk)) for ieee, nwk in net.nwk_addresses.items()],
+        )
+
+        await self._db.executemany(
+            f"""INSERT INTO network_routes{DB_V} (backup_id, destination, next_hop)
+                    VALUES (?,?,?)""",
+            [
+                (backup_id, int(dst), int(next_hop))
+                for dst, next_hop in net.route_table.items()
+            ],
+        )
+
+    async def _read_network_backups(self) -> list[zigpy.backups.NetworkBackup]:
+        """Reconstruct every stored `NetworkBackup` from the granular tables."""
+        async with self.execute(
+            f"""SELECT
+                    id, backup_time,
+                    node_ieee, node_nwk, node_logical_type,
+                    node_model, node_manufacturer, node_version,
+                    extended_pan_id, pan_id, nwk_update_id, nwk_manager_id,
+                    channel, channel_mask, security_level, tx_power,
+                    network_key, network_key_seq,
+                    network_key_tx_counter, network_key_rx_counter,
+                    tc_link_key, tc_link_key_partner_ieee, tc_link_key_seq,
+                    tc_link_key_tx_counter, tc_link_key_rx_counter,
+                    stack_specific, metadata, source
+                FROM network_info{DB_V} ORDER BY backup_time"""
+        ) as cursor:
+            rows = await cursor.fetchall()
+
+        backups = []
+
+        for (
+            backup_id,
+            backup_time,
+            node_ieee,
+            node_nwk,
+            node_logical_type,
+            node_model,
+            node_manufacturer,
+            node_version,
+            extended_pan_id,
+            pan_id,
+            nwk_update_id,
+            nwk_manager_id,
+            channel,
+            channel_mask,
+            security_level,
+            tx_power,
+            network_key,
+            network_key_seq,
+            network_key_tx_counter,
+            network_key_rx_counter,
+            tc_link_key,
+            tc_link_key_partner_ieee,
+            tc_link_key_seq,
+            tc_link_key_tx_counter,
+            tc_link_key_rx_counter,
+            stack_specific,
+            metadata,
+            source,
+        ) in rows:
+            node_info = zigpy.state.NodeInfo(
+                nwk=t.NWK(node_nwk),
+                ieee=node_ieee,
+                logical_type=zdo_t.LogicalType(node_logical_type),
+                model=node_model,
+                manufacturer=node_manufacturer,
+                version=node_version,
+            )
+
+            # Sorted by partner IEEE to match `NetworkInfo.from_dict`
+            key_table = []
+            async with self.execute(
+                f"""SELECT partner_ieee, key, tx_counter, rx_counter, seq
+                    FROM network_link_keys{DB_V}
+                    WHERE backup_id=? ORDER BY partner_ieee""",
+                (backup_id,),
+            ) as cursor:
+                async for partner_ieee, key, tx_counter, rx_counter, seq in cursor:
+                    key_table.append(
+                        zigpy.state.Key(
+                            key=t.KeyData(key),
+                            tx_counter=tx_counter,
+                            rx_counter=rx_counter,
+                            seq=seq,
+                            partner_ieee=partner_ieee,
+                        )
+                    )
+
+            children = []
+            async with self.execute(
+                f"SELECT ieee FROM network_children{DB_V} WHERE backup_id=? ORDER BY ieee",
+                (backup_id,),
+            ) as cursor:
+                async for (ieee,) in cursor:
+                    children.append(ieee)
+
+            nwk_addresses = {}
+            async with self.execute(
+                f"SELECT ieee, nwk FROM network_addresses{DB_V} WHERE backup_id=?",
+                (backup_id,),
+            ) as cursor:
+                async for ieee, nwk in cursor:
+                    nwk_addresses[ieee] = t.NWK(nwk)
+
+            route_table = {}
+            async with self.execute(
+                f"SELECT destination, next_hop FROM network_routes{DB_V} WHERE backup_id=?",
+                (backup_id,),
+            ) as cursor:
+                async for destination, next_hop in cursor:
+                    route_table[t.NWK(destination)] = t.NWK(next_hop)
+
+            network_info = zigpy.state.NetworkInfo(
+                extended_pan_id=t.ExtendedPanId(extended_pan_id),
+                pan_id=t.PanId(pan_id),
+                nwk_update_id=t.uint8_t(nwk_update_id),
+                nwk_manager_id=t.NWK(nwk_manager_id),
+                channel=t.uint8_t(channel),
+                channel_mask=t.Channels(channel_mask),
+                security_level=t.uint8_t(security_level),
+                network_key=zigpy.state.Key(
+                    key=t.KeyData(network_key),
+                    seq=network_key_seq,
+                    tx_counter=network_key_tx_counter,
+                    rx_counter=network_key_rx_counter,
+                ),
+                tc_link_key=zigpy.state.Key(
+                    key=t.KeyData(tc_link_key),
+                    partner_ieee=tc_link_key_partner_ieee,
+                    seq=tc_link_key_seq,
+                    tx_counter=tc_link_key_tx_counter,
+                    rx_counter=tc_link_key_rx_counter,
+                ),
+                key_table=key_table,
+                children=children,
+                route_table=route_table,
+                tx_power=tx_power,
+                nwk_addresses=nwk_addresses,
+                stack_specific=json.loads(stack_specific),
+                metadata=json.loads(metadata),
+                source=source,
+            )
+
+            backups.append(
+                zigpy.backups.NetworkBackup(
+                    backup_time=datetime.fromtimestamp(backup_time, tz=UTC),
+                    network_info=network_info,
+                    node_info=node_info,
+                )
+            )
+
+        return backups
 
     async def _read_all_attributes(
         self,
@@ -1096,18 +1322,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     async def _load_network_backups(self) -> None:
         self._application.backups.backups.clear()
 
-        async with self.execute(
-            f"SELECT * FROM network_backups{DB_V} ORDER BY id"
-        ) as cursor:
-            backups = []
-
-            async for _id, backup_json in cursor:
-                backup = zigpy.backups.NetworkBackup.from_dict(json.loads(backup_json))
-                backups.append(backup)
-
-        backups.sort(key=lambda b: b.backup_time)
-
-        for backup in backups:
+        for backup in await self._read_network_backups():
             self._application.backups.add_backup(backup, suppress_event=True)
 
     async def _load_ota_query_cache(self) -> None:
@@ -1243,6 +1458,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 (self._migrate_to_v13, 13),
                 (self._migrate_to_v14, 14),
                 (self._migrate_to_v15, 15),
+                (self._migrate_to_v16, 16),
             ]:
                 if db_version >= min(to_db_version, DB_VERSION):
                     continue
@@ -1708,3 +1924,32 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             }
         )
         # ota_query_cache_v15 is new and starts empty
+
+    async def _migrate_to_v16(self) -> None:
+        """Schema v16 decomposes the `network_backups` JSON blob into split tables."""
+        await self._migrate_tables(
+            {
+                "devices_v15": "devices_v16",
+                "endpoints_v15": "endpoints_v16",
+                "neighbors_v15": "neighbors_v16",
+                "routes_v15": "routes_v16",
+                "node_descriptors_v15": "node_descriptors_v16",
+                "groups_v15": "groups_v16",
+                "group_members_v15": "group_members_v16",
+                "relays_v15": "relays_v16",
+                "clusters_v15": "clusters_v16",
+                "attributes_cache_v15": "attributes_cache_v16",
+                "ota_query_cache_v15": "ota_query_cache_v16",
+                # The JSON blobs are decomposed below rather than copied verbatim
+                "network_backups_v15": None,
+            }
+        )
+
+        async with self.execute(
+            "SELECT backup_json FROM network_backups_v15 ORDER BY id"
+        ) as cursor:
+            backup_jsons = [backup_json for (backup_json,) in await cursor.fetchall()]
+
+        for backup_json in backup_jsons:
+            backup = zigpy.backups.NetworkBackup.from_dict(json.loads(backup_json))
+            await self._write_network_backup(backup)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -791,11 +791,15 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         self, event: zigpy.backups.NetworkRouteUpdatedEvent
     ) -> None:
         self.enqueue(
-            "_save_network_route", event.destination, event.next_hop, event.removed
+            "_save_network_route",
+            event.destination,
+            event.next_hop,
+            event.path_cost,
+            event.removed,
         )
 
     async def _save_network_route(
-        self, destination: t.NWK, next_hop: t.NWK, removed: bool
+        self, destination: t.NWK, next_hop: t.NWK, path_cost: t.uint8_t, removed: bool
     ) -> None:
         if self._current_backup_id is None:
             return
@@ -807,12 +811,20 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             )
         else:
             await self.execute(
-                f"""INSERT INTO network_routes{DB_V} (backup_id, destination, next_hop)
-                        VALUES (?, ?, ?)
+                f"""INSERT INTO network_routes{DB_V}
+                            (backup_id, destination, next_hop, path_cost)
+                        VALUES (?, ?, ?, ?)
                         ON CONFLICT (backup_id, destination)
-                        DO UPDATE SET next_hop=excluded.next_hop
-                            WHERE next_hop != excluded.next_hop""",
-                (self._current_backup_id, int(destination), int(next_hop)),
+                        DO UPDATE SET next_hop=excluded.next_hop,
+                                      path_cost=excluded.path_cost
+                            WHERE next_hop != excluded.next_hop
+                               OR path_cost != excluded.path_cost""",
+                (
+                    self._current_backup_id,
+                    int(destination),
+                    int(next_hop),
+                    int(path_cost),
+                ),
             )
 
         await self._db.commit()
@@ -898,11 +910,12 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         )
 
         await self._db.executemany(
-            f"""INSERT INTO network_routes{DB_V} (backup_id, destination, next_hop)
-                    VALUES (?,?,?)""",
+            f"""INSERT INTO network_routes{DB_V}
+                        (backup_id, destination, next_hop, path_cost)
+                    VALUES (?,?,?,?)""",
             [
-                (backup_id, int(dst), int(next_hop))
-                for dst, next_hop in net.route_table.items()
+                (backup_id, int(dst), int(route.next_hop), int(route.path_cost))
+                for dst, route in net.route_table.items()
             ],
         )
 
@@ -1006,11 +1019,14 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
             route_table = {}
             async with self.execute(
-                f"SELECT destination, next_hop FROM network_routes{DB_V} WHERE backup_id=?",
+                f"""SELECT destination, next_hop, path_cost
+                        FROM network_routes{DB_V} WHERE backup_id=?""",
                 (backup_id,),
             ) as cursor:
-                async for destination, next_hop in cursor:
-                    route_table[t.NWK(destination)] = t.NWK(next_hop)
+                async for destination, next_hop, path_cost in cursor:
+                    route_table[t.NWK(destination)] = zigpy.state.Route(
+                        next_hop=t.NWK(next_hop), path_cost=t.uint8_t(path_cost)
+                    )
 
             network_info = zigpy.state.NetworkInfo(
                 extended_pan_id=t.ExtendedPanId(extended_pan_id),

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -132,6 +132,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         self.running = False
         self._worker_task = asyncio.create_task(self._worker())
 
+        # The backup that reactive updates (frame counters, routes) write to: the most
+        # recent one. Tracked here so those hot writes target it by id directly.
+        self._current_backup_id: int | None = None
+
     async def initialize_tables(self) -> None:
         async with self.execute("PRAGMA integrity_check") as cursor:
             rows = await cursor.fetchall()
@@ -742,27 +746,44 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
             f"DELETE FROM network_info{DB_V} WHERE backup_time=?",
             (backup_time.timestamp(),),
         )
+
+        # The removed backup may have been the current one; repoint to the newest that
+        # remains (this rare path can afford the lookup the hot path avoids).
+        async with self.execute(
+            f"SELECT id FROM network_info{DB_V} ORDER BY backup_time DESC LIMIT 1"
+        ) as cursor:
+            row = await cursor.fetchone()
+        self._current_backup_id = row[0] if row is not None else None
+
         await self._db.commit()
 
-    def on_network_state_updated(
-        self, event: zigpy.backups.NetworkStateUpdatedEvent
+    def on_network_frame_counter_updated(
+        self, event: zigpy.backups.NetworkFrameCounterUpdatedEvent
     ) -> None:
-        self.enqueue("_save_network_state_fields", event.network_info)
+        self.enqueue("_save_network_frame_counter", event.frame_counter)
 
-    async def _save_network_state_fields(
-        self, network_info: zigpy.state.NetworkInfo
-    ) -> None:
-        # Update just the volatile frame counters on the current (most recent) backup,
-        # rather than rewriting the whole decomposed snapshot.
+    async def _save_network_frame_counter(self, frame_counter: int) -> None:
+        # Update just the NWK counter on the current backup, rather than rewriting the
+        # whole decomposed snapshot.
+        if self._current_backup_id is None:
+            return
         await self.execute(
-            f"""UPDATE network_info{DB_V}
-                    SET network_key_tx_counter=?, tc_link_key_tx_counter=?
-                    WHERE id=(SELECT id FROM network_info{DB_V}
-                                  ORDER BY backup_time DESC LIMIT 1)""",
-            (
-                int(network_info.network_key.tx_counter),
-                int(network_info.tc_link_key.tx_counter),
-            ),
+            f"UPDATE network_info{DB_V} SET network_key_tx_counter=? WHERE id=?",
+            (int(frame_counter), self._current_backup_id),
+        )
+        await self._db.commit()
+
+    def on_aps_frame_counter_updated(
+        self, event: zigpy.backups.ApsFrameCounterUpdatedEvent
+    ) -> None:
+        self.enqueue("_save_aps_frame_counter", event.frame_counter)
+
+    async def _save_aps_frame_counter(self, frame_counter: int) -> None:
+        if self._current_backup_id is None:
+            return
+        await self.execute(
+            f"UPDATE network_info{DB_V} SET tc_link_key_tx_counter=? WHERE id=?",
+            (int(frame_counter), self._current_backup_id),
         )
         await self._db.commit()
 
@@ -776,20 +797,13 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     async def _save_network_route(
         self, destination: t.NWK, next_hop: t.NWK, removed: bool
     ) -> None:
-        async with self.execute(
-            f"SELECT id FROM network_info{DB_V} ORDER BY backup_time DESC LIMIT 1"
-        ) as cursor:
-            row = await cursor.fetchone()
-
-        if row is None:
+        if self._current_backup_id is None:
             return
-
-        (backup_id,) = row
 
         if removed:
             await self.execute(
                 f"DELETE FROM network_routes{DB_V} WHERE backup_id=? AND destination=?",
-                (backup_id, int(destination)),
+                (self._current_backup_id, int(destination)),
             )
         else:
             await self.execute(
@@ -798,7 +812,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                         ON CONFLICT (backup_id, destination)
                         DO UPDATE SET next_hop=excluded.next_hop
                             WHERE next_hop != excluded.next_hop""",
-                (backup_id, int(destination), int(next_hop)),
+                (self._current_backup_id, int(destination), int(next_hop)),
             )
 
         await self._db.commit()
@@ -853,6 +867,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         ) as cursor:
             backup_id = cursor.lastrowid
 
+        # Reactive updates persist against the backup just written (the current one)
+        self._current_backup_id = backup_id
+
         await self._db.executemany(
             f"""INSERT INTO network_link_keys{DB_V}
                     (backup_id, partner_ieee, key, tx_counter, rx_counter, seq)
@@ -906,6 +923,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 FROM network_info{DB_V} ORDER BY backup_time"""
         ) as cursor:
             rows = await cursor.fetchall()
+
+        # The most recent backup (last by backup_time) is the one reactive updates target
+        if rows:
+            self._current_backup_id = rows[-1][0]
 
         backups = []
 

--- a/zigpy/appdb_schemas/schema_v16.sql
+++ b/zigpy/appdb_schemas/schema_v16.sql
@@ -310,6 +310,7 @@ CREATE TABLE network_routes_v16 (
     backup_id INTEGER NOT NULL,
     destination INTEGER NOT NULL,
     next_hop INTEGER NOT NULL,
+    path_cost INTEGER NOT NULL,
 
     FOREIGN KEY(backup_id)
         REFERENCES network_info_v16(id)

--- a/zigpy/appdb_schemas/schema_v16.sql
+++ b/zigpy/appdb_schemas/schema_v16.sql
@@ -1,0 +1,320 @@
+PRAGMA user_version = 16;
+
+-- devices
+DROP TABLE IF EXISTS devices_v16;
+CREATE TABLE devices_v16 (
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+    last_seen REAL NOT NULL
+);
+
+CREATE UNIQUE INDEX devices_idx_v16
+    ON devices_v16(ieee);
+
+
+-- endpoints
+DROP TABLE IF EXISTS endpoints_v16;
+CREATE TABLE endpoints_v16 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    profile_id INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v16(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX endpoint_idx_v16
+    ON endpoints_v16(ieee, endpoint_id);
+
+
+-- clusters
+DROP TABLE IF EXISTS clusters_v16;
+CREATE TABLE clusters_v16 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v16(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX clusters_idx_v16
+    ON clusters_v16(ieee, endpoint_id, cluster_type, cluster_id);
+
+
+-- attributes
+DROP TABLE IF EXISTS attributes_cache_v16;
+CREATE TABLE attributes_cache_v16 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    cluster_type INTEGER NOT NULL,
+    cluster_id INTEGER NOT NULL,
+    attr_id INTEGER NOT NULL,
+    manufacturer_code INTEGER,
+    -- NULL is not considered equal to itself in unique indexes, so we need a non-NULL
+    -- column to use in the unique index
+    manufacturer_code_idx INTEGER NOT NULL GENERATED ALWAYS AS (IFNULL(manufacturer_code, -2)) STORED,
+    status INTEGER,
+    value BLOB,
+    last_updated REAL NOT NULL,
+
+    -- Quirks can create "virtual" clusters and endpoints that won't be present in the
+    -- DB but whose values still need to be cached
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v16(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX attributes_cache_idx_v16
+    ON attributes_cache_v16(ieee, endpoint_id, cluster_type, cluster_id, attr_id, manufacturer_code_idx);
+
+
+-- neighbors
+DROP TABLE IF EXISTS neighbors_v16;
+CREATE TABLE neighbors_v16 (
+    device_ieee ieee NOT NULL,
+    extended_pan_id ieee NOT NULL,
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+    device_type INTEGER NOT NULL,
+    rx_on_when_idle INTEGER NOT NULL,
+    relationship INTEGER NOT NULL,
+    reserved1 INTEGER NOT NULL,
+    permit_joining INTEGER NOT NULL,
+    reserved2 INTEGER NOT NULL,
+    depth INTEGER NOT NULL,
+    lqi INTEGER NOT NULL,
+
+    FOREIGN KEY(device_ieee)
+        REFERENCES devices_v16(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX neighbors_idx_v16
+    ON neighbors_v16(device_ieee);
+
+
+-- routes (per-device ZDO routing tables, scanned via Mgmt_Rtg_rsp)
+DROP TABLE IF EXISTS routes_v16;
+CREATE TABLE routes_v16 (
+    device_ieee ieee NOT NULL,
+    dst_nwk INTEGER NOT NULL,
+    route_status INTEGER NOT NULL,
+    memory_constrained INTEGER NOT NULL,
+    many_to_one INTEGER NOT NULL,
+    route_record_required INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    next_hop INTEGER NOT NULL
+);
+
+CREATE INDEX routes_idx_v16
+    ON routes_v16(device_ieee);
+
+
+-- node descriptors
+DROP TABLE IF EXISTS node_descriptors_v16;
+CREATE TABLE node_descriptors_v16 (
+    ieee ieee NOT NULL,
+
+    logical_type INTEGER NOT NULL,
+    complex_descriptor_available INTEGER NOT NULL,
+    user_descriptor_available INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    aps_flags INTEGER NOT NULL,
+    frequency_band INTEGER NOT NULL,
+    mac_capability_flags INTEGER NOT NULL,
+    manufacturer_code INTEGER NOT NULL,
+    maximum_buffer_size INTEGER NOT NULL,
+    maximum_incoming_transfer_size INTEGER NOT NULL,
+    server_mask INTEGER NOT NULL,
+    maximum_outgoing_transfer_size INTEGER NOT NULL,
+    descriptor_capability_field INTEGER NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v16(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX node_descriptors_idx_v16
+    ON node_descriptors_v16(ieee);
+
+
+-- groups
+DROP TABLE IF EXISTS groups_v16;
+CREATE TABLE groups_v16 (
+    group_id INTEGER NOT NULL,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX groups_idx_v16
+    ON groups_v16(group_id);
+
+
+-- group members
+DROP TABLE IF EXISTS group_members_v16;
+CREATE TABLE group_members_v16 (
+    group_id INTEGER NOT NULL,
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+
+    FOREIGN KEY(group_id)
+        REFERENCES groups_v16(group_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v16(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX group_members_idx_v16
+    ON group_members_v16(group_id, ieee, endpoint_id);
+
+
+-- relays
+DROP TABLE IF EXISTS relays_v16;
+CREATE TABLE relays_v16 (
+    ieee ieee NOT NULL,
+    relays BLOB NOT NULL,
+
+    FOREIGN KEY(ieee)
+        REFERENCES devices_v16(ieee)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX relays_idx_v16
+    ON relays_v16(ieee);
+
+
+-- OTA query cache: stores fields from the last query_next_image command per device
+DROP TABLE IF EXISTS ota_query_cache_v16;
+CREATE TABLE ota_query_cache_v16 (
+    ieee ieee NOT NULL,
+    endpoint_id INTEGER NOT NULL,
+    manufacturer_code INTEGER NOT NULL,
+    image_type INTEGER NOT NULL,
+    current_file_version INTEGER NOT NULL,
+    hardware_version INTEGER,
+    last_updated REAL NOT NULL,
+
+    FOREIGN KEY(ieee, endpoint_id)
+        REFERENCES endpoints_v16(ieee, endpoint_id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX ota_query_cache_idx_v16
+    ON ota_query_cache_v16(ieee, endpoint_id);
+
+
+-- network backups, decomposed into one info row plus child rows per `backup_id`
+DROP TABLE IF EXISTS network_info_v16;
+CREATE TABLE network_info_v16 (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    backup_time REAL NOT NULL,
+
+    -- coordinator node identity
+    node_ieee ieee NOT NULL,
+    node_nwk INTEGER NOT NULL,
+    node_logical_type INTEGER NOT NULL,
+    node_model TEXT,
+    node_manufacturer TEXT,
+    node_version TEXT,
+
+    -- network identity
+    extended_pan_id ieee NOT NULL,
+    pan_id INTEGER NOT NULL,
+    nwk_update_id INTEGER NOT NULL,
+    nwk_manager_id INTEGER NOT NULL,
+    channel INTEGER NOT NULL,
+    channel_mask INTEGER NOT NULL,
+    security_level INTEGER NOT NULL,
+    tx_power INTEGER,
+
+    -- network key + its outgoing (tx) frame counter
+    network_key BLOB NOT NULL,
+    network_key_seq INTEGER NOT NULL,
+    network_key_tx_counter INTEGER NOT NULL,
+    network_key_rx_counter INTEGER NOT NULL,
+
+    -- trust center link key
+    tc_link_key BLOB NOT NULL,
+    tc_link_key_partner_ieee ieee NOT NULL,
+    tc_link_key_seq INTEGER NOT NULL,
+    tc_link_key_tx_counter INTEGER NOT NULL,
+    tc_link_key_rx_counter INTEGER NOT NULL,
+
+    -- opaque, small, mostly-immutable per-stack data
+    stack_specific TEXT,
+    metadata TEXT,
+    source TEXT
+);
+
+
+-- per-device APS link keys
+DROP TABLE IF EXISTS network_link_keys_v16;
+CREATE TABLE network_link_keys_v16 (
+    backup_id INTEGER NOT NULL,
+    partner_ieee ieee NOT NULL,
+    key BLOB NOT NULL,
+    tx_counter INTEGER NOT NULL,
+    rx_counter INTEGER NOT NULL,
+    seq INTEGER NOT NULL,
+
+    FOREIGN KEY(backup_id)
+        REFERENCES network_info_v16(id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX network_link_keys_idx_v16
+    ON network_link_keys_v16(backup_id, partner_ieee);
+
+
+-- coordinator children
+DROP TABLE IF EXISTS network_children_v16;
+CREATE TABLE network_children_v16 (
+    backup_id INTEGER NOT NULL,
+    ieee ieee NOT NULL,
+
+    FOREIGN KEY(backup_id)
+        REFERENCES network_info_v16(id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX network_children_idx_v16
+    ON network_children_v16(backup_id, ieee);
+
+
+-- NWK to EUI64 address cache
+DROP TABLE IF EXISTS network_addresses_v16;
+CREATE TABLE network_addresses_v16 (
+    backup_id INTEGER NOT NULL,
+    ieee ieee NOT NULL,
+    nwk INTEGER NOT NULL,
+
+    FOREIGN KEY(backup_id)
+        REFERENCES network_info_v16(id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX network_addresses_idx_v16
+    ON network_addresses_v16(backup_id, ieee);
+
+
+-- next-hop route cache
+DROP TABLE IF EXISTS network_routes_v16;
+CREATE TABLE network_routes_v16 (
+    backup_id INTEGER NOT NULL,
+    destination INTEGER NOT NULL,
+    next_hop INTEGER NOT NULL,
+
+    FOREIGN KEY(backup_id)
+        REFERENCES network_info_v16(id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX network_routes_idx_v16
+    ON network_routes_v16(backup_id, destination);

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -929,18 +929,28 @@ class ControllerApplication(zigpy.util.ListenableMixin, EventBase, abc.ABC):
         )
 
     def network_route_updated(
-        self, destination: t.NWK, next_hop: t.NWK, *, removed: bool = False
+        self,
+        destination: t.NWK,
+        next_hop: t.NWK = t.NWK(0xFFFF),
+        path_cost: t.uint8_t = t.uint8_t(0xFF),
+        *,
+        removed: bool = False,
     ) -> None:
         """Called when a next-hop route is changed."""
         if removed:
             self.state.network_info.route_table.pop(destination, None)
         else:
-            self.state.network_info.route_table[destination] = next_hop
+            self.state.network_info.route_table[destination] = zigpy.state.Route(
+                next_hop=next_hop, path_cost=path_cost
+            )
 
         self.emit(
             NetworkRouteUpdatedEvent.event_type,
             NetworkRouteUpdatedEvent(
-                destination=destination, next_hop=next_hop, removed=removed
+                destination=destination,
+                next_hop=next_hop,
+                path_cost=path_cost,
+                removed=removed,
             ),
         )
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -20,7 +20,11 @@ import warnings
 
 import zigpy.appdb
 import zigpy.backups
-from zigpy.backups import NetworkRouteUpdatedEvent, NetworkStateUpdatedEvent
+from zigpy.backups import (
+    ApsFrameCounterUpdatedEvent,
+    NetworkFrameCounterUpdatedEvent,
+    NetworkRouteUpdatedEvent,
+)
 import zigpy.config as conf
 from zigpy.const import INTERFERENCE_MESSAGE
 from zigpy.datastructures import RequestLimiter
@@ -187,8 +191,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, EventBase, abc.ABC):
 
         self._db_event_unsubs = [
             self.on_event(
-                NetworkStateUpdatedEvent.event_type,
-                self._dblistener.on_network_state_updated,
+                NetworkFrameCounterUpdatedEvent.event_type,
+                self._dblistener.on_network_frame_counter_updated,
+            ),
+            self.on_event(
+                ApsFrameCounterUpdatedEvent.event_type,
+                self._dblistener.on_aps_frame_counter_updated,
             ),
             self.on_event(
                 NetworkRouteUpdatedEvent.event_type,
@@ -904,11 +912,20 @@ class ControllerApplication(zigpy.util.ListenableMixin, EventBase, abc.ABC):
         else:
             device.relays = zigpy.util.filter_relays(relays)
 
-    def network_state_updated(self) -> None:
-        """Called after volatile network state changes."""
+    def network_frame_counter_updated(self, frame_counter: int) -> None:
+        """Called when the radio reports the NWK outgoing frame counter advancing."""
+        self.state.network_info.network_key.tx_counter = frame_counter
         self.emit(
-            NetworkStateUpdatedEvent.event_type,
-            NetworkStateUpdatedEvent(network_info=self.state.network_info),
+            NetworkFrameCounterUpdatedEvent.event_type,
+            NetworkFrameCounterUpdatedEvent(frame_counter=frame_counter),
+        )
+
+    def aps_frame_counter_updated(self, frame_counter: int) -> None:
+        """Called when the radio reports the APS outgoing frame counter advancing."""
+        self.state.network_info.tc_link_key.tx_counter = frame_counter
+        self.emit(
+            ApsFrameCounterUpdatedEvent.event_type,
+            ApsFrameCounterUpdatedEvent(frame_counter=frame_counter),
         )
 
     def network_route_updated(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -20,11 +20,13 @@ import warnings
 
 import zigpy.appdb
 import zigpy.backups
+from zigpy.backups import NetworkRouteUpdatedEvent, NetworkStateUpdatedEvent
 import zigpy.config as conf
 from zigpy.const import INTERFERENCE_MESSAGE
 from zigpy.datastructures import RequestLimiter
 import zigpy.device
 import zigpy.endpoint
+from zigpy.event import EventBase
 import zigpy.exceptions
 import zigpy.group
 import zigpy.listeners
@@ -57,7 +59,7 @@ CHANNEL_CHANGE_SETTINGS_RELOAD_DELAY_S = 1.0
 RADIO_ENTRY_POINT_GROUP = "zigpy.radio"
 
 
-class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
+class ControllerApplication(zigpy.util.ListenableMixin, EventBase, abc.ABC):
     SCHEMA = conf.CONFIG_SCHEMA
 
     # User-facing metadata, set by radio libraries advertising themselves via the
@@ -69,6 +71,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     _probe_configs: list[dict[str, Any]] = []
 
     def __init__(self, config: dict) -> None:
+        super().__init__()
+
         self.devices: dict[t.EUI64, zigpy.device.Device] = {}
         self.state: zigpy.state.State = zigpy.state.State()
         self._listeners = {}
@@ -181,9 +185,24 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.backups.add_listener(self._dblistener)
         self.topology.add_listener(self._dblistener)
 
+        self._db_event_unsubs = [
+            self.on_event(
+                NetworkStateUpdatedEvent.event_type,
+                self._dblistener.on_network_state_updated,
+            ),
+            self.on_event(
+                NetworkRouteUpdatedEvent.event_type,
+                self._dblistener.on_network_route_updated,
+            ),
+        ]
+
     def _remove_db_listeners(self):
         if self._dblistener is None:
             return
+
+        for unsub in getattr(self, "_db_event_unsubs", []):
+            unsub()
+        self._db_event_unsubs = []
 
         self.topology.remove_listener(self._dblistener)
         self.backups.remove_listener(self._dblistener)
@@ -884,6 +903,29 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             )
         else:
             device.relays = zigpy.util.filter_relays(relays)
+
+    def network_state_updated(self) -> None:
+        """Called after volatile network state changes."""
+        self.emit(
+            NetworkStateUpdatedEvent.event_type,
+            NetworkStateUpdatedEvent(network_info=self.state.network_info),
+        )
+
+    def network_route_updated(
+        self, destination: t.NWK, next_hop: t.NWK, *, removed: bool = False
+    ) -> None:
+        """Called when a next-hop route is changed."""
+        if removed:
+            self.state.network_info.route_table.pop(destination, None)
+        else:
+            self.state.network_info.route_table[destination] = next_hop
+
+        self.emit(
+            NetworkRouteUpdatedEvent.event_type,
+            NetworkRouteUpdatedEvent(
+                destination=destination, next_hop=next_hop, removed=removed
+            ),
+        )
 
     @classmethod
     async def probe(cls, device_config: dict[str, Any]) -> bool | dict[str, Any]:

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -7,7 +7,7 @@ import copy
 import dataclasses
 from datetime import UTC, datetime
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 import zigpy.config as conf
 import zigpy.state
@@ -19,6 +19,26 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 BACKUP_FORMAT_VERSION = 1
+
+
+@dataclasses.dataclass(kw_only=True, frozen=True)
+class NetworkStateUpdatedEvent:
+    """Network state changed (outgoing frame counters) and should be persisted."""
+
+    event_type: Final[str] = "network_state_updated"
+
+    network_info: zigpy.state.NetworkInfo
+
+
+@dataclasses.dataclass(kw_only=True, frozen=True)
+class NetworkRouteUpdatedEvent:
+    """The next-hop route to a destination was established, changed, or removed."""
+
+    event_type: Final[str] = "network_route_updated"
+
+    destination: t.NWK
+    next_hop: t.NWK
+    removed: bool = False
 
 
 @dataclasses.dataclass

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import zigpy.application
 
 LOGGER = logging.getLogger(__name__)
-BACKUP_FORMAT_VERSION = 1
+BACKUP_FORMAT_VERSION = 2
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)
@@ -47,6 +47,7 @@ class NetworkRouteUpdatedEvent:
 
     destination: t.NWK
     next_hop: t.NWK
+    path_cost: t.uint8_t = t.uint8_t(0xFF)
     removed: bool = False
 
 
@@ -146,6 +147,16 @@ class NetworkBackup(t.BaseDataclassMixin):
             if "tx_power" not in obj["network_info"]:
                 obj = copy.deepcopy(obj)
                 obj["network_info"]["tx_power"] = None
+
+            # Version 2 gave each route table entry a path cost. Older backups stored
+            # the bare next hop; wrap it with the "unknown" cost sentinel.
+            if version < 2:
+                obj = copy.deepcopy(obj)
+                obj["network_info"]["route_table"] = {
+                    dst: {"next_hop": next_hop, "path_cost": 0xFF}
+                    for dst, next_hop in obj["network_info"]["route_table"].items()
+                }
+                version = 2
 
             return cls(
                 version=BACKUP_FORMAT_VERSION,
@@ -342,8 +353,8 @@ def _network_backup_to_open_coordinator_backup(backup: NetworkBackup) -> dict[st
                     for key in network_info.key_table
                 },
                 "route_table": {
-                    str(t.NWK(dst))[2:]: str(t.NWK(next_hop))[2:]
-                    for dst, next_hop in network_info.route_table.items()
+                    str(t.NWK(dst))[2:]: route.as_dict()
+                    for dst, route in network_info.route_table.items()
                 },
                 "tx_power": network_info.tx_power,
                 **network_info.metadata,
@@ -491,8 +502,16 @@ def _open_coordinator_backup_to_network_backup(obj: dict[str, Any]) -> NetworkBa
         # XXX: Devices that are not children, have no NWK address, and have no link key
         #      are effectively ignored, since there is no place to write them
 
-    for dst, next_hop in obj["metadata"]["internal"].get("route_table", {}).items():
-        network_info.route_table[t.NWK.convert(dst)] = t.NWK.convert(next_hop)
+    for dst, route in obj["metadata"]["internal"].get("route_table", {}).items():
+        # Older backups stored just the next hop instead of a {next_hop, path_cost} map
+        if isinstance(route, dict):
+            network_info.route_table[t.NWK.convert(dst)] = zigpy.state.Route.from_dict(
+                route
+            )
+        else:
+            network_info.route_table[t.NWK.convert(dst)] = zigpy.state.Route(
+                next_hop=t.NWK.convert(route)
+            )
 
     network_info.tx_power = obj["metadata"]["internal"].get("tx_power")
 

--- a/zigpy/backups.py
+++ b/zigpy/backups.py
@@ -22,12 +22,21 @@ BACKUP_FORMAT_VERSION = 1
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)
-class NetworkStateUpdatedEvent:
-    """Network state changed (outgoing frame counters) and should be persisted."""
+class NetworkFrameCounterUpdatedEvent:
+    """The outgoing NWK-layer (network key) frame counter advanced."""
 
-    event_type: Final[str] = "network_state_updated"
+    event_type: Final[str] = "network_frame_counter_updated"
 
-    network_info: zigpy.state.NetworkInfo
+    frame_counter: int
+
+
+@dataclasses.dataclass(kw_only=True, frozen=True)
+class ApsFrameCounterUpdatedEvent:
+    """The outgoing APS-layer frame counter advanced."""
+
+    event_type: Final[str] = "aps_frame_counter_updated"
+
+    frame_counter: int
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)

--- a/zigpy/state.py
+++ b/zigpy/state.py
@@ -54,6 +54,27 @@ class Key(t.BaseDataclassMixin):
 
 
 @dataclasses.dataclass
+class Route(t.BaseDataclassMixin):
+    """A next-hop route entry."""
+
+    next_hop: t.NWK
+    path_cost: t.uint8_t = t.uint8_t(0xFF)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "next_hop": str(t.NWK(self.next_hop))[2:],
+            "path_cost": self.path_cost,
+        }
+
+    @classmethod
+    def from_dict(cls, obj: dict[str, Any]) -> Route:
+        return cls(
+            next_hop=t.NWK.convert(obj["next_hop"]),
+            path_cost=t.uint8_t(obj["path_cost"]),
+        )
+
+
+@dataclasses.dataclass
 class NodeInfo(t.BaseDataclassMixin):
     """Controller Application network Node information."""
 
@@ -113,7 +134,7 @@ class NetworkInfo(t.BaseDataclassMixin):
     )
     key_table: list[Key] = dataclasses.field(default_factory=list)
     children: list[t.EUI64] = dataclasses.field(default_factory=list)
-    route_table: dict[t.NWK, t.NWK] = dataclasses.field(default_factory=dict)
+    route_table: dict[t.NWK, Route] = dataclasses.field(default_factory=dict)
     tx_power: int | None = None
 
     # If exposed by the stack, NWK addresses of other connected devices on the network
@@ -143,8 +164,8 @@ class NetworkInfo(t.BaseDataclassMixin):
             "key_table": [key.as_dict() for key in self.key_table],
             "children": sorted(str(ieee) for ieee in self.children),
             "route_table": {
-                str(t.NWK(dst))[2:]: str(t.NWK(next_hop))[2:]
-                for dst, next_hop in self.route_table.items()
+                str(t.NWK(dst))[2:]: route.as_dict()
+                for dst, route in self.route_table.items()
             },
             "tx_power": self.tx_power,
             "nwk_addresses": {
@@ -174,8 +195,8 @@ class NetworkInfo(t.BaseDataclassMixin):
             ),
             children=[t.EUI64.convert(ieee) for ieee in obj["children"]],
             route_table={
-                t.NWK.convert(dst): t.NWK.convert(next_hop)
-                for dst, next_hop in obj["route_table"].items()
+                t.NWK.convert(dst): Route.from_dict(route)
+                for dst, route in obj["route_table"].items()
             },
             tx_power=obj["tx_power"],
             nwk_addresses={


### PR DESCRIPTION
This PR requires https://github.com/zigpy/zigpy/pull/1835 to be merged first, as otherwise there is too much churn during normal network operation.

---

In order to fully backup and restore a Ziggurat network, we will need to persist a bit more data in the zigpy database. This PR breaks up the monolithic backup JSON into separate tables, allowing us to update counters, etc. without rewriting the whole JSON blob at once. It allows us to backup and restore active routes, child devices, etc. and quickly restart the stack.