### PR TITLE
Only decrement `_active_requests_by_tier` on success

### DIFF
--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -710,7 +710,7 @@ async def test_request_limiter_cancel_waiting():
 
 
 async def test_request_limiter_cancel_waiting_then_task_cancelled() -> None:
-    """Test that a cancelled waiter not corrupt the active-request bookkeeping."""
+    """Test that a cancelled waiter does not corrupt the active-request bookkeeping."""
     limiter = datastructures.RequestLimiter(1, {1: 1.0})
 
     async def acquire():

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -709,6 +709,38 @@ async def test_request_limiter_cancel_waiting():
             await task2
 
 
+async def test_request_limiter_cancel_waiting_then_task_cancelled() -> None:
+    """Test that a cancelled waiter not corrupt the active-request bookkeeping."""
+    limiter = datastructures.RequestLimiter(1, {1: 1.0})
+
+    async def acquire():
+        async with limiter(priority=1):
+            await asyncio.sleep(60)
+
+    # Hold the only slot so the next acquire must wait
+    async with limiter(priority=1):
+        assert limiter.active_requests == 1
+
+        task = asyncio.create_task(acquire())
+        await asyncio.sleep(0)  # Let the task start waiting
+        assert limiter.waiting_requests == 1
+
+        # `cancel_waiting` resolves the future with an exception and the task is
+        # then cancelled: cancellation wins, so the acquire raises `CancelledError`
+        # even though no slot was ever granted.
+        limiter.cancel_waiting(RuntimeError("rejoin"))
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The waiter never acquired a slot, so the active count is unchanged
+        assert limiter.active_requests == 1
+
+    # Releasing the outer slot must not trip the bookkeeping assertion
+    assert limiter.active_requests == 0
+
+
 async def test_request_limiter_backwards_compatibility() -> None:
     """Test `max_value` property proxying `max_concurrency`."""
     limiter = datastructures.RequestLimiter(5, {1: 1.0})

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -274,6 +274,38 @@ async def test_dynamic_bounded_semaphore_cancellation():
     assert not sem.locked()
 
 
+async def test_dynamic_bounded_semaphore_cancel_waiting_then_task_cancelled() -> None:
+    """Test that a cancelled waiter does not corrupt the active-request bookkeeping."""
+    sem = datastructures.PriorityDynamicBoundedSemaphore(1)
+
+    async def acquire():
+        async with sem:
+            await asyncio.sleep(60)
+
+    # Hold the only slot so the next acquire must wait
+    async with sem:
+        assert sem.value == 0
+
+        task = asyncio.create_task(acquire())
+        await asyncio.sleep(0)  # Let the task start waiting
+        assert len(sem._waiters) == 1
+
+        # `cancel_waiting` resolves the future with an exception and the task is
+        # then cancelled: cancellation wins, so the acquire raises `CancelledError`
+        # even though no slot was ever granted.
+        sem.cancel_waiting(RuntimeError("rejoin"))
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The waiter never acquired a slot, so the active count is unchanged
+        assert sem.value == 0
+
+    # Releasing the outer slot must not trip the bookkeeping assertion
+    assert sem.value == 1
+
+
 async def test_priority_lock():
     """Test priority lock."""
 

--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -517,7 +517,10 @@ class RequestLimiter:
                     self._waiters.remove(waiter_obj)
                     heapq.heapify(self._waiters)
         except asyncio.CancelledError:
-            if fut.done() and not fut.cancelled():
+            # Only undo the bookkeeping if the slot was actually granted. If the future
+            # instead carries an exception (e.g. from `cancel_waiting`), no slot was
+            # ever acquired and there is nothing to release.
+            if fut.done() and not fut.cancelled() and fut.exception() is None:
                 self._active_requests_by_tier[effective_tier] -= 1
 
             raise

--- a/zigpy/datastructures.py
+++ b/zigpy/datastructures.py
@@ -145,8 +145,10 @@ class PriorityDynamicBoundedSemaphore:
             finally:
                 self._waiters.remove(obj)
         except asyncio.CancelledError:
-            # Currently the only exception designed be able to occur here.
-            if fut.done() and not fut.cancelled():
+            # Only undo the bookkeeping if the slot was actually granted. If the future
+            # instead carries an exception (e.g. from `cancel_waiting`), no slot was
+            # ever acquired and there is nothing to release.
+            if fut.done() and not fut.cancelled() and fut.exception() is None:
                 # Our Future was successfully set to True via _wake_up_next(),
                 # but we are not about to successfully acquire(). Therefore we
                 # must undo the bookkeeping already done and attempt to wake


### PR DESCRIPTION
Fixes https://github.com/zigpy/zigpy/issues/1854.

If a waiting request is cancelled quickly, the cancellation can desynchronize the `_active_requests_by_tier` counter.