### PR TITLE
Add APIs for attaching command reply callbacks

### DIFF
--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import itertools
 import time
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -72,7 +73,13 @@ FW_IMAGE = zigpy.ota.OtaImageWithMetadata(
 )
 
 
-def make_packet(dev: zigpy.device.Device, cluster: Cluster, cmd_name: str, **kwargs):
+def make_packet(
+    dev: zigpy.device.Device,
+    cluster: Cluster,
+    cmd_name: str,
+    src_ep: int = 1,
+    **kwargs,
+):
     req_hdr, req_cmd = cluster._create_request(
         general=False,
         command_id=cluster.commands_by_name[cmd_name].id,
@@ -85,7 +92,7 @@ def make_packet(dev: zigpy.device.Device, cluster: Cluster, cmd_name: str, **kwa
 
     return t.ZigbeePacket(
         src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
-        src_ep=1,
+        src_ep=src_ep,
         dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
         dst_ep=1,
         tsn=req_hdr.tsn,
@@ -383,6 +390,163 @@ async def test_ota_manager():
     assert result == foundation.Status.SUCCESS
 
     assert bytes(reconstructed_firmware) == FW_IMAGE.firmware.serialize()
+
+
+@pytest.mark.parametrize("device_ep", [1, 2])
+async def test_ota_manager_multiple_ota_endpoints(device_ep: int) -> None:
+    """Test that an update driven from any OTA endpoint of a device is answered."""
+
+    app = make_app({})
+    dev = add_initialized_device(
+        app, nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77")
+    )
+
+    ep2 = dev.add_endpoint(2)
+    ep2.status = zigpy.endpoint.Status.ZDO_INIT
+    ep2.profile_id = 260
+    ep2.device_type = zigpy.profiles.zha.DeviceType.PUMP
+
+    for ep_id in (1, 2):
+        dev.endpoints[ep_id].add_output_cluster(Ota.cluster_id)
+
+    cluster = dev.endpoints[device_ep].out_clusters[Ota.cluster_id]
+
+    reconstructed_firmware = bytearray()
+    reply_endpoints = set()
+
+    async def send_packet(packet: t.ZigbeePacket):
+        if packet.cluster_id != Ota.cluster_id:
+            return
+
+        hdr, cmd = cluster.deserialize(packet.data.serialize())
+        assert FW_IMAGE.firmware is not None
+
+        if isinstance(cmd, Ota.ImageNotifyCommand):
+            # `image_notify` is sent to the first endpoint exposing the cluster
+            assert packet.dst_ep == 1
+
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "query_next_image",
+                    src_ep=device_ep,
+                    field_control=Ota.QueryNextImageCommand.FieldControl.HardwareVersion,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    current_file_version=FW_IMAGE.firmware.header.file_version - 10,
+                    hardware_version=1,
+                )
+            )
+            return
+
+        # Every reply to the device is sent back to the endpoint that asked
+        reply_endpoints.add(packet.dst_ep)
+
+        if isinstance(cmd, Ota.ClientCommandDefs.query_next_image_response.schema):
+            assert cmd.status == foundation.Status.SUCCESS
+
+            dev.application.packet_received(
+                make_packet(
+                    dev,
+                    cluster,
+                    "image_block",
+                    src_ep=device_ep,
+                    field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                    manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                    image_type=FW_IMAGE.firmware.header.image_type,
+                    file_version=FW_IMAGE.firmware.header.file_version,
+                    file_offset=0,
+                    maximum_data_size=40,
+                    request_node_addr=dev.ieee,
+                )
+            )
+        elif isinstance(cmd, Ota.ClientCommandDefs.image_block_response.schema):
+            assert cmd.status == foundation.Status.SUCCESS
+
+            reconstructed_firmware[
+                cmd.file_offset : cmd.file_offset + len(cmd.image_data)
+            ] = cmd.image_data
+
+            if cmd.file_offset + len(cmd.image_data) == len(
+                FW_IMAGE.firmware.serialize()
+            ):
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        cluster,
+                        "upgrade_end",
+                        src_ep=device_ep,
+                        status=foundation.Status.SUCCESS,
+                        manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                        image_type=FW_IMAGE.firmware.header.image_type,
+                        file_version=FW_IMAGE.firmware.header.file_version,
+                    )
+                )
+            else:
+                dev.application.packet_received(
+                    make_packet(
+                        dev,
+                        cluster,
+                        "image_block",
+                        src_ep=device_ep,
+                        field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+                        manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+                        image_type=FW_IMAGE.firmware.header.image_type,
+                        file_version=FW_IMAGE.firmware.header.file_version,
+                        file_offset=cmd.file_offset + 40,
+                        maximum_data_size=40,
+                        request_node_addr=dev.ieee,
+                    )
+                )
+
+    dev.application.send_packet = AsyncMock(side_effect=send_packet)
+    result = await update_firmware(dev, FW_IMAGE)
+
+    assert result == foundation.Status.SUCCESS
+    assert bytes(reconstructed_firmware) == FW_IMAGE.firmware.serialize()
+    assert reply_endpoints == {device_ep}
+
+
+async def test_ota_manager_registration_failure_unwinds() -> None:
+    """Test that a failure to own every OTA command leaves nothing registered."""
+
+    app = make_app({})
+    dev = add_initialized_device(
+        app, nwk=0x1234, ieee=t.EUI64.convert("00:11:22:33:44:55:66:77")
+    )
+    cluster = dev.endpoints[1].add_output_cluster(Ota.cluster_id)
+
+    # Something else already owns the last command the manager registers
+    unsub = cluster.respond_to_command(
+        Ota.ServerCommandDefs.upgrade_end, AsyncMock(), default=False
+    )
+
+    with pytest.raises(ValueError, match="a non-default owner is already registered"):
+        await update_firmware(dev, FW_IMAGE)
+
+    unsub()
+
+    # The earlier registrations did not leak: the cluster's own defaults answer again
+    cluster.image_block_response = AsyncMock()
+    packet = make_packet(
+        dev,
+        cluster,
+        "image_block",
+        field_control=Ota.ImageBlockCommand.FieldControl.RequestNodeAddr,
+        manufacturer_code=FW_IMAGE.firmware.header.manufacturer_id,
+        image_type=FW_IMAGE.firmware.header.image_type,
+        file_version=FW_IMAGE.firmware.header.file_version,
+        file_offset=0,
+        maximum_data_size=40,
+        request_node_addr=dev.ieee,
+    )
+    dev.packet_received(packet)
+    await asyncio.sleep(0)
+
+    assert cluster.image_block_response.mock_calls == [
+        call(foundation.Status.ABORT, tsn=packet.tsn)
+    ]
 
 
 async def test_ota_manager_image_page():

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -501,6 +501,21 @@ async def test_handle_unknown_cluster(dev, caplog) -> None:
     assert "Ignoring message on unknown cluster: 0x9999" in caplog.text
 
 
+async def test_device_owns_poll_control_checkin(dev) -> None:
+    """Test that a device claims the check-in, so no Default Response duplicates it."""
+    ep = dev.add_endpoint(1)
+
+    with patch.object(device.Device, "poll_control_checkin_callback") as checkin:
+        cluster = ep.add_input_cluster(PollControl.cluster_id)
+        hdr, command = cluster.deserialize(b"\x09\x4c\x00")
+
+        with patch.object(cluster, "send_default_rsp") as rsp:
+            cluster.handle_message(hdr, command)
+
+    assert checkin.mock_calls == [call(hdr, command)]
+    assert len(rsp.mock_calls) == 0
+
+
 async def test_update_device_firmware_no_ota_cluster(dev):
     """Test that device firmware updates fails: no ota cluster."""
     mock_image = MagicMock()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -516,6 +516,60 @@ async def test_device_owns_poll_control_checkin(dev) -> None:
     assert len(rsp.mock_calls) == 0
 
 
