### PR TITLE
Granular frame scheduling and error types

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,10 +86,6 @@ def raise_on_bad_log_formatting():
 
 
 class BaseApp(zigpy.application.ControllerApplication):
-    async def send_packet(self, packet):
-        async with self._limit_concurrency(priority=packet.priority):
-            return await self._send_packet(packet)
-
     async def _send_packet(self, packet):
         await asyncio.sleep(0)
 
@@ -219,7 +215,9 @@ def make_app(
     app.device_initialized = Mock(wraps=app.device_initialized)
     app.listener_event = Mock(wraps=app.listener_event)
     app.get_sequence = MagicMock(wraps=app.get_sequence, return_value=123)
+    # `send_packet` is the public submission API, `_send_packet` is a single attempt
     app.send_packet = AsyncMock(wraps=app.send_packet)
+    app._send_packet = AsyncMock(wraps=app._send_packet)
     app.write_network_info = AsyncMock(wraps=app.write_network_info)
 
     return app

--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -158,7 +158,7 @@ async def test_ota_manger_stall(image_with_metadata: OtaImageWithMetadata) -> No
                 # Do nothing, just let it time out
                 pass
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
 
     status = await dev.update_firmware(img)
     assert status == foundation.Status.TIMEOUT
@@ -203,7 +203,7 @@ async def test_ota_manger_device_reject(
                     )
                 )
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
 
     status = await dev.update_firmware(img)
     assert status == foundation.Status.NO_IMAGE_AVAILABLE
@@ -371,7 +371,7 @@ async def test_ota_manager():
                 )
             )
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
     result = await update_firmware(dev, FW_IMAGE, progress_callback)
 
@@ -572,7 +572,7 @@ async def test_ota_manager_image_page():
                 )
             )
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
     result = await update_firmware(dev, FW_IMAGE, progress_callback)
 
@@ -650,7 +650,7 @@ async def test_ota_manager_image_page_invalid_size():
                 )
             )
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
     result = await update_firmware(dev, FW_IMAGE, progress_callback)
 
@@ -732,7 +732,7 @@ async def test_ota_manager_image_page_failure():
 
             start_failing = True
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
     result = await update_firmware(dev, FW_IMAGE, progress_callback)
 
@@ -838,7 +838,7 @@ async def test_ota_manager_final_block_timeout(use_pages: bool) -> None:
 
             request_block(next_offset)
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
 
     result = await update_firmware(dev, FW_IMAGE)
 
@@ -895,7 +895,7 @@ async def test_ota_manager_deferred_download():
                 )
             )
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
 
     # Mock fetch() to return the complete image
     mock_fetch = AsyncMock(return_value=FW_IMAGE)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -11,7 +11,6 @@ import pytest
 
 import zigpy.application
 import zigpy.config as conf
-from zigpy.datastructures import RequestLimiter
 import zigpy.device
 import zigpy.endpoint
 from zigpy.exceptions import (
@@ -782,7 +781,7 @@ async def test_request_concurrency():
             await asyncio.sleep(0.1)
             current_concurrency -= 1
 
-            if packet % 10 == 7:
+            if packet.dst.address % 10 == 7:
                 # Fail randomly
                 raise DeliveryError("Failure")
 
@@ -793,7 +792,12 @@ async def test_request_concurrency():
 
     await asyncio.gather(
         *[
-            app.send_packet(t.ZigbeePacket(priority=t.PacketPriority.HIGH))
+            app.send_packet(
+                t.ZigbeePacket(
+                    priority=t.PacketPriority.HIGH,
+                    dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(i)),
+                )
+            )
             for i in range(100)
         ],
         return_exceptions=True,
@@ -1680,25 +1684,22 @@ async def test_packet_capture(app) -> None:
         assert app._packet_capture_change_channel.mock_calls == [call(channel=25)]
 
 
-async def test_request_priority(app) -> None:
-    app._concurrent_requests_semaphore = RequestLimiter(
-        max_concurrency=1, capacities={t.PacketPriority.LOW: 1}
+async def test_request_priority(app, packet) -> None:
+    app._scheduler.max_in_flight = 1
+
+    packet_low = packet.replace(priority=t.PacketPriority.LOW)
+    packet_normal = packet.replace(priority=t.PacketPriority.NORMAL)
+    packet_high = packet.replace(priority=t.PacketPriority.HIGH)
+    packet_critical = packet.replace(priority=t.PacketPriority.CRITICAL)
+
+    await asyncio.gather(
+        app.send_packet(packet_low),
+        app.send_packet(packet_normal),
+        app.send_packet(packet_high),
+        app.send_packet(packet_critical),
     )
 
-    with patch.object(app, "_send_packet", wraps=app._send_packet) as mock_send_packet:
-        packet_low = Mock(name="LOW", priority=t.PacketPriority.LOW)
-        packet_normal = Mock(name="NORMAL", priority=t.PacketPriority.NORMAL)
-        packet_high = Mock(name="HIGH", priority=t.PacketPriority.HIGH)
-        packet_critical = Mock(name="CRITICAL", priority=t.PacketPriority.CRITICAL)
-
-        await asyncio.gather(
-            app.send_packet(packet_low),
-            app.send_packet(packet_normal),
-            app.send_packet(packet_high),
-            app.send_packet(packet_critical),
-        )
-
-    assert mock_send_packet.mock_calls == [
+    assert app._send_packet.mock_calls == [
         # The low priority packet made it through first, locking up the queue
         call(packet_low),
         # The critical one bypasses all others even though it's sent last
@@ -1711,15 +1712,15 @@ async def test_request_priority(app) -> None:
 async def test_request_priority_context_concurrency(app, packet):
     """Test that request_priority contexts work correctly with concurrent tasks."""
     # Limit concurrency to see priority ordering effects
-    app._concurrent_requests_semaphore = RequestLimiter(
-        max_concurrency=1, capacities={t.PacketPriority.LOW: 1}
-    )
+    app._scheduler.max_in_flight = 1
 
     with patch.object(app, "_send_packet", wraps=app._send_packet) as mock_send:
 
         async def task_with_priority(name: str, priority: int):
             async with app.request_priority(priority):
-                await app.send_packet(packet.replace(data=name.encode()))
+                await app.send_packet(
+                    packet.replace(data=t.SerializableBytes(name.encode()))
+                )
 
         # Start multiple concurrent tasks with different priority contexts
         await asyncio.gather(
@@ -1731,13 +1732,31 @@ async def test_request_priority_context_concurrency(app, packet):
             ),
         )
 
-    # Verify packets were processed in priority order, not send order
+    # Verify packets were processed in priority order, not send order. The contextvar
+    # priority is stamped onto the packet at submission.
     assert mock_send.mock_calls == [
         # The low priority task started first but gets processed in priority order
-        call(packet.replace(data=b"low")),
-        call(packet.replace(data=b"critical")),
-        call(packet.replace(data=b"high")),
-        call(packet.replace(data=b"normal")),
+        call(
+            packet.replace(
+                data=t.SerializableBytes(b"low"), priority=t.PacketPriority.LOW
+            )
+        ),
+        call(
+            packet.replace(
+                data=t.SerializableBytes(b"critical"),
+                priority=t.PacketPriority.CRITICAL,
+            )
+        ),
+        call(
+            packet.replace(
+                data=t.SerializableBytes(b"high"), priority=t.PacketPriority.HIGH
+            )
+        ),
+        call(
+            packet.replace(
+                data=t.SerializableBytes(b"normal"), priority=t.PacketPriority.NORMAL
+            )
+        ),
     ]
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2231,8 +2231,10 @@ async def test_update_firmware_triggers_reinterview(monkeypatch, dev):
     dev.reinterview.assert_awaited_once()
 
 
-async def test_request_retry_success(app) -> None:
+@pytest.mark.parametrize("use_scheduler", [True, False])
+async def test_request_retry_success(app, use_scheduler) -> None:
     """Test retry logic succeeding after a few attempts."""
+    app._uses_scheduler = use_scheduler
     tsn = 0x12
 
     dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
@@ -2305,8 +2307,10 @@ async def test_request_retry_success(app) -> None:
     assert len(app._send_packet.mock_calls) == 3
 
 
-async def test_request_retry_failure(app) -> None:
+@pytest.mark.parametrize("use_scheduler", [True, False])
+async def test_request_retry_failure(app, use_scheduler) -> None:
     """Test retry logic when all attempts fail."""
+    app._uses_scheduler = use_scheduler
     dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
     dev.node_desc = make_node_desc()
 
@@ -2371,8 +2375,10 @@ async def test_request_retry_failure(app) -> None:
     ]
 
 
-async def test_request_retry_reply_timeout(app) -> None:
+@pytest.mark.parametrize("use_scheduler", [True, False])
+async def test_request_retry_reply_timeout(app, use_scheduler) -> None:
     """Test retry logic when a request is enqueued but no reply arrives, then a later attempt succeeds."""
+    app._uses_scheduler = use_scheduler
     tsn = 0x12
 
     dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -128,7 +128,7 @@ async def test_initialize_sends_image_notify(
         await dev.initialize()
 
     # image_notify is the last packet sent during initialization
-    packet = app.send_packet.call_args_list[0][0][0]
+    packet = app._send_packet.call_args_list[0][0][0]
     hdr, cmd = ota.deserialize(packet.data.serialize())
     assert isinstance(cmd, Ota.ImageNotifyCommand)
     assert cmd.payload_type == Ota.ImageNotifyCommand.PayloadType.QueryJitter
@@ -213,7 +213,7 @@ async def test_initialize_ep_failed(monkeypatch, dev):
 
 async def test_failed_request(dev):
     assert dev.last_seen is None
-    dev._application.send_packet = AsyncMock(
+    dev._application._send_packet = AsyncMock(
         side_effect=zigpy.exceptions.DeliveryError("Uh oh")
     )
     with pytest.raises(zigpy.exceptions.DeliveryError):
@@ -762,7 +762,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
                     )
                 )
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
 
     cleared_events = []
@@ -779,7 +779,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     # Wait for background tasks (post-OTA query_next_image handling)
     await asyncio.sleep(0)
     # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
-    assert dev.application.send_packet.await_count == 8
+    assert dev.application._send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(40, 70, 57.142857142857146)
     assert progress_callback.call_args_list[1] == call(70, 70, 100.0)
@@ -790,21 +790,21 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     assert cluster.last_query_cmd is not None
 
     progress_callback.reset_mock()
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     result = await dev.update_firmware(
         fw_image, progress_callback=progress_callback, force=True
     )
 
     await asyncio.sleep(0)
     # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
-    assert dev.application.send_packet.await_count == 8
+    assert dev.application._send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(40, 70, 57.142857142857146)
     assert progress_callback.call_args_list[1] == call(70, 70, 100.0)
     assert result == foundation.Status.SUCCESS
 
     # Post-OTA image_notify failure: OTA still succeeds
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     progress_callback.reset_mock()
     caplog.clear()
     original_image_notify = cluster.image_notify
@@ -825,12 +825,12 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     caplog.clear()
 
     # _image_query_req exception test
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     progress_callback.reset_mock()
     image_notify = cluster.image_notify
     cluster.image_notify = AsyncMock(side_effect=zigpy.exceptions.DeliveryError("Foo"))
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
-    assert dev.application.send_packet.await_count == 0
+    assert dev.application._send_packet.await_count == 0
     assert progress_callback.call_count == 0
     assert "OTA image_notify handler exception" in caplog.text
     assert result != foundation.Status.SUCCESS
@@ -838,14 +838,14 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     caplog.clear()
 
     # _image_query_req exception test
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     progress_callback.reset_mock()
     query_next_image_response = cluster.query_next_image_response
     cluster.query_next_image_response = AsyncMock(
         side_effect=zigpy.exceptions.DeliveryError("Foo")
     )
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
-    assert dev.application.send_packet.await_count == 1  # just image notify
+    assert dev.application._send_packet.await_count == 1  # just image notify
     assert progress_callback.call_count == 0
     assert "OTA query_next_image handler exception" in caplog.text
     assert result != foundation.Status.SUCCESS
@@ -853,7 +853,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     caplog.clear()
 
     # _image_block_req exception test
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     progress_callback.reset_mock()
     image_block_response = cluster.image_block_response
     cluster.image_block_response = AsyncMock(
@@ -861,7 +861,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     )
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
     assert (
-        dev.application.send_packet.await_count == 2
+        dev.application._send_packet.await_count == 2
     )  # just image notify + query next image
     assert progress_callback.call_count == 0
     assert "OTA image_block handler exception" in caplog.text
@@ -870,7 +870,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     caplog.clear()
 
     # _upgrade_end exception test
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     progress_callback.reset_mock()
     upgrade_end_response = cluster.upgrade_end_response
     cluster.upgrade_end_response = AsyncMock(
@@ -878,9 +878,11 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     )
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
     assert (
-        dev.application.send_packet.await_count == 4
+        dev.application._send_packet.await_count == 4
     )  # just image notify, qne, and 2 img blocks
-    assert progress_callback.call_count == 2
+    # The second block's progress is suppressed: the instantly-failing upgrade_end
+    # resolves the update before the block's send handle is awaited
+    assert progress_callback.call_count == 1
     assert "OTA upgrade_end handler exception" in caplog.text
     assert result != foundation.Status.SUCCESS
     cluster.upgrade_end_response = upgrade_end_response
@@ -924,7 +926,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
                     )
                 )
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
 
     progress_callback.reset_mock()
     image_block_response = cluster.image_block_response
@@ -933,7 +935,7 @@ async def test_update_device_firmware(monkeypatch, dev, caplog):
     )
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
     assert (
-        dev.application.send_packet.await_count == 2
+        dev.application._send_packet.await_count == 2
     )  # just image notify, qne, img block response fails
     assert progress_callback.call_count == 0
     assert "OTA image_block handler[MALFORMED_COMMAND] exception" in caplog.text
