### PR TITLE
Extend OTA timeout for no progress

### DIFF
--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from zigpy.ota.providers import OtaImageWithMetadata
 
 
-MAX_TIME_WITHOUT_PROGRESS = 30
+MAX_TIME_WITHOUT_PROGRESS = 60
 
 
 def _image_block_size_for_manufacturer(


### PR DESCRIPTION
### Problem
Silicon Labs EFR32 chips perform full firmware CRC validation after receiving the last OTA block.
The constant `MAX_TIME_WITHOUT_PROGRESS` was hardcoded to 30 seconds in zigpy.

My custom hardware has a fixed 31-second firmware CRC verification phase after receiving the final OTA block. This duration exceeds zigpy's original 30s idle timeout limit.

This problem does not appear when using other Zigbee gateways/stacks I tested:
- zigbee2mqtt
- SONOFF Zigbee Bridge Pro
- NXP official Zigbee gateway
These platforms implement a longer idle timeout for OTA sessions, so the 31s validation window does not trigger a timeout error there.
For reference, my standard off-the-shelf Silicon Labs devices only spend ~28s on CRC checks, which fits within the original 30s limit and work fine in ZHA without modification.

#### End user visible result:
- Device finishes flashing & CRC verification successfully
- Device sends OTA end request after validation completes
- zigpy has already aborted the OTA session due to timeout
- ZHA incorrectly marks the entire upgrade as failed

### Solution
Bump `MAX_TIME_WITHOUT_PROGRESS` from 30 seconds to 60 seconds.
- 60s would already resolve the timeout for my custom device with 31s validation
- 60s adds a generous safety buffer for custom builds, larger firmware images, or slower MCU clock setups

This change improves general compatibility with any device that requires lengthy post-download integrity checks, not only Silicon Labs hardware. It does not impact fast, standard OTA transfers.

### Reproduction Steps
1. Pair the custom Silicon Labs EFR32MG21/EFR32MG2x device to ZHA via zigpy
2. Start a full Zigbee OTA firmware update
3. Wait until the final OTA data block is fully transmitted
4. The device pauses for a fixed 31s to run full CRC validation before sending its OTA end request
5. ZHA reports a timeout failure despite successful firmware flashing and verification on the hardware

### Verification
After modifying `MAX_TIME_WITHOUT_PROGRESS = 60`:
- Device completes the 31s CRC check and transmits its OTA end request to zigpy
- zigpy does not timeout and properly handles the incoming end request
- ZHA displays the OTA upgrade status as fully successful

### Additional Notes
1. This idle timeout only activates when no new OTA data blocks are received. Normal ongoing OTA transfers reset the timer on every received block, so fast standard upgrades are completely unaffected by this change.
2. The 31-second post-download CRC validation is fixed on my custom hardware. Other tested Zigbee gateways avoid this failure because they use higher idle timeout thresholds for OTA workflows. Standard unmodified Silicon Labs hardware only requires ~28s validation and works within the original 30s limit.