+async def test_quirk_displaces_device_poll_control_checkin(dev) -> None:
+    """Test that a cluster owning the check-in itself displaces the device's owner."""
+    quirk_calls = []
+
+    class CustomPollControl(PollControl):
+        _skip_registry = True
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.respond_to_command(
+                PollControl.ClientCommandDefs.checkin,
+                lambda hdr, cmd: quirk_calls.append(cmd),
+            )
+
+    ep = dev.add_endpoint(1)
+
+    # Building the endpoint does not raise, even though the device owns the check-in too
+    cluster = ep.add_input_cluster(
+        PollControl.cluster_id, cluster=CustomPollControl(ep)
+    )
+
+    hdr, command = cluster._create_request(
+        general=False,
+        command_id=PollControl.ClientCommandDefs.checkin.id,
+        schema=PollControl.ClientCommandDefs.checkin.schema,
+        tsn=0x4C,
+        disable_default_response=False,
+        direction=foundation.Direction.Server_to_Client,
+        args=(),
+        kwargs={},
+    )
+
+    with (
+        patch.object(device.Device, "poll_control_checkin_callback") as checkin,
+        patch.object(cluster, "send_default_rsp") as rsp,
+    ):
+        dev.packet_received(
+            t.ZigbeePacket(
+                src=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=dev.nwk),
+                src_ep=1,
+                dst=t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000),
+                dst_ep=1,
+                tsn=hdr.tsn,
+                profile_id=260,
+                cluster_id=PollControl.cluster_id,
+                data=t.SerializableBytes(hdr.serialize() + command.serialize()),
+            )
+        )
+
+    assert [c.command.name for c in quirk_calls] == ["checkin"]
+    assert len(checkin.mock_calls) == 0
+    assert len(rsp.mock_calls) == 0
+
+
 async def test_update_device_firmware_no_ota_cluster(dev):
     """Test that device firmware updates fails: no ota cluster."""
     mock_image = MagicMock()

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -890,6 +890,137 @@ async def test_two_command_owners_rejected(endpoint):
     cluster.respond_to_command(zcl.ANY_COMMAND, MagicMock(), default=True)
 
 
+async def test_specific_command_owner_displaces_any_command_owner(endpoint):
+    """Test that only the most specific owner of a command replies to it."""
+    cluster = endpoint.add_input_cluster(OnOff.cluster_id)
+    on_hdr, on_command = cluster._create_request(
+        general=False,
+        command_id=OnOff.ServerCommandDefs.on.id,
+        schema=OnOff.ServerCommandDefs.on.schema,
+        tsn=0x7B,
+        disable_default_response=False,
+        direction=foundation.Direction.Client_to_Server,
+        args=(),
+        kwargs={},
+    )
+    off_hdr, off_command = cluster._create_request(
+        general=False,
+        command_id=OnOff.ServerCommandDefs.off.id,
+        schema=OnOff.ServerCommandDefs.off.schema,
+        tsn=0x7C,
+        disable_default_response=False,
+        direction=foundation.Direction.Client_to_Server,
+        args=(),
+        kwargs={},
+    )
+
+    any_owner = MagicMock()
+    cluster.respond_to_command(zcl.ANY_COMMAND, any_owner)
+
+    on_owner = MagicMock()
+    unsub = cluster.respond_to_command(OnOff.ServerCommandDefs.on, on_owner)
+
+    # Both are non-default and overlap, so the specific one alone answers `on`
+    cluster.handle_message(on_hdr, on_command)
+    assert on_owner.mock_calls == [call(on_hdr, on_command)]
+    assert len(any_owner.mock_calls) == 0
+
+    # Every other command is still answered by the catch-all
+    cluster.handle_message(off_hdr, off_command)
+    assert any_owner.mock_calls == [call(off_hdr, off_command)]
+
+    # And it takes `on` back once the specific owner goes away
+    any_owner.reset_mock()
+    unsub()
+    cluster.handle_message(on_hdr, on_command)
+    assert any_owner.mock_calls == [call(on_hdr, on_command)]
+
+
+async def test_command_owner_displaces_more_specific_default_owner(endpoint):
+    """Test that a non-default owner outranks a default owner of a specific command."""
+    cluster = endpoint.add_input_cluster(OnOff.cluster_id)
+    hdr, command = cluster._create_request(
+        general=False,
+        command_id=OnOff.ServerCommandDefs.on.id,
+        schema=OnOff.ServerCommandDefs.on.schema,
+        tsn=0x7B,
+        disable_default_response=False,
+        direction=foundation.Direction.Client_to_Server,
+        args=(),
+        kwargs={},
+    )
+
+    default_on_owner = MagicMock()
+    cluster.respond_to_command(
+        OnOff.ServerCommandDefs.on, default_on_owner, default=True
+    )
+
+    any_owner = MagicMock()
+    cluster.respond_to_command(zcl.ANY_COMMAND, any_owner)
+
+    cluster.handle_message(hdr, command)
+    assert any_owner.mock_calls == [call(hdr, command)]
+    assert len(default_on_owner.mock_calls) == 0
+
+
+async def test_failing_command_owner_does_not_stop_handling(endpoint, caplog):
+    """Test that an owner raising is logged and the frame is still handled."""
+    cluster = endpoint.add_input_cluster(OnOff.cluster_id)
+    hdr, command = cluster._create_request(
+        general=False,
+        command_id=OnOff.ServerCommandDefs.on.id,
+        schema=OnOff.ServerCommandDefs.on.schema,
+        tsn=0x7B,
+        disable_default_response=False,
+        direction=foundation.Direction.Client_to_Server,
+        args=(),
+        kwargs={},
+    )
+
+    events = []
+    cluster.on_command(OnOff.ServerCommandDefs.on, events.append)
+
+    def owner(hdr, command):
+        raise RuntimeError("boom")
+
+    cluster.respond_to_command(OnOff.ServerCommandDefs.on, owner)
+
+    with caplog.at_level(logging.WARNING):
+        cluster.handle_message(hdr, command)
+
+    assert "Owner of command 0x01 failed" in caplog.text
+    assert [e.command for e in events] == [command]
+
+
+async def test_command_owner_unsubscribe_is_idempotent(endpoint):
+    """Test that a stale unsubscribe cannot remove a later registration."""
+    cluster = endpoint.add_input_cluster(OnOff.cluster_id)
+    hdr, command = cluster._create_request(
+        general=False,
+        command_id=OnOff.ServerCommandDefs.on.id,
+        schema=OnOff.ServerCommandDefs.on.schema,
+        tsn=0x7B,
+        disable_default_response=False,
+        direction=foundation.Direction.Client_to_Server,
+        args=(),
+        kwargs={},
+    )
+
+    owner = MagicMock()
+    unsub = cluster.respond_to_command(OnOff.ServerCommandDefs.on, owner)
+    unsub()
+
+    # The same callback is registered again, and the stale unsub must not touch it
+    cluster.respond_to_command(OnOff.ServerCommandDefs.on, owner)
+    unsub()
+
+    with patch.object(cluster, "send_default_rsp") as rsp:
+        cluster.handle_message(hdr, command)
+
+    assert owner.mock_calls == [call(hdr, command)]
+    assert len(rsp.mock_calls) == 0
+
+
 async def test_on_command_filters_by_command(endpoint):
     """Test that on_command only fires for its own command, sync or async."""
     cluster = endpoint.add_input_cluster(OnOff.cluster_id)
@@ -939,15 +1070,52 @@ async def test_cluster_command_received_event(endpoint):
     assert event.command_id == OnOff.ServerCommandDefs.on.id
     assert event.tsn == 0x7B
 
+    assert event.raw_command is None
+
     # An unknown command id cannot be decoded, so `command` is None
     listener.reset_mock()
-    unknown_hdr, raw = cluster.deserialize(b"\x01\x7c\xee")
-    assert isinstance(raw, bytes)
-    cluster.handle_message(unknown_hdr, raw)
+    unknown_hdr = foundation.ZCLHeader.cluster(tsn=0x7C, command_id=0xEE)
+    cluster.handle_message(unknown_hdr, b"\xaa\xbb")
 
     (event,) = [c.args[0] for c in listener.mock_calls]
     assert event.command is None
     assert event.command_id == 0xEE
+
+    # ...but the payload it could not decode is still there
+    assert event.raw_command == b"\xaa\xbb"
+
+
+async def test_any_command_owner_owns_undecodable_command(endpoint):
+    """Test that an `ANY_COMMAND` owner answers a command the cluster cannot decode."""
+    cluster = endpoint.add_input_cluster(OnOff.cluster_id)
+
+    owner = MagicMock()
+    cluster.respond_to_command(zcl.ANY_COMMAND, owner)
+
+    # The cluster defines no command 0xEE, so there is no schema to build a request from
+    hdr = foundation.ZCLHeader.cluster(tsn=0x7C, command_id=0xEE)
+    assert hdr.frame_control.disable_default_response == 0
+
+    with patch.object(cluster, "send_default_rsp") as rsp:
+        cluster.handle_message(hdr, b"\xaa\xbb")
+
+    assert owner.mock_calls == [call(hdr, None)]
+    assert len(rsp.mock_calls) == 0
+
+    owner.reset_mock()
+    on_hdr, on_command = cluster._create_request(
+        general=False,
+        command_id=OnOff.ServerCommandDefs.on.id,
+        schema=OnOff.ServerCommandDefs.on.schema,
+        tsn=0x7B,
+        disable_default_response=False,
+        direction=foundation.Direction.Client_to_Server,
+        args=(),
+        kwargs={},
+    )
+    cluster.handle_message(on_hdr, on_command)
+
+    assert owner.mock_calls == [call(on_hdr, on_command)]
 
 
 def test_detects_clusters_that_take_over_command_handling():
