### PR TITLE
Add Zigbee Direct Configuration cluster

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -946,6 +946,31 @@ async def test_force_route_discovery(app, device, packet) -> None:
     ]
 
 
+async def test_request_zigbee_direct_aps_encryption(app, device, packet) -> None:
+    await app.request(
+        device=device,
+        profile=0x1234,
+        cluster=clusters.general.ZigbeeDirectConfiguration.cluster_id,
+        src_ep=0x9A,
+        dst_ep=0xBC,
+        sequence=0xDE,
+        data=b"test data",
+        expect_reply=True,
+        use_ieee=False,
+        extended_timeout=False,
+    )
+
+    assert app.send_packet.mock_calls == [
+        call(
+            packet.replace(
+                cluster_id=clusters.general.ZigbeeDirectConfiguration.cluster_id,
+                tx_options=packet.tx_options | t.TransmitOptions.APS_Encryption,
+                priority=t.PacketPriority.NORMAL,
+            )
+        ),
+    ]
+
+
 def test_build_source_route_has_relays(app):
     device = MagicMock()
     device.relays = [0x1234, 0x5678]

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -12,13 +12,7 @@ from zigpy import device, types, zcl
 import zigpy.endpoint
 from zigpy.ota import OTA, OtaImagesResult
 from zigpy.zcl import OtaImageAvailableEvent, OtaQueryCacheUpdatedEvent, foundation
-from zigpy.zcl.clusters.general import (
-    Basic,
-    KeepAlive,
-    Ota,
-    Time,
-    ZigbeeDirectConfiguration,
-)
+from zigpy.zcl.clusters.general import Basic, KeepAlive, Ota, Time
 import zigpy.zcl.clusters.security as sec
 from zigpy.zdo import types as zdo_t
 
@@ -174,29 +168,6 @@ async def test_keepalive_cluster() -> None:
             value=300,
         ),
     )
-
-
-def test_zigbee_direct_configuration_cluster() -> None:
-    configure_interface = (
-        ZigbeeDirectConfiguration.ServerCommandDefs.configure_interface.schema(
-            interface_state=ZigbeeDirectConfiguration.InterfaceState.Enabled
-        )
-    )
-    assert configure_interface.serialize() == b"\x01"
-
-    configure_timeout = ZigbeeDirectConfiguration.ServerCommandDefs.configure_anonymous_join_timeout.schema(
-        anonymous_join_timeout=3600
-    )
-    assert configure_timeout.serialize() == b"\x10\x0e\x00"
-
-    rsp, rest = (
-        ZigbeeDirectConfiguration.ClientCommandDefs.configure_interface_rsp.schema.deserialize(
-            b"\x00\x01"
-        )
-    )
-    assert not rest
-    assert rsp.status == foundation.Status.SUCCESS
-    assert rsp.interface_state == ZigbeeDirectConfiguration.InterfaceState.Enabled
 
 
 def _make_patched_datetime(fake_now):

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -12,7 +12,13 @@ from zigpy import device, types, zcl
 import zigpy.endpoint
 from zigpy.ota import OTA, OtaImagesResult
 from zigpy.zcl import OtaImageAvailableEvent, OtaQueryCacheUpdatedEvent, foundation
-from zigpy.zcl.clusters.general import Basic, KeepAlive, Ota, Time
+from zigpy.zcl.clusters.general import (
+    Basic,
+    KeepAlive,
+    Ota,
+    Time,
+    ZigbeeDirectConfiguration,
+)
 import zigpy.zcl.clusters.security as sec
 from zigpy.zdo import types as zdo_t
 
@@ -168,6 +174,29 @@ async def test_keepalive_cluster() -> None:
             value=300,
         ),
     )
+
+
+def test_zigbee_direct_configuration_cluster() -> None:
+    configure_interface = (
+        ZigbeeDirectConfiguration.ServerCommandDefs.configure_interface.schema(
+            interface_state=ZigbeeDirectConfiguration.InterfaceState.Enabled
+        )
+    )
+    assert configure_interface.serialize() == b"\x01"
+
+    configure_timeout = ZigbeeDirectConfiguration.ServerCommandDefs.configure_anonymous_join_timeout.schema(
+        anonymous_join_timeout=3600
+    )
+    assert configure_timeout.serialize() == b"\x10\x0e\x00"
+
+    rsp, rest = (
+        ZigbeeDirectConfiguration.ClientCommandDefs.configure_interface_rsp.schema.deserialize(
+            b"\x00\x01"
+        )
+    )
+    assert not rest
+    assert rsp.status == foundation.Status.SUCCESS
+    assert rsp.interface_state == ZigbeeDirectConfiguration.InterfaceState.Enabled
 
 
 def _make_patched_datetime(fake_now):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1134,6 +1134,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         if force_route_discovery:
             tx_options |= t.TransmitOptions.FORCE_ROUTE_DISCOVERY
 