@@ -1181,7 +1183,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
                     )
                 )
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
     progress_callback = MagicMock()
     result = await dev.update_firmware(fw_image, progress_callback)
     assert (
@@ -1194,33 +1196,33 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     # Wait for background tasks (post-OTA query_next_image handling)
     await asyncio.sleep(0)
     # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
-    assert dev.application.send_packet.await_count == 8
+    assert dev.application._send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(64, 70, 91.42857142857143)
     assert progress_callback.call_args_list[1] == call(70, 70, 100.0)
     assert result == foundation.Status.SUCCESS
 
     progress_callback.reset_mock()
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     result = await dev.update_firmware(
         fw_image, progress_callback=progress_callback, force=True
     )
 
     await asyncio.sleep(0)
     # 6 OTA + 1 post-OTA image_notify + 1 post-OTA query_next_image_response
-    assert dev.application.send_packet.await_count == 8
+    assert dev.application._send_packet.await_count == 8
     assert progress_callback.call_count == 2
     assert progress_callback.call_args_list[0] == call(64, 70, 91.42857142857143)
     assert progress_callback.call_args_list[1] == call(70, 70, 100.0)
     assert result == foundation.Status.SUCCESS
 
     # _image_query_req exception test
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     progress_callback.reset_mock()
     image_notify = cluster.image_notify
     cluster.image_notify = AsyncMock(side_effect=zigpy.exceptions.DeliveryError("Foo"))
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
-    assert dev.application.send_packet.await_count == 0
+    assert dev.application._send_packet.await_count == 0
     assert progress_callback.call_count == 0
     assert "OTA image_notify handler exception" in caplog.text
     assert result != foundation.Status.SUCCESS
@@ -1228,14 +1230,14 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     caplog.clear()
 
     # _image_query_req exception test
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     progress_callback.reset_mock()
     query_next_image_response = cluster.query_next_image_response
     cluster.query_next_image_response = AsyncMock(
         side_effect=zigpy.exceptions.DeliveryError("Foo")
     )
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
-    assert dev.application.send_packet.await_count == 1  # just image notify
+    assert dev.application._send_packet.await_count == 1  # just image notify
     assert progress_callback.call_count == 0
     assert "OTA query_next_image handler exception" in caplog.text
     assert result != foundation.Status.SUCCESS
@@ -1243,7 +1245,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     caplog.clear()
 
     # _image_block_req exception test
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     progress_callback.reset_mock()
     image_block_response = cluster.image_block_response
     cluster.image_block_response = AsyncMock(
@@ -1251,7 +1253,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     )
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
     assert (
-        dev.application.send_packet.await_count == 2
+        dev.application._send_packet.await_count == 2
     )  # just image notify + query next image
     assert progress_callback.call_count == 0
     assert "OTA image_block handler exception" in caplog.text
@@ -1260,7 +1262,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     caplog.clear()
 
     # _upgrade_end exception test
-    dev.application.send_packet.reset_mock()
+    dev.application._send_packet.reset_mock()
     progress_callback.reset_mock()
     upgrade_end_response = cluster.upgrade_end_response
     cluster.upgrade_end_response = AsyncMock(
@@ -1268,9 +1270,11 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     )
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
     assert (
-        dev.application.send_packet.await_count == 4
+        dev.application._send_packet.await_count == 4
     )  # just image notify, qne, and 2 img blocks
-    assert progress_callback.call_count == 2
+    # The second block's progress is suppressed: the instantly-failing upgrade_end
+    # resolves the update before the block's send handle is awaited
+    assert progress_callback.call_count == 1
     assert "OTA upgrade_end handler exception" in caplog.text
     assert result != foundation.Status.SUCCESS
     cluster.upgrade_end_response = upgrade_end_response
@@ -1314,7 +1318,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
                     )
                 )
 
-    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    dev.application._send_packet = AsyncMock(side_effect=send_packet)
 
     progress_callback.reset_mock()
     image_block_response = cluster.image_block_response
@@ -1323,7 +1327,7 @@ async def test_update_legrand_device_firmware(monkeypatch, dev, caplog):
     )
     result = await dev.update_firmware(fw_image, progress_callback=progress_callback)
     assert (
-        dev.application.send_packet.await_count == 2
+        dev.application._send_packet.await_count == 2
     )  # just image notify, qne, img block response fails
     assert progress_callback.call_count == 0
     assert "OTA image_block handler[MALFORMED_COMMAND] exception" in caplog.text
@@ -1434,6 +1438,9 @@ async def test_debouncing(dev):
 
 async def test_device_concurrency(dev: device.Device) -> None:
     """Test that the device can handle multiple requests concurrently."""
+    # This exercises the legacy per-device limiter, replaced by the scheduler's
+    # per-destination window
+    dev._application._uses_scheduler = False
     dev._concurrent_requests_semaphore = RequestLimiter(
         max_concurrency=1, capacities={t.PacketPriority.LOW: 1}
     )
@@ -1522,6 +1529,7 @@ async def test_duplicate_request_sending(dev: device.Device) -> None:
 
     dev._application.request = AsyncMock(side_effect=delayed_receive)
     dev._concurrent_requests_semaphore.max_concurrency = 100000
+    dev._application._scheduler.destination_window = None
 
     # We send 256 + 1 requests
     errors = await asyncio.gather(
@@ -1902,10 +1910,12 @@ async def test_attribute_report_not_matched_with_request(dev):
     ep = dev.add_endpoint(1)
     ep.add_input_cluster(OnOff.cluster_id)
 
-    with patch.object(dev._application, "send_packet") as mock_packet_send:
+    with patch.object(dev._application, "_send_packet") as mock_packet_send:
         request_task = asyncio.create_task(dev.endpoints[1].on_off.on())
 
-        # Get the TSN that was used for the request
+        # Get the TSN that was used for the request. The scheduler dispatches the
+        # attempt in its own task, one tick after the request task submits.
+        await asyncio.sleep(0)
         await asyncio.sleep(0)
         assert len(mock_packet_send.mock_calls) == 1
         sent_packet = mock_packet_send.mock_calls[0].args[0]
@@ -2283,7 +2293,7 @@ async def test_request_retry_success(app) -> None:
             ),
         )
 
-    app.send_packet.side_effect = send_packet
+    app._send_packet.side_effect = send_packet
     dev.get_sequence = MagicMock(return_value=tsn)
 
     rsp = await dev.endpoints[1].basic.reset_fact_default()
@@ -2292,7 +2302,7 @@ async def test_request_retry_success(app) -> None:
         status=foundation.Status.SUCCESS,
     )
 
-    assert len(app.send_packet.mock_calls) == 3
+    assert len(app._send_packet.mock_calls) == 3
 
 
 async def test_request_retry_failure(app) -> None:
@@ -2304,7 +2314,7 @@ async def test_request_retry_failure(app) -> None:
     ep.status = endpoint.Status.ZDO_INIT
     ep.add_input_cluster(Basic.cluster_id)
 