@@ -985,6 +1153,53 @@ def test_detects_clusters_that_take_over_command_handling():
     assert Ota._takes_over_command_handling is False
     assert TakeoverQuirk._takes_over_command_handling is True
     assert InheritedTakeover._takes_over_command_handling is True
+
+
+async def test_takeover_quirk_displaces_cluster_default_owners(endpoint):
+    """Test that a cluster's own default owners stand down for an unmigrated override."""
+    requests = []
+
+    with pytest.warns(DeprecationWarning, match="overrides `handle_cluster_request`"):
+
+        class TakeoverOta(Ota):
+            _skip_registry = True
+
+            def handle_cluster_request(self, hdr, args, *, dst_addressing=None):
+                requests.append(args)
+
+    cluster = TakeoverOta(endpoint, is_server=False)
+    cluster.image_block_response = AsyncMock()
+
+    hdr = foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.image_block.id
+    )
+    command = Ota.ServerCommandDefs.image_block.schema(
+        field_control=0,
+        manufacturer_code=0x1234,
+        image_type=0x5678,
+        file_version=1,
+        file_offset=0,
+        maximum_data_size=64,
+        request_node_addr=t.EUI64.convert("11:22:33:44:55:66:77:88"),
+        minimum_block_period=0,
+    )
+
+    cluster.handle_message(hdr, command)
+    await asyncio.sleep(0)
+
+    # The override is the only thing that replies
+    assert requests == [command]
+    assert len(cluster.image_block_response.mock_calls) == 0
+
+    # An OTAManager can still take over from the quirk for the duration of an upgrade
+    manager_calls = []
+    cluster.respond_to_command(
+        Ota.ServerCommandDefs.image_block, lambda hdr, cmd: manager_calls.append(cmd)
+    )
+    cluster.handle_message(hdr, command)
+    await asyncio.sleep(0)
+
+    assert manager_calls == [command]
 
 
 async def test_owner_suppresses_default_response(endpoint):

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, call, patch, sentinel
+import warnings
 
 import pytest
 
@@ -30,7 +31,7 @@ from zigpy.zcl import (
     _chunk_records_by_size,
     foundation,
 )
-from zigpy.zcl.clusters.general import Basic, OnOff, Ota
+from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PollControl
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.helpers import ReportingConfig
@@ -841,6 +842,170 @@ async def test_handle_cluster_request_handler(cluster):
     hdr = foundation.ZCLHeader.cluster(123, 0x00)
     cluster.handle_cluster_request(hdr, [sentinel.arg1, sentinel.arg2])
     await asyncio.sleep(0)
+
+
+async def test_command_owner_displaces_default_owner(endpoint):
+    """Test that a default owner stands down while a non-default one is registered."""
+    cluster = endpoint.add_input_cluster(OnOff.cluster_id)
+    hdr, command = cluster.deserialize(b"\x01\x7b\x01")  # on
+
+    default_owner = MagicMock()
+    cluster.respond_to_command(zcl.ANY_COMMAND, default_owner, default=True)
+
+    cluster.handle_message(hdr, command)
+    assert default_owner.mock_calls == [call(hdr, command)]
+
+    # An owner for this command takes over, without unregistering the default
+    default_owner.reset_mock()
+    owner = MagicMock()
+    unsub = cluster.respond_to_command(OnOff.ServerCommandDefs.on, owner)
+
+    cluster.handle_message(hdr, command)
+    assert owner.mock_calls == [call(hdr, command)]
+    assert len(default_owner.mock_calls) == 0
+
+    # A different command is untouched, so the default still owns it
+    other_hdr, other_command = cluster.deserialize(b"\x01\x7c\x00")  # off
+    cluster.handle_message(other_hdr, other_command)
+    assert default_owner.mock_calls == [call(other_hdr, other_command)]
+
+    # Once the owner goes away the default resumes
+    default_owner.reset_mock()
+    unsub()
+    cluster.handle_message(hdr, command)
+    assert default_owner.mock_calls == [call(hdr, command)]
+
+
+async def test_two_command_owners_rejected(endpoint):
+    """Test that a second owner for one command is refused, not silently stacked."""
+    cluster = endpoint.add_input_cluster(OnOff.cluster_id)
+    cluster.respond_to_command(OnOff.ServerCommandDefs.on, MagicMock())
+
+    with pytest.raises(ValueError, match="already registered"):
+        cluster.respond_to_command(OnOff.ServerCommandDefs.on, MagicMock())
+
+    # A different command, and any number of defaults, are fine
+    cluster.respond_to_command(OnOff.ServerCommandDefs.off, MagicMock())
+    cluster.respond_to_command(zcl.ANY_COMMAND, MagicMock(), default=True)
+    cluster.respond_to_command(zcl.ANY_COMMAND, MagicMock(), default=True)
+
+
+async def test_on_command_filters_by_command(endpoint):
+    """Test that on_command only fires for its own command, sync or async."""
+    cluster = endpoint.add_input_cluster(OnOff.cluster_id)
+
+    on_events = []
+    async_on_events = []
+    any_events = []
+
+    cluster.on_command(OnOff.ServerCommandDefs.on, on_events.append)
+    cluster.on_command(zcl.ANY_COMMAND, any_events.append)
+
+    async def async_listener(event):
+        async_on_events.append(event)
+
+    cluster.on_command(OnOff.ServerCommandDefs.on, async_listener)
+
+    on_hdr, on_command = cluster.deserialize(b"\x01\x7b\x01")
+    cluster.handle_message(on_hdr, on_command)
+    off_hdr, off_command = cluster.deserialize(b"\x01\x7c\x00")
+    cluster.handle_message(off_hdr, off_command)
+    await asyncio.sleep(0)
+
+    assert [e.command for e in on_events] == [on_command]
+    assert [e.command for e in async_on_events] == [on_command]
+    assert [e.command for e in any_events] == [on_command, off_command]
+
+    # An undecodable command reaches ANY_COMMAND subscribers only
+    unknown_hdr, raw = cluster.deserialize(b"\x01\x7d\xee")
+    cluster.handle_message(unknown_hdr, raw)
+
+    assert [e.command for e in on_events] == [on_command]
+    assert [e.command for e in any_events] == [on_command, off_command, None]
+
+
+async def test_cluster_command_received_event(endpoint):
+    """Test that observers get the typed command, and `None` when it cannot be decoded."""
+    cluster = endpoint.add_input_cluster(OnOff.cluster_id)
+    listener = MagicMock()
+    cluster.on_event(zcl.ClusterCommandReceivedEvent.event_type, listener)
+
+    hdr, command = cluster.deserialize(b"\x01\x7b\x01")  # on
+    cluster.handle_message(hdr, command)
+
+    (event,) = [c.args[0] for c in listener.mock_calls]
+    assert event.command is command
+    assert event.command.command.name == "on"
+    assert event.command_id == OnOff.ServerCommandDefs.on.id
+    assert event.tsn == 0x7B
+
+    # An unknown command id cannot be decoded, so `command` is None
+    listener.reset_mock()
+    unknown_hdr, raw = cluster.deserialize(b"\x01\x7c\xee")
+    assert isinstance(raw, bytes)
+    cluster.handle_message(unknown_hdr, raw)
+
+    (event,) = [c.args[0] for c in listener.mock_calls]
+    assert event.command is None
+    assert event.command_id == 0xEE
+
+
+def test_detects_clusters_that_take_over_command_handling():
+    """Test that overriding handle_cluster_request is detectable, quirks included."""
+
+    # `_skip_registry` so these do not displace OnOff in the global cluster registry
+    class PlainQuirk(OnOff):
+        """A quirk that only adds definitions, so the base class still answers."""
+
+        _skip_registry = True
+
+    with pytest.warns(DeprecationWarning, match="overrides `handle_cluster_request`"):
+
+        class TakeoverQuirk(OnOff):
+            _skip_registry = True
+
+            def handle_cluster_request(self, hdr, args, *, dst_addressing=None):
+                pass
+
+    # Only the class introducing the override warns, not everything beneath it
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+
+        class InheritedTakeover(TakeoverQuirk):
+            """Inherits the override, so it is still taking over."""
+
+            _skip_registry = True
+
+    assert zcl.Cluster._takes_over_command_handling is False
+    assert OnOff._takes_over_command_handling is False
+    assert PlainQuirk._takes_over_command_handling is False
+
+    # No cluster shipped by zigpy takes over any more, so the remaining users of
+    # `handle_cluster_request` are all quirks
+    assert Ota._takes_over_command_handling is False
+    assert TakeoverQuirk._takes_over_command_handling is True
+    assert InheritedTakeover._takes_over_command_handling is True
+
+
+async def test_owner_suppresses_default_response(endpoint):
+    """Test that an owned command gets no Default Response, only the owner's reply."""
+    # Both would carry the same TSN, endpoints and cluster: two replies to one command
+    cluster = endpoint.add_input_cluster(PollControl.cluster_id)
+
+    # A check-in that does *not* disable the default response
+    hdr, command = cluster.deserialize(b"\x09\x4c\x00")
+    assert hdr.frame_control.disable_default_response == 0
+    assert command.command.name == "checkin"
+
+    with patch.object(cluster, "send_default_rsp") as rsp:
+        cluster.handle_message(hdr, command)
+    assert len(rsp.mock_calls) == 1
+
+    cluster.respond_to_command(PollControl.ClientCommandDefs.checkin, MagicMock())
+
+    with patch.object(cluster, "send_default_rsp") as rsp:
+        cluster.handle_message(hdr, command)
+    assert len(rsp.mock_calls) == 0
 
 
 async def test_handle_cluster_general_request_disable_default_rsp(endpoint):

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -468,40 +468,14 @@ async def test_ota_handle_image_block_req(ota_cluster):
     ]
 
 
