### PR TITLE
Re-read `INSUFFICIENT_SPACE` attributes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -414,7 +414,10 @@ def mock_attribute_reads(
             if attr_def in mock_reads:
                 value = mock_reads[attr_def]()
 
-                if isinstance(value, foundation.Status):
+                if value is None:
+                    # Omit the record from the response entirely
+                    continue
+                elif isinstance(value, foundation.Status):
                     record.status = value
                 else:
                     record.status = foundation.Status.SUCCESS

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2639,6 +2639,132 @@ async def test_read_attributes_chunked_by_count(app_mock) -> None:
     }
 
 
+async def test_read_attributes_insufficient_space_retry_success(app_mock) -> None:
+    """An INSUFFICIENT_SPACE record is re-read individually and can then succeed."""
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            attr_0 = foundation.ZCLAttributeDef(id=0xFF00, type=t.uint8_t)
+            attr_1 = foundation.ZCLAttributeDef(id=0xFF01, type=t.uint8_t)
+            attr_2 = foundation.ZCLAttributeDef(id=0xFF02, type=t.uint8_t)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    attrs = [
+        TestCluster.AttributeDefs.attr_0,
+        TestCluster.AttributeDefs.attr_1,
+        TestCluster.AttributeDefs.attr_2,
+    ]
+
+    supported = {
+        TestCluster.AttributeDefs.attr_0: 10,
+        # Runs out of space in the batched read, but fits when read alone
+        TestCluster.AttributeDefs.attr_1: mock.Mock(
+            side_effect=[foundation.Status.INSUFFICIENT_SPACE, 20]
+        ),
+        TestCluster.AttributeDefs.attr_2: 30,
+    }
+
+    with mock_attribute_reads(cluster, supported) as (mock_read, _):
+        success, failure = await cluster.read_attributes(attrs)
+
+    assert success == {
+        TestCluster.AttributeDefs.attr_0: 10,
+        TestCluster.AttributeDefs.attr_1: 20,
+        TestCluster.AttributeDefs.attr_2: 30,
+    }
+    assert failure == {}
+
+    # The batched read, then a solo re-read of the attribute that didn't fit
+    chunks = [call_obj.args[0] for call_obj in mock_read.call_args_list]
+    assert chunks == [[0xFF00, 0xFF01, 0xFF02], [0xFF01]]
+
+
+async def test_read_attributes_insufficient_space_retry_persistent(app_mock) -> None:
+    """An attribute that still doesn't fit when read alone is a terminal failure."""
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            attr_0 = foundation.ZCLAttributeDef(id=0xFF00, type=t.uint8_t)
+            attr_1 = foundation.ZCLAttributeDef(id=0xFF01, type=t.uint8_t)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    attrs = [TestCluster.AttributeDefs.attr_0, TestCluster.AttributeDefs.attr_1]
+
+    supported = {
+        TestCluster.AttributeDefs.attr_0: 10,
+        # Never fits, even when read alone
+        TestCluster.AttributeDefs.attr_1: mock.Mock(
+            return_value=foundation.Status.INSUFFICIENT_SPACE
+        ),
+    }
+
+    with mock_attribute_reads(cluster, supported) as (mock_read, _):
+        success, failure = await cluster.read_attributes(attrs)
+
+    assert success == {TestCluster.AttributeDefs.attr_0: 10}
+    assert failure == {
+        TestCluster.AttributeDefs.attr_1: foundation.Status.INSUFFICIENT_SPACE
+    }
+
+    chunks = [call_obj.args[0] for call_obj in mock_read.call_args_list]
+    assert chunks == [[0xFF00, 0xFF01], [0xFF01]]
+
+
+@pytest.mark.parametrize("omitted_again", [False, True])
+async def test_read_attributes_omitted_record_retry(
+    app_mock, omitted_again: bool
+) -> None:
+    """Records omitted from a response are re-read individually (ZCL R8 §2.5.2.3)."""
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            attr_0 = foundation.ZCLAttributeDef(id=0xFF00, type=t.uint8_t)
+            attr_1 = foundation.ZCLAttributeDef(id=0xFF01, type=t.uint8_t)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    attrs = [TestCluster.AttributeDefs.attr_0, TestCluster.AttributeDefs.attr_1]
+
+    supported = {
+        TestCluster.AttributeDefs.attr_0: 10,
+        TestCluster.AttributeDefs.attr_1: mock.Mock(
+            side_effect=[None, None] if omitted_again else [None, 20]
+        ),
+    }
+
+    with mock_attribute_reads(cluster, supported) as (mock_read, _):
+        success, failure = await cluster.read_attributes(attrs)
+
+    if omitted_again:
+        assert success == {TestCluster.AttributeDefs.attr_0: 10}
+        assert failure == {
+            TestCluster.AttributeDefs.attr_1: foundation.Status.INSUFFICIENT_SPACE
+        }
+    else:
+        assert success == {
+            TestCluster.AttributeDefs.attr_0: 10,
+            TestCluster.AttributeDefs.attr_1: 20,
+        }
+        assert failure == {}
+
+    chunks = [call_obj.args[0] for call_obj in mock_read.call_args_list]
+    assert chunks == [[0xFF00, 0xFF01], [0xFF01]]
+
+
 async def test_write_attributes_chunked_by_size(app_mock) -> None:
     """Write_attributes splits requests if a single one would exceed the limit."""
 

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2763,6 +2763,42 @@ async def test_read_attributes_insufficient_space_retry_persistent(app_mock) -> 
     assert chunks == [[0xFF00, 0xFF01], [0xFF01]]
 
 