-    app.send_packet.side_effect = [
+    app._send_packet.side_effect = [
         zigpy.exceptions.DeliveryError("Failure"),
         zigpy.exceptions.DeliveryError("Failure"),
         zigpy.exceptions.DeliveryError("Failure"),
@@ -2325,7 +2335,7 @@ async def test_request_retry_failure(app) -> None:
         )
 
     packet = t.ZigbeePacket(
-        priority=None,
+        priority=t.PacketPriority.NORMAL,
         src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
         src_ep=1,
         dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
@@ -2341,7 +2351,7 @@ async def test_request_retry_failure(app) -> None:
         non_member_radius=0,
     )
 
-    assert app.send_packet.mock_calls == [
+    assert app._send_packet.mock_calls == [
         call(packet),
         call(
             packet.replace(
@@ -2425,7 +2435,7 @@ async def test_request_retry_reply_timeout(app) -> None:
             ),
         )
 
-    app.send_packet.side_effect = send_packet
+    app._send_packet.side_effect = send_packet
     dev.get_sequence = MagicMock(return_value=tsn)
 
     rsp = await dev.endpoints[1].basic.reset_fact_default(timeout=0.01, retry_delay=0)
@@ -2434,15 +2444,18 @@ async def test_request_retry_reply_timeout(app) -> None:
         status=foundation.Status.SUCCESS,
     )
 
-    assert len(app.send_packet.mock_calls) == 3
+    assert len(app._send_packet.mock_calls) == 3
 
 
 async def test_request_retry_delay_releases_concurrency(app) -> None:
     """A request awaiting its post-retry delay must not hold a concurrency slot."""
+    # This exercises the legacy per-device limiter; the scheduler equivalent is
+    # covered by the retry-parking tests in test_scheduler.py
+    app._uses_scheduler = False
     dev = app.add_device(nwk=0x1234, ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"))
 
     # Every send fails, so each request enters its (long) post-retry delay
-    app.send_packet.side_effect = zigpy.exceptions.DeliveryError("Failure")
+    app._send_packet.side_effect = zigpy.exceptions.DeliveryError("Failure")
 
     async def make_request(sequence: int) -> None:
         await dev.request(
@@ -2467,10 +2480,10 @@ async def test_request_retry_delay_releases_concurrency(app) -> None:
         # should still get its first attempt sent: the concurrency slot is released
         # *before* the delay, not held during it.
         async with asyncio.timeout(1):
-            while len(app.send_packet.mock_calls) < len(tasks):
+            while len(app._send_packet.mock_calls) < len(tasks):
                 await asyncio.sleep(0)
 
-        assert len(app.send_packet.mock_calls) == len(tasks)
+        assert len(app._send_packet.mock_calls) == len(tasks)
 
         # Tear down the still-pending requests so the task group can exit
         for task in tasks:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -376,6 +376,54 @@ async def test_transient_destination_scope(make_scheduler):
     await asyncio.wait_for(blocked, 1)
     assert len(radio.sent) == 3
 
+    # Lane-scoped backpressure says nothing about radio capacity
+    assert sched._window == sched.max_in_flight
+
+
+async def test_broadcast_domain_rate_limit(make_scheduler):
+    """Test all broadcast traffic sharing one rate-limited scheduling domain."""
+    sched, radio = make_scheduler()
+    loop = asyncio.get_running_loop()
+
+    broadcast = make_packet().replace(
+        dst=t.AddrModeAddress(
+            addr_mode=t.AddrMode.Broadcast,
+            address=t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
+        )
+    )
+    groupcast = make_packet().replace(
+        dst=t.AddrModeAddress(addr_mode=t.AddrMode.Group, address=t.Group(0x0002))
+    )
+
+    # The firmware's broadcast budget rejects with an exact retry hint
+    radio.effects = [
+        TransientSendError(
+            "rate limited", scope=FailureScope.DESTINATION, retry_in=0.1
+        ),
+        None,
+        None,
+        None,
+    ]
+
+    start = loop.time()
+    h_broadcast = sched.submit(broadcast)
+    await asyncio.sleep(0.01)
+
+    # A groupcast contends for the same budget: it defers instead of probing
+    h_group = sched.submit(groupcast)
+    await asyncio.sleep(0.01)
+    assert h_group.park_reason is scheduler.ParkReason.DESTINATION_BLOCKED
+
+    # Unicasts are unaffected by the broadcast domain block
+    await sched.submit(make_packet(nwk=0x0001))
+    assert len(radio.sent) == 2
+
+    await asyncio.gather(h_broadcast, h_group)
+
+    # The rejected broadcast retried no earlier than the firmware's promise
+    assert radio.times[2] - start >= 0.09
+    assert sched._window == sched.max_in_flight
+
 
 async def test_awaiting_wake(make_scheduler):
     """Test frames parking until the sleepy destination is heard from."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -7,6 +7,7 @@ from zigpy.exceptions import (
     DeliveryError,
     FailureScope,
     NetworkBusyError,
+    PermanentSendError,
     RadioBusyError,
     SendCancelledError,
     SupersededError,
@@ -459,7 +460,7 @@ async def test_awaiting_wake(make_scheduler):
     sched, radio = make_scheduler()
     radio.effects = [TransactionExpiredError("no poll"), None]
 
-    handle = sched.submit(make_packet(nwk=0xABCD))
+    handle = sched.submit(make_packet(nwk=0xABCD), park_on_wake=True)
     await asyncio.sleep(0.01)
 
     assert handle.park_reason is scheduler.ParkReason.AWAITING_WAKE
@@ -476,6 +477,180 @@ async def test_awaiting_wake(make_scheduler):
     )
     await asyncio.wait_for(handle, 1)
     assert len(radio.sent) == 2
+
+
+async def test_transaction_expired_consumes_attempts_by_default(make_scheduler):
+    """Test a non-polling destination failing the send unless parking is opted into."""
+    sched, radio = make_scheduler(retry_delay=0.01)
+    radio.effects = [TransactionExpiredError("no poll")] * 5
+
+    handle = sched.submit(make_packet(nwk=0xABCD), retries=1)
+
+    with pytest.raises(TransactionExpiredError):
+        await asyncio.wait_for(handle, 1)
+
+    assert len(radio.sent) == 2
+
+
+async def test_parked_send_expires(make_scheduler):
+    """Test an awaiting-wake send expiring at its deadline without a liveness signal."""
+    sched, radio = make_scheduler()
+    loop = asyncio.get_running_loop()
+    radio.effects = [TransactionExpiredError("no poll")]
+
+    handle = sched.submit(
+        make_packet(nwk=0xABCD), park_on_wake=True, expires_at=loop.time() + 0.1
+    )
+    await asyncio.sleep(0.01)
+    assert handle.park_reason is scheduler.ParkReason.AWAITING_WAKE
+
+    with pytest.raises(SendCancelledError):
+        await asyncio.wait_for(handle, 1)
+
+    assert len(radio.sent) == 1
+
+
+async def test_expired_at_submission(make_scheduler):
+    """Test a send already expired at submission failing without a radio attempt."""
+    sched, radio = make_scheduler()
+    loop = asyncio.get_running_loop()
+
+    handle = sched.submit(make_packet(), expires_at=loop.time() - 1)
+
+    with pytest.raises(SendCancelledError):
+        await handle
+
+    assert not radio.sent
+
+
+async def test_coalesced_send_survives_global_backpressure(make_scheduler):
+    """Test global backpressure re-registering the re-queued send's coalesce key."""
+    sched, radio = make_scheduler()
+    radio.effects = [RadioBusyError("full", retry_in=0.01), None]
+
+    handle = sched.submit(make_packet(key=("k",)), retries=0)
+    await asyncio.wait_for(handle, 1)
+
+    assert len(radio.sent) == 2
+    assert not sched._task.done()
+
+
+async def test_late_reply_does_not_resurrect_send(make_scheduler):
+    """Test a reply racing an in-flight retry attempt not reviving the send."""
+    sched, radio = make_scheduler()
+    radio.effects = [None, radio.hold]
+
+    handle = sched.submit(
+        make_packet(),
+        expect_reply=True,
+        retries=3,
+        retry_delay=0.01,
+        reply_timeout=0.05,
+    )
+
+    # The first attempt confirms but gets no reply; the retry attempt is held in
+    # flight when the original reply finally lands
+    while len(radio.sent) < 2:
+        await asyncio.sleep(0.01)
+
+    assert handle.resolve_reply("late reply")
+    radio.gate.set()
+
+    assert (await handle) == "late reply"
+
+    # The completed retry attempt must not resurrect the resolved send
+    await asyncio.sleep(0.3)
+    assert len(radio.sent) == 2
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [PermanentSendError("frame too long"), SendCancelledError("cancelled by radio")],
+)
+async def test_permanent_failures_are_not_retried(make_scheduler, exc):
+    """Test permanent and cancellation verdicts failing fast."""
+    sched, radio = make_scheduler(retry_delay=0.01)
+    radio.effects = [exc] * 5
+
+    handle = sched.submit(make_packet(), retries=3)
+
+    with pytest.raises(type(exc)):
+        await asyncio.wait_for(handle, 1)
+
+    assert len(radio.sent) == 1
+
+
+async def test_timeout_error_is_retried(make_scheduler):
+    """Test a radio-level timeout consuming an attempt instead of failing terminally."""
+    sched, radio = make_scheduler(retry_delay=0.01)
+    radio.effects = [TimeoutError("radio hiccup"), None]
+
+    handle = sched.submit(make_packet(), retries=1)
+    await asyncio.wait_for(handle, 1)
+
+    assert len(radio.sent) == 2
+
+
+async def test_reply_resolution_releases_deferred_send(make_scheduler):
+    """Test a reply freeing the destination window waking deferred sends promptly."""
+    sched, radio = make_scheduler(destination_window=1)
+    loop = asyncio.get_running_loop()
+
+    first = sched.submit(make_packet(tsn=1), expect_reply=True, reply_timeout=5)
+    await asyncio.sleep(0.01)
+    assert first.state is scheduler.SendState.AWAITING_REPLY
+
+    deferred = sched.submit(make_packet(tsn=2))
+    await asyncio.sleep(0.01)
+    assert deferred.park_reason is scheduler.ParkReason.DESTINATION_BLOCKED
+
+    # Resolving the interaction frees the slot and must wake the dispatch loop,
+    # not wait for the stale 5s reply deadline
+    start = loop.time()
+    first.resolve_reply("done")
+    await asyncio.wait_for(deferred, 1)
+    assert loop.time() - start < 1
+
+
+async def test_cancel_clears_coalesce_registration(make_scheduler):
+    """Test a cancelled keyed send not superseding a later same-key send."""
+    sched, radio = make_scheduler(max_in_flight=1)
+    radio.effects = [radio.hold]
+
+    blocker = sched.submit(make_packet(nwk=0x0001))
+    await asyncio.sleep(0.01)
+
+    h1 = sched.submit(make_packet(data=b"cancelled", key=("k",)))
+    assert h1.cancel()
+
+    h2 = sched.submit(make_packet(data=b"fresh", key=("k",)))
+    radio.gate.set()
+    await blocker
+    await h2
+
+    assert radio.sent[-1].data.serialize() == b"fresh"
+
+
+async def test_supersede_while_parking_awaiting_wake(make_scheduler):
+    """Test a newer same-key send superseding an entry as it parks awaiting wake."""
+    sched, radio = make_scheduler(max_in_flight=1)
+
+    async def gated_expire(packet):
+        await radio.gate.wait()
+        raise TransactionExpiredError("no poll")
+
+    radio.effects = [gated_expire]
+
+    h1 = sched.submit(make_packet(data=b"first", key=("k",)), park_on_wake=True)
+    await asyncio.sleep(0.01)
+    h2 = sched.submit(make_packet(data=b"second", key=("k",)))
+    radio.gate.set()
+
+    with pytest.raises(SupersededError):
+        await h1
+
+    await h2
+    assert [p.data.serialize() for p in radio.sent] == [b"first", b"second"]
 
 
 @pytest.mark.parametrize("retries", [0, 2])
@@ -666,7 +841,7 @@ async def test_scheduler_repr(make_scheduler):
     sched, radio = make_scheduler(max_in_flight=1)
     radio.effects = [TransactionExpiredError("no poll"), radio.hold]
 
-    parked = sched.submit(make_packet(nwk=0x0001))
+    parked = sched.submit(make_packet(nwk=0x0001), park_on_wake=True)
     await asyncio.sleep(0.01)
     assert parked.park_reason is scheduler.ParkReason.AWAITING_WAKE
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -198,6 +198,35 @@ async def test_supersession(make_scheduler):
     assert [p.data.serialize() for p in radio.sent] == [b"data", b"third"]
 
 
+async def test_supersession_keeps_queue_position(make_scheduler):
+    """Test that a trickle of superseding sends cannot starve the coalesced entry."""
+    sched, radio = make_scheduler(max_in_flight=1)
+    radio.effects = [radio.hold]
+
+    blocker = sched.submit(make_packet(nwk=0x0001))
+    await asyncio.sleep(0.01)
+
+    # The coalesced send is submitted first, then unrelated contention piles up
+    first = sched.submit(make_packet(nwk=0x000A, data=b"v1", key=("k",)))
+    others = [sched.submit(make_packet(nwk=i, tsn=i)) for i in range(0x000B, 0x000F)]
+
+    # A steady trickle of supersessions must not push it back in the queue
+    for i in range(2, 5):
+        newest = sched.submit(make_packet(nwk=0x000A, data=b"v%d" % i, key=("k",)))
+
+    radio.gate.set()
+    await blocker
+    await asyncio.gather(newest, *others)
+
+    with pytest.raises(SupersededError):
+        await first
+
+    # The coalesced send dispatched at the *first* submission's queue position,
+    # ahead of the contention submitted after it, carrying the newest payload
+    assert radio.sent[1].data.serialize() == b"v4"
+    assert [p.dst.address for p in radio.sent[2:]] == [0x000B, 0x000C, 0x000D, 0x000E]
+
+
 async def test_supersession_does_not_replace_in_flight(make_scheduler):
     """Test that an in-flight send is never superseded."""
     sched, radio = make_scheduler()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,617 @@
+import asyncio
+
+import pytest
+
+from zigpy import scheduler
+from zigpy.exceptions import (
+    DeliveryError,
+    FailureScope,
+    NetworkBusyError,
+    RadioBusyError,
+    SendCancelledError,
+    SupersededError,
+    TransactionExpiredError,
+    TransientSendError,
+)
+import zigpy.types as t
+
+SENT = scheduler.SendStage.SENT
+CONFIRMED = scheduler.SendStage.CONFIRMED
+REPLIED = scheduler.SendStage.REPLIED
+
+
+def make_packet(nwk=0x1234, data=b"data", key=None, priority=None, tsn=0x01):
+    return t.ZigbeePacket(
+        src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0000)),
+        src_ep=1,
+        dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(nwk)),
+        dst_ep=1,
+        tsn=tsn,
+        profile_id=0x0104,
+        cluster_id=0x0006,
+        data=t.SerializableBytes(data),
+        priority=priority,
+        coalesce_key=key,
+    )
+
+
+class FakeRadio:
+    """A radio whose per-send behavior is scripted via `effects`.
+
+    Each send pops the next effect: `None` succeeds, an exception is raised, and an
+    async callable is awaited (e.g. to hold a send in flight on `gate`).
+    """
+
+    def __init__(self):
+        self.sent = []
+        self.options = []
+        self.times = []
+        self.effects = []
+        self.gate = asyncio.Event()
+        self.in_progress = 0
+        self.max_in_progress = 0
+        self.cancelled = 0
+
+    async def send_packet(self, packet):
+        self.sent.append(packet)
+        self.options.append(packet.tx_options)
+        self.times.append(asyncio.get_running_loop().time())
+
+        self.in_progress += 1
+        self.max_in_progress = max(self.max_in_progress, self.in_progress)
+
+        try:
+            effect = self.effects.pop(0) if self.effects else None
+
+            if callable(effect):
+                await effect(packet)
+            elif effect is not None:
+                raise effect
+        finally:
+            self.in_progress -= 1
+
+    async def hold(self, packet):
+        try:
+            await self.gate.wait()
+        except asyncio.CancelledError:
+            # A radio's own cleanup (e.g. a wire-level send cancellation) runs here
+            self.cancelled += 1
+            raise
+
+
+@pytest.fixture
+async def make_scheduler():
+    created = []
+
+    def factory(**kwargs):
+        radio = FakeRadio()
+        sched = scheduler.SendScheduler(radio.send_packet, **kwargs)
+        created.append(sched)
+        return sched, radio
+
+    yield factory
+
+    for sched in created:
+        sched.stop()
+
+
+@pytest.mark.parametrize(
+    ("final_stage", "resolutions", "expected"),
+    [
+        # A confirmed success back-fills the sent stage
+        (CONFIRMED, [(CONFIRMED, None)], {SENT: None, CONFIRMED: None}),
+        # An error at the first stage forward-fills every later stage
+        (
+            REPLIED,
+            [(SENT, DeliveryError("x"))],
+            {SENT: DeliveryError, CONFIRMED: DeliveryError, REPLIED: DeliveryError},
+        ),
+        # The first write to a stage wins, but a late error still fails the rest
+        (
+            CONFIRMED,
+            [(SENT, None), (SENT, DeliveryError("x"))],
+            {SENT: None, CONFIRMED: DeliveryError},
+        ),
+        # A sent success followed by a confirmed error
+        (
+            CONFIRMED,
+            [(SENT, None), (CONFIRMED, DeliveryError("x"))],
+            {SENT: None, CONFIRMED: DeliveryError},
+        ),
+        # A reply value back-fills the earlier stages with success, not the value
+        (
+            REPLIED,
+            [(REPLIED, "reply")],
+            {SENT: None, CONFIRMED: None, REPLIED: "reply"},
+        ),
+    ],
+)
+async def test_send_slot_write_rules(final_stage, resolutions, expected):
+    """Test the slot's write-once staged resolution rules."""
+    slot = scheduler.SendSlot(final_stage)
+
+    for stage, result in resolutions:
+        slot.resolve(stage, result)
+
+    for stage in scheduler.SendStage:
+        if stage > final_stage:
+            continue
+
+        if stage not in expected:
+            assert not slot.is_resolved(stage)
+            continue
+
+        assert slot.is_resolved(stage)
+        value = expected[stage]
+
+        if isinstance(value, type) and issubclass(value, BaseException):
+            with pytest.raises(value):
+                await slot.wait(stage)
+        else:
+            assert (await slot.wait(stage)) == value
+
+
+async def test_submit_success(make_scheduler):
+    """Test a simple send resolving all stages."""
+    sched, radio = make_scheduler()
+
+    handle = sched.submit(make_packet())
+    assert handle.state in (scheduler.SendState.QUEUED, scheduler.SendState.IN_FLIGHT)
+
+    await handle
+    await handle.sent()
+    await handle.confirmed()
+
+    assert handle.state is scheduler.SendState.DONE
+    assert handle.park_reason is None
+    assert len(radio.sent) == 1
+    assert radio.sent[0].data.serialize() == b"data"
+
+
+async def test_supersession(make_scheduler):
+    """Test queued same-key sends superseding one another in place."""
+    sched, radio = make_scheduler(max_in_flight=1)
+    radio.effects = [radio.hold]
+
+    # Occupy the only in-flight slot so subsequent sends stay queued
+    blocker = sched.submit(make_packet(nwk=0x0001))
+    await asyncio.sleep(0.01)
+
+    h1 = sched.submit(make_packet(data=b"first", key=("k",)))
+    h2 = sched.submit(make_packet(data=b"second", key=("k",)))
+    h3 = sched.submit(make_packet(data=b"third", key=("k",)))
+
+    with pytest.raises(SupersededError):
+        await h1
+
+    with pytest.raises(SupersededError):
+        await h2
+
+    assert h1.state is scheduler.SendState.DONE
+    assert h1.park_reason is None
+
+    radio.gate.set()
+    await blocker
+    await h3
+
+    # Only the blocker and the final version of the coalesced send reached the radio
+    assert [p.data.serialize() for p in radio.sent] == [b"data", b"third"]
+
+
+async def test_supersession_does_not_replace_in_flight(make_scheduler):
+    """Test that an in-flight send is never superseded."""
+    sched, radio = make_scheduler()
+    radio.effects = [radio.hold]
+
+    h1 = sched.submit(make_packet(data=b"first", key=("k",)))
+    await asyncio.sleep(0.01)
+    assert h1.state is scheduler.SendState.IN_FLIGHT
+
+    h2 = sched.submit(make_packet(data=b"second", key=("k",)))
+    radio.gate.set()
+
+    await h1
+    await h2
+
+    assert [p.data.serialize() for p in radio.sent] == [b"first", b"second"]
+
+
+async def test_retry_superseded_while_in_flight(make_scheduler):
+    """Test a failed send's retry being superseded by a newer same-key send."""
+    sched, radio = make_scheduler(retry_delay=0.01, max_in_flight=1)
+
+    async def gated_fail(packet):
+        await radio.gate.wait()
+        raise DeliveryError("nope")
+
+    radio.effects = [gated_fail]
+
+    h1 = sched.submit(make_packet(data=b"first", key=("k",)), retries=3)
+    await asyncio.sleep(0.01)
+
+    # A newer send with the same key arrives while the first is in flight and stays
+    # queued behind it
+    h2 = sched.submit(make_packet(data=b"second", key=("k",)))
+    radio.gate.set()
+
+    # The first send's retry is abandoned in favor of the newer send
+    with pytest.raises(SupersededError):
+        await h1
+
+    await h2
+    assert [p.data.serialize() for p in radio.sent] == [b"first", b"second"]
+
+
+async def test_cancel_queued(make_scheduler):
+    """Test guaranteed cancellation of a queued send."""
+    sched, radio = make_scheduler(max_in_flight=1)
+    radio.effects = [radio.hold]
+
+    blocker = sched.submit(make_packet(nwk=0x0001))
+    await asyncio.sleep(0.01)
+
+    handle = sched.submit(make_packet())
+    assert handle.cancel()
+    assert not handle.cancel()
+
+    with pytest.raises(SendCancelledError):
+        await handle
+
+    radio.gate.set()
+    await blocker
+    assert len(radio.sent) == 1
+
+
+async def test_cancel_in_flight_is_best_effort(make_scheduler):
+    """Test that cancelling an in-flight send cancels the attempt for radio cleanup."""
+    sched, radio = make_scheduler()
+    radio.effects = [radio.hold]
+
+    handle = sched.submit(make_packet())
+    await asyncio.sleep(0.01)
+
+    assert handle.state is scheduler.SendState.IN_FLIGHT
+    assert handle.cancel()
+
+    with pytest.raises(SendCancelledError):
+        await handle
+
+    # The attempt was cancelled inside the radio, triggering its own cleanup
+    assert radio.cancelled == 1
+    assert not handle.cancel()
+
+
+async def test_staged_sent_stage(make_scheduler):
+    """Test a staged radio resolving the sent stage ahead of the delivery verdict."""
+    sched, radio = make_scheduler()
+
+    async def sent_then_gate(packet):
+        sched.resolve_sent(packet)
+        await radio.gate.wait()
+
+    radio.effects = [sent_then_gate]
+
+    handle = sched.submit(make_packet())
+    await asyncio.wait_for(handle.sent(), 1)
+    assert handle.state is scheduler.SendState.IN_FLIGHT
+
+    radio.gate.set()
+    await handle.confirmed()
+
+    # An unknown packet is ignored
+    sched.resolve_sent(make_packet())
+
+
+async def test_transient_backpressure_consumes_no_attempts(make_scheduler):
+    """Test transient rejections re-parking the frame without consuming retries."""
+    sched, radio = make_scheduler()
+    radio.effects = [
+        RadioBusyError("full", retry_in=0.01),
+        RadioBusyError("full", retry_in=0.01),
+        None,
+    ]
+
+    handle = sched.submit(make_packet(), retries=0)
+    await handle
+
+    assert len(radio.sent) == 3
+
+
+async def test_wake_on_confirm(make_scheduler):
+    """Test a slot-exhaustion block clearing on the next completion, not the timer."""
+    sched, radio = make_scheduler(max_in_flight=2)
+    loop = asyncio.get_running_loop()
+
+    radio.effects = [radio.hold, RadioBusyError("full", retry_in=60), None]
+
+    blocker = sched.submit(make_packet(nwk=0x0001))
+    rejected = sched.submit(make_packet(nwk=0x0002))
+    await asyncio.sleep(0.01)
+
+    start = loop.time()
+    radio.gate.set()
+    await blocker
+    await asyncio.wait_for(rejected, 1)
+
+    # The rejected send retried as soon as the blocker completed, not after 60s
+    assert loop.time() - start < 1
+
+
+async def test_network_busy_backoff_is_timed(make_scheduler):
+    """Test channel congestion waiting out its backoff."""
+    sched, radio = make_scheduler()
+    radio.effects = [NetworkBusyError("busy", retry_in=0.1), None]
+
+    handle = sched.submit(make_packet())
+    await handle
+
+    assert len(radio.sent) == 2
+    assert radio.times[1] - radio.times[0] >= 0.09
+
+
+async def test_transient_destination_scope(make_scheduler):
+    """Test destination-scoped backpressure only blocking that destination."""
+    sched, radio = make_scheduler()
+    radio.effects = [
+        TransientSendError("hold on", scope=FailureScope.DESTINATION, retry_in=0.1),
+        None,
+        None,
+    ]
+
+    blocked = sched.submit(make_packet(nwk=0x0001))
+    await asyncio.sleep(0.01)
+
+    # Liveness from a blocked destination with nothing awaiting wake is a no-op
+    sched.destination_seen(
+        t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x0001))
+    )
+
+    other = sched.submit(make_packet(nwk=0x0002))
+    await other
+
+    # The other destination was not affected by the block
+    assert blocked.state is not scheduler.SendState.DONE
+    assert blocked.park_reason is scheduler.ParkReason.DESTINATION_BLOCKED
+
+    await asyncio.wait_for(blocked, 1)
+    assert len(radio.sent) == 3
+
+
+async def test_awaiting_wake(make_scheduler):
+    """Test frames parking until the sleepy destination is heard from."""
+    sched, radio = make_scheduler()
+    radio.effects = [TransactionExpiredError("no poll"), None]
+
+    handle = sched.submit(make_packet(nwk=0xABCD))
+    await asyncio.sleep(0.01)
+
+    assert handle.park_reason is scheduler.ParkReason.AWAITING_WAKE
+
+    # Liveness from an unrelated destination does nothing
+    sched.destination_seen(
+        t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0x9999))
+    )
+    await asyncio.sleep(0.01)
+    assert handle.park_reason is scheduler.ParkReason.AWAITING_WAKE
+
+    sched.destination_seen(
+        t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=t.NWK(0xABCD))
+    )
+    await asyncio.wait_for(handle, 1)
+    assert len(radio.sent) == 2
+
+
+@pytest.mark.parametrize("retries", [0, 2])
+async def test_delivery_failure_retries(make_scheduler, retries):
+    """Test delivery failures consuming attempts and forcing route discovery."""
+    sched, radio = make_scheduler(retry_delay=0.01)
+    radio.effects = [DeliveryError("nope")] * 10
+
+    # The coalesce key is re-registered across retries
+    handle = sched.submit(make_packet(key=("k",)), retries=retries)
+
+    with pytest.raises(DeliveryError):
+        await handle
+
+    assert len(radio.sent) == retries + 1
+
+    # Every retry attempt forces route discovery
+    for options in radio.options[1:]:
+        assert t.TransmitOptions.FORCE_ROUTE_DISCOVERY in options
+
+
+async def test_priority_ordering(make_scheduler):
+    """Test queued sends dispatching in priority order, FIFO within a priority."""
+    sched, radio = make_scheduler(max_in_flight=1)
+    radio.effects = [radio.hold]
+
+    blocker = sched.submit(make_packet(nwk=0x0001, tsn=0x00))
+    await asyncio.sleep(0.01)
+
+    handles = [
+        sched.submit(make_packet(tsn=0x10, priority=t.PacketPriority.NORMAL)),
+        sched.submit(make_packet(tsn=0x11, priority=t.PacketPriority.LOW)),
+        sched.submit(make_packet(tsn=0x12, priority=t.PacketPriority.CRITICAL)),
+        sched.submit(make_packet(tsn=0x13, priority=t.PacketPriority.HIGH)),
+        sched.submit(make_packet(tsn=0x14, priority=t.PacketPriority.NORMAL)),
+    ]
+
+    radio.gate.set()
+    await blocker
+    await asyncio.gather(*handles)
+
+    assert [p.tsn for p in radio.sent[1:]] == [0x12, 0x13, 0x10, 0x14, 0x11]
+
+
+async def test_expiry(make_scheduler):
+    """Test a queued send expiring before dispatch."""
+    sched, radio = make_scheduler(max_in_flight=1)
+    radio.effects = [radio.hold]
+    loop = asyncio.get_running_loop()
+
+    blocker = sched.submit(make_packet(nwk=0x0001))
+    await asyncio.sleep(0.01)
+
+    handle = sched.submit(make_packet(), expires_at=loop.time() - 1)
+    radio.gate.set()
+    await blocker
+
+    with pytest.raises(SendCancelledError):
+        await handle
+
+    assert len(radio.sent) == 1
+
+
+async def test_window_clamp_and_growth(make_scheduler):
+    """Test the adaptive window shrinking on rejection and growing on completion."""
+    sched, radio = make_scheduler(max_in_flight=4)
+    radio.effects = [RadioBusyError("full", retry_in=0.01), None]
+
+    handle = sched.submit(make_packet())
+    await handle
+
+    # Clamped to 1 by the rejection, then grown by the completed attempt
+    assert sched._window == 2
+
+    assert sched.max_in_flight == 4
+    sched.max_in_flight = 16
+    assert sched.max_in_flight == 16
+    assert sched._window == 16
+
+
+async def test_stop_fails_pending_sends(make_scheduler):
+    """Test stopping the scheduler failing every unresolved send."""
+    sched, radio = make_scheduler(max_in_flight=1)
+    radio.effects = [radio.hold]
+
+    in_flight = sched.submit(make_packet(nwk=0x0001))
+    await asyncio.sleep(0.01)
+    queued = sched.submit(make_packet(nwk=0x0002))
+
+    sched.stop()
+
+    with pytest.raises(SendCancelledError):
+        await in_flight
+
+    with pytest.raises(SendCancelledError):
+        await queued
+
+    # The scheduler restarts lazily on the next submit
+    handle = sched.submit(make_packet(nwk=0x0003))
+    await handle
+    assert radio.sent[-1].dst.address == 0x0003
+
+
+async def test_destination_window(make_scheduler):
+    """Test the per-destination in-flight window."""
+    sched, radio = make_scheduler(destination_window=1)
+
+    async def slow(packet):
+        await asyncio.sleep(0.02)
+
+    radio.effects = [slow] * 6
+
+    same = [sched.submit(make_packet(nwk=0x0001, tsn=i)) for i in range(3)]
+    await asyncio.gather(*same)
+    assert radio.max_in_progress == 1
+
+    radio.max_in_progress = 0
+    radio.in_progress = 0
+    different = [sched.submit(make_packet(nwk=i, tsn=i)) for i in range(1, 4)]
+    await asyncio.gather(*different)
+    assert radio.max_in_progress == 3
+
+
+async def test_unexpected_exception_is_terminal(make_scheduler):
+    """Test a non-delivery exception resolving the send instead of stranding it."""
+    sched, radio = make_scheduler()
+    radio.effects = [RuntimeError("radio exploded")] * 5
+
+    handle = sched.submit(make_packet(), retries=3)
+
+    with pytest.raises(RuntimeError):
+        await handle
+
+    # Terminal: no retries were attempted
+    assert len(radio.sent) == 1
+
+
+async def test_replied_stage(make_scheduler):
+    """Test the reply stage being resolved by the response-matching layer."""
+    sched, radio = make_scheduler()
+
+    handle = sched.submit(make_packet(), expect_reply=True)
+    await handle.confirmed()
+
+    assert not handle._slot.is_resolved(REPLIED)
+    handle.resolve_reply("the reply")
+
+    assert (await handle) == "the reply"
+    assert (await handle.replied()) == "the reply"
+
+
+async def test_replied_stage_error_propagates(make_scheduler):
+    """Test a delivery error resolving the reply stage too."""
+    sched, radio = make_scheduler()
+    radio.effects = [DeliveryError("nope")]
+
+    handle = sched.submit(make_packet(), expect_reply=True, retries=0)
+
+    with pytest.raises(DeliveryError):
+        await handle
+
+
+async def test_superseded_handle_state(make_scheduler):
+    """Test a superseded handle reporting a terminal state."""
+    sched, radio = make_scheduler(max_in_flight=1)
+    radio.effects = [radio.hold]
+
+    blocker = sched.submit(make_packet(nwk=0x0001))
+    await asyncio.sleep(0.01)
+
+    h1 = sched.submit(make_packet(data=b"first", key=("k",)))
+    h2 = sched.submit(make_packet(data=b"second", key=("k",)))
+
+    assert h1.state is scheduler.SendState.DONE
+    assert h1.park_reason is None
+    assert h2.state is scheduler.SendState.QUEUED
+
+    # A superseded handle can no longer cancel the entry
+    assert not h1.cancel()
+
+    radio.gate.set()
+    await blocker
+    await h2
+
+
+async def test_scheduler_repr(make_scheduler):
+    """Test the queue status representation counting live entries."""
+    sched, radio = make_scheduler(max_in_flight=1)
+    radio.effects = [TransactionExpiredError("no poll"), radio.hold]
+
+    parked = sched.submit(make_packet(nwk=0x0001))
+    await asyncio.sleep(0.01)
+    assert parked.park_reason is scheduler.ParkReason.AWAITING_WAKE
+
+    in_flight = sched.submit(make_packet(nwk=0x0002))
+    await asyncio.sleep(0.01)
+    queued = sched.submit(make_packet(nwk=0x0003))
+
+    assert (
+        "queued=1 in_flight=1 awaiting_reply=0 retry_backoff=0"
+        " destination_blocked=0 awaiting_wake=1 window=1/1" in repr(sched)
+    )
+
+    radio.gate.set()
+    await in_flight
+    await queued
+
+
+def test_packet_size_sleepy_weighting():
+    """Test sleepy destinations weighing heavier against the byte budget."""
+    packet = make_packet()
+    sleepy = make_packet().replace(extended_timeout=True)
+
+    assert scheduler.packet_size(sleepy) == (
+        scheduler.SLEEPY_SIZE_WEIGHT * scheduler.packet_size(packet)
+    )

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1368,7 +1368,7 @@ async def test_zcl_reply_direction(app_mock):
 
     await asyncio.sleep(0.1)
 