-@pytest.mark.parametrize(
-    ("command", "kwargs"),
-    [
-        (
-            Ota.ServerCommandDefs.image_page,
-            {
-                "field_control": 0,
-                "manufacturer_code": 0x1234,
-                "image_type": 0x5678,
-                "file_version": 1,
-                "file_offset": 0,
-                "maximum_data_size": 64,
-                "page_size": 128,
-                "response_spacing": 0,
-            },
-        ),
-        (
-            Ota.ServerCommandDefs.query_specific_file,
-            {
-                "request_node_addr": types.EUI64.convert("11:22:33:44:55:66:77:88"),
-                "manufacturer_code": 0x1234,
-                "image_type": 0x5678,
-                "file_version": 1,
-                "current_zigbee_stack_version": 2,
-            },
-        ),
-    ],
-)
-async def test_ota_unimplemented_request(dev, command, kwargs, caplog):
+async def test_ota_unimplemented_request(dev, caplog):
     """Test that a request zigpy has no response for gets no Default Response either."""
     ep = dev.add_endpoint(1)
     cluster = ep.add_output_cluster(Ota.cluster_id)
 
-    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(tsn=0x12, command_id=command.id)
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
+        tsn=0x12, command_id=Ota.ServerCommandDefs.query_specific_file.id
+    )
     assert hdr.frame_control.disable_default_response == 0
 
     with (
@@ -520,7 +494,16 @@ async def test_ota_unimplemented_request(dev, command, kwargs, caplog):
                 profile_id=260,
                 cluster_id=Ota.cluster_id,
                 data=types.SerializableBytes(
-                    hdr.serialize() + command.schema(**kwargs).serialize()
+                    hdr.serialize()
+                    + Ota.ServerCommandDefs.query_specific_file.schema(
+                        request_node_addr=types.EUI64.convert(
+                            "11:22:33:44:55:66:77:88"
+                        ),
+                        manufacturer_code=0x1234,
+                        image_type=0x5678,
+                        file_version=1,
+                        current_zigbee_stack_version=2,
+                    ).serialize()
                 ),
             )
         )

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+import logging
 import re
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -465,6 +466,68 @@ async def test_ota_handle_image_block_req(ota_cluster):
     assert ota_cluster.image_block_response.mock_calls == [
         call(zcl.foundation.Status.ABORT, tsn=hdr.tsn)
     ]
+
+
+@pytest.mark.parametrize(
+    ("command", "kwargs"),
+    [
+        (
+            Ota.ServerCommandDefs.image_page,
+            {
+                "field_control": 0,
+                "manufacturer_code": 0x1234,
+                "image_type": 0x5678,
+                "file_version": 1,
+                "file_offset": 0,
+                "maximum_data_size": 64,
+                "page_size": 128,
+                "response_spacing": 0,
+            },
+        ),
+        (
+            Ota.ServerCommandDefs.query_specific_file,
+            {
+                "request_node_addr": types.EUI64.convert("11:22:33:44:55:66:77:88"),
+                "manufacturer_code": 0x1234,
+                "image_type": 0x5678,
+                "file_version": 1,
+                "current_zigbee_stack_version": 2,
+            },
+        ),
+    ],
+)
+async def test_ota_unimplemented_request(dev, command, kwargs, caplog):
+    """Test that a request zigpy has no response for gets no Default Response either."""
+    ep = dev.add_endpoint(1)
+    cluster = ep.add_output_cluster(Ota.cluster_id)
+
+    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(tsn=0x12, command_id=command.id)
+    assert hdr.frame_control.disable_default_response == 0
+
+    with (
+        patch.object(cluster, "send_default_rsp") as rsp,
+        caplog.at_level(logging.DEBUG),
+    ):
+        dev.packet_received(
+            types.ZigbeePacket(
+                src=types.AddrModeAddress(
+                    addr_mode=types.AddrMode.NWK, address=dev.nwk
+                ),
+                src_ep=1,
+                dst=types.AddrModeAddress(addr_mode=types.AddrMode.NWK, address=0x0000),
+                dst_ep=1,
+                tsn=hdr.tsn,
+                profile_id=260,
+                cluster_id=Ota.cluster_id,
+                data=types.SerializableBytes(
+                    hdr.serialize() + command.schema(**kwargs).serialize()
+                ),
+            )
+        )
+        await asyncio.sleep(0)
+
+    assert "No response implemented" in caplog.text
+    assert len(rsp.mock_calls) == 0
 
 
 def test_ias_zone_type():

--- a/tests/test_zcl_clusters.py
+++ b/tests/test_zcl_clusters.py
@@ -16,7 +16,7 @@ from zigpy.zcl.clusters.general import Basic, KeepAlive, Ota, Time
 import zigpy.zcl.clusters.security as sec
 from zigpy.zdo import types as zdo_t
 
-from .async_mock import AsyncMock, MagicMock, call, patch, sentinel
+from .async_mock import AsyncMock, MagicMock, call, patch
 
 IMAGE_SIZE = 0x2345
 IMAGE_OFFSET = 0x2000
@@ -350,35 +350,22 @@ def ota_cluster(dev):
         yield cluster
 
 
-async def test_ota_handle_cluster_req_wrapper(ota_cluster, caplog):
-    ota_cluster._handle_query_next_image = AsyncMock()
-
-    hdr = zigpy.zcl.foundation.ZCLHeader.cluster(123, 0x01)
-    ota_cluster.handle_cluster_request(hdr, [sentinel.args])
-    assert ota_cluster._handle_query_next_image.call_count == 1
-    assert ota_cluster._handle_query_next_image.mock_calls[0].args == (
-        hdr,
-        [sentinel.args],
-    )
-    ota_cluster._handle_query_next_image.reset_mock()
-
-    # This command isn't currently handled
-    hdr.command_id = 0x08
-    ota_cluster.handle_cluster_request(hdr, [sentinel.just_args])
-    assert ota_cluster._handle_query_next_image.call_count == 0
-
-
 async def test_ota_handle_query_next_image(ota_cluster):
     dev = ota_cluster.endpoint.device
 
     ota_cluster.query_next_image_response = AsyncMock()
     dev.ota_in_progress = False
 
-    # TODO: get rid of `sentinel` and mock the actual command
     hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
         tsn=0x12, command_id=Ota.ServerCommandDefs.query_next_image.id
     )
-    cmd = MagicMock()
+    cmd = Ota.ServerCommandDefs.query_next_image.schema(
+        field_control=0,
+        manufacturer_code=0x1234,
+        image_type=0x5678,
+        current_file_version=1,
+        hardware_version=1,
+    )
 
     cache_events = []
     ota_cluster.on_event(OtaQueryCacheUpdatedEvent.event_type, cache_events.append)
@@ -394,7 +381,7 @@ async def test_ota_handle_query_next_image(ota_cluster):
     ota.get_ota_images = AsyncMock(
         return_value=OtaImagesResult(upgrades=(), downgrades=())
     )