+async def test_read_attributes_insufficient_space_single_chunk_no_retry(
+    app_mock,
+) -> None:
+    """A single-attribute chunk is already isolated, so it is not re-read."""
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            attr_0 = foundation.ZCLAttributeDef(id=0xFF00, type=t.uint8_t)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    supported = {
+        TestCluster.AttributeDefs.attr_0: mock.Mock(
+            return_value=foundation.Status.INSUFFICIENT_SPACE
+        ),
+    }
+
+    with mock_attribute_reads(cluster, supported) as (mock_read, _):
+        success, failure = await cluster.read_attributes(
+            [TestCluster.AttributeDefs.attr_0]
+        )
+
+    assert success == {}
+    assert failure == {
+        TestCluster.AttributeDefs.attr_0: foundation.Status.INSUFFICIENT_SPACE
+    }
+
+    # Read exactly once: no redundant solo re-read of an already-isolated attribute
+    chunks = [call_obj.args[0] for call_obj in mock_read.call_args_list]
+    assert chunks == [[0xFF00]]
+
+
 @pytest.mark.parametrize("omitted_again", [False, True])
 async def test_read_attributes_omitted_record_retry(
     app_mock, omitted_again: bool

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2669,6 +2669,10 @@ async def test_read_attributes_insufficient_space_retry_success(app_mock) -> Non
         TestCluster.AttributeDefs.attr_2: 30,
     }
 
+    events = []
+    cluster.on_event(AttributeReadEvent.event_type, events.append)
+    cluster.on_event(AttributeUpdatedEvent.event_type, events.append)
+
     with mock_attribute_reads(cluster, supported) as (mock_read, _):
         success, failure = await cluster.read_attributes(attrs)
 
@@ -2682,6 +2686,45 @@ async def test_read_attributes_insufficient_space_retry_success(app_mock) -> Non
     # The batched read, then a solo re-read of the attribute that didn't fit
     chunks = [call_obj.args[0] for call_obj in mock_read.call_args_list]
     assert chunks == [[0xFF00, 0xFF01, 0xFF02], [0xFF01]]
+
+    assert events == [
+        AttributeReadEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=TestCluster.cluster_id,
+            attribute_name=TestCluster.AttributeDefs.attr_0.name,
+            attribute_id=TestCluster.AttributeDefs.attr_0.id,
+            manufacturer_code=None,
+            raw_value=10,
+            value=10,
+        ),
+        AttributeReadEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=TestCluster.cluster_id,
+            attribute_name=TestCluster.AttributeDefs.attr_2.name,
+            attribute_id=TestCluster.AttributeDefs.attr_2.id,
+            manufacturer_code=None,
+            raw_value=30,
+            value=30,
+        ),
+        # No event for attr_1's INSUFFICIENT_SPACE record; the solo re-read then emits
+        # its AttributeReadEvent last, after the two attributes that succeeded in the
+        # batch
+        AttributeReadEvent(
+            device_ieee=str(dev.ieee),
+            endpoint_id=1,
+            cluster_type=zcl.ClusterType.Server,
+            cluster_id=TestCluster.cluster_id,
+            attribute_name=TestCluster.AttributeDefs.attr_1.name,
+            attribute_id=TestCluster.AttributeDefs.attr_1.id,
+            manufacturer_code=None,
+            raw_value=20,
+            value=20,
+        ),
+    ]
 
 
 async def test_read_attributes_insufficient_space_retry_persistent(app_mock) -> None:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1169,6 +1169,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
         # Now, we can perform the reads for each manufacturer code group
         for manufacturer_code, attribute_group in reads_by_manuf_code.items():