+        if cluster == zigpy.zcl.clusters.general.ZigbeeDirectConfiguration.cluster_id:
+            # All interactions with the Zigbee Direct Configuration cluster require
+            # APS encryption (with the Trust Center link key, in a centralized
+            # security network)
+            tx_options |= t.TransmitOptions.APS_Encryption
+
         await self.send_packet(
             t.ZigbeePacket(
                 src=src,

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2453,3 +2453,58 @@ class KeepAlive(Cluster):
         # Spec default (0x012C). Represents the jitter (in _seconds_) that a Zigbee 4.0
         # device will add to the time base when checking if the trust center is alive.
         return t.uint16_t(300)
+
+
+class ZigbeeDirectInterfaceState(t.bitmap8):
+    """Zigbee Direct interface state bitmap."""
+
+    Enabled = 0b00000001
+
+
+class ZigbeeDirectConfiguration(Cluster):
+    """Zigbee Direct Configuration cluster definition.
+
+    Configures Zigbee Direct on a Zigbee Direct Device (ZDD). Commands are
+    only accepted via unicast and, in a centralized security network, all
+    interactions with this cluster require APS encryption with the Trust
+    Center link key.
+    """
+
+    InterfaceState: Final = ZigbeeDirectInterfaceState
+
+    cluster_id: Final[t.uint16_t] = 0x003D
+    ep_attribute: Final = "zigbee_direct_configuration"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Zigbee Direct Configuration cluster attributes."""
+
+        interface_state: Final = ZCLAttributeDef(
+            id=0x0000, type=ZigbeeDirectInterfaceState, access="r", mandatory=True
+        )
+        # Timeout in seconds (0x000000-0x100000, or 0xFFFFFF for no timeout)
+        # during which a ZVD can establish a provisioning session using the
+        # Anonymous Well-Known Secret while the network is open
+        anonymous_join_timeout: Final = ZCLAttributeDef(
+            id=0x0001, type=t.uint24_t, access="r", mandatory=True
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Zigbee Direct Configuration cluster server commands."""
+
+        configure_interface: Final = ZCLCommandDef(
+            id=0x00, schema={"interface_state": ZigbeeDirectInterfaceState}
+        )
+        configure_anonymous_join_timeout: Final = ZCLCommandDef(
+            id=0x01, schema={"anonymous_join_timeout": t.uint24_t}
+        )
+
+    class ClientCommandDefs(BaseCommandDefs):
+        """Zigbee Direct Configuration cluster client commands."""
+
+        configure_interface_rsp: Final = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "status": foundation.Status,
+                "interface_state": ZigbeeDirectInterfaceState,
+            },
+        )


### PR DESCRIPTION
## Proposed change

This PR adds support for the Zigbee Direct Configuration cluster (`0x003D`). This cluster is utilized by some Ubisys devices. Implementing this cluster would allow users to turn off the BLE interface, for example.

For details, see the [Zigbee Direct Specification v1.1](https://csa-iot.org/developer-resource/specifications-download-request/) (doc 20-27688, section 11.3), referenced by Zigbee R23 core spec.

Related Z2M PRs:
- https://github.com/Koenkk/zigbee-herdsman/issues/1760
- https://github.com/Koenkk/zigbee-herdsman/pull/1761/
- https://github.com/Koenkk/zigbee-herdsman/pull/1762

### APS encryption

One thing to note, that is also further discussed in the above Z2M issue, is that frames need to be sent with APS encryption enabled per 11.3.5.1. Otherwise, the devices reject them: `NOT_AUTHORIZED`. So `ControllerApplication.request()` now sets `TransmitOptions.APS_Encryption` for unicasts to this cluster.

Note: zigpy-znp already honors `TransmitOptions.APS_Encryption`, but bellows and zigpy-deconz currently ignore it, so those radio libraries need small follow-up PRs for this to work there.

### Other LLM-generated notes

<details><summary>AI description of cluster definition & added tests (click to expand)</summary>
<p>

### Cluster definition

New `ZigbeeDirectConfiguration` cluster in `zigpy/zcl/clusters/general.py`, matching spec section 11.3.5 (Tables 57–63):

- Attributes: `interface_state` (`map8`, bit 0 = Zigbee Direct interface enabled) and `anonymous_join_timeout` (`uint24`, seconds; `0x000000`–`0x100000` or `0xFFFFFF` for no timeout), both read-only and mandatory.
- Server commands: `configure_interface` (`0x00`) to enable/disable the Zigbee Direct BLE interface and `configure_anonymous_join_timeout` (`0x01`).
- Client command: `configure_interface_rsp` (`0x00`) carrying a status and the current interface state.

### Testing

- ~~Round-trip serialization tests for the new command schemas.~~
- A test asserting that `ControllerApplication.request()` sets the APS encryption flag on packets addressed to cluster `0x003D`.


</p>
</details> 