-    ota_cluster.handle_cluster_request(hdr, cmd)
+    ota_cluster.handle_message(hdr, cmd)
     await asyncio.sleep(0)
 
     assert ota_cluster.query_next_image_response.mock_calls == [
@@ -416,7 +403,7 @@ async def test_ota_handle_query_next_image(ota_cluster):
     ota.get_ota_images = AsyncMock(
         return_value=OtaImagesResult(upgrades=(img,), downgrades=())
     )
-    ota_cluster.handle_cluster_request(hdr, cmd)
+    ota_cluster.handle_message(hdr, cmd)
     await asyncio.sleep(0)
 
     assert ota_cluster.query_next_image_response.mock_calls == [
@@ -438,10 +425,19 @@ async def test_ota_handle_image_block_req(ota_cluster):
     hdr = zigpy.zcl.foundation.ZCLHeader.cluster(
         tsn=0x12, command_id=Ota.ServerCommandDefs.image_block.id
     )
-    cmd = MagicMock()
+    cmd = Ota.ServerCommandDefs.image_block.schema(
+        field_control=0,
+        manufacturer_code=0x1234,
+        image_type=0x5678,
+        file_version=1,
+        file_offset=0,
+        maximum_data_size=64,
+        request_node_addr=types.EUI64.convert("11:22:33:44:55:66:77:88"),
+        minimum_block_period=0,
+    )
 
     # Stop the upgrade, none is in progress
-    ota_cluster.handle_cluster_request(hdr, cmd)
+    ota_cluster.handle_message(hdr, cmd)
     await asyncio.sleep(0)
 
     assert ota_cluster.image_block_response.mock_calls == [
@@ -450,12 +446,25 @@ async def test_ota_handle_image_block_req(ota_cluster):
 
     ota_cluster.image_block_response.reset_mock()
 
-    # If we flip the progress flag, send nothing
-    dev.ota_in_progress = True
-    ota_cluster.handle_cluster_request(hdr, cmd)
+    # An OTAManager owning the command displaces the cluster, which sends nothing
+    manager_calls = []
+    unsub = ota_cluster.respond_to_command(
+        Ota.ServerCommandDefs.image_block, lambda hdr, cmd: manager_calls.append(cmd)
+    )
+    ota_cluster.handle_message(hdr, cmd)
     await asyncio.sleep(0)
 
+    assert manager_calls == [cmd]
     assert ota_cluster.image_block_response.mock_calls == []
+
+    # Once the upgrade ends the cluster takes over again
+    unsub()
+    ota_cluster.handle_message(hdr, cmd)
+    await asyncio.sleep(0)
+
+    assert ota_cluster.image_block_response.mock_calls == [
+        call(zcl.foundation.Status.ABORT, tsn=hdr.tsn)
+    ]
 
 
 def test_ias_zone_type():

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -131,13 +131,15 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         # Retained for backwards compatibility, will be removed in a future release
         self.status = Status.NEW
 
-        self._on_remove_callbacks.append(
-            self._application.register_callback_listener(
-                src=self,
-                filters=[PollControl.ClientCommandDefs.checkin.schema()],
-                callback=self.poll_control_checkin_callback,
+    def cluster_added(self, cluster: Cluster) -> None:
+        """Take ownership of the commands this device's clusters let us answer."""
+        if cluster.cluster_id == PollControl.cluster_id:
+            self._on_remove_callbacks.append(
+                cluster.respond_to_command(
+                    PollControl.ClientCommandDefs.checkin,
+                    self.poll_control_checkin_callback,
+                )
             )
-        )
 
     def create_task(
         self, target: Coroutine[Any, Any, _R], name: str | None = None

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -134,10 +134,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def cluster_added(self, cluster: Cluster) -> None:
         """Take ownership of the commands this device's clusters let us answer."""
         if cluster.cluster_id == PollControl.cluster_id:
+            # Owned as a default so a quirk registering its own check-in owner displaces
+            # us instead of making cluster creation raise
             self._on_remove_callbacks.append(
                 cluster.respond_to_command(
                     PollControl.ClientCommandDefs.checkin,
                     self.poll_control_checkin_callback,
+                    default=True,
                 )
             )
 

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -112,6 +112,8 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         if self._device.application._dblistener is not None:
             self._device.application._dblistener.register_cluster_events(cluster)
 
+        self._device.cluster_added(cluster)
+
         return cluster
 
     def add_output_cluster(
@@ -131,6 +133,8 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         if self._device.application._dblistener is not None:
             self._device.application._dblistener.register_cluster_events(cluster)
+
+        self._device.cluster_added(cluster)
 
         return cluster
 

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -6,6 +6,7 @@ import asyncio
 from asyncio import timeout as asyncio_timeout
 from collections.abc import Callable
 import contextlib
+import functools
 from typing import TYPE_CHECKING
 
 import zigpy.datastructures
@@ -60,9 +61,17 @@ class OTAManager:
         force: bool = False,
     ) -> None:
         self.device = device
+
+        # `image_notify` goes to the first endpoint exposing the cluster, but requests
+        # can come from any of them
         self.ota_cluster = device.find_cluster(
             cluster_id=Ota.cluster_id, cluster_type=ClusterType.Client
         )
+        self.ota_clusters = [
+            ep.out_clusters[Ota.cluster_id]
+            for ep in device.non_zdo_endpoints
+            if Ota.cluster_id in ep.out_clusters
+        ]
 
         self.image = image
         self._image_data = image.firmware.serialize()
@@ -77,28 +86,26 @@ class OTAManager:
         self.stack = contextlib.ExitStack()
 
     def __enter__(self) -> Self:
-        # Owning these for the duration of the upgrade displaces the cluster's own
+        handlers: dict[foundation.ZCLCommandDef, Callable] = {
+            Ota.ServerCommandDefs.query_next_image: self._image_query_req,
+            Ota.ServerCommandDefs.image_block: self._image_block_req,
+            Ota.ServerCommandDefs.image_page: self._image_page_req,
+            Ota.ServerCommandDefs.upgrade_end: self._upgrade_end,
+        }
+
+        # Owning these for the duration of the upgrade displaces the clusters' own
         # default owners, which resume once this stack is closed
-        self.stack.callback(
-            self.ota_cluster.respond_to_command(
-                Ota.ServerCommandDefs.query_next_image, self._image_query_req
-            )
-        )
-        self.stack.callback(
-            self.ota_cluster.respond_to_command(
-                Ota.ServerCommandDefs.image_block, self._image_block_req
-            )
-        )
-        self.stack.callback(
-            self.ota_cluster.respond_to_command(
-                Ota.ServerCommandDefs.image_page, self._image_page_req
-            )
-        )
-        self.stack.callback(
-            self.ota_cluster.respond_to_command(
-                Ota.ServerCommandDefs.upgrade_end, self._upgrade_end
-            )
-        )
+        with contextlib.ExitStack() as stack:
+            for cluster in self.ota_clusters:
+                for command, handler in handlers.items():
+                    stack.callback(
+                        cluster.respond_to_command(
+                            command, functools.partial(handler, cluster)
+                        )
+                    )
+
+            # Kept only once every registration succeeded, the rest unwind otherwise
+            self.stack = stack.pop_all()
 
         return self
 
@@ -117,7 +124,10 @@ class OTAManager:
             self._upgrade_end_future.set_result(status)
 
     async def _image_query_req(
-        self, hdr: foundation.ZCLHeader, command: QueryNextImageCommand
+        self,
+        cluster: Ota,
+        hdr: foundation.ZCLHeader,
+        command: QueryNextImageCommand,
     ) -> None:
         """Handle image query request."""
 
@@ -131,7 +141,7 @@ class OTAManager:
             status = foundation.Status.SUCCESS
 
         try:
-            await self.ota_cluster.query_next_image_response(
+            await cluster.query_next_image_response(
                 status=status,
                 manufacturer_code=self.image.firmware.header.manufacturer_id,
                 image_type=self.image.firmware.header.image_type,
@@ -146,10 +156,12 @@ class OTAManager:
         if status != foundation.Status.SUCCESS:
             self._finish(status)
 
-    async def _finish_malformed_image_block_response(self, handler: str, tsn: int):
+    async def _finish_malformed_image_block_response(
+        self, cluster: Ota, handler: str, tsn: int
+    ):
         """Create an image block response failure."""
         try:
-            await self.ota_cluster.image_block_response(
+            await cluster.image_block_response(
                 status=foundation.Status.MALFORMED_COMMAND, tsn=tsn
             )
         except Exception as ex:  # noqa: BLE001
@@ -160,7 +172,10 @@ class OTAManager:
         self._finish(foundation.Status.MALFORMED_COMMAND)
 
     async def _image_block_req(
-        self, hdr: foundation.ZCLHeader, command: ImageBlockCommand
+        self,
+        cluster: Ota,
+        hdr: foundation.ZCLHeader,
+        command: ImageBlockCommand,
     ) -> None:
         """Handle image block request."""
         default_image_block_size = _image_block_size_for_manufacturer(
@@ -172,13 +187,13 @@ class OTAManager:
 
         if not block:
             await self._finish_malformed_image_block_response(
-                "image_block", tsn=hdr.tsn
+                cluster, "image_block", tsn=hdr.tsn
             )
             return
 
         try:
             async with self.device.application.request_priority(t.PacketPriority.LOW):
-                await self.ota_cluster.image_block_response(
+                await cluster.image_block_response(
                     status=foundation.Status.SUCCESS,
                     manufacturer_code=self.image.firmware.header.manufacturer_id,
                     image_type=self.image.firmware.header.image_type,
@@ -206,7 +221,10 @@ class OTAManager:
             self.device.debug("OTA image_block handler exception", exc_info=ex)
 
     async def _image_page_req(
-        self, hdr: foundation.ZCLHeader, command: ImagePageCommand
+        self,
+        cluster: Ota,
+        hdr: foundation.ZCLHeader,
+        command: ImagePageCommand,
     ) -> None:
         """Handle image page request."""
         offset = command.file_offset
@@ -219,6 +237,7 @@ class OTAManager:
 
         if bytes_remaining <= 0:
             await self._finish_malformed_image_block_response(
+                cluster,
                 "image_page_req",
                 tsn=hdr.tsn,
             )
@@ -237,8 +256,8 @@ class OTAManager:
                     t.PacketPriority.LOW
                 ):
                     # Once we have a way to send requests without waiting for replies,
-                    # this can be converted to just `self.ota_cluster.image_block_response`.
-                    await self.ota_cluster.request(
+                    # this can be converted to just `cluster.image_block_response`.
+                    await cluster.request(
                         general=False,
                         command_id=Ota.ClientCommandDefs.image_block_response.id,
                         schema=Ota.ClientCommandDefs.image_block_response.schema,
@@ -272,11 +291,14 @@ class OTAManager:
             await asyncio.sleep(command.response_spacing / 1000)
 
     async def _upgrade_end(
-        self, hdr: foundation.ZCLHeader, command: foundation.CommandSchema
+        self,
+        cluster: Ota,
+        hdr: foundation.ZCLHeader,
+        command: foundation.CommandSchema,
     ) -> None:
         """Handle upgrade end request."""
         try:
-            await self.ota_cluster.upgrade_end_response(
+            await cluster.upgrade_end_response(
                 manufacturer_code=self.image.firmware.header.manufacturer_id,
                 image_type=self.image.firmware.header.image_type,
                 file_version=self.image.firmware.header.file_version,

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -77,43 +77,26 @@ class OTAManager:
         self.stack = contextlib.ExitStack()
 
     def __enter__(self) -> Self:
-        self.stack.enter_context(
-            self.device._application.callback_for_response(
-                src=self.device,
-                filters=[
-                    Ota.ServerCommandDefs.query_next_image.schema(),
-                ],
-                callback=self._image_query_req,
+        # Owning these for the duration of the upgrade displaces the cluster's own
+        # default owners, which resume once this stack is closed
+        self.stack.callback(
+            self.ota_cluster.respond_to_command(
+                Ota.ServerCommandDefs.query_next_image, self._image_query_req
             )
         )
-
-        self.stack.enter_context(
-            self.device._application.callback_for_response(
-                src=self.device,
-                filters=[
-                    Ota.ServerCommandDefs.image_block.schema(),
-                ],
-                callback=self._image_block_req,
+        self.stack.callback(
+            self.ota_cluster.respond_to_command(
+                Ota.ServerCommandDefs.image_block, self._image_block_req
             )
         )
-
-        self.stack.enter_context(
-            self.device._application.callback_for_response(
-                src=self.device,
-                filters=[
-                    Ota.ServerCommandDefs.image_page.schema(),
-                ],
-                callback=self._image_page_req,
+        self.stack.callback(
+            self.ota_cluster.respond_to_command(
+                Ota.ServerCommandDefs.image_page, self._image_page_req
             )
         )
-
-        self.stack.enter_context(
-            self.device._application.callback_for_response(
-                src=self.device,
-                filters=[
-                    Ota.ServerCommandDefs.upgrade_end.schema(),
-                ],
-                callback=self._upgrade_end,
+        self.stack.callback(
+            self.ota_cluster.respond_to_command(
+                Ota.ServerCommandDefs.upgrade_end, self._upgrade_end
             )
         )
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -308,6 +308,8 @@ class ClusterCommandReceivedEvent:
     tsn: int
     # `None` when the cluster does not define this command id, so it cannot be decoded
     command: CommandSchema | None
+    # The undecoded payload, provided only when `command` is `None`
+    raw_command: bytes | None = None
 
 
 class AnyCommandType(enum.Enum):
@@ -990,6 +992,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     command_id=hdr.command_id,
                     tsn=hdr.tsn,
                     command=command,
+                    raw_command=None if command is not None else args,
                 ),
             )
             self.handle_cluster_request(hdr, args)
@@ -1048,7 +1051,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         """Register the owner of a received command, responsible for replying to it.
 
         A `default` owner is skipped while any non-default owner is registered for the
-        same command, but stays registered so it resumes if that owner goes away.
+        same command, but stays registered so it resumes if that owner goes away. An
+        owner of a specific command likewise displaces an `ANY_COMMAND` owner.
         """
         key = self._command_key(command)
         owners = self._default_command_owners if default else self._command_owners
@@ -1059,22 +1063,41 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             )
 
         owners[key].append(callback)
+        subscribed = True
 
         def unsubscribe() -> None:
-            if callback in owners[key]:
+            # Tied to this registration, so calling it twice cannot remove a later one
+            nonlocal subscribed
+
+            if subscribed:
+                subscribed = False
                 owners[key].remove(callback)
 
         return unsubscribe
 
+    def _own_command_by_default(
+        self,
+        command: foundation.ZCLCommandDef | AnyCommandType,
+        callback: Callable,
+    ) -> None:
+        """Own a command as the cluster class's own default handler."""
+        # A subclass overriding `handle_cluster_request` has taken over replying, so
+        # answering here too would reply twice to one command
+        if self._takes_over_command_handling:
+            return
+
+        self.respond_to_command(command, callback, default=True)
+
     def _owners_for(self, command: CommandSchema | None) -> list[Callable]:
-        """The owners that will answer a received command, defaults only as a fallback."""
-        keys = self._command_keys(command)
-        owners = [cb for key in keys for cb in self._command_owners[key]]
+        """The most specific owners of a command, defaults only as a fallback."""
+        # Only one registration answers: two would each reply reusing the same TSN
+        for owners in (self._command_owners, self._default_command_owners):
+            for key in self._command_keys(command):
+                if owners[key]:
+                    # Copied so an owner unsubscribing itself cannot mutate it
+                    return list(owners[key])
 
-        if owners:
-            return owners
-
-        return [cb for key in keys for cb in self._default_command_owners[key]]
+        return []
 
     def _dispatch_command_owners(
         self, hdr: foundation.ZCLHeader, command: CommandSchema | None
@@ -1086,7 +1109,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                 # the default `ZigbeeException` catch would swallow a DeliveryError
                 self.create_catching_task(callback(hdr, command), exceptions=())
             else:
-                callback(hdr, command)
+                # An async owner fails within its own task, so a sync one cannot either
+                try:
+                    callback(hdr, command)
+                except Exception:  # noqa: BLE001
+                    self.warning(
+                        "Owner of command 0x%02X failed", hdr.command_id, exc_info=True
+                    )
 
     def handle_cluster_request(
         self,

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -979,27 +979,40 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         self.debug(
             "Received command 0x%02X (TSN %d): %s", hdr.command_id, hdr.tsn, args
         )
-        if hdr.frame_control.is_cluster:
-            command = args if isinstance(args, CommandSchema) else None
-            self._dispatch_command_owners(hdr, command)
-            self.emit(
-                ClusterCommandReceivedEvent.event_type,
-                ClusterCommandReceivedEvent(
-                    device_ieee=str(self.endpoint.device.ieee),
-                    endpoint_id=self.endpoint.endpoint_id,
-                    cluster_type=self._type,
-                    cluster_id=self.cluster_id,
-                    command_id=hdr.command_id,
-                    tsn=hdr.tsn,
-                    command=command,
-                    raw_command=None if command is not None else args,
-                ),
-            )
-            self.handle_cluster_request(hdr, args)
-            self.listener_event("cluster_command", hdr.tsn, hdr.command_id, args)
+        if not hdr.frame_control.is_cluster:
+            self.listener_event("general_command", hdr, args)
+            self.handle_cluster_general_request(hdr, args)
             return
-        self.listener_event("general_command", hdr, args)
-        self.handle_cluster_general_request(hdr, args)
+
+        command = args if isinstance(args, CommandSchema) else None
+
+        for callback in self._command_owners_for(command):
+            if iscoroutinefunction(callback):
+                self.create_catching_task(callback(hdr, command), exceptions=())
+            else:
+                # An async owner fails within its own task, so a sync one cannot either
+                try:
+                    callback(hdr, command)
+                except Exception:  # noqa: BLE001
+                    self.warning(
+                        "Owner of command 0x%02X failed", hdr.command_id, exc_info=True
+                    )
+
+        self.emit(
+            ClusterCommandReceivedEvent.event_type,
+            ClusterCommandReceivedEvent(
+                device_ieee=str(self.endpoint.device.ieee),
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_type=self._type,
+                cluster_id=self.cluster_id,
+                command_id=hdr.command_id,
+                tsn=hdr.tsn,
+                command=command,
+                raw_command=None if command is not None else args,
+            ),
+        )
+        self.handle_cluster_request(hdr, args)
+        self.listener_event("cluster_command", hdr.tsn, hdr.command_id, args)
 
     @staticmethod
     def _command_key(
@@ -1075,22 +1088,8 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
         return unsubscribe
 
-    def _own_command_by_default(
-        self,
-        command: foundation.ZCLCommandDef | AnyCommandType,
-        callback: Callable,
-    ) -> None:
-        """Own a command as the cluster class's own default handler."""
-        # A subclass overriding `handle_cluster_request` has taken over replying, so
-        # answering here too would reply twice to one command
-        if self._takes_over_command_handling:
-            return
-
-        self.respond_to_command(command, callback, default=True)
-
-    def _owners_for(self, command: CommandSchema | None) -> list[Callable]:
+    def _command_owners_for(self, command: CommandSchema | None) -> list[Callable]:
         """The most specific owners of a command, defaults only as a fallback."""
-        # Only one registration answers: two would each reply reusing the same TSN
         for owners in (self._command_owners, self._default_command_owners):
             for key in self._command_keys(command):
                 if owners[key]:
@@ -1098,24 +1097,6 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                     return list(owners[key])
 
         return []
-
-    def _dispatch_command_owners(
-        self, hdr: foundation.ZCLHeader, command: CommandSchema | None
-    ) -> None:
-        """Hand a received command to its owner, or to the default owner if it has none."""
-        for callback in self._owners_for(command):
-            if iscoroutinefunction(callback):
-                # `exceptions=()` because an owner failing to reply must stay visible:
-                # the default `ZigbeeException` catch would swallow a DeliveryError
-                self.create_catching_task(callback(hdr, command), exceptions=())
-            else:
-                # An async owner fails within its own task, so a sync one cannot either
-                try:
-                    callback(hdr, command)
-                except Exception:  # noqa: BLE001
-                    self.warning(
-                        "Owner of command 0x%02X failed", hdr.command_id, exc_info=True
-                    )
 
     def handle_cluster_request(
         self,
@@ -1142,7 +1123,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         # An owner answers the command with a specific response, reusing its TSN, so a
         # Default Response would be a second reply to the same transaction. A default
         # owner counts: it is still the one answering when no other owner exists.
-        if self._owners_for(command):
+        if self._command_owners_for(command):
             return
 
         if not hdr.frame_control.disable_default_response:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 import enum
 import functools
+from inspect import iscoroutinefunction
 import itertools
 import logging
 import types
@@ -293,6 +294,35 @@ class OtaQueryCacheClearedEvent:
     endpoint_id: int
 
 
+@dataclass(kw_only=True, frozen=True)
+class ClusterCommandReceivedEvent:
+    """Event generated when a cluster command is received."""
+
+    event_type: Final[str] = "cluster_command_received"
+
+    device_ieee: str
+    endpoint_id: int
+    cluster_type: ClusterType
+    cluster_id: int
+    command_id: int
+    tsn: int
+    # `None` when the cluster does not define this command id, so it cannot be decoded
+    command: CommandSchema | None
+
+
+class AnyCommandType(enum.Enum):
+    """Singleton type for a registration covering every command on a cluster."""
+
+    _singleton = 0
+
+
+ANY_COMMAND = AnyCommandType._singleton  # noqa: SLF001
+
+# A command def is identified by its direction and id: a server and a client command
+# may share an id, and `with_compiled_schema` replaces the def object itself
+CommandKey = tuple[foundation.Direction, int] | AnyCommandType
+
+
 def convert_list_schema(
     schema: Sequence[type], command_id: int, direction: foundation.Direction
 ) -> type[t.Struct]:
@@ -368,9 +398,30 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
     _registry: dict = {}
     _registry_range: dict = {}
 
+    # Set per subclass by `__init_subclass__`
+    _takes_over_command_handling: bool = False
+
     def __init_subclass__(cls) -> None:
         if cls.cluster_id is not None:
             cls.cluster_id = t.ClusterId(cls.cluster_id)
+
+        # A cluster that overrides `handle_cluster_request` has taken over command
+        # handling, including whether a Default Response is sent, so the base class
+        # must not second-guess it. True for custom quirks we cannot audit.
+        cls._takes_over_command_handling = (
+            cls.handle_cluster_request is not Cluster.handle_cluster_request
+        )
+
+        # Warn once per class, and only for a class that introduces the override, so a
+        # subclass of an unmigrated quirk does not repeat its parent's warning
+        if "handle_cluster_request" in cls.__dict__:
+            warnings.warn(
+                f"{cls.__name__} overrides `handle_cluster_request`, which will be"
+                f" removed. Use `Cluster.respond_to_command()` for commands it replies"
+                f" to and `Cluster.on_command()` for the rest.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Compile the old command definitions
         for commands in [cls.server_commands, cls.client_commands]:
@@ -546,6 +597,14 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
 
         # We proxy `_attr_cache` because custom quirks can overwrite it with a dict
         self._attr_cache_internal: AttributeCache = AttributeCache(self)
+
+        # Keyed by (direction, command id), or ANY_COMMAND for a cluster-wide handler.
+        # Owners are responsible for replying; a default owner stands down whenever a
+        # non-default one is registered, without being unregistered itself.
+        self._command_owners: dict[CommandKey, list[Callable]] = defaultdict(list)
+        self._default_command_owners: dict[CommandKey, list[Callable]] = defaultdict(
+            list
+        )
 
         # Register event handlers for cache side effects, allowing quirks to
         # override emit() or the handler to prevent cache modifications.
@@ -919,11 +978,115 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             "Received command 0x%02X (TSN %d): %s", hdr.command_id, hdr.tsn, args
         )
         if hdr.frame_control.is_cluster:
+            command = args if isinstance(args, CommandSchema) else None
+            self._dispatch_command_owners(hdr, command)
+            self.emit(
+                ClusterCommandReceivedEvent.event_type,
+                ClusterCommandReceivedEvent(
+                    device_ieee=str(self.endpoint.device.ieee),
+                    endpoint_id=self.endpoint.endpoint_id,
+                    cluster_type=self._type,
+                    cluster_id=self.cluster_id,
+                    command_id=hdr.command_id,
+                    tsn=hdr.tsn,
+                    command=command,
+                ),
+            )
             self.handle_cluster_request(hdr, args)
             self.listener_event("cluster_command", hdr.tsn, hdr.command_id, args)
             return
         self.listener_event("general_command", hdr, args)
         self.handle_cluster_general_request(hdr, args)
+
+    @staticmethod
+    def _command_key(
+        command: foundation.ZCLCommandDef | AnyCommandType,
+    ) -> CommandKey:
+        if command is ANY_COMMAND:
+            return ANY_COMMAND
+
+        return (command.direction, command.id)
+
+    def _command_keys(self, command: CommandSchema | None) -> list[CommandKey]:
+        """The keys a received command matches, most specific first."""
+        if command is None:
+            return [ANY_COMMAND]
+
+        return [self._command_key(command.command), ANY_COMMAND]
+
+    def on_command(
+        self,
+        command: foundation.ZCLCommandDef | AnyCommandType,
+        callback: Callable,
+    ) -> Callable[[], None]:
+        """Subscribe to a received command, without taking responsibility for replying."""
+        # Sugar over ClusterCommandReceivedEvent, so that callers do not each write the
+        # same command id dispatch. An undecodable command only matches ANY_COMMAND.
+        key = self._command_key(command)
+
+        if iscoroutinefunction(callback):
+
+            async def listener(event: ClusterCommandReceivedEvent) -> None:
+                if key in self._command_keys(event.command):
+                    await callback(event)
+
+        else:
+
+            def listener(event: ClusterCommandReceivedEvent) -> None:
+                if key in self._command_keys(event.command):
+                    callback(event)
+
+        return self.on_event(ClusterCommandReceivedEvent.event_type, listener)
+
+    def respond_to_command(
+        self,
+        command: foundation.ZCLCommandDef | AnyCommandType,
+        callback: Callable,
+        *,
+        default: bool = False,
+    ) -> Callable[[], None]:
+        """Register the owner of a received command, responsible for replying to it.
+
+        A `default` owner is skipped while any non-default owner is registered for the
+        same command, but stays registered so it resumes if that owner goes away.
+        """
+        key = self._command_key(command)
+        owners = self._default_command_owners if default else self._command_owners
+
+        if not default and self._command_owners[key]:
+            raise ValueError(
+                f"{self}: a non-default owner is already registered for {command}"
+            )
+
+        owners[key].append(callback)
+
+        def unsubscribe() -> None:
+            if callback in owners[key]:
+                owners[key].remove(callback)
+
+        return unsubscribe
+
+    def _owners_for(self, command: CommandSchema | None) -> list[Callable]:
+        """The owners that will answer a received command, defaults only as a fallback."""
+        keys = self._command_keys(command)
+        owners = [cb for key in keys for cb in self._command_owners[key]]
+
+        if owners:
+            return owners
+
+        return [cb for key in keys for cb in self._default_command_owners[key]]
+
+    def _dispatch_command_owners(
+        self, hdr: foundation.ZCLHeader, command: CommandSchema | None
+    ) -> None:
+        """Hand a received command to its owner, or to the default owner if it has none."""
+        for callback in self._owners_for(command):
+            if iscoroutinefunction(callback):
+                # `exceptions=()` because an owner failing to reply must stay visible:
+                # the default `ZigbeeException` catch would swallow a DeliveryError
+                self.create_catching_task(callback(hdr, command), exceptions=())
+            else:
+                callback(hdr, command)
 
     def handle_cluster_request(
         self,
@@ -938,6 +1101,20 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
             hdr.command_id,
             args,
         )
+
+        self.maybe_send_default_rsp(hdr, args)
+
+    def maybe_send_default_rsp(
+        self, hdr: foundation.ZCLHeader, args: CommandSchema | bytes
+    ) -> None:
+        """Send the Default Response owed for a received cluster command, if any."""
+        command = args if isinstance(args, CommandSchema) else None
+
+        # An owner answers the command with a specific response, reusing its TSN, so a
+        # Default Response would be a second reply to the same transaction. A default
+        # owner counts: it is still the one answering when no other owner exists.
+        if self._owners_for(command):
+            return
 
         if not hdr.frame_control.disable_default_response:
             self.send_default_rsp(

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any, Final, Self
+from typing import Final, Self
 
 import zigpy.types as t
 from zigpy.zcl import Cluster, OtaQueryCacheUpdatedEvent, foundation
@@ -2033,6 +2033,35 @@ class Ota(Cluster):
         super().__init__(*args, **kwargs)
         self.last_query_cmd: QueryNextImageCommand | None = None
 
+        # Owned as defaults so that an OTAManager takes over for the duration of an
+        # upgrade and these resume afterwards. Every one of them is answered by its
+        # paired response command, never by a Default Response.
+        self.respond_to_command(
+            self.ServerCommandDefs.query_next_image,
+            self._handle_query_next_image,
+            default=True,
+        )
+        self.respond_to_command(
+            self.ServerCommandDefs.image_block,
+            self._handle_image_block_req,
+            default=True,
+        )
+        self.respond_to_command(
+            self.ServerCommandDefs.image_page,
+            self._unimplemented_request,
+            default=True,
+        )
+        self.respond_to_command(
+            self.ServerCommandDefs.upgrade_end,
+            self._unimplemented_request,
+            default=True,
+        )
+        self.respond_to_command(
+            self.ServerCommandDefs.query_specific_file,
+            self._unimplemented_request,
+            default=True,
+        )
+
     class AttributeDefs(BaseAttributeDefs):
         upgrade_server_id: Final = ZCLAttributeDef(
             id=0x0000, type=t.EUI64, access="r", mandatory=True
@@ -2129,34 +2158,13 @@ class Ota(Cluster):
             },
         )
 
-    def handle_cluster_request(
-        self,
-        hdr: foundation.ZCLHeader,
-        args: list[Any],
-        *,
-        # This parameter is unused and kept only for backwards compatibility
-        dst_addressing: t.AddrMode | None = None,
-    ):
-        # We don't want the cluster to do anything here because it would interfere with
-        # the OTA manager
-        device = self.endpoint.device
-        if device.ota_in_progress:
-            return
+    def _unimplemented_request(self, hdr: foundation.ZCLHeader, cmd) -> None:
+        """Claim a request whose paired response zigpy does not implement yet.
 
-        if (
-            hdr.direction == foundation.Direction.Client_to_Server
-            and hdr.command_id == self.ServerCommandDefs.query_next_image.id
-        ):
-            self.create_catching_task(
-                self._handle_query_next_image(hdr, args),
-            )
-        elif (
-            hdr.direction == foundation.Direction.Client_to_Server
-            and hdr.command_id == self.ServerCommandDefs.image_block.id
-        ):
-            self.create_catching_task(
-                self._handle_image_block_req(hdr, args),
-            )
+        The device is waiting for that response, so a Default Response in its place
+        would only mislead it.
+        """
+        self.debug("No response implemented for %s, ignoring it", hdr.command_id)
 
     async def _handle_query_next_image(self, hdr, cmd):
         # Cache the query command fields for proactive OTA lookups

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2033,9 +2033,13 @@ class Ota(Cluster):
         super().__init__(*args, **kwargs)
         self.last_query_cmd: QueryNextImageCommand | None = None
 
+        # If a subclass overrides `handle_cluster_request`, do not interfere. Note: this
+        # will be removed in a future release.
+        if self._takes_over_command_handling:
+            return
+
         # Owned as defaults so that an OTAManager takes over for the duration of an
-        # upgrade and these resume afterwards. Every one of them is answered by its
-        # paired response command, never by a Default Response.
+        # upgrade and then falls back to generic defaults.
         self.respond_to_command(
             self.ServerCommandDefs.query_next_image,
             self._handle_query_next_image,
@@ -2048,7 +2052,7 @@ class Ota(Cluster):
         )
         self.respond_to_command(
             self.ServerCommandDefs.image_page,
-            self._unimplemented_request,
+            self._handle_image_block_req,
             default=True,
         )
         self.respond_to_command(
@@ -2159,14 +2163,10 @@ class Ota(Cluster):
         )
 
     def _unimplemented_request(self, hdr: foundation.ZCLHeader, cmd) -> None:
-        """Claim a request whose paired response zigpy does not implement yet.
-
-        The device is waiting for that response, so a Default Response in its place
-        would only mislead it.
-        """
+        """Claim a request whose paired response zigpy does not implement yet."""
         self.debug("No response implemented for %s, ignoring it", hdr.command_id)
 
-    async def _handle_query_next_image(self, hdr, cmd):
+    async def _handle_query_next_image(self, hdr: foundation.ZCLHeader, cmd: QueryNextImageCommand) -> None:
         # Cache the query command fields for proactive OTA lookups
         self.last_query_cmd = cmd
         self.emit(

--- a/zigpy/zcl/clusters/general.py
+++ b/zigpy/zcl/clusters/general.py
@@ -2166,7 +2166,11 @@ class Ota(Cluster):
         """Claim a request whose paired response zigpy does not implement yet."""
         self.debug("No response implemented for %s, ignoring it", hdr.command_id)
 
-    async def _handle_query_next_image(self, hdr: foundation.ZCLHeader, cmd: QueryNextImageCommand) -> None:
+    async def _handle_query_next_image(
+        self,
+        hdr: foundation.ZCLHeader,
+        cmd: QueryNextImageCommand,  # type:ignore[valid-type]
+    ) -> None:
         # Cache the query command fields for proactive OTA lookups
         self.last_query_cmd = cmd
         self.emit(


### PR DESCRIPTION
This PR adds `Cluster.respond_to_command` and `Cluster.on_command`, providing dedicated APIs for both replying to and reacting to commands. The dual API is a little strange but the purpose of having both is to allow zigpy to internally use `respond_to_command` for a ZCL default response implementation that is overridden by concrete subclasses.

The purpose of this change is to fix a bug flagged in https://github.com/zigpy/ziggurat/issues/56: zigpy currently responds to poll control checkins with an extra default response due to our lack of a proper API to do this.