+            retry_attrs: list[foundation.ZCLAttributeDef] = []
+
             for i in range(0, len(attribute_group), MAX_READ_ATTRIBUTES_PER_REQ):
                 chunk = attribute_group[i : i + MAX_READ_ATTRIBUTES_PER_REQ]
                 result = await self.read_attributes_raw(
@@ -1177,85 +1179,156 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     **kwargs,
                 )
 
-                # The read response should contain only these attributes
-                potential_attributes = {attr_def.id: attr_def for attr_def in chunk}
+                retry_attrs.extend(
+                    self._process_read_attributes_response(
+                        result,
+                        chunk,
+                        attribute_map,
+                        manufacturer_code,
+                        success,
+                        failure,
+                        allow_retry=True,
+                    )
+                )
 
-                if not isinstance(result[0], list):
-                    # If we get back a single response status, all reads failed
-                    for attr_def in chunk:
-                        failure[attribute_map[attr_def]] = result[0]
-                else:
-                    for record in result[0]:
-                        attr_def = potential_attributes[record.attrid]
+            # Attributes whose records did not fit in the response frame
+            # (`INSUFFICIENT_SPACE`) or were omitted from it entirely are re-read one
+            # at a time, giving each value the whole frame (ZCL R8 §2.5.2.3). An
+            # attribute that still does not fit when read alone is a terminal failure.
+            for attr_def in retry_attrs:
+                result = await self.read_attributes_raw(
+                    [attr_def.id],
+                    manufacturer=manufacturer_code,
+                    **kwargs,
+                )
 
-                        if record.status == foundation.Status.SUCCESS:
-                            if record.value.value is None:
-                                # TODO: remove this workaround when `LocalDataCluster` and
-                                # `_VALID_ATTRIBUTES` are removed from quirks. There is no
-                                # way for `value` to actually be `None` when read from a
-                                # real device.
-                                value = None
-                            else:
-                                value = attr_def.type(record.value.value)
-
-                            success[attribute_map[attr_def]] = value
-
-                            cached_value = self._legacy_apply_quirk_attribute_update(
-                                attr_def, value
-                            )
-
-                            if cached_value is None:
-                                # Quirk swallowed the attribute
-                                continue
-                            elif cached_value != value:
-                                # Quirk transformed the value, emit AttributeUpdatedEvent
-                                self.emit(
-                                    AttributeUpdatedEvent.event_type,
-                                    AttributeUpdatedEvent(
-                                        device_ieee=str(self.endpoint.device.ieee),
-                                        endpoint_id=self.endpoint.endpoint_id,
-                                        cluster_type=self._type,
-                                        cluster_id=self.cluster_id,
-                                        attribute_name=attr_def.name,
-                                        attribute_id=attr_def.id,
-                                        manufacturer_code=manufacturer_code,
-                                        value=cached_value,
-                                    ),
-                                )
-                            else:
-                                # Value unchanged, emit AttributeReadEvent
-                                self.emit(
-                                    AttributeReadEvent.event_type,
-                                    AttributeReadEvent(
-                                        device_ieee=str(self.endpoint.device.ieee),
-                                        endpoint_id=self.endpoint.endpoint_id,
-                                        cluster_type=self._type,
-                                        cluster_id=self.cluster_id,
-                                        attribute_name=attr_def.name,
-                                        attribute_id=attr_def.id,
-                                        manufacturer_code=manufacturer_code,
-                                        raw_value=record.value.value,
-                                        value=value,
-                                    ),
-                                )
-                        else:
-                            if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
-                                self.emit(
-                                    AttributeUnsupportedEvent.event_type,
-                                    AttributeUnsupportedEvent(
-                                        device_ieee=str(self.endpoint.device.ieee),
-                                        endpoint_id=self.endpoint.endpoint_id,
-                                        cluster_type=self._type,
-                                        cluster_id=self.cluster_id,
-                                        attribute_name=attr_def.name,
-                                        attribute_id=attr_def.id,
-                                        manufacturer_code=manufacturer_code,
-                                    ),
-                                )
-
-                            failure[attribute_map[attr_def]] = record.status
+                self._process_read_attributes_response(
+                    result,
+                    [attr_def],
+                    attribute_map,
+                    manufacturer_code,
+                    success,
+                    failure,
+                    allow_retry=False,
+                )
 
         return success, failure