-    packet = app_mock.send_packet.mock_calls[0].args[0]
+    packet = app_mock._send_packet.mock_calls[0].args[0]
     assert packet.cluster_id == zcl.clusters.general.OnOff.cluster_id
 
     # The direction is correct

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -30,6 +30,7 @@ import zigpy.group
 import zigpy.listeners
 import zigpy.ota
 import zigpy.profiles
+import zigpy.scheduler
 import zigpy.state
 import zigpy.topology
 import zigpy.types as t
@@ -88,6 +89,18 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._concurrent_requests_semaphore = RequestLimiter(
             max_concurrency=self._config[conf.CONF_MAX_CONCURRENT_REQUESTS],
             capacities=self._config[conf.CONF_EXPERIMENTAL][conf.CONF_CONCURRENCY],
+        )
+
+        # Late-bound so `_send_packet` can be patched or rebound after construction
+        self._scheduler = zigpy.scheduler.SendScheduler(
+            lambda packet: self._send_packet(packet),
+            max_in_flight=self._config[conf.CONF_MAX_CONCURRENT_REQUESTS],
+            destination_window=zigpy.device.MAX_DEVICE_CONCURRENCY,
+        )
+
+        # Only radios implementing `_send_packet` route sends through the scheduler
+        self._uses_scheduler = (
+            type(self)._send_packet is not ControllerApplication._send_packet
         )
 
         self.ota = zigpy.ota.OTA(self._config[conf.CONF_OTA], self)
