### PR TITLE
Add coordinator group subscription APIs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,10 +171,10 @@ class App(BaseApp):
         else:
             return 10
 
-    async def _subscribe_to_multicast_group(self, group_id: t.GroupId) -> None:
+    async def _subscribe_to_multicast_group(self, group_id: t.Group) -> None:
         pass
 
-    async def _unsubscribe_from_multicast_group(self, group_id: t.GroupId) -> None:
+    async def _unsubscribe_from_multicast_group(self, group_id: t.Group) -> None:
         pass
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,12 @@ class App(BaseApp):
         else:
             return 10
 
+    async def _subscribe_to_multicast_group(self, group_id: t.GroupId) -> None:
+        pass
+
+    async def _unsubscribe_from_multicast_group(self, group_id: t.GroupId) -> None:
+        pass
+
 
 def recursive_dict_merge(
     obj: dict[str, typing.Any], updates: dict[str, typing.Any]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,10 +171,14 @@ class App(BaseApp):
         else:
             return 10
 
-    async def _subscribe_to_multicast_group(self, group_id: t.Group) -> None:
+    async def _subscribe_to_multicast_group(
+        self, group_id: t.Group, endpoint_id: int
+    ) -> None:
         pass
 
-    async def _unsubscribe_from_multicast_group(self, group_id: t.Group) -> None:
+    async def _unsubscribe_from_multicast_group(
+        self, group_id: t.Group, endpoint_id: int
+    ) -> None:
         pass
 
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -2055,9 +2055,17 @@ async def test_coordinator_group_subscribe_unsubscribe(
     # Subscribe to a group
     with patch.object(app, "_subscribe_to_multicast_group") as mock_subscribe:
         await app.subscribe_to_multicast_group(0x1234)
-        assert mock_subscribe.mock_calls == [call(group_id=0x1234)]
+        await app.subscribe_to_multicast_group(0x1234, endpoint_id=2)
+        assert mock_subscribe.mock_calls == [
+            call(group_id=0x1234, endpoint_id=1),
+            call(group_id=0x1234, endpoint_id=2),
+        ]
 
     # Unsubscribe from a group
     with patch.object(app, "_unsubscribe_from_multicast_group") as mock_unsubscribe:
         await app.unsubscribe_from_multicast_group(0x1234)
-        assert mock_unsubscribe.mock_calls == [call(group_id=0x1234)]
+        await app.unsubscribe_from_multicast_group(0x1234, endpoint_id=2)
+        assert mock_unsubscribe.mock_calls == [
+            call(group_id=0x1234, endpoint_id=1),
+            call(group_id=0x1234, endpoint_id=2),
+        ]

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -2044,3 +2044,20 @@ async def test_device_resolver_new_kwarg():
     )
     assert app_default._device_resolver is None
     assert app_default._uninitialized_packet_handler is None
+
+
+async def test_coordinator_group_subscribe_unsubscribe(
+    app: zigpy.application.ControllerApplication,
+) -> None:
+    """Test that the coordinator can subscribe and unsubscribe from group messages."""
+    await app.startup()
+
+    # Subscribe to a group
+    with patch.object(app, "_subscribe_to_multicast_group") as mock_subscribe:
+        await app.subscribe_to_multicast_group(0x1234)
+        assert mock_subscribe.mock_calls == [call(group_id=0x1234)]
+
+    # Unsubscribe from a group
+    with patch.object(app, "_unsubscribe_from_multicast_group") as mock_unsubscribe:
+        await app.unsubscribe_from_multicast_group(0x1234)
+        assert mock_unsubscribe.mock_calls == [call(group_id=0x1234)]

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1672,20 +1672,28 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self, group_id: t.Group, endpoint_id: int = 1
     ) -> None:
         """Ask the coordinator firmware to subscribe to a group, if needed."""
-        await self._subscribe_to_multicast_group(group_id=group_id)
+        await self._subscribe_to_multicast_group(
+            group_id=group_id, endpoint_id=endpoint_id
+        )
 
     # @abc.abstractmethod
-    async def _subscribe_to_multicast_group(self, group_id: t.Group) -> None:
+    async def _subscribe_to_multicast_group(
+        self, group_id: t.Group, endpoint_id: int
+    ) -> None:
         """Ask the coordinator firmware to subscribe to a group, if needed."""
 
     async def unsubscribe_from_multicast_group(
         self, group_id: t.Group, endpoint_id: int = 1
     ) -> None:
         """Ask the coordinator firmware to unsubscribe from a group, if needed."""
-        await self._unsubscribe_from_multicast_group(group_id=group_id)
+        await self._unsubscribe_from_multicast_group(
+            group_id=group_id, endpoint_id=endpoint_id
+        )
 
     # @abc.abstractmethod
-    async def _unsubscribe_from_multicast_group(self, group_id: t.Group) -> None:
+    async def _unsubscribe_from_multicast_group(
+        self, group_id: t.Group, endpoint_id: int
+    ) -> None:
         """Ask the coordinator firmware to unsubscribe from a group, if needed."""
 
     async def permit(self, time_s: int = 60, node: t.EUI64 | str | None = None) -> None:

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1668,7 +1668,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     async def _packet_capture_change_channel(self, channel: int) -> None:
         """Change the channel of an active packet capture, internal."""
 
-    async def subscribe_to_multicast_group(self, group_id: t.Group) -> None:
+    async def subscribe_to_multicast_group(
+        self, group_id: t.Group, endpoint_id: int = 1
+    ) -> None:
         """Ask the coordinator firmware to subscribe to a group, if needed."""
         await self._subscribe_to_multicast_group(group_id=group_id)
 
@@ -1676,7 +1678,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     async def _subscribe_to_multicast_group(self, group_id: t.Group) -> None:
         """Ask the coordinator firmware to subscribe to a group, if needed."""
 
-    async def unsubscribe_from_multicast_group(self, group_id: t.Group) -> None:
+    async def unsubscribe_from_multicast_group(
+        self, group_id: t.Group, endpoint_id: int = 1
+    ) -> None:
         """Ask the coordinator firmware to unsubscribe from a group, if needed."""
         await self._unsubscribe_from_multicast_group(group_id=group_id)
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1668,6 +1668,22 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     async def _packet_capture_change_channel(self, channel: int) -> None:
         """Change the channel of an active packet capture, internal."""
 
+    async def subscribe_to_multicast_group(self, group_id: t.Group) -> None:
+        """Ask the coordinator firmware to subscribe to a group, if needed."""
+        await self._subscribe_to_multicast_group(group_id=group_id)
+
+    # @abc.abstractmethod
+    async def _subscribe_to_multicast_group(self, group_id: t.Group) -> None:
+        """Ask the coordinator firmware to subscribe to a group, if needed."""
+
+    async def unsubscribe_from_multicast_group(self, group_id: t.Group) -> None:
+        """Ask the coordinator firmware to unsubscribe from a group, if needed."""
+        await self._unsubscribe_from_multicast_group(group_id=group_id)
+
+    # @abc.abstractmethod
+    async def _unsubscribe_from_multicast_group(self, group_id: t.Group) -> None:
+        """Ask the coordinator firmware to unsubscribe from a group, if needed."""
+
     async def permit(self, time_s: int = 60, node: t.EUI64 | str | None = None) -> None:
         """Permit joining on a specific node or all router nodes."""
         assert 0 <= time_s <= 254


### PR DESCRIPTION
Some coordinators (namely SiLabs without our firmware patches) require groups to be explicitly registered in order for packets addressed to that group to be forwarded by the firmware.

These new APIs will be used by quirks to better support the few devices that require explicit group registration.