+
+    def _process_read_attributes_response(
+        self,
+        result: Any,
+        chunk: list[foundation.ZCLAttributeDef],
+        attribute_map: dict[
+            foundation.ZCLAttributeDef, int | str | foundation.ZCLAttributeDef
+        ],
+        manufacturer_code: int | None,
+        success: dict,
+        failure: dict,
+        *,
+        allow_retry: bool,
+    ) -> list[foundation.ZCLAttributeDef]:
+        """Process a Read Attributes Response, updating `success`/`failure` in place."""
+
+        # If we get back a single response status, all reads failed
+        if not isinstance(result[0], list):
+            for attr_def in chunk:
+                failure[attribute_map[attr_def]] = result[0]
+
+            return []
+
+        # All reads in this chunk used the same manufacturer code
+        seen_attr_ids: set[int] = set()
+
+        # The read response should contain only these attributes
+        potential_attributes = {attr_def.id: attr_def for attr_def in chunk}
+        insufficient_space_attrs: list[foundation.ZCLAttributeDef] = []
+
+        for record in result[0]:
+            attr_def = potential_attributes[record.attrid]
+            seen_attr_ids.add(record.attrid)
+
+            if record.status == foundation.Status.INSUFFICIENT_SPACE and allow_retry:
+                # The value did not fit; re-read it alone with the full frame
+                insufficient_space_attrs.append(attr_def)
+            elif record.status == foundation.Status.SUCCESS:
+                if record.value.value is None:
+                    # TODO: remove this workaround when `LocalDataCluster` and
+                    # `_VALID_ATTRIBUTES` are removed from quirks. There is no
+                    # way for `value` to actually be `None` when read from a
+                    # real device.
+                    value = None
+                else:
+                    value = attr_def.type(record.value.value)
+
+                success[attribute_map[attr_def]] = value
+
+                cached_value = self._legacy_apply_quirk_attribute_update(
+                    attr_def, value
+                )
+
+                if cached_value is None:
+                    # Quirk swallowed the attribute
+                    continue
+                elif cached_value != value:
+                    # Quirk transformed the value, emit AttributeUpdatedEvent
+                    self.emit(
+                        AttributeUpdatedEvent.event_type,
+                        AttributeUpdatedEvent(
+                            device_ieee=str(self.endpoint.device.ieee),
+                            endpoint_id=self.endpoint.endpoint_id,
+                            cluster_type=self._type,
+                            cluster_id=self.cluster_id,
+                            attribute_name=attr_def.name,
+                            attribute_id=attr_def.id,
+                            manufacturer_code=manufacturer_code,
+                            value=cached_value,
+                        ),
+                    )
+                else:
+                    # Value unchanged, emit AttributeReadEvent
+                    self.emit(
+                        AttributeReadEvent.event_type,
+                        AttributeReadEvent(
+                            device_ieee=str(self.endpoint.device.ieee),
+                            endpoint_id=self.endpoint.endpoint_id,
+                            cluster_type=self._type,
+                            cluster_id=self.cluster_id,
+                            attribute_name=attr_def.name,
+                            attribute_id=attr_def.id,
+                            manufacturer_code=manufacturer_code,
+                            raw_value=record.value.value,
+                            value=value,
+                        ),
+                    )
+            else:
+                if record.status == foundation.Status.UNSUPPORTED_ATTRIBUTE:
+                    self.emit(
+                        AttributeUnsupportedEvent.event_type,
+                        AttributeUnsupportedEvent(
+                            device_ieee=str(self.endpoint.device.ieee),
+                            endpoint_id=self.endpoint.endpoint_id,
+                            cluster_type=self._type,
+                            cluster_id=self.cluster_id,
+                            attribute_name=attr_def.name,
+                            attribute_id=attr_def.id,
+                            manufacturer_code=manufacturer_code,
+                        ),
+                    )
+
+                failure[attribute_map[attr_def]] = record.status
+
+        # Attributes omitted from the response entirely (ZCL R8 §2.5.2.3): re-read
+        # them individually, or mark them failed if this was already a solo re-read.
+        for attr_def in chunk:
+            if attr_def.id in seen_attr_ids:
+                continue
+
+            if allow_retry:
+                insufficient_space_attrs.append(attr_def)
+            else:
+                failure[attribute_map[attr_def]] = foundation.Status.INSUFFICIENT_SPACE
+
+        return insufficient_space_attrs
 
     def _on_attribute_unsupported(self, event: AttributeUnsupportedEvent) -> None:
         """Handle an attribute being reported as unsupported by the device."""

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1187,7 +1187,9 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         manufacturer_code,
                         success,
                         failure,
-                        allow_retry=True,
+                        # A single-attribute chunk is already being read in isolation,
+                        # so there is nothing to gain from a solo re-read
+                        allow_retry=len(chunk) > 1,
                     )
                 )
 


### PR DESCRIPTION
Fixes #1855.

If a batch of attributes contains an `INSUFFICIENT_SPACE` failure, we should re-read the affected attributes _once_ in isolation to ensure they have as much room as possible in the frame.