@@ -578,6 +591,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     async def shutdown(self, *, db: bool = True) -> None:
         """Shutdown controller."""
+        self._scheduler.stop()
+
         if self._watchdog_task is not None:
             self._watchdog_task.cancel()
 
@@ -1060,11 +1075,27 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
             yield
 
-    @abc.abstractmethod
     async def send_packet(self, packet: t.ZigbeePacket) -> None:
         """Send a Zigbee packet using the appropriate addressing mode and provided options."""
+        if packet.priority is None:
+            packet = packet.replace(priority=self._packet_priority_var.get())
+
+        # Retries are still owned by `Device.request`. Radios that have not migrated to
+        # `_send_packet` override this method entirely and bypass the scheduler.
+        await self._scheduler.submit(packet, retries=0)
+
+    async def _send_packet(self, packet: t.ZigbeePacket) -> None:
+        """Make a single attempt to send a frame: no queueing, retries, or pacing."""
 
         raise NotImplementedError  # pragma: no cover
+
+    def packet_sent(self, packet: t.ZigbeePacket) -> None:
+        """Radio callback: the mesh accepted the frame, ahead of its delivery verdict.
+
+        Optional. A radio that cannot distinguish acceptance from delivery never calls
+        this; the sent stage then resolves together with the confirmation.
+        """
+        self._scheduler.resolve_sent(packet)
 
     def build_source_route_to(self, dest: zigpy.device.Device) -> list[t.NWK] | None:
         """Compute a source route to the destination device."""
@@ -1075,7 +1106,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # TODO: utilize topology scanner information
         return dest.relays[::-1]
 
-    async def request(
+    def build_packet(
         self,
         device: zigpy.device.Device,
         profile: t.uint16_t,
@@ -1089,22 +1120,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         use_ieee: bool = False,
         extended_timeout: bool = False,
         ask_for_ack: bool | None = None,
-        priority: int = t.PacketPriority.NORMAL,
+        priority: int | None = None,
         force_route_discovery: bool = False,
-    ) -> tuple[zigpy.zcl.foundation.Status, str]:
-        """Submit and send data out as an unicast transmission.
-        :param device: destination device
-        :param profile: Zigbee Profile ID to use for outgoing message
-        :param cluster: cluster id where the message is being sent
-        :param src_ep: source endpoint id
-        :param dst_ep: destination endpoint id
-        :param sequence: transaction sequence number of the message
-        :param data: Zigbee message payload
-        :param expect_reply: True if this is essentially a request
-        :param use_ieee: use EUI64 for destination addressing
-        :param extended_timeout: instruct the radio to use slower APS retries
-        :param force_route_discovery: force route re-discovery for this transmission
-        """
+    ) -> t.ZigbeePacket:
+        """Build an outgoing unicast packet destined for a device."""
+        if priority is None:
+            priority = self._packet_priority_var.get()
 
         if use_ieee:
             src = t.AddrModeAddress(
@@ -1140,20 +1161,67 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             # security network)
             tx_options |= t.TransmitOptions.APS_Encryption
 
+        return t.ZigbeePacket(
+            src=src,
+            src_ep=src_ep,
+            dst=dst,
+            dst_ep=dst_ep,
+            tsn=sequence,
+            profile_id=profile,
+            cluster_id=cluster,
+            data=t.SerializableBytes(data),
+            extended_timeout=extended_timeout,
+            source_route=source_route,
+            tx_options=tx_options,
+            priority=priority,
+        )
+
+    async def request(
+        self,
+        device: zigpy.device.Device,
+        profile: t.uint16_t,
+        cluster: t.uint16_t,
+        src_ep: t.uint8_t,
+        dst_ep: t.uint8_t,
+        sequence: t.uint8_t,
+        data: bytes,
+        *,
+        expect_reply: bool = True,
+        use_ieee: bool = False,
+        extended_timeout: bool = False,
+        ask_for_ack: bool | None = None,
+        priority: int = t.PacketPriority.NORMAL,
+        force_route_discovery: bool = False,
+    ) -> tuple[zigpy.zcl.foundation.Status, str]:
+        """Submit and send data out as an unicast transmission.
+        :param device: destination device
+        :param profile: Zigbee Profile ID to use for outgoing message
+        :param cluster: cluster id where the message is being sent
+        :param src_ep: source endpoint id
+        :param dst_ep: destination endpoint id
+        :param sequence: transaction sequence number of the message
+        :param data: Zigbee message payload
+        :param expect_reply: True if this is essentially a request
+        :param use_ieee: use EUI64 for destination addressing
+        :param extended_timeout: instruct the radio to use slower APS retries
+        :param force_route_discovery: force route re-discovery for this transmission
+        """
+
         await self.send_packet(
-            t.ZigbeePacket(
-                src=src,
+            self.build_packet(
+                device=device,
+                profile=profile,
+                cluster=cluster,
                 src_ep=src_ep,
-                dst=dst,
                 dst_ep=dst_ep,
-                tsn=sequence,
-                profile_id=profile,
-                cluster_id=cluster,
-                data=t.SerializableBytes(data),
+                sequence=sequence,
+                data=data,
+                expect_reply=expect_reply,
+                use_ieee=use_ieee,
                 extended_timeout=extended_timeout,
-                source_route=source_route,
-                tx_options=tx_options,
+                ask_for_ack=ask_for_ack,
                 priority=priority,
+                force_route_discovery=force_route_discovery,
             )
         )
 
@@ -1306,6 +1374,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         LOGGER.debug("Received a packet: %r", packet)
         assert packet.src is not None
         assert packet.dst is not None
+
+        # Any incoming packet is a liveness indicator for its source
+        self._scheduler.destination_seen(packet.src)
 
         # Peek into ZDO packets to handle possible ZDO notifications
         if zigpy.zdo.ZDO_ENDPOINT in (packet.src_ep, packet.dst_ep):

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1085,7 +1085,14 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         await self._scheduler.submit(packet, retries=0)
 
     async def _send_packet(self, packet: t.ZigbeePacket) -> None:
-        """Make a single attempt to send a frame: no queueing, retries, or pacing."""
+        """Make a single attempt to send a frame: no queueing, retries, or pacing.
+
+        The exception contract is load-bearing: `TransientSendError` re-parks the
+        frame without consuming an attempt, `PermanentSendError` and
+        `SendCancelledError` fail it immediately, any other `DeliveryError` or a
+        `TimeoutError` consumes a retry attempt, and every other exception is a
+        terminal verdict. Radios must wrap retryable transport failures accordingly.
+        """
 
         raise NotImplementedError  # pragma: no cover
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -35,6 +35,7 @@ from zigpy.exceptions import DeliveryError
 import zigpy.listeners
 from zigpy.ota.manager import update_firmware
 from zigpy.profiles import zha, zll
+import zigpy.scheduler
 import zigpy.types as t
 import zigpy.util
 from zigpy.zcl import Cluster, ClusterType, OtaQueryCacheClearedEvent, foundation
@@ -109,7 +110,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._manufacturer: str | None = None
         self._model: str | None = None
         self.node_desc: zdo_t.NodeDescriptor | None = None
-        self._requests: dict[ResponseKey, asyncio.Future] = {}
+        self._requests: dict[
+            ResponseKey, asyncio.Future | zigpy.scheduler.SendHandle
+        ] = {}
         self._relays: t.Relays | None = None
         self._skip_configuration: bool = False
         self._send_sequence: int = 0
@@ -666,6 +669,44 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         else:
             rsp_key = None
 
+        if self._application._uses_scheduler:
+            packet = self._application.build_packet(
+                device=self,
+                profile=profile,
+                cluster=cluster,
+                src_ep=src_ep,
+                dst_ep=dst_ep,
+                sequence=sequence,
+                data=data,
+                expect_reply=expect_reply,
+                use_ieee=use_ieee,
+                extended_timeout=extended_timeout,
+                ask_for_ack=ask_for_ack,
+                priority=priority,
+                **kwargs,
+            )
+
+            handle = self._application._scheduler.submit(
+                packet,
+                expect_reply=expect_reply,
+                retries=retries,
+                retry_delay=retry_delay,
+                reply_timeout=timeout,
+            )
+
+            if not expect_reply:
+                await handle
+                return None
+
+            assert rsp_key is not None
+            self._requests[rsp_key] = handle
+
+            try:
+                return await handle
+            finally:
+                handle.cancel()
+                del self._requests[rsp_key]
+
         max_attempts = retries + 1
 
         # Use a lambda so we don't leave the coroutine unawaited in case of an exception
@@ -888,8 +929,8 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self, rsp_key: ResponseKey, cmd: typing.Any | None, error: Exception | None
     ) -> bool:
         """Handle response matching for pending requests, returns True if packet was matched."""
-        future = self._requests.get(rsp_key)
-        if future is None:
+        request = self._requests.get(rsp_key)
+        if request is None:
             return False
 
         # Attribute reports often collide with command responses, they should never be
@@ -902,11 +943,19 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         ):
             return False
 
+        if isinstance(request, zigpy.scheduler.SendHandle):
+            if not request.resolve_reply(error if error is not None else cmd):
+                self.debug(
+                    "Reply for %s ignored -- probably duplicate response", rsp_key
+                )
+
+            return True
+
         try:
             if error is not None:
-                future.set_exception(error)
+                request.set_exception(error)
             else:
