### PR TITLE
Send oversized attribute records instead of failing the request

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2914,20 +2914,76 @@ def test_chunk_records_by_size(sizes, max_bytes, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    ("sizes", "max_bytes"),
+    ("sizes", "max_bytes", "expected"),
     [
         # A single record larger than the limit, on its own
-        ([15], 10),
-        # An oversized record surrounded by ones that would otherwise fit
-        ([3, 15, 4], 10),
+        ([15], 10, [[15]]),
+        # An oversized record does not take the records around it down with it
+        ([3, 15, 4], 10, [[3], [15], [4]]),
+        # Records before an oversized one still pack together
+        ([3, 3, 15, 4], 10, [[3, 3], [15], [4]]),
+        # Consecutive oversized records each get a chunk of their own
+        ([15, 15], 10, [[15], [15]]),
     ],
 )
-def test_chunk_records_by_size_oversized_record(sizes, max_bytes) -> None:
-    """A record that on its own exceeds max_bytes can never be sent, so the chunker
-    fails loudly instead of emitting an oversized chunk the transport would reject.
+def test_chunk_records_by_size_oversized_record(
+    sizes, max_bytes, expected, caplog
+) -> None:
+    """A record that on its own exceeds max_bytes is emitted as its own chunk.
+
+    Chunking cannot make such a record any smaller and max_bytes is a conservative
+    budget rather than a protocol limit, so the request is attempted and the device
+    or the transport gets to reject it, instead of failing locally.
     """
-    with pytest.raises(ValueError, match="too large to fit in a single request"):
-        _chunk_records_by_size(sizes, lambda size: size, max_bytes=max_bytes)
+    chunks = _chunk_records_by_size(sizes, lambda size: size, max_bytes=max_bytes)
+
+    assert chunks == expected
+    assert caplog.text.count("exceeds the 10 byte request budget") == sum(
+        size > max_bytes for size in sizes
+    )
+
+
+async def test_write_attributes_oversized_record(app_mock) -> None:
+    """An attribute record over the size budget is still sent, on its own."""
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            attr_small = foundation.ZCLAttributeDef(id=0xFF00, type=t.uint8_t)
+            attr_big = foundation.ZCLAttributeDef(id=0xFF01, type=t.LVBytes)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    # 2 bytes of attribute id + 1 type + 1 length prefix + 55 bytes of value
+    oversized = b"\xaa" * 55
+
+    with mock_attribute_writes(
+        cluster,
+        {
+            TestCluster.AttributeDefs.attr_small: foundation.Status.SUCCESS,
+            TestCluster.AttributeDefs.attr_big: foundation.Status.SUCCESS,
+        },
+    ) as (mock_write, _):
+        [results] = await cluster.write_attributes(
+            {
+                TestCluster.AttributeDefs.attr_small: 1,
+                TestCluster.AttributeDefs.attr_big: oversized,
+            }
+        )
+
+    # The small record is sent normally, the oversized one in a request of its own
+    assert mock_write.call_count == 2
+    chunks = [call_obj.args[0] for call_obj in mock_write.call_args_list]
+    assert [[a.attrid for a in chunk] for chunk in chunks] == [[0xFF00], [0xFF01]]
+
+    [big_record] = chunks[1]
+    assert len(big_record.serialize()) == 59 > MAX_ATTRIBUTE_RECORDS_BYTES
+
+    assert len(results) == 2
+    assert all(r.status == foundation.Status.SUCCESS for r in results)
 
 
 def test_manufacturer_id_override_manuf_specific_cluster(app_mock) -> None:

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, call, patch, sentinel
@@ -2929,13 +2930,9 @@ def test_chunk_records_by_size(sizes, max_bytes, expected) -> None:
 def test_chunk_records_by_size_oversized_record(
     sizes, max_bytes, expected, caplog
 ) -> None:
-    """A record that on its own exceeds max_bytes is emitted as its own chunk.
-
-    Chunking cannot make such a record any smaller and max_bytes is a conservative
-    budget rather than a protocol limit, so the request is attempted and the device
-    or the transport gets to reject it, instead of failing locally.
-    """
-    chunks = _chunk_records_by_size(sizes, lambda size: size, max_bytes=max_bytes)
+    """A record that on its own exceeds max_bytes is emitted as its own chunk."""
+    with caplog.at_level(logging.DEBUG, logger="zigpy.zcl"):
+        chunks = _chunk_records_by_size(sizes, lambda size: size, max_bytes=max_bytes)
 
     assert chunks == expected
     assert caplog.text.count("exceeds the 10 byte request budget") == sum(

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -53,7 +53,13 @@ def _chunk_records_by_size(
     *,
     max_bytes: int = MAX_ATTRIBUTE_RECORDS_BYTES,
 ) -> list[list[_RecordT]]:
-    """Split records into chunks not exceeding max_bytes of serialized payload."""
+    """Split records into chunks not exceeding max_bytes of serialized payload.
+
+    A record that on its own exceeds max_bytes is emitted as its own chunk: chunking
+    cannot make it any smaller, and max_bytes is a conservative budget rather than a
+    protocol limit, so it is better to attempt the request and let the device or the
+    transport reject it than to fail locally without ever sending anything.
+    """
     chunks: list[list[_RecordT]] = []
     chunk_size = 0
 
@@ -61,10 +67,17 @@ def _chunk_records_by_size(
         record_size = get_size(record)
 
         if record_size > max_bytes:
-            raise ValueError(
-                f"Record {record!r} is too large to fit in a single request: "
-                f"{record_size} > {max_bytes} bytes"
+            LOGGER.warning(
+                "Record %r exceeds the %d byte request budget (%d bytes), sending it"
+                " on its own",
+                record,
+                max_bytes,
+                record_size,
             )
+            chunks.append([record])
+            # Nothing else may share a chunk that is already over budget
+            chunk_size = max_bytes + 1
+            continue
 
         if not chunks or chunk_size + record_size > max_bytes:
             chunks.append([])

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -53,13 +53,7 @@ def _chunk_records_by_size(
     *,
     max_bytes: int = MAX_ATTRIBUTE_RECORDS_BYTES,
 ) -> list[list[_RecordT]]:
-    """Split records into chunks not exceeding max_bytes of serialized payload.
-
-    A record that on its own exceeds max_bytes is emitted as its own chunk: chunking
-    cannot make it any smaller, and max_bytes is a conservative budget rather than a
-    protocol limit, so it is better to attempt the request and let the device or the
-    transport reject it than to fail locally without ever sending anything.
-    """
+    """Split records into chunks not exceeding max_bytes of serialized payload."""
     chunks: list[list[_RecordT]] = []
     chunk_size = 0
 
@@ -67,7 +61,10 @@ def _chunk_records_by_size(
         record_size = get_size(record)
 
         if record_size > max_bytes:
-            LOGGER.warning(
+            # Chunking can't shrink a single record, so send it alone and let the
+            # device reject it. `max_bytes + 1` keeps the next record out of this
+            # chunk, whatever its size.
+            LOGGER.debug(
                 "Record %r exceeds the %d byte request budget (%d bytes), sending it"
                 " on its own",
                 record,
@@ -75,7 +72,6 @@ def _chunk_records_by_size(
                 record_size,
             )
             chunks.append([record])
-            # Nothing else may share a chunk that is already over budget
             chunk_size = max_bytes + 1
             continue
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -53,7 +53,7 @@ def _chunk_records_by_size(
     *,
     max_bytes: int = MAX_ATTRIBUTE_RECORDS_BYTES,
 ) -> list[list[_RecordT]]:
-    """Split records into chunks not exceeding max_bytes of serialized payload."""
+    """Split records into chunks of at most max_bytes, except oversized records."""
     chunks: list[list[_RecordT]] = []
     chunk_size = 0
 
@@ -65,9 +65,8 @@ def _chunk_records_by_size(
             # device reject it. `max_bytes + 1` keeps the next record out of this
             # chunk, whatever its size.
             LOGGER.debug(
-                "Record %r exceeds the %d byte request budget (%d bytes), sending it"
+                "Record exceeds the %d byte request budget (%d bytes), sending it"
                 " on its own",
-                record,
                 max_bytes,
                 record_size,
             )


### PR DESCRIPTION
## Proposed change

This PR changes the behavior when trying to write attributes over the 50 byte limit set by zigpy, so that an oversized write is always attempted as a standalone write, instead of aborting all writes. Note the device may still reject it but many devices have (slightly) higher limits. See [this comment](https://github.com/zigpy/zigpy/issues/1862#issuecomment-5092090137) for more context.

This addresses the following issue:
- Fixes #1862

## AI "summary"

`_chunk_records_by_size` raised when a single attribute record exceeded `MAX_ATTRIBUTE_RECORDS_BYTES`, so `write_attributes` and `configure_reporting` failed locally without sending anything. Chunking can't make an indivisible record any smaller, so the raise turns "might work" into "guaranteed not to work" without ever asking the device.

Such a record is now emitted as its own chunk, with a debug log. The 50 byte budget is a conservative heuristic rather than a protocol limit — zigpy has no transport-level size check to defer to, doesn't fragment, and never handles `APS_ASDU_TOO_LONG`, and `write_attributes_raw()` already sends these payloads unchunked. If the request really is too large, the failure still happens, just one layer down as a delivery failure or a device-reported status, which is both more accurate and more actionable than a local `ValueError`.

This also stops one oversized record from taking its siblings down with it: `[3, 15, 4]` with `max_bytes=10` previously raised before anything was sent, and now yields `[[3], [15], [4]]`.

The motivating case is the Aqara E1 radiator thermostat (`lumi.airrtc.agl001`), which switches its temperature source by writing a 55 byte proprietary blob to `0xFFF2` — a 59 byte record. Zigbee2MQTT sends the byte-identical write as one unfragmented request successfully, and the device's node descriptor reports a `maximum_buffer_size` of 127, so the 64 byte frame fits comfortably. It's rejected only by zigpy's local budget check.

`MAX_ATTRIBUTE_RECORDS_BYTES` itself is deliberately untouched. Per the node-descriptor survey in the issue, 50 sits about 3 bytes under the records budget implied by the most common `maximum_buffer_size` in the wild, so it's a good batching budget and shouldn't be raised.

### Tests

- `test_chunk_records_by_size_oversized_record` flips from asserting `pytest.raises` to asserting the chunking and the debug log, covering an oversized record alone, surrounded by fitting records, preceded by records that pack together, and back to back oversized records.
- `test_write_attributes_oversized_record` is new and goes end to end through `write_attributes`, asserting a 59 byte record (the Aqara payload size) actually reaches the wire in a request of its own while a small sibling is sent separately.

All five fail on unmodified `dev`.

### Notes

- `chunk_size` is set to `max_bytes + 1` rather than `max_bytes` after an oversized record, so the next record starts a fresh chunk regardless of its size.
- `configure_reporting` inherits the same relaxation, since it shares the chunker. In practice a reporting config maxes out around 16 bytes, so it shouldn't trip either way.
- Second commit applies the review feedback from the issue: debug rather than warning log level, and a short inline comment on the oversized branch in place of an expanded function docstring.