-                future.set_result(cmd)
+                request.set_result(cmd)
         except asyncio.InvalidStateError:
             self.debug(
                 "Invalid state on future for %s -- probably duplicate response",

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import typing
 
 if typing.TYPE_CHECKING:
@@ -38,8 +39,73 @@ class DeliveryError(ZigbeeException):
         self.status = status
 
 
+class MacNoAckError(DeliveryError):
+    """The next hop (or the destination, if direct) did not MAC-acknowledge the frame."""
+
+
+class CcaFailureError(DeliveryError):
+    """The frame was not transmitted: clear channel assessment failed (RF interference)."""
+
+
+class ApsNoAckError(DeliveryError):
+    """The destination did not send an end-to-end APS acknowledgment."""
+
+
+class NoRouteError(DeliveryError):
+    """No route to the destination exists and route discovery failed."""
+
+
+class TransactionExpiredError(DeliveryError):
+    """The frame expired at the parent before the sleepy destination polled for it."""
+
+
 class SendError(DeliveryError):
-    """Message could not be enqueued."""
+    """Message could not be enqueued: the frame never left the radio."""
+
+
+class PermanentSendError(SendError):
+    """The frame cannot be sent as-is and retrying will not help."""
+
+
+class FailureScope(enum.Enum):
+    """What a transient send failure applies to."""
+
+    # The radio or the channel as a whole: no send will currently succeed
+    GLOBAL = "global"
+    # Only sends to this frame's destination are affected
+    DESTINATION = "destination"
+
+
+class TransientSendError(SendError):
+    """The radio temporarily cannot accept the frame, it can be retried later."""
+
+    def __init__(
+        self,
+        message: str,
+        status: int | None = None,
+        *,
+        scope: FailureScope = FailureScope.GLOBAL,
+        retry_in: float | None = None,
+    ):
+        super().__init__(message, status)
+        self.scope = scope
+        self.retry_in = retry_in
+
+
+class RadioBusyError(TransientSendError):
+    """The radio's transmit queue, message table, or buffer pool is full."""
+
+
+class NetworkBusyError(TransientSendError):
+    """The RF channel or the mesh is congested."""
+
+
+class SendCancelledError(SendError):
+    """The send was cancelled before its frame left the radio."""
+
+
+class SupersededError(SendCancelledError):
+    """The send was replaced by a newer one with the same coalescing key."""
 
 
 class InvalidResponse(ZigbeeException):

--- a/zigpy/scheduler.py
+++ b/zigpy/scheduler.py
@@ -49,12 +49,26 @@ DestKey: typing.TypeAlias = tuple[t.AddrMode, typing.Any]
 _UNSET = object()
 
 
+# The broadcast domain: a single scheduling lane for every broadcast and groupcast.
+# Each Zigbee stack keeps every broadcast in a delivery table for ~9s to suppress
+# relay loops, a hard firmware-wide limit shared by all broadcast traffic, so the
+# whole class is paced and blocked together.
+BROADCAST_DEST_KEY: DestKey = (t.AddrMode.Broadcast, None)
+
+
 def packet_dest_key(packet: t.ZigbeePacket) -> DestKey:
     assert packet.dst is not None
+
+    if packet.dst.addr_mode in (t.AddrMode.Broadcast, t.AddrMode.Group):
+        return BROADCAST_DEST_KEY
+
     return (packet.dst.addr_mode, packet.dst.address)
 
 
 def format_dest_key(key: DestKey) -> str:
+    if key == BROADCAST_DEST_KEY:
+        return "Broadcast"
+
     return f"{key[0].name}:{key[1]!r}"
 
 
@@ -719,31 +733,45 @@ class SendScheduler:
             # The frame never left the radio: no attempt is consumed
             transient = True
             now = loop.time()
-            self._window = max(1, len(self._in_flight) - 1)
 
-            LOGGER.debug(
-                "Radio backpressure (%r), window clamped to %d: %r",
-                exc,
-                self._window,
-                self,
-            )
-
-            if exc.scope is FailureScope.DESTINATION:
+            if (
+                exc.scope is FailureScope.DESTINATION
+                or entry.dest_key == BROADCAST_DEST_KEY
+            ):
+                # Backpressure limited to this entry's lane: a destination's own
+                # congestion, or the firmware-wide broadcast budget. Rejections here
+                # say nothing about unicast radio capacity, so the window is left
+                # alone. Broadcast-domain rejections block the whole class even when
+                # the radio can only report a generic global status.
                 dest = self._destination(entry.dest_key)
                 dest.blocked_until = now + (
                     exc.retry_in
                     if exc.retry_in is not None
                     else DEFAULT_DESTINATION_BACKOFF
                 )
+                LOGGER.debug(
+                    "Backpressure on %s (%r), blocked for %.2fs: %r",
+                    format_dest_key(entry.dest_key),
+                    exc,
+                    dest.blocked_until - now,
+                    self,
+                )
                 self._park_deferred(entry, ParkReason.DESTINATION_BLOCKED)
                 self._timer.reschedule(dest.blocked_until - now)
             else:
+                self._window = max(1, len(self._in_flight) - 1)
                 self._blocked_until = now + (
                     exc.retry_in if exc.retry_in is not None else DEFAULT_GLOBAL_BACKOFF
                 )
                 # Slot/buffer exhaustion also clears as soon as an in-flight frame
                 # completes; channel congestion only clears on the timer
                 self._unblock_on_completion = isinstance(exc, RadioBusyError)
+                LOGGER.debug(
+                    "Radio backpressure (%r), window clamped to %d: %r",
+                    exc,
+                    self._window,
+                    self,
+                )
                 self._push_ready(entry)
                 self._timer.reschedule(self._blocked_until - now)
         except TransactionExpiredError:

--- a/zigpy/scheduler.py
+++ b/zigpy/scheduler.py
@@ -15,6 +15,7 @@ import zigpy.datastructures
 from zigpy.exceptions import (
     DeliveryError,
     FailureScope,
+    PermanentSendError,
     RadioBusyError,
     SendCancelledError,
     SupersededError,
@@ -106,7 +107,7 @@ class ParkReason(enum.Enum):
     RETRY_BACKOFF = "retry_backoff"
     # The destination is temporarily unable to accept frames or its window is full
     DESTINATION_BLOCKED = "destination_blocked"
-    # The sleepy destination did not poll: parked with no deadline until it is heard from
+    # The sleepy destination did not poll: parked until it is heard from (opt-in)
     AWAITING_WAKE = "awaiting_wake"
 
 
@@ -172,6 +173,9 @@ class QueuedSend:
     retry_delay: float
     reply_timeout: float
     submitted_at: float = 0.0
+    # Park until the destination is heard from when it does not poll, instead of
+    # consuming a retry attempt (opt-in: only safe for callers that bound the wait)
+    park_on_wake: bool = False
     state: SendState = SendState.QUEUED
     park_reason: ParkReason | None = None
     not_before: float = 0.0
@@ -238,7 +242,6 @@ class DestinationState:
     # Open interactions: dispatched sends up to and including their reply wait
     in_flight: int = 0
     blocked_until: float = 0.0
-    last_alive: float = 0.0
     deferred: list[QueuedSend] = dataclasses.field(default_factory=list)
 
     def is_idle(self, now: float) -> bool:
@@ -371,6 +374,7 @@ class SendScheduler:
         retry_delay: float | None = None,
         reply_timeout: float | None = None,
         expires_at: float | None = None,
+        park_on_wake: bool = False,
     ) -> SendHandle:
         """Admit a packet for sending and return a staged handle over it.
 
@@ -403,6 +407,7 @@ class SendScheduler:
             entry.expires_at = expires_at
             entry.retry_delay = retry_delay
             entry.reply_timeout = reply_timeout
+            entry.park_on_wake = park_on_wake
             old_slot.resolve(SendStage.SENT, SupersededError("Send was superseded"))
             LOGGER.debug(
                 "Superseded queued send %r to %s",
@@ -424,6 +429,7 @@ class SendScheduler:
             expires_at=expires_at,
             retry_delay=retry_delay,
             reply_timeout=reply_timeout,
+            park_on_wake=park_on_wake,
         )
 
         if key is not None:
@@ -433,10 +439,16 @@ class SendScheduler:
         # every gate is open, avoiding the dispatch loop's added latency
         now = asyncio.get_running_loop().time()
         entry.submitted_at = now
+
+        if entry.expires_at is not None and now >= entry.expires_at:
+            self._finalize(entry, SendCancelledError("Send expired before dispatch"))
+            return SendHandle(self, entry, entry.slot)
+
         dest = self._destination(entry.dest_key)
 
         if (
             not self._ready
+            and not dest.deferred
             and self._can_dispatch(now)
             and self._dest_can_dispatch(dest, now)
         ):
@@ -495,8 +507,6 @@ class SendScheduler:
             return
 
         dest = self._destinations[key]
-        dest.last_alive = asyncio.get_running_loop().time()
-
         woken = [e for e in dest.deferred if e.park_reason is ParkReason.AWAITING_WAKE]
 
         if not woken:
@@ -529,6 +539,8 @@ class SendScheduler:
         dest = self._destinations[entry.dest_key]
         dest.in_flight -= 1
         self._maybe_evict(entry.dest_key, asyncio.get_running_loop().time())
+        # A freed interaction slot may unblock sends deferred on the window
+        self._wake.set()
 
     def _finalize(
         self,
@@ -538,6 +550,12 @@ class SendScheduler:
         stage: SendStage = SendStage.CONFIRMED,
     ) -> None:
         self._release_dest_slot(entry)
+
+        if entry.dest_key in self._destinations:
+            dest = self._destinations[entry.dest_key]
+            if entry in dest.deferred:
+                dest.deferred.remove(entry)
+
         entry.state = SendState.DONE
         entry.park_reason = None
         entry.slot.resolve(stage, result)
@@ -641,6 +659,7 @@ class SendScheduler:
             self._wake.clear()
 
             now = asyncio.get_running_loop().time()
+            self._expire_entries(now)
             self._release_reply_timeouts(now)
             self._release_parked(now)
             self._release_destinations(now)
@@ -704,7 +723,7 @@ class SendScheduler:
 
         # An in-flight send can no longer be superseded
         key = entry.coalesce_key
-        if key is not None and self._coalesce[key] is entry:
+        if key is not None and key in self._coalesce and self._coalesce[key] is entry:
             del self._coalesce[key]
 
         dest.in_flight += 1
@@ -734,7 +753,10 @@ class SendScheduler:
             transient = True
             now = loop.time()
 
-            if (
+            if entry.state is SendState.DONE:
+                # Resolved while in flight (late reply or cancellation)
+                pass
+            elif (
                 exc.scope is FailureScope.DESTINATION
                 or entry.dest_key == BROADCAST_DEST_KEY
             ):
@@ -772,19 +794,33 @@ class SendScheduler:
                     self._window,
                     self,
                 )
-                self._push_ready(entry)
+                if self._restore_coalesce(entry):
+                    self._push_ready(entry)
+
                 self._timer.reschedule(self._blocked_until - now)
-        except TransactionExpiredError:
-            # The sleepy destination did not poll: park until it is heard from
-            LOGGER.debug(
-                "Destination %s did not poll, parking send until it wakes",
-                format_dest_key(entry.dest_key),
-            )
+        except (PermanentSendError, SendCancelledError) as exc:
+            # Retrying cannot help: fail immediately
             self._grow_window()
-            self._park_deferred(entry, ParkReason.AWAITING_WAKE)
-        except DeliveryError as exc:
+            self._finalize(entry, exc)
+        except TransactionExpiredError as exc:
             self._grow_window()
-            self._retry_or_fail(entry, exc, loop.time())
+
+            if entry.state is SendState.DONE:
+                pass
+            elif entry.park_on_wake:
+                # The sleepy destination did not poll: park until it is heard from
+                LOGGER.debug(
+                    "Destination %s did not poll, parking send until it wakes",
+                    format_dest_key(entry.dest_key),
+                )
+                self._park_deferred(entry, ParkReason.AWAITING_WAKE)
+            else:
+                self._retry_or_fail(entry, exc, loop.time())
+        except (DeliveryError, TimeoutError) as exc:
+            self._grow_window()
+
+            if entry.state is not SendState.DONE:
+                self._retry_or_fail(entry, exc, loop.time())
         except Exception as exc:  # noqa: BLE001
             # Anything else is a terminal verdict for this send
             self._grow_window()
@@ -792,14 +828,23 @@ class SendScheduler:
         else:
             self._grow_window()
 
-            if entry.slot.final_stage is SendStage.REPLIED:
+            if entry.state is SendState.DONE:
+                # Resolved while in flight (late reply or cancellation)
+                pass
+            elif entry.slot.final_stage is SendStage.REPLIED:
                 entry.slot.resolve(SendStage.CONFIRMED, None)
                 self._await_reply(entry, loop.time())
             else:
                 self._finalize(entry)
         finally:
             self._in_flight.discard(entry)
-            del self._in_flight_by_packet[id(packet)]
+
+            if (
+                id(packet) in self._in_flight_by_packet
+                and self._in_flight_by_packet[id(packet)] is entry
+            ):
+                del self._in_flight_by_packet[id(packet)]
+
             entry.attempt_task = None
             self._bytes_in_flight -= entry.size
 
@@ -814,6 +859,15 @@ class SendScheduler:
                 self._blocked_until = 0.0
 
             self._wake.set()
+
+    def _expire_entries(self, now: float) -> None:
+        for entry in set(self._all_entries()):
+            if (
+                entry.expires_at is not None
+                and now >= entry.expires_at
+                and entry.state in (SendState.QUEUED, SendState.PARKED)
+            ):
+                self._finalize(entry, SendCancelledError("Send expired"))
 
     def _release_reply_timeouts(self, now: float) -> None:
         while self._awaiting_reply and self._awaiting_reply[0][0] <= now:
@@ -866,6 +920,13 @@ class SendScheduler:
         for dest in self._destinations.values():
             if dest.deferred and now < dest.blocked_until:
                 deadlines.append(dest.blocked_until)  # noqa: PERF401
+
+        for entry in set(self._all_entries()):
+            if entry.expires_at is not None and entry.state in (
+                SendState.QUEUED,
+                SendState.PARKED,
+            ):
+                deadlines.append(entry.expires_at)  # noqa: PERF401
 
         if deadlines:
             self._timer.reschedule(max(0.0, min(deadlines) - now))

--- a/zigpy/scheduler.py
+++ b/zigpy/scheduler.py
@@ -1,0 +1,843 @@
+"""Outgoing frame scheduler: explicit queueing, parking, and coalescing of sends."""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import dataclasses
+import enum
+import heapq
+import itertools
+import logging
+import typing
+
+import zigpy.datastructures
+from zigpy.exceptions import (
+    DeliveryError,
+    FailureScope,
+    RadioBusyError,
+    SendCancelledError,
+    SupersededError,
+    TransactionExpiredError,
+    TransientSendError,
+)
+import zigpy.types as t
+
+LOGGER = logging.getLogger(__name__)
+
+# Rough per-frame overhead on top of the ASDU: MAC, NWK, NWK security, and APS headers
+FRAME_OVERHEAD = 44
+
+# A frame to a sleepy destination occupies radio buffers for far longer (parent-side
+# indirect buffering), so it weighs heavier against the byte budget
+SLEEPY_SIZE_WEIGHT = 4
+
+DEFAULT_ATTEMPTS = 3
+DEFAULT_RETRY_DELAY = 1.0
+DEFAULT_GLOBAL_BACKOFF = 0.5
+DEFAULT_DESTINATION_BACKOFF = 1.0
+DEFAULT_REPLY_TIMEOUT = 10.0
+
+# Queue status is logged at most this often, and only when the scheduler is busy
+STATUS_LOG_INTERVAL = 30.0
+
+# The destination address fields that identify a rate-limiting domain. NWK and IEEE
+# addressing of the same device intentionally do not unify: IEEE-addressed sends form
+# their own domain, as a known limitation.
+DestKey: typing.TypeAlias = tuple[t.AddrMode, typing.Any]
+
+_UNSET = object()
+
+
+def packet_dest_key(packet: t.ZigbeePacket) -> DestKey:
+    assert packet.dst is not None
+    return (packet.dst.addr_mode, packet.dst.address)
+
+
+def format_dest_key(key: DestKey) -> str:
+    return f"{key[0].name}:{key[1]!r}"
+
+
+def packet_size(packet: t.ZigbeePacket) -> int:
+    size = FRAME_OVERHEAD + len(packet.data.serialize())
+
+    if packet.extended_timeout:
+        size *= SLEEPY_SIZE_WEIGHT
+
+    return size
+
+
+class SendStage(enum.IntEnum):
+    """A send's observable stages, in resolution order."""
+
+    # The radio accepted the frame
+    SENT = 1
+    # The delivery verdict: TX status, APS ack, or broadcast handoff
+    CONFIRMED = 2
+    # A matching ZDO/ZCL response was received (only for sends expecting a reply)
+    REPLIED = 3
+
+
+class SendState(enum.Enum):
+    QUEUED = "queued"
+    PARKED = "parked"
+    IN_FLIGHT = "in_flight"
+    # Confirmed by the radio, waiting for the matched reply (or its deadline)
+    AWAITING_REPLY = "awaiting_reply"
+    DONE = "done"
+
+
+class ParkReason(enum.Enum):
+    # A delivery failure with attempts remaining, waiting out the retry delay
+    RETRY_BACKOFF = "retry_backoff"
+    # The destination is temporarily unable to accept frames or its window is full
+    DESTINATION_BLOCKED = "destination_blocked"
+    # The sleepy destination did not poll: parked with no deadline until it is heard from
+    AWAITING_WAKE = "awaiting_wake"
+
+
+class SendSlot:
+    """Staged, write-once results of a single send.
+
+    The write rules mirror Ziggurat's `SendSlot`: the first write to a stage wins, a
+    successful resolution back-fills every earlier unset stage, and an error resolves
+    every unset stage.
+    """
+
+    def __init__(self, final_stage: SendStage) -> None:
+        self.final_stage = final_stage
+        self._results: dict[SendStage, typing.Any] = {
+            stage: _UNSET for stage in SendStage if stage <= final_stage
+        }
+        self._events: dict[SendStage, asyncio.Event] = {
+            stage: asyncio.Event() for stage in self._results
+        }
+
+    def resolve(self, stage: SendStage, result: typing.Any = None) -> None:
+        if isinstance(result, BaseException):
+            stages = [s for s in self._results if self._results[s] is _UNSET]
+        else:
+            stages = [
+                s for s in self._results if s <= stage and self._results[s] is _UNSET
+            ]
+
+        for s in stages:
+            if isinstance(result, BaseException) or s == stage:
+                self._results[s] = result
+            else:
+                self._results[s] = None
+
+            self._events[s].set()
+
+    def is_resolved(self, stage: SendStage) -> bool:
+        return self._results[stage] is not _UNSET
+
+    async def wait(self, stage: SendStage) -> typing.Any:
+        await self._events[stage].wait()
+        result = self._results[stage]
+
+        if isinstance(result, BaseException):
+            raise result
+
+        return result
+
+
+@dataclasses.dataclass(eq=False)
+class QueuedSend:
+    """A reified outgoing frame, owned by the scheduler from submission to resolution."""
+
+    packet: t.ZigbeePacket
+    slot: SendSlot
+    seq: int
+    dest_key: DestKey
+    coalesce_key: typing.Hashable
+    priority: int
+    size: int
+    attempts_remaining: int
+    expires_at: float | None
+    retry_delay: float
+    reply_timeout: float
+    submitted_at: float = 0.0
+    state: SendState = SendState.QUEUED
+    park_reason: ParkReason | None = None
+    not_before: float = 0.0
+    # Holding a slot in the destination's interaction window (from dispatch until the
+    # send is terminal or parked, including the reply wait)
+    holds_dest_slot: bool = False
+    # The current attempt's task, for best-effort in-flight cancellation
+    attempt_task: asyncio.Task | None = None
+
+
+class SendHandle:
+    """An awaitable, staged view over one submitted send.
+
+    Awaiting the handle awaits its terminal stage. A superseded handle keeps its own
+    (already resolved) slot; the entry lives on under the replacement's slot.
+    """
+
+    def __init__(
+        self, scheduler: SendScheduler, entry: QueuedSend, slot: SendSlot
+    ) -> None:
+        self._scheduler = scheduler
+        self._entry = entry
+        self._slot = slot
+
+    async def sent(self) -> None:
+        await self._slot.wait(SendStage.SENT)
+
+    async def confirmed(self) -> None:
+        await self._slot.wait(SendStage.CONFIRMED)
+
+    async def replied(self) -> typing.Any:
+        return await self._slot.wait(SendStage.REPLIED)
+
+    def __await__(self) -> typing.Generator[typing.Any, None, typing.Any]:
+        return self._slot.wait(self._slot.final_stage).__await__()
+
+    def resolve_reply(self, result: typing.Any) -> bool:
+        """Resolve the reply stage, called by the response-matching layer."""
+        return self._scheduler.resolve_reply(self._entry, self._slot, result)
+
+    @property
+    def state(self) -> SendState:
+        if self._slot is not self._entry.slot:
+            return SendState.DONE
+
+        return self._entry.state
+
+    @property
+    def park_reason(self) -> ParkReason | None:
+        if self._slot is not self._entry.slot:
+            return None
+
+        return self._entry.park_reason
+
+    def cancel(self) -> bool:
+        """Cancel the send. Guaranteed for a queued or parked send, no-op otherwise."""
+        return self._scheduler.cancel(self._entry, self._slot)
+
+
+@dataclasses.dataclass
+class DestinationState:
+    """Ephemeral per-destination scheduling state, evicted as soon as it is idle."""
+
+    # Open interactions: dispatched sends up to and including their reply wait
+    in_flight: int = 0
+    blocked_until: float = 0.0
+    last_alive: float = 0.0
+    deferred: list[QueuedSend] = dataclasses.field(default_factory=list)
+
+    def is_idle(self, now: float) -> bool:
+        return not self.in_flight and not self.deferred and now >= self.blocked_until
+
+
+class SendScheduler:
+    """Owns every outgoing frame between submission and the radio.
+
+    Dispatches queued sends to `send_packet` in priority order, paced by an adaptive
+    in-flight window (frames and weighted bytes). Transient radio backpressure parks
+    frames instead of failing them and never consumes a retry attempt. Queued and
+    parked sends sharing a coalesce key supersede one another.
+    """
+
+    def __init__(
+        self,
+        send_packet: typing.Callable[[t.ZigbeePacket], typing.Awaitable[None]],
+        *,
+        max_in_flight: int = 8,
+        max_in_flight_bytes: int | None = None,
+        destination_window: int | None = None,
+        retry_delay: float = DEFAULT_RETRY_DELAY,
+    ) -> None:
+        self._send_packet = send_packet
+        self._max_in_flight = max_in_flight
+        self._max_in_flight_bytes = max_in_flight_bytes
+        self._destination_window = destination_window
+        self._retry_delay = retry_delay
+
+        self._seq = itertools.count()
+        self._ready: list[tuple[int, int, QueuedSend]] = []
+        self._parked: list[tuple[float, int, QueuedSend]] = []
+        self._awaiting_reply: list[tuple[float, int, QueuedSend]] = []
+        self._destinations: dict[DestKey, DestinationState] = {}
+        self._coalesce: dict[typing.Hashable, QueuedSend] = {}
+        self._in_flight: set[QueuedSend] = set()
+        self._in_flight_by_packet: dict[int, QueuedSend] = {}
+        self._attempt_tasks: set[asyncio.Task] = set()
+
+        # AIMD window: clamped on transient backpressure, grown on success
+        self._window = max_in_flight
+        self._bytes_in_flight = 0
+        self._blocked_until = 0.0
+        self._unblock_on_completion = False
+
+        self._wake = asyncio.Event()
+        self._timer = zigpy.datastructures.ReschedulableTimeout(self._wake.set)
+        self._task: asyncio.Task | None = None
+        self._last_status_log = 0.0
+
+    def __repr__(self) -> str:
+        # The heaps hold onto stale entries until they are lazily popped, so the
+        # live states are counted instead, deduplicated by identity
+        entries = set(self._all_entries())
+        states = collections.Counter(e.state for e in entries)
+        reasons = collections.Counter(
+            e.park_reason for e in entries if e.state is SendState.PARKED
+        )
+
+        return (
+            f"<{type(self).__name__}"
+            f" queued={states[SendState.QUEUED]}"
+            f" in_flight={len(self._in_flight)}"
+            f" awaiting_reply={states[SendState.AWAITING_REPLY]}"
+            f" retry_backoff={reasons[ParkReason.RETRY_BACKOFF]}"
+            f" destination_blocked={reasons[ParkReason.DESTINATION_BLOCKED]}"
+            f" awaiting_wake={reasons[ParkReason.AWAITING_WAKE]}"
+            f" window={self._window}/{self._max_in_flight}"
+            f" bytes_in_flight={self._bytes_in_flight}"
+            f" destinations={len(self._destinations)}"
+            f">"
+        )
+
+    @property
+    def max_in_flight(self) -> int:
+        return self._max_in_flight
+
+    @max_in_flight.setter
+    def max_in_flight(self, value: int) -> None:
+        """Update the in-flight ceiling, resetting the adaptive window."""
+        self._max_in_flight = value
+        self._window = value
+        self._wake.set()
+
+    @property
+    def destination_window(self) -> int | None:
+        return self._destination_window
+
+    @destination_window.setter
+    def destination_window(self, value: int | None) -> None:
+        """Update the per-destination interaction window."""
+        self._destination_window = value
+        self._wake.set()
+
+    def start(self) -> None:
+        self._task = asyncio.get_running_loop().create_task(self._dispatch_loop())
+
+    def stop(self) -> None:
+        """Stop dispatching and fail every unresolved send."""
+        LOGGER.debug("Stopping scheduler: %r", self)
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+        for task in self._attempt_tasks:
+            task.cancel()
+
+        self._timer.cancel()
+
+        for entry in list(self._all_entries()):
+            if entry.state is not SendState.DONE:
+                self._finalize(entry, SendCancelledError("Scheduler was stopped"))
+
+        self._ready.clear()
+        self._parked.clear()
+        self._awaiting_reply.clear()
+
+        # Cancelled in-flight attempt tasks still run their cleanup, which needs the
+        # destination states: only the parked entries are dropped here
+        for dest in self._destinations.values():
+            dest.deferred.clear()
+
+    def submit(
+        self,
+        packet: t.ZigbeePacket,
+        *,
+        expect_reply: bool = False,
+        retries: int = DEFAULT_ATTEMPTS - 1,
+        retry_delay: float | None = None,
+        reply_timeout: float | None = None,
+        expires_at: float | None = None,
+    ) -> SendHandle:
+        """Admit a packet for sending and return a staged handle over it.
+
+        If the packet carries a `coalesce_key` matching a queued or parked send, that
+        send is superseded in place: it keeps its queue position, its payload and
+        handle are replaced, and the old handle resolves with `SupersededError`.
+        """
+        if self._task is None:
+            self.start()
+
+        key = packet.coalesce_key
+        final_stage = SendStage.REPLIED if expect_reply else SendStage.CONFIRMED
+
+        if retry_delay is None:
+            retry_delay = self._retry_delay
+
+        if reply_timeout is None:
+            reply_timeout = DEFAULT_REPLY_TIMEOUT
+
+        if key is not None and key in self._coalesce:
+            entry = self._coalesce[key]
+            assert entry.state in (SendState.QUEUED, SendState.PARKED)
+            assert entry.dest_key == packet_dest_key(packet)
+
+            old_slot = entry.slot
+            entry.packet = packet
+            entry.slot = SendSlot(final_stage)
+            entry.size = packet_size(packet)
+            entry.attempts_remaining = retries + 1
+            entry.expires_at = expires_at
+            entry.retry_delay = retry_delay
+            entry.reply_timeout = reply_timeout
+            old_slot.resolve(SendStage.SENT, SupersededError("Send was superseded"))
+            LOGGER.debug(
+                "Superseded queued send %r to %s",
+                key,
+                format_dest_key(entry.dest_key),
+            )
+
+            return SendHandle(self, entry, entry.slot)
+
+        entry = QueuedSend(
+            packet=packet,
+            slot=SendSlot(final_stage),
+            seq=next(self._seq),
+            dest_key=packet_dest_key(packet),
+            coalesce_key=key,
+            priority=packet.priority if packet.priority is not None else 0,
+            size=packet_size(packet),
+            attempts_remaining=retries + 1,
+            expires_at=expires_at,
+            retry_delay=retry_delay,
+            reply_timeout=reply_timeout,
+        )
+
+        if key is not None:
+            self._coalesce[key] = entry
+
+        # Fast path: dispatch synchronously when nothing is ahead in the queue and
+        # every gate is open, avoiding the dispatch loop's added latency
+        now = asyncio.get_running_loop().time()
+        entry.submitted_at = now
+        dest = self._destination(entry.dest_key)
+
+        if (
+            not self._ready
+            and self._can_dispatch(now)
+            and self._dest_can_dispatch(dest, now)
+        ):
+            self._dispatch(entry, dest)
+        else:
+            self._maybe_evict(entry.dest_key, now)
+            self._push_ready(entry)
+            LOGGER.debug(
+                "Queueing send to %s: %r", format_dest_key(entry.dest_key), self
+            )
+
+        return SendHandle(self, entry, entry.slot)
+
+    def cancel(self, entry: QueuedSend, slot: SendSlot) -> bool:
+        if slot is not entry.slot:
+            # The handle was superseded, its own slot is already resolved
+            return False
+
+        if entry.state is SendState.DONE:
+            return False
+
+        if entry.state is SendState.IN_FLIGHT:
+            # Cancelling the attempt triggers the radio's own cleanup (e.g. a
+            # wire-level send cancellation); the frame may already be on the air
+            assert entry.attempt_task is not None
+            entry.attempt_task.cancel()
+            return True
+
+        self._finalize(entry, SendCancelledError("Send was cancelled"))
+        return True
+
+    def resolve_sent(self, packet: t.ZigbeePacket) -> None:
+        """Resolve an in-flight packet's sent stage, called by a staged radio."""
+        if id(packet) in self._in_flight_by_packet:
+            self._in_flight_by_packet[id(packet)].slot.resolve(SendStage.SENT, None)
+
+    def resolve_reply(
+        self, entry: QueuedSend, slot: SendSlot, result: typing.Any
+    ) -> bool:
+        """Terminally resolve a send with its matched reply (or reply parsing error).
+
+        A late reply is honored even if the entry is already parked for a retry; a
+        reply for a superseded or finished send is ignored.
+        """
+        if slot is not entry.slot or entry.state is SendState.DONE:
+            return False
+
+        self._finalize(entry, result, stage=SendStage.REPLIED)
+        return True
+
+    def destination_seen(self, dst: t.AddrModeAddress) -> None:
+        """Feed a liveness indicator: release sends parked awaiting this destination."""
+        key = (dst.addr_mode, dst.address)
+
+        if key not in self._destinations:
+            return
+
+        dest = self._destinations[key]
+        dest.last_alive = asyncio.get_running_loop().time()
+
+        woken = [e for e in dest.deferred if e.park_reason is ParkReason.AWAITING_WAKE]
+
+        if not woken:
+            return
+
+        LOGGER.debug(
+            "Destination %s is awake, releasing %d parked sends",
+            format_dest_key(key),
+            len(woken),
+        )
+        dest.deferred = [e for e in dest.deferred if e not in woken]
+
+        for entry in woken:
+            self._push_ready(entry)
+
+    # -- internal state transitions --------------------------------------------------
+
+    def _push_ready(self, entry: QueuedSend) -> None:
+        entry.state = SendState.QUEUED
+        entry.park_reason = None
+        entry.submitted_at = asyncio.get_running_loop().time()
+        heapq.heappush(self._ready, (-entry.priority, entry.seq, entry))
+        self._wake.set()
+
+    def _release_dest_slot(self, entry: QueuedSend) -> None:
+        if not entry.holds_dest_slot:
+            return
+
+        entry.holds_dest_slot = False
+        dest = self._destinations[entry.dest_key]
+        dest.in_flight -= 1
+        self._maybe_evict(entry.dest_key, asyncio.get_running_loop().time())
+
+    def _finalize(
+        self,
+        entry: QueuedSend,
+        result: typing.Any = None,
+        *,
+        stage: SendStage = SendStage.CONFIRMED,
+    ) -> None:
+        self._release_dest_slot(entry)
+        entry.state = SendState.DONE
+        entry.park_reason = None
+        entry.slot.resolve(stage, result)
+
+        key = entry.coalesce_key
+        if key is not None and key in self._coalesce and self._coalesce[key] is entry:
+            del self._coalesce[key]
+
+    def _restore_coalesce(self, entry: QueuedSend) -> bool:
+        """Re-register a formerly in-flight entry; a newer same-key send wins instead."""
+        if entry.coalesce_key is None:
+            return True
+
+        if entry.coalesce_key in self._coalesce:
+            self._finalize(entry, SupersededError("Send was superseded during a retry"))
+            return False
+
+        self._coalesce[entry.coalesce_key] = entry
+        return True
+
+    def _park_retry(self, entry: QueuedSend, now: float) -> None:
+        self._release_dest_slot(entry)
+
+        if not self._restore_coalesce(entry):
+            return
+
+        entry.state = SendState.PARKED
+        entry.park_reason = ParkReason.RETRY_BACKOFF
+        entry.not_before = now + entry.retry_delay
+        heapq.heappush(self._parked, (entry.not_before, entry.seq, entry))
+        self._timer.reschedule(entry.retry_delay)
+
+    def _retry_or_fail(self, entry: QueuedSend, exc: BaseException, now: float) -> None:
+        entry.attempts_remaining -= 1
+
+        if entry.attempts_remaining > 0:
+            LOGGER.debug(
+                "Send to %s failed (%r), retrying in %.1fs (%d attempts left)",
+                format_dest_key(entry.dest_key),
+                exc,
+                entry.retry_delay,
+                entry.attempts_remaining,
+            )
+            # Replaced, not mutated: the already-dispatched packet stays untouched
+            entry.packet = entry.packet.replace(
+                tx_options=(
+                    entry.packet.tx_options | t.TransmitOptions.FORCE_ROUTE_DISCOVERY
+                )
+            )
+            self._park_retry(entry, now)
+        else:
+            self._finalize(entry, exc)
+
+    def _await_reply(self, entry: QueuedSend, now: float) -> None:
+        entry.state = SendState.AWAITING_REPLY
+        entry.park_reason = None
+        deadline = now + entry.reply_timeout
+        heapq.heappush(self._awaiting_reply, (deadline, entry.seq, entry))
+        self._timer.reschedule(entry.reply_timeout)
+
+    def _park_deferred(self, entry: QueuedSend, reason: ParkReason) -> None:
+        if not self._restore_coalesce(entry):
+            return
+
+        entry.state = SendState.PARKED
+        entry.park_reason = reason
+        self._destination(entry.dest_key).deferred.append(entry)
+
+    def _grow_window(self) -> None:
+        # The radio accepted the frame, so the window was not the constraint. A
+        # delivery failure says nothing about radio capacity: only a transient
+        # enqueue rejection shrinks the window.
+        self._window = min(self._window + 1, self._max_in_flight)
+
+    def _destination(self, key: DestKey) -> DestinationState:
+        if key not in self._destinations:
+            self._destinations[key] = DestinationState()
+
+        return self._destinations[key]
+
+    def _maybe_evict(self, key: DestKey, now: float) -> None:
+        if key in self._destinations and self._destinations[key].is_idle(now):
+            del self._destinations[key]
+
+    def _all_entries(self) -> typing.Iterator[QueuedSend]:
+        for _, _, entry in self._ready:
+            yield entry
+        for _, _, entry in self._parked:
+            yield entry
+        for _, _, entry in self._awaiting_reply:
+            yield entry
+        for dest in self._destinations.values():
+            yield from dest.deferred
+        yield from self._in_flight
+
+    # -- dispatch ---------------------------------------------------------------------
+
+    async def _dispatch_loop(self) -> None:
+        while True:
+            await self._wake.wait()
+            self._wake.clear()
+
+            now = asyncio.get_running_loop().time()
+            self._release_reply_timeouts(now)
+            self._release_parked(now)
+            self._release_destinations(now)
+
+            while self._ready and self._can_dispatch(now):
+                _, _, entry = heapq.heappop(self._ready)
+
+                if entry.state is not SendState.QUEUED:
+                    continue
+
+                if entry.expires_at is not None and now >= entry.expires_at:
+                    self._finalize(
+                        entry, SendCancelledError("Send expired before dispatch")
+                    )
+                    continue
+
+                dest = self._destination(entry.dest_key)
+
+                if not self._dest_can_dispatch(dest, now):
+                    entry.state = SendState.PARKED
+                    entry.park_reason = ParkReason.DESTINATION_BLOCKED
+                    dest.deferred.append(entry)
+                    continue
+
+                LOGGER.debug(
+                    "Dispatching queued send to %s after %.2fs",
+                    format_dest_key(entry.dest_key),
+                    now - entry.submitted_at,
+                )
+                self._dispatch(entry, dest)
+
+            if now - self._last_status_log > STATUS_LOG_INTERVAL and (
+                self._in_flight or set(self._all_entries())
+            ):
+                self._last_status_log = now
+                LOGGER.debug("Send queue status: %r", self)
+
+            self._rearm_timer(now)
+
+    def _dest_can_dispatch(self, dest: DestinationState, now: float) -> bool:
+        return now >= dest.blocked_until and (
+            self._destination_window is None
+            or dest.in_flight < self._destination_window
+        )
+
+    def _can_dispatch(self, now: float) -> bool:
+        if now < self._blocked_until:
+            return False
+
+        if len(self._in_flight) >= self._window:
+            return False
+
+        return (
+            self._max_in_flight_bytes is None
+            or self._bytes_in_flight < self._max_in_flight_bytes
+        )
+
+    def _dispatch(self, entry: QueuedSend, dest: DestinationState) -> None:
+        entry.state = SendState.IN_FLIGHT
+        entry.park_reason = None
+
+        # An in-flight send can no longer be superseded
+        key = entry.coalesce_key
+        if key is not None and self._coalesce[key] is entry:
+            del self._coalesce[key]
+
+        dest.in_flight += 1
+        entry.holds_dest_slot = True
+        self._in_flight.add(entry)
+        self._in_flight_by_packet[id(entry.packet)] = entry
+        self._bytes_in_flight += entry.size
+
+        task = asyncio.get_running_loop().create_task(self._attempt(entry))
+        entry.attempt_task = task
+        self._attempt_tasks.add(task)
+        task.add_done_callback(self._attempt_tasks.remove)
+
+    async def _attempt(self, entry: QueuedSend) -> None:
+        loop = asyncio.get_running_loop()
+        transient = False
+        # A retry replaces `entry.packet` before this attempt's cleanup runs
+        packet = entry.packet
+
+        try:
+            await self._send_packet(packet)
+        except asyncio.CancelledError:
+            self._finalize(entry, SendCancelledError("Send was cancelled"))
+            raise
+        except TransientSendError as exc:
+            # The frame never left the radio: no attempt is consumed
+            transient = True
+            now = loop.time()
+            self._window = max(1, len(self._in_flight) - 1)
+
+            LOGGER.debug(
+                "Radio backpressure (%r), window clamped to %d: %r",
+                exc,
+                self._window,
+                self,
+            )
+
+            if exc.scope is FailureScope.DESTINATION:
+                dest = self._destination(entry.dest_key)
+                dest.blocked_until = now + (
+                    exc.retry_in
+                    if exc.retry_in is not None
+                    else DEFAULT_DESTINATION_BACKOFF
+                )
+                self._park_deferred(entry, ParkReason.DESTINATION_BLOCKED)
+                self._timer.reschedule(dest.blocked_until - now)
+            else:
+                self._blocked_until = now + (
+                    exc.retry_in if exc.retry_in is not None else DEFAULT_GLOBAL_BACKOFF
+                )
+                # Slot/buffer exhaustion also clears as soon as an in-flight frame
+                # completes; channel congestion only clears on the timer
+                self._unblock_on_completion = isinstance(exc, RadioBusyError)
+                self._push_ready(entry)
+                self._timer.reschedule(self._blocked_until - now)
+        except TransactionExpiredError:
+            # The sleepy destination did not poll: park until it is heard from
+            LOGGER.debug(
+                "Destination %s did not poll, parking send until it wakes",
+                format_dest_key(entry.dest_key),
+            )
+            self._grow_window()
+            self._park_deferred(entry, ParkReason.AWAITING_WAKE)
+        except DeliveryError as exc:
+            self._grow_window()
+            self._retry_or_fail(entry, exc, loop.time())
+        except Exception as exc:  # noqa: BLE001
+            # Anything else is a terminal verdict for this send
+            self._grow_window()
+            self._finalize(entry, exc)
+        else:
+            self._grow_window()
+
+            if entry.slot.final_stage is SendStage.REPLIED:
+                entry.slot.resolve(SendStage.CONFIRMED, None)
+                self._await_reply(entry, loop.time())
+            else:
+                self._finalize(entry)
+        finally:
+            self._in_flight.discard(entry)
+            del self._in_flight_by_packet[id(packet)]
+            entry.attempt_task = None
+            self._bytes_in_flight -= entry.size
+
+            # An interaction awaiting its reply keeps its destination slot
+            if entry.state is not SendState.AWAITING_REPLY:
+                self._release_dest_slot(entry)
+
+            # A completed frame frees a radio slot: lift a slot-exhaustion block
+            # early instead of waiting out its backoff
+            if not transient and self._unblock_on_completion:
+                self._unblock_on_completion = False
+                self._blocked_until = 0.0
+
+            self._wake.set()
+
+    def _release_reply_timeouts(self, now: float) -> None:
+        while self._awaiting_reply and self._awaiting_reply[0][0] <= now:
+            _, _, entry = heapq.heappop(self._awaiting_reply)
+
+            if entry.state is SendState.AWAITING_REPLY:
+                self._retry_or_fail(entry, TimeoutError("No response received"), now)
+
+    def _release_parked(self, now: float) -> None:
+        while self._parked and self._parked[0][0] <= now:
+            _, _, entry = heapq.heappop(self._parked)
+
+            if (
+                entry.state is SendState.PARKED
+                and entry.park_reason is ParkReason.RETRY_BACKOFF
+            ):
+                self._push_ready(entry)
+
+    def _release_destinations(self, now: float) -> None:
+        for key in list(self._destinations):
+            dest = self._destinations[key]
+
+            if not self._dest_can_dispatch(dest, now):
+                continue
+
+            released = [
+                e
+                for e in dest.deferred
+                if e.park_reason is ParkReason.DESTINATION_BLOCKED
+            ]
+            dest.deferred = [e for e in dest.deferred if e not in released]
+
+            for entry in released:
+                self._push_ready(entry)
+
+            self._maybe_evict(key, now)
+
+    def _rearm_timer(self, now: float) -> None:
+        deadlines = []
+
+        if self._parked:
+            deadlines.append(self._parked[0][0])
+
+        if self._awaiting_reply:
+            deadlines.append(self._awaiting_reply[0][0])
+
+        if self._ready and now < self._blocked_until:
+            deadlines.append(self._blocked_until)
+
+        for dest in self._destinations.values():
+            if dest.deferred and now < dest.blocked_until:
+                deadlines.append(dest.blocked_until)  # noqa: PERF401
+
+        if deadlines:
+            self._timer.reschedule(max(0.0, min(deadlines) - now))

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -604,6 +604,9 @@ class ZigbeePacket(BaseDataclassMixin):
     # Higher priority will try to be sent before lower
     priority: int | None = dataclasses.field(default=None)
 
+    # Queued outgoing packets sharing a coalesce key supersede one another
+    coalesce_key: typing.Hashable = dataclasses.field(default=None)
+
     # Set to `None` when the packet is outgoing
     src: AddrModeAddress | None = dataclasses.field(default=None)
     src_ep: basic.uint8_t | None = dataclasses.field(default=None)
@@ -654,6 +657,7 @@ class ZigbeePacket(BaseDataclassMixin):
                 self.lqi,
                 self.rssi,
                 self.priority,
+                self.coalesce_key,
             )
         )
 


### PR DESCRIPTION
This is an experimental PR to port some of the Ziggurat frame scheduling improvements back to zigpy. bellows and zigpy-ziggurat are the current test targets but the other radio libraries will be migrated once the API stabilizes so the compatibility shim in this PR can be removed.

- Radio libraries now implement `_send_packet`, not `send_packet`, and remove all concurrency and rate limiting. It's a simple interface to send a single packet. Nothing more.
- Rate limiting is done dynamically based on radio backpressure indicators and takes into account both concurrency and total bytes used by each request.
- There are now granular zigpy error codes for enqueuing errors (packet is too long, no space in buffers, firmware concurrency limit is exhausted, etc.) and delivery errors (CCA, broadcast storm, no ACK, no route, etc.).
- Sends go through multiple stages: queued (we want to send and are waiting for a slot), parked (we are waiting for a sleepy end device to wake up), in-flight (we sent the packet and are waiting for a transmission confirmation), awaiting reply, and done. Before, we encoded this entire delivery mechanism within Python stack frame locals. Now, we know exactly what is being sent, queued, etc. Good for a future debug UI.
- Requests to sleeping end devices can be parked and will wait until the device is awake. This benefits from the granular request state tracking because we can tell _where_ a request timed out: we can still attach a 60s delivery timeout to a request that waits 1 hour for a device to wake up.
- `coalesce_key` allows requests to supersede one another. This allows multiple queued up requests that control the same device state (i.e. bulb color or switch state) to replace one another, allowing them to effectively occupy the same send slot when waiting for the radio to free up. We can further improve this rate limit groupcasts better.

Radio library branches:
- https://github.com/puddly/bellows/tree/puddly/zigpy-scheduling-api
- https://github.com/zigpy/zigpy-ziggurat/tree/puddly/zigpy-scheduling-api

This PR + one of those is enough to test this PR out.