### PR TITLE
Split up `BaseDevice` into `GreenPowerDevice` and `ZigbeeDevice`

### DIFF
--- a/tests/ota/test_ota_matching.py
+++ b/tests/ota/test_ota_matching.py
@@ -15,6 +15,7 @@ from tests.conftest import add_initialized_device, make_app
 from tests.ota.test_ota_providers import SelfContainedOtaImageMetadata, make_device
 from zigpy import config
 import zigpy.device
+from zigpy.device import GreenPowerDevice
 import zigpy.ota
 from zigpy.ota.image import FieldControl
 from zigpy.ota.providers import (
@@ -27,6 +28,7 @@ from zigpy.ota.providers import (
 import zigpy.types
 from zigpy.zcl import ClusterType, OtaImageAvailableEvent
 from zigpy.zcl.clusters.general import Ota
+from zigpy.zgp.types import ApplicationID, SrcID
 
 
 @pytest.fixture
@@ -646,6 +648,12 @@ async def test_check_all_devices_for_ota(query_cmd) -> None:
     add_initialized_device(
         app, nwk=0x5678, ieee=zigpy.types.EUI64.convert("AA:BB:CC:DD:EE:FF:00:11")
     )
+
+    # A Green Power device is not OTA-capable, should be skipped
+    gpd = GreenPowerDevice(
+        app, application_id=ApplicationID.SrcID, src_id=SrcID(0x12345678)
+    )
+    app.devices[gpd.ieee] = gpd
 
     images_result = zigpy.ota.OtaImagesResult(upgrades=(), downgrades=())
     app.ota.get_ota_images = AsyncMock(return_value=images_result)

--- a/tests/test_appdb.py
+++ b/tests/test_appdb.py
@@ -32,7 +32,7 @@ from zigpy.const import (
     SIG_MODEL,
     SIG_NODE_DESC,
 )
-from zigpy.device import Device, Status
+from zigpy.device import Device, GreenPowerDevice, Status
 import zigpy.endpoint
 import zigpy.ota
 import zigpy.types as t
@@ -45,6 +45,7 @@ from zigpy.zcl import (
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota
 from zigpy.zcl.foundation import Status as ZCLStatus, ZCLAttributeDef
 from zigpy.zdo import types as zdo_t
+from zigpy.zgp.types import ApplicationID, SrcID
 
 pytestmark = pytest.mark.usefixtures("auto_kill_aiosqlite")
 
@@ -2081,5 +2082,21 @@ async def test_get_last_ota_query_cmd_returns_none(tmp_path):
     app.device_initialized(dev)
 
     assert dev.get_last_ota_query_cmd() is None
+
+    await app.shutdown()
+
+
+async def test_load_with_green_power_device(tmp_path):
+    """A GPD in `app.devices` has no endpoints whose attribute cache needs clearing."""
+    db = tmp_path / "test.db"
+    app = make_app({conf.CONF_DATABASE: str(db)})
+    gpd = GreenPowerDevice(
+        app, application_id=ApplicationID.SrcID, src_id=SrcID(0x12345678)
+    )
+    app.devices[gpd.ieee] = gpd
+
+    await app._load_db()
+
+    assert app.devices[gpd.ieee] is gpd
 
     await app.shutdown()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1778,7 +1778,7 @@ async def test_callback_wrapping(
             "zigpy.application",
             logging.WARNING,
             (
-                "Device <Device model=None manuf=None nwk=0x1234 "
+                "Device <ZigbeeDevice model=None manuf=None nwk=0x1234 "
                 "ieee=07:06:05:04:03:02:01:00 is_initialized=False> "
                 "callback failed - ValueError('Boom!')"
             ),
@@ -1807,7 +1807,7 @@ async def test_callback_wrapping_async(
             "zigpy.application",
             logging.WARNING,
             (
-                "Device <Device model=None manuf=None nwk=0x1234 "
+                "Device <ZigbeeDevice model=None manuf=None nwk=0x1234 "
                 "ieee=07:06:05:04:03:02:01:00 is_initialized=False> "
                 "callback failed - ValueError('Boom!')"
             ),

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -121,8 +121,10 @@ async def _remove(
         else:
             raise TimeoutError
 
-    device = MagicMock()
+    device = MagicMock(spec=zigpy.device.ZigbeeDevice)
     device.ieee = ieee
+    device.nwk = 0x1234
+    device.zdo = MagicMock()
     device.zdo.leave.side_effect = leave
 
     if has_node_desc:
@@ -805,9 +807,10 @@ async def test_request_concurrency():
 
 @pytest.fixture
 def device():
-    device = MagicMock()
+    device = MagicMock(spec=zigpy.device.ZigbeeDevice)
     device.nwk = 0xABCD
     device.ieee = t.EUI64.convert("aa:bb:cc:dd:11:22:33:44")
+    device._concurrent_requests_semaphore = MagicMock()
 
     return device
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2462,3 +2462,32 @@ async def test_request_retry_delay_releases_concurrency(app) -> None:
         # Tear down the still-pending requests so the task group can exit
         for task in tasks:
             task.cancel()
+
+
+async def test_radio_details_deprecated(dev) -> None:
+    with pytest.deprecated_call():
+        dev.radio_details(lqi=120, rssi=-45)
+
+    assert dev.lqi == 120
+    assert dev.rssi == -45
+
+    with pytest.deprecated_call():
+        dev.radio_details(lqi=99)
+
+    assert dev.lqi == 99
+    assert dev.rssi == -45
+
+    with pytest.deprecated_call():
+        dev.radio_details(rssi=-80)
+
+    assert dev.lqi == 99
+    assert dev.rssi == -80
+
+
+async def test_update_last_seen_deprecated(dev) -> None:
+    assert dev.last_seen is None
+
+    with pytest.deprecated_call():
+        dev.update_last_seen()
+
+    assert dev.last_seen is not None

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -227,20 +227,6 @@ def test_skip_configuration(dev):
     assert dev.skip_configuration is True
 
 
-def test_radio_details(dev):
-    dev.radio_details(1, 2)
-    assert dev.lqi == 1
-    assert dev.rssi == 2
-
-    dev.radio_details(lqi=3)
-    assert dev.lqi == 3
-    assert dev.rssi == 2
-
-    dev.radio_details(rssi=4)
-    assert dev.lqi == 3
-    assert dev.rssi == 4
-
-
 async def test_handle_message_deserialize_error(dev):
     ep = dev.add_endpoint(3)
     ep.deserialize = MagicMock(side_effect=ValueError)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2179,6 +2179,7 @@ async def test_reinterview_during_ota(dev):
     dev._application._device_reinterviewed.assert_not_called()
 
 
+@patch("zigpy.device.AFTER_OTA_ATTR_READ_DELAY", 0.01)
 async def test_update_firmware_triggers_reinterview(monkeypatch, dev):
     """Test that successful OTA triggers reinterview."""
     ep = dev.add_endpoint(1)

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -9,11 +9,13 @@ import pytest
 from tests.conftest import App, make_ieee, make_neighbor, make_route
 import zigpy.config as conf
 import zigpy.device
+from zigpy.device import GreenPowerDevice
 import zigpy.endpoint
 import zigpy.profiles
 import zigpy.topology
 import zigpy.types as t
 import zigpy.zdo.types as zdo_t
+from zigpy.zgp.types import ApplicationID, SrcID
 
 
 @pytest.fixture(autouse=True)
@@ -203,6 +205,19 @@ async def test_scan_end_device(topology, make_initialized_device) -> None:
         # The device will not be scanned because it is not a router
         assert len(dev.zdo.Mgmt_Lqi_req.mock_calls) == 0
         assert len(dev.zdo.Mgmt_Rtg_req.mock_calls) == 0
+
+
+async def test_scan_skips_gp_device(topology) -> None:
+    app = topology._app
+    gpd = GreenPowerDevice(
+        app, application_id=ApplicationID.SrcID, src_id=SrcID(0x12345678)
+    )
+    app.devices[gpd.ieee] = gpd
+
+    await topology.scan()
+
+    assert gpd.ieee not in topology.neighbors
+    assert gpd.ieee not in topology.routes
 
 
 async def test_scan_explicit_device(topology, make_initialized_device) -> None:

--- a/tests/zgp/test_application.py
+++ b/tests/zgp/test_application.py
@@ -158,6 +158,14 @@ async def test_remove_gpd(app, gpd):
     assert call("device_removed", gpd) in app.listener_event.mock_calls
 
 
+async def test_reinterview_gpd(app, gpd):
+    """Commissioning fully describes a GPD, so re-interviewing it does nothing."""
+    await app.reinterview_device(gpd.ieee)
+
+    assert app.devices[gpd.ieee] is gpd
+    assert call("device_reinterviewed", gpd) not in app.listener_event.mock_calls
+
+
 async def test_handle_join_gpd(app, gpd, caplog):
     app.handle_join(0x1234, gpd.ieee, None)
 

--- a/tests/zgp/test_application.py
+++ b/tests/zgp/test_application.py
@@ -1,0 +1,174 @@
+"""Tests for Green Power packet handling in the controller application."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import call
+
+import pytest
+
+from tests.conftest import add_initialized_device, make_ieee
+from tests.zgp.test_tunneling import (
+    COMMISSIONING_NOTIFICATION_ID,
+    NOTIFICATION_ID,
+    make_commissioning_options,
+    make_notification_options,
+    make_tunnel_packet,
+)
+from zigpy.device import GreenPowerDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.greenpower import (
+    CommissioningNotificationSchema,
+    NotificationSchema,
+)
+from zigpy.zgp.types import (
+    ApplicationID,
+    GPDCommandID,
+    GPDCommandPayload,
+    GPLinkQuality,
+    GPPGPDLink,
+    SecurityKeyType,
+    SecurityLevel,
+    SrcID,
+)
+
+SRC = t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x9876)
+DST = t.AddrModeAddress(addr_mode=t.AddrMode.NWK, address=0x0000)
+
+
+@pytest.fixture
+def gpd(app):
+    device = GreenPowerDevice(
+        app, application_id=ApplicationID.SrcID, src_id=SrcID(0x12345678)
+    )
+    app.devices[device.ieee] = device
+    return device
+
+
+def make_notification_packet(suffix: bytes = b"") -> t.ZigbeePacket:
+    command = NotificationSchema(
+        options=make_notification_options(),
+        gpd_id=0x12345678,
+        frame_counter=100,
+        command_id=GPDCommandID.Toggle,
+        payload=GPDCommandPayload(b""),
+        gpp_short_addr=0xAABB,
+        gpp_gpd_link=GPPGPDLink(rssi=20, link_quality=GPLinkQuality.High),
+    )
+
+    return make_tunnel_packet(
+        NOTIFICATION_ID, command.serialize() + suffix, src=SRC, dst=DST
+    )
+
+
+async def test_tunneled_notification_is_delivered(app, gpd):
+    events = []
+    gpd.on_event("gp_command_received", events.append)
+
+    app.packet_received(make_notification_packet())
+
+    assert len(events) == 1
+    assert events[0].command_id == GPDCommandID.Toggle
+    assert gpd.frame_counter == 100
+
+
+async def test_tunneled_notification_security_failed(app, gpd, caplog):
+    command = CommissioningNotificationSchema(
+        options=make_commissioning_options(
+            security_level=SecurityLevel.Encrypted,
+            security_key_type=SecurityKeyType.IndividualKey,
+            security_failed=1,
+        ),
+        gpd_id=0x12345678,
+        frame_counter=42,
+        command_id=GPDCommandID.CommissioningRequest,
+        payload=GPDCommandPayload(b""),
+        gpp_short_addr=0x1234,
+        gpp_gpd_link=GPPGPDLink(rssi=20, link_quality=GPLinkQuality.High),
+        mic=0xDEADBEEF,
+    )
+    packet = make_tunnel_packet(
+        COMMISSIONING_NOTIFICATION_ID, command.serialize(), src=SRC, dst=DST
+    )
+
+    events = []
+    gpd.on_event("gp_command_received", events.append)
+
+    with caplog.at_level(logging.DEBUG):
+        app.packet_received(packet)
+
+    assert "could not decrypt" in caplog.text
+    assert len(events) == 0
+
+
+async def test_tunneled_notification_malformed(app, gpd, caplog):
+    events = []
+    gpd.on_event("gp_command_received", events.append)
+
+    app.packet_received(make_notification_packet(suffix=b"\xde\xad"))
+
+    assert "Failed to convert tunneled GP packet" in caplog.text
+    assert len(events) == 0
+
+
+async def test_gp_packet_from_unknown_device(app, caplog):
+    packet = t.ZigbeeGpPacket(
+        application_id=ApplicationID.SrcID,
+        src_id=SrcID(0x99999999),
+        command_id=GPDCommandID.Toggle,
+    )
+    app.gp_packet_received(packet)
+
+    assert "unknown device" in caplog.text
+
+
+async def test_gp_packet_for_non_gp_device(app, caplog):
+    dev = add_initialized_device(app, nwk=0x1234, ieee=make_ieee(1))
+
+    packet = t.ZigbeeGpPacket(
+        application_id=ApplicationID.IEEE,
+        ieee=dev.ieee,
+        command_id=GPDCommandID.Toggle,
+    )
+    app.gp_packet_received(packet)
+
+    assert "non-GP device" in caplog.text
+
+
+async def test_zigbee_packet_from_gp_device(app, gpd, caplog):
+    packet = t.ZigbeePacket(
+        src=t.AddrModeAddress(addr_mode=t.AddrMode.IEEE, address=gpd.ieee),
+        src_ep=1,
+        dst=DST,
+        dst_ep=1,
+        tsn=0x12,
+        profile_id=260,
+        cluster_id=0x0006,
+        data=t.SerializableBytes(b""),
+    )
+    app.packet_received(packet)
+
+    assert "non-Zigbee device" in caplog.text
+
+
+async def test_remove_gpd(app, gpd):
+    await app.remove(gpd.ieee)
+
+    assert gpd.ieee not in app.devices
+    assert call("device_removed", gpd) in app.listener_event.mock_calls
+
+
+async def test_handle_join_gpd(app, gpd, caplog):
+    app.handle_join(0x1234, gpd.ieee, None)
+
+    assert "Ignoring join announcement" in caplog.text
+    assert app.devices[gpd.ieee] is gpd
+    assert call("device_joined", gpd) not in app.listener_event.mock_calls
+
+
+async def test_handle_leave_gpd(app, gpd, caplog):
+    app.handle_leave(gpd.nwk, gpd.ieee)
+
+    assert "Ignoring leave announcement" in caplog.text
+    assert app.devices[gpd.ieee] is gpd
+    assert call("device_left", gpd) not in app.listener_event.mock_calls

--- a/tests/zgp/test_commands.py
+++ b/tests/zgp/test_commands.py
@@ -881,19 +881,6 @@ def test_manufacturer_defined_payload() -> None:
 
 
 @pytest.mark.parametrize(
-    "command_id",
-    [
-        command_id
-        for command_id in GPDCommandID
-        if command_id not in (GPDCommandID.AnySensorCommand, GPDCommandID.AnyCommand)
-    ],
-)
-def test_every_command_id_is_mapped(command_id: GPDCommandID) -> None:
-    """Every command ID that can appear on the wire needs a mapping entry."""
-    assert command_id in GPD_COMMAND_SCHEMAS
-
-
-@pytest.mark.parametrize(
     "command_id", [GPDCommandID.AnySensorCommand, GPDCommandID.AnyCommand]
 )
 def test_translation_table_pseudo_ids_are_unmapped(command_id: GPDCommandID) -> None:
@@ -905,20 +892,6 @@ def test_translation_table_pseudo_ids_are_unmapped(command_id: GPDCommandID) -> 
 def test_manufacturer_defined_range_is_mapped(command_id: int) -> None:
     """The whole 0xB0 - 0xBF range is manufacturer-defined (Table 55)."""
     assert GPD_COMMAND_SCHEMAS[GPDCommandID(command_id)] is GPManufacturerDefinedPayload
-
-
-@pytest.mark.parametrize(
-    "command_id",
-    [
-        GPDCommandID.ReadAttributesResponse,
-        GPDCommandID.CompactAttributeReporting,
-        GPDCommandID.ApplicationDescription,
-        GPDCommandID.WriteAttributes,
-    ],
-)
-def test_unimplemented_payloads_are_explicitly_none(command_id: GPDCommandID) -> None:
-    """Commands whose payload parser is still missing map to `None`, not absence."""
-    assert GPD_COMMAND_SCHEMAS[command_id] is None
 
 
 def test_unknown_command_id_is_unmapped() -> None:

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -1,0 +1,187 @@
+"""Tests for Green Power device packet handling."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from zigpy.device import GreenPowerDevice
+import zigpy.types as t
+from zigpy.zgp.types import (
+    ApplicationID,
+    GPDCommandID,
+    SecurityKeyType,
+    SecurityLevel,
+    SrcID,
+)
+
+TIMESTAMP = datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def device() -> GreenPowerDevice:
+    return GreenPowerDevice(
+        None, application_id=ApplicationID.SrcID, src_id=SrcID(0x12345678)
+    )
+
+
+@pytest.fixture
+def events(device) -> list:
+    events = []
+    device.on_event("gp_command_received", events.append)
+    return events
+
+
+def make_packet(
+    frame_counter: int,
+    *,
+    security_level: SecurityLevel = SecurityLevel.Encrypted,
+    security_key_type: SecurityKeyType = SecurityKeyType.GPDGroupKey,
+    offset: timedelta = timedelta(0),
+    lqi: int = 200,
+    rssi: int = -50,
+) -> t.ZigbeeGpPacket:
+    return t.ZigbeeGpPacket(
+        timestamp=TIMESTAMP + offset,
+        application_id=ApplicationID.SrcID,
+        src_id=SrcID(0x12345678),
+        command_id=GPDCommandID.Toggle,
+        frame_counter=t.uint32_t(frame_counter),
+        security_level=security_level,
+        security_key_type=security_key_type,
+        lqi=t.uint8_t(lqi),
+        rssi=t.int8s(rssi),
+    )
+
+
+def commission_security(device: GreenPowerDevice) -> None:
+    device.security_level = SecurityLevel.Encrypted
+    device.security_key_type = SecurityKeyType.GPDGroupKey
+
+
+def test_missing_gpd_id() -> None:
+    with pytest.raises(ValueError, match="`src_id` is required"):
+        GreenPowerDevice(None, application_id=ApplicationID.SrcID)
+
+    with pytest.raises(ValueError, match="`ieee` is required"):
+        GreenPowerDevice(None, application_id=ApplicationID.IEEE)
+
+
+def test_packet_received(device, events) -> None:
+    device.packet_received(make_packet(1000))
+
+    assert len(events) == 1
+    assert events[0].device_ieee == str(device.ieee)
+    assert events[0].command_id == GPDCommandID.Toggle
+    assert device.frame_counter == 1000
+    assert device.last_seen == TIMESTAMP.timestamp()
+    assert device.lqi == 200
+    assert device.rssi == -50
+
+
+def test_relayed_duplicate_does_not_refresh_state(device, events) -> None:
+    """The same GPDF forwarded by a second, worse proxy keeps the first reception."""
+    device.packet_received(make_packet(1000))
+    device.packet_received(
+        make_packet(1000, offset=timedelta(seconds=0.5), lqi=3, rssi=-120)
+    )
+
+    assert len(events) == 1
+    assert device.lqi == 200
+    assert device.rssi == -50
+    assert device.last_seen == TIMESTAMP.timestamp()
+
+
+def test_replay_does_not_refresh_state(device, events) -> None:
+    """A protected frame failing the freshness check does not indicate liveness."""
+    device.packet_received(make_packet(1000))
+    device.packet_received(make_packet(500, offset=timedelta(days=3), lqi=1, rssi=-100))
+
+    assert len(events) == 1
+    assert device.frame_counter == 1000
+    assert device.lqi == 200
+    assert device.rssi == -50
+    assert device.last_seen == TIMESTAMP.timestamp()
+
+
+@pytest.mark.parametrize(
+    ("offsets", "expected_events"),
+    [
+        # A repeated MAC sequence number within the 2s window is a duplicate
+        ([timedelta(seconds=1)], 1),
+        # Outside of it, it is a new (e.g. random sequence number) frame
+        ([timedelta(seconds=3)], 2),
+        # The window is anchored at the last accepted frame: it does not slide
+        # forward on each filtered duplicate
+        ([timedelta(seconds=1.5), timedelta(seconds=3)], 2),
+    ],
+)
+def test_unprotected_duplicate_window(device, events, offsets, expected_events) -> None:
+    device.packet_received(
+        make_packet(
+            7,
+            security_level=SecurityLevel.NoSecurity,
+            security_key_type=SecurityKeyType.NoKey,
+        )
+    )
+
+    for offset in offsets:
+        device.packet_received(
+            make_packet(
+                7,
+                security_level=SecurityLevel.NoSecurity,
+                security_key_type=SecurityKeyType.NoKey,
+                offset=offset,
+            )
+        )
+
+    assert len(events) == expected_events
+
+
+@pytest.mark.parametrize(
+    ("security_level", "security_key_type"),
+    [
+        (SecurityLevel.NoSecurity, SecurityKeyType.NoKey),
+        (SecurityLevel.FullFrameCounterAndMIC, SecurityKeyType.GPDGroupKey),
+        (SecurityLevel.Encrypted, SecurityKeyType.IndividualKey),
+    ],
+)
+def test_security_mismatch_is_dropped(
+    device, events, security_level, security_key_type
+) -> None:
+    """Frames not matching the commissioned security parameters are silently dropped."""
+    commission_security(device)
+
+    device.packet_received(make_packet(5000))
+    device.packet_received(
+        make_packet(
+            42,
+            security_level=security_level,
+            security_key_type=security_key_type,
+            offset=timedelta(seconds=10),
+        )
+    )
+
+    assert len(events) == 1
+    assert device.frame_counter == 5000
+
+
+def test_unprotected_frame_cannot_reset_frame_counter(device, events) -> None:
+    """An unprotected inject must not break the anti-replay counter (A.3.5.2.4.2)."""
+    commission_security(device)
+
+    device.packet_received(make_packet(5000))
+    device.packet_received(make_packet(4000, offset=timedelta(seconds=10)))
+    device.packet_received(
+        make_packet(
+            42,
+            security_level=SecurityLevel.NoSecurity,
+            security_key_type=SecurityKeyType.NoKey,
+            offset=timedelta(seconds=20),
+        )
+    )
+    device.packet_received(make_packet(4000, offset=timedelta(seconds=30)))
+
+    assert len(events) == 1
+    assert device.frame_counter == 5000

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -8,17 +8,19 @@ import pytest
 
 from zigpy.device import GreenPowerDevice
 import zigpy.types as t
-from zigpy.zgp.commands import GPStepPayload
+from zigpy.zgp.commands import GPGenericSwitchConfiguration, GPStepPayload
 from zigpy.zgp.types import (
     ApplicationID,
     GPDCommandID,
     SecurityKeyType,
     SecurityLevel,
     SrcID,
+    SwitchType,
 )
 from zigpy.zgp.util import derive_alias
 
 TIMESTAMP = datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)
+IEEE = t.EUI64.convert("11:22:33:44:55:66:77:88")
 
 
 @pytest.fixture
@@ -45,11 +47,15 @@ def make_packet(
     offset: timedelta = timedelta(0),
     lqi: int = 200,
     rssi: int = -50,
+    application_id: ApplicationID = ApplicationID.SrcID,
+    endpoint: int | None = None,
 ) -> t.ZigbeeGpPacket:
     return t.ZigbeeGpPacket(
         timestamp=TIMESTAMP + offset,
-        application_id=ApplicationID.SrcID,
-        src_id=SrcID(0x12345678),
+        application_id=application_id,
+        src_id=SrcID(0x12345678) if application_id is ApplicationID.SrcID else None,
+        ieee=IEEE if application_id is ApplicationID.IEEE else None,
+        endpoint=None if endpoint is None else t.uint8_t(endpoint),
         command_id=command_id,
         payload=t.SerializableBytes(payload),
         frame_counter=t.uint32_t(frame_counter),
@@ -74,16 +80,15 @@ def test_missing_gpd_id() -> None:
 
 
 def test_ieee_addressed_gpd() -> None:
-    ieee = t.EUI64.convert("11:22:33:44:55:66:77:88")
     device = GreenPowerDevice(
-        None, application_id=ApplicationID.IEEE, ieee=ieee, endpoint=t.uint8_t(3)
+        None, application_id=ApplicationID.IEEE, ieee=IEEE, endpoint=t.uint8_t(3)
     )
 
-    assert device.ieee == ieee
-    assert device.nwk == derive_alias(ieee)
+    assert device.ieee == IEEE
+    assert device.nwk == derive_alias(IEEE)
     assert device.src_id is None
     assert device.endpoint == 3
-    assert device.name == f"GreenPowerDevice {ieee}"
+    assert device.name == f"GreenPowerDevice {IEEE}"
 
 
 def test_device_properties(device) -> None:
@@ -94,6 +99,9 @@ def test_device_properties(device) -> None:
     assert device.manufacturer_id is None
 
     device.gpd_manufacturer_id = t.uint16_t(0x1234)
+    device.switch_configuration = GPGenericSwitchConfiguration(
+        num_contacts=2, switch_type=SwitchType.Rocker, _reserved=0
+    )
 
     assert device.manufacturer_id == 0x1234
     assert device.get_signature() == {
@@ -106,6 +114,7 @@ def test_device_properties(device) -> None:
         "commands": [],
         "server_cluster_ids": [],
         "client_cluster_ids": [],
+        "switch_configuration": GPGenericSwitchConfiguration(0x22),
     }
 
 
@@ -252,3 +261,21 @@ def test_unprotected_frame_cannot_reset_frame_counter(device, events) -> None:
 
     assert len(events) == 1
     assert device.frame_counter == 5000
+
+
+@pytest.mark.parametrize("endpoint", [3, 5, 0x00, 0xFF])
+def test_ieee_frame_endpoint_passthrough(endpoint) -> None:
+    """IEEE addressing delivers the frame's endpoint, wildcards included."""
+    device = GreenPowerDevice(
+        None, application_id=ApplicationID.IEEE, ieee=IEEE, endpoint=t.uint8_t(3)
+    )
+
+    events = []
+    device.on_event("gp_command_received", events.append)
+
+    device.packet_received(
+        make_packet(1000, application_id=ApplicationID.IEEE, endpoint=endpoint)
+    )
+
+    assert len(events) == 1
+    assert events[0].endpoint_id == endpoint

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -14,6 +14,7 @@ from zigpy.zgp.types import (
     GPDCommandID,
     SecurityKeyType,
     SecurityLevel,
+    SecurityStatus,
     SrcID,
     SwitchType,
 )
@@ -44,6 +45,7 @@ def make_packet(
     payload: bytes = b"",
     security_level: SecurityLevel = SecurityLevel.Encrypted,
     security_key_type: SecurityKeyType = SecurityKeyType.GPDGroupKey,
+    security_status: SecurityStatus | None = None,
     offset: timedelta = timedelta(0),
     lqi: int = 200,
     rssi: int = -50,
@@ -61,6 +63,7 @@ def make_packet(
         frame_counter=t.uint32_t(frame_counter),
         security_level=security_level,
         security_key_type=security_key_type,
+        security_status=security_status,
         lqi=t.uint8_t(lqi),
         rssi=t.int8s(rssi),
     )
@@ -230,9 +233,26 @@ def test_security_mismatch_is_dropped(
     device.packet_received(make_packet(5000))
     device.packet_received(
         make_packet(
-            42,
+            6000,
             security_level=security_level,
             security_key_type=security_key_type,
+            offset=timedelta(seconds=10),
+        )
+    )
+
+    assert len(events) == 1
+    assert device.frame_counter == 5000
+
+
+def test_undecrypted_frame_is_dropped(device, events) -> None:
+    """An encrypted GPDF the radio did not decrypt has no readable command ID."""
+    commission_security(device)
+
+    device.packet_received(make_packet(5000))
+    device.packet_received(
+        make_packet(
+            6000,
+            security_status=SecurityStatus.Unprocessed,
             offset=timedelta(seconds=10),
         )
     )

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -102,6 +102,7 @@ def test_device_properties(device) -> None:
     device.switch_configuration = GPGenericSwitchConfiguration(
         num_contacts=2, switch_type=SwitchType.Rocker, _reserved=0
     )
+    device.mac_seq_num_capability = True
 
     assert device.manufacturer_id == 0x1234
     assert device.get_signature() == {
@@ -115,6 +116,7 @@ def test_device_properties(device) -> None:
         "server_cluster_ids": [],
         "client_cluster_ids": [],
         "switch_configuration": GPGenericSwitchConfiguration(0x22),
+        "mac_seq_num_capability": True,
     }
 
 

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -80,14 +80,11 @@ def test_missing_gpd_id() -> None:
 
 
 def test_ieee_addressed_gpd() -> None:
-    device = GreenPowerDevice(
-        None, application_id=ApplicationID.IEEE, ieee=IEEE, endpoint=t.uint8_t(3)
-    )
+    device = GreenPowerDevice(None, application_id=ApplicationID.IEEE, ieee=IEEE)
 
     assert device.ieee == IEEE
     assert device.nwk == derive_alias(IEEE)
     assert device.src_id is None
-    assert device.endpoint == 3
     assert device.name == f"GreenPowerDevice {IEEE}"
 
 
@@ -108,7 +105,6 @@ def test_device_properties(device) -> None:
     assert device.get_signature() == {
         "application_id": ApplicationID.SrcID,
         "src_id": 0x12345678,
-        "endpoint": None,
         "device_id": None,
         "manufacturer_id": 0x1234,
         "model_id": None,
@@ -268,9 +264,7 @@ def test_unprotected_frame_cannot_reset_frame_counter(device, events) -> None:
 @pytest.mark.parametrize("endpoint", [3, 5, 0x00, 0xFF])
 def test_ieee_frame_endpoint_passthrough(endpoint) -> None:
     """IEEE addressing delivers the frame's endpoint, wildcards included."""
-    device = GreenPowerDevice(
-        None, application_id=ApplicationID.IEEE, ieee=IEEE, endpoint=t.uint8_t(3)
-    )
+    device = GreenPowerDevice(None, application_id=ApplicationID.IEEE, ieee=IEEE)
 
     events = []
     device.on_event("gp_command_received", events.append)

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -235,7 +235,7 @@ def test_security_mismatch_is_dropped(
 
 
 def test_unprotected_frame_cannot_reset_frame_counter(device, events) -> None:
-    """An unprotected inject must not break the anti-replay counter (A.3.5.2.4.2)."""
+    """An unprotected inject must not break the anti-replay counter (A.3.5.2.4)."""
     commission_security(device)
 
     device.packet_received(make_packet(5000))

--- a/tests/zgp/test_device.py
+++ b/tests/zgp/test_device.py
@@ -8,6 +8,7 @@ import pytest
 
 from zigpy.device import GreenPowerDevice
 import zigpy.types as t
+from zigpy.zgp.commands import GPStepPayload
 from zigpy.zgp.types import (
     ApplicationID,
     GPDCommandID,
@@ -15,6 +16,7 @@ from zigpy.zgp.types import (
     SecurityLevel,
     SrcID,
 )
+from zigpy.zgp.util import derive_alias
 
 TIMESTAMP = datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)
 
@@ -36,6 +38,8 @@ def events(device) -> list:
 def make_packet(
     frame_counter: int,
     *,
+    command_id: GPDCommandID = GPDCommandID.Toggle,
+    payload: bytes = b"",
     security_level: SecurityLevel = SecurityLevel.Encrypted,
     security_key_type: SecurityKeyType = SecurityKeyType.GPDGroupKey,
     offset: timedelta = timedelta(0),
@@ -46,7 +50,8 @@ def make_packet(
         timestamp=TIMESTAMP + offset,
         application_id=ApplicationID.SrcID,
         src_id=SrcID(0x12345678),
-        command_id=GPDCommandID.Toggle,
+        command_id=command_id,
+        payload=t.SerializableBytes(payload),
         frame_counter=t.uint32_t(frame_counter),
         security_level=security_level,
         security_key_type=security_key_type,
@@ -68,6 +73,42 @@ def test_missing_gpd_id() -> None:
         GreenPowerDevice(None, application_id=ApplicationID.IEEE)
 
 
+def test_ieee_addressed_gpd() -> None:
+    ieee = t.EUI64.convert("11:22:33:44:55:66:77:88")
+    device = GreenPowerDevice(
+        None, application_id=ApplicationID.IEEE, ieee=ieee, endpoint=t.uint8_t(3)
+    )
+
+    assert device.ieee == ieee
+    assert device.nwk == derive_alias(ieee)
+    assert device.src_id is None
+    assert device.endpoint == 3
+    assert device.name == f"GreenPowerDevice {ieee}"
+
+
+def test_device_properties(device) -> None:
+    assert device.src_id == 0x12345678
+    assert device.nwk == derive_alias(0x12345678)
+    assert device.name == "GreenPowerDevice 0x12345678"
+    assert device.is_initialized
+    assert device.manufacturer_id is None
+
+    device.gpd_manufacturer_id = t.uint16_t(0x1234)
+
+    assert device.manufacturer_id == 0x1234
+    assert device.get_signature() == {
+        "application_id": ApplicationID.SrcID,
+        "src_id": 0x12345678,
+        "endpoint": None,
+        "device_id": None,
+        "manufacturer_id": 0x1234,
+        "model_id": None,
+        "commands": [],
+        "server_cluster_ids": [],
+        "client_cluster_ids": [],
+    }
+
+
 def test_packet_received(device, events) -> None:
     device.packet_received(make_packet(1000))
 
@@ -78,6 +119,32 @@ def test_packet_received(device, events) -> None:
     assert device.last_seen == TIMESTAMP.timestamp()
     assert device.lqi == 200
     assert device.rssi == -50
+
+
+def test_packet_received_parses_command(device, events) -> None:
+    device.packet_received(
+        make_packet(1, command_id=GPDCommandID.StepUp, payload=b"\x05\x0a\x00")
+    )
+
+    assert len(events) == 1
+    assert events[0].command == GPStepPayload(step_size=5, transition_time=10)
+
+
+def test_packet_received_unparseable_payload(device, events) -> None:
+    """A GPDF whose payload fails to parse is still delivered, without a command."""
+    device.packet_received(make_packet(1, command_id=GPDCommandID.StepUp, payload=b""))
+
+    assert len(events) == 1
+    assert events[0].command is None
+
+
+def test_packet_received_command_without_schema(device, events) -> None:
+    device.packet_received(
+        make_packet(1, command_id=GPDCommandID.ApplicationDescription, payload=b"\x01")
+    )
+
+    assert len(events) == 1
+    assert events[0].command is None
 
 
 def test_relayed_duplicate_does_not_refresh_state(device, events) -> None:

--- a/tests/zgp/test_tunneling.py
+++ b/tests/zgp/test_tunneling.py
@@ -266,6 +266,37 @@ def test_is_gp_tunnel_packet(kwargs, expected):
     assert is_gp_tunnel_packet(packet) == expected
 
 
+def test_is_gp_tunnel_packet_undecodable_header():
+    packet = make_tunnel_packet(NOTIFICATION_ID, b"")
+    packet = packet.replace(data=t.SerializableBytes(b"\x01"))
+
+    assert not is_gp_tunnel_packet(packet)
+
+
+def test_notification_response_direction():
+    """GP Notification Response shares an ID with GP Notification: not a tunnel."""
+    command = NotificationSchema(
+        options=make_notification_options(proxy_info_present=0),
+        gpd_id=0x12345678,
+        frame_counter=1,
+        command_id=GPDCommandID.Toggle,
+        payload=GPDCommandPayload(b""),
+    )
+    hdr = foundation.ZCLHeader.cluster(
+        tsn=0x12,
+        command_id=NOTIFICATION_ID,
+        direction=foundation.Direction.Server_to_Client,
+    )
+    packet = make_tunnel_packet(NOTIFICATION_ID, b"").replace(
+        data=t.SerializableBytes(hdr.serialize() + command.serialize())
+    )
+
+    assert not is_gp_tunnel_packet(packet)
+
+    with pytest.raises(ValueError, match="Not a client-to-server command"):
+        gp_packet_from_zcl(packet)
+
+
 def test_non_cluster_command():
     hdr = foundation.ZCLHeader.general(
         tsn=0x12, command_id=foundation.GeneralCommand.Read_Attributes

--- a/tests/zgp/test_tunneling.py
+++ b/tests/zgp/test_tunneling.py
@@ -221,6 +221,27 @@ def test_notification_without_proxy_info():
 
     assert gp_packet.lqi is None
     assert gp_packet.rssi is None
+    assert gp_packet.gpp_distance is None
+
+
+def test_notification_from_legacy_proxy():
+    """A Green Power 1.0 proxy sends a Distance byte instead of the GPP-GPD link."""
+    command = NotificationSchema(
+        options=make_notification_options(proxy_info_present=0, rx_after_tx=1),
+        gpd_id=0x12345678,
+        frame_counter=1,
+        command_id=GPDCommandID.Off,
+        payload=GPDCommandPayload(b""),
+        gpp_short_addr=0xAABB,
+        gpp_distance=0x42,
+    )
+    packet = make_tunnel_packet(NOTIFICATION_ID, command.serialize())
+
+    gp_packet = gp_packet_from_zcl(packet)
+
+    assert gp_packet.lqi is None
+    assert gp_packet.rssi is None
+    assert gp_packet.gpp_distance == 0x42
 
 
 @pytest.mark.parametrize(

--- a/tests/zgp/test_tunneling.py
+++ b/tests/zgp/test_tunneling.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from zigpy.exceptions import GPSecurityProcessingFailed
 import zigpy.profiles.zgp
 import zigpy.types as t
 from zigpy.zcl import foundation
@@ -179,7 +180,7 @@ def test_commissioning_notification_security_failed():
     )
     packet = make_tunnel_packet(COMMISSIONING_NOTIFICATION_ID, command.serialize())
 
-    with pytest.raises(ValueError, match="Security processing"):
+    with pytest.raises(GPSecurityProcessingFailed, match="Security processing"):
         gp_packet_from_zcl(packet)
 
 

--- a/tests/zgp/test_tunneling.py
+++ b/tests/zgp/test_tunneling.py
@@ -1,0 +1,279 @@
+"""Tests for conversion of ZCL-tunneled GP frames into GP packets."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+import zigpy.profiles.zgp
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.greenpower import (
+    CommissioningNotificationOptions,
+    CommissioningNotificationSchema,
+    GreenPowerProxy,
+    NotificationOptions,
+    NotificationSchema,
+)
+from zigpy.zgp.tunneling import gp_packet_from_zcl, is_gp_tunnel_packet
+from zigpy.zgp.types import (
+    GP_CLUSTER_ID,
+    GP_ENDPOINT,
+    ApplicationID,
+    GPDCommandID,
+    GPDCommandPayload,
+    GPLinkQuality,
+    GPPGPDLink,
+    SecurityKeyType,
+    SecurityLevel,
+)
+
+TIMESTAMP = datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)
+
+NOTIFICATION_ID = GreenPowerProxy.ServerCommandDefs.notification.id
+COMMISSIONING_NOTIFICATION_ID = (
+    GreenPowerProxy.ServerCommandDefs.commissioning_notification.id
+)
+
+
+def make_tunnel_packet(command_id: int, payload: bytes, **kwargs) -> t.ZigbeePacket:
+    hdr = foundation.ZCLHeader.cluster(tsn=0x12, command_id=command_id)
+
+    return t.ZigbeePacket(
+        timestamp=TIMESTAMP,
+        profile_id=zigpy.profiles.zgp.PROFILE_ID,
+        cluster_id=GP_CLUSTER_ID,
+        src_ep=GP_ENDPOINT,
+        dst_ep=GP_ENDPOINT,
+        data=t.SerializableBytes(hdr.serialize() + payload),
+        **kwargs,
+    )
+
+
+def make_notification_options(**kwargs) -> NotificationOptions:
+    return NotificationOptions(
+        **{
+            "application_id": ApplicationID.SrcID,
+            "also_unicast": 0,
+            "also_derived_group": 1,
+            "also_commissioned_group": 0,
+            "security_level": SecurityLevel.FullFrameCounterAndMIC,
+            "security_key_type": SecurityKeyType.NWKKey,
+            "rx_after_tx": 0,
+            "tx_queue_full": 1,
+            "bidirectional_cap": 0,
+            "proxy_info_present": 1,
+            "_reserved": 0,
+            **kwargs,
+        }
+    )
+
+
+def make_commissioning_options(**kwargs) -> CommissioningNotificationOptions:
+    return CommissioningNotificationOptions(
+        **{
+            "application_id": ApplicationID.SrcID,
+            "rx_after_tx": 0,
+            "security_level": SecurityLevel.NoSecurity,
+            "security_key_type": SecurityKeyType.NoKey,
+            "security_failed": 0,
+            "bidirectional_cap": 0,
+            "proxy_info_present": 1,
+            "_reserved": 0,
+            **kwargs,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("gpd_kwargs", "expected_src_id", "expected_ieee", "expected_endpoint"),
+    [
+        (
+            {
+                "options": make_notification_options(),
+                "gpd_id": 0x12345678,
+            },
+            0x12345678,
+            None,
+            None,
+        ),
+        (
+            {
+                "options": make_notification_options(application_id=ApplicationID.IEEE),
+                "gpd_ieee": t.EUI64.convert("11:22:33:44:55:66:77:88"),
+                "gpd_endpoint": 3,
+            },
+            None,
+            t.EUI64.convert("11:22:33:44:55:66:77:88"),
+            3,
+        ),
+    ],
+)
+def test_notification(gpd_kwargs, expected_src_id, expected_ieee, expected_endpoint):
+    command = NotificationSchema(
+        frame_counter=1000,
+        command_id=GPDCommandID.Toggle,
+        payload=GPDCommandPayload(b"\x01\x02"),
+        gpp_short_addr=0xAABB,
+        gpp_gpd_link=GPPGPDLink(rssi=20, link_quality=GPLinkQuality.High),
+        **gpd_kwargs,
+    )
+    packet = make_tunnel_packet(NOTIFICATION_ID, command.serialize())
+
+    gp_packet = gp_packet_from_zcl(packet)
+
+    assert gp_packet.timestamp == TIMESTAMP
+    assert gp_packet.application_id == gpd_kwargs["options"].application_id
+    assert gp_packet.src_id == expected_src_id
+    assert gp_packet.ieee == expected_ieee
+    assert gp_packet.endpoint == expected_endpoint
+    assert gp_packet.command_id == GPDCommandID.Toggle
+    assert gp_packet.payload.serialize() == b"\x01\x02"
+    assert gp_packet.frame_counter == 1000
+    assert gp_packet.security_level == SecurityLevel.FullFrameCounterAndMIC
+    assert gp_packet.security_key_type == SecurityKeyType.NWKKey
+    # GPPGPDLink 20 * 2 - 110 = -70 dBm, High spread over the 0-255 LQI range
+    assert gp_packet.rssi == -70
+    assert gp_packet.lqi == 170
+
+
+def test_commissioning_notification():
+    command = CommissioningNotificationSchema(
+        options=make_commissioning_options(),
+        gpd_id=0x01020304,
+        frame_counter=42,
+        command_id=GPDCommandID.CommissioningRequest,
+        payload=GPDCommandPayload(b"\x02\x00"),
+        gpp_short_addr=0x1234,
+        gpp_gpd_link=GPPGPDLink(rssi=0, link_quality=GPLinkQuality.Poor),
+    )
+    packet = make_tunnel_packet(COMMISSIONING_NOTIFICATION_ID, command.serialize())
+
+    gp_packet = gp_packet_from_zcl(packet)
+
+    assert gp_packet.src_id == 0x01020304
+    assert gp_packet.command_id == GPDCommandID.CommissioningRequest
+    assert gp_packet.payload.serialize() == b"\x02\x00"
+    assert gp_packet.frame_counter == 42
+    assert gp_packet.security_level == SecurityLevel.NoSecurity
+    assert gp_packet.security_key_type == SecurityKeyType.NoKey
+    assert gp_packet.rssi == -110
+    assert gp_packet.lqi == 0
+
+
+def test_commissioning_notification_security_failed():
+    command = CommissioningNotificationSchema(
+        options=make_commissioning_options(
+            security_level=SecurityLevel.Encrypted,
+            security_key_type=SecurityKeyType.IndividualKey,
+            security_failed=1,
+        ),
+        gpd_id=0x01020304,
+        frame_counter=42,
+        command_id=GPDCommandID.CommissioningRequest,
+        payload=GPDCommandPayload(b"\xaa\xbb"),
+        gpp_short_addr=0x1234,
+        gpp_gpd_link=GPPGPDLink(rssi=20, link_quality=GPLinkQuality.High),
+        mic=0xDEADBEEF,
+    )
+    packet = make_tunnel_packet(COMMISSIONING_NOTIFICATION_ID, command.serialize())
+
+    with pytest.raises(ValueError, match="Security processing"):
+        gp_packet_from_zcl(packet)
+
+
+def test_notification_unspecified_payload():
+    """A payload length byte of 0xff means unspecified/no payload."""
+    command = NotificationSchema(
+        options=make_notification_options(),
+        gpd_id=0x12345678,
+        frame_counter=1,
+        command_id=GPDCommandID.On,
+        payload=GPDCommandPayload(b""),
+        gpp_short_addr=0xAABB,
+        gpp_gpd_link=GPPGPDLink(rssi=10, link_quality=GPLinkQuality.Moderate),
+    )
+    data = command.serialize()
+
+    # Splice the 0x00 length byte into the legacy 0xff "unspecified" marker
+    assert data[11:12] == b"\x00"
+    data = data[:11] + b"\xff" + data[12:]
+
+    packet = make_tunnel_packet(NOTIFICATION_ID, data)
+    gp_packet = gp_packet_from_zcl(packet)
+
+    assert gp_packet.payload.serialize() == b""
+
+
+def test_notification_without_proxy_info():
+    command = NotificationSchema(
+        options=make_notification_options(proxy_info_present=0),
+        gpd_id=0x12345678,
+        frame_counter=1,
+        command_id=GPDCommandID.Off,
+        payload=GPDCommandPayload(b""),
+    )
+    packet = make_tunnel_packet(NOTIFICATION_ID, command.serialize())
+
+    gp_packet = gp_packet_from_zcl(packet)
+
+    assert gp_packet.lqi is None
+    assert gp_packet.rssi is None
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({}, True),
+        ({"profile_id": 0x0104}, False),
+        ({"cluster_id": 0x0006}, False),
+        ({"src_ep": 1}, False),
+    ],
+)
+def test_is_gp_tunnel_packet(kwargs, expected):
+    command = NotificationSchema(
+        options=make_notification_options(proxy_info_present=0),
+        gpd_id=0x12345678,
+        frame_counter=1,
+        command_id=GPDCommandID.Toggle,
+        payload=GPDCommandPayload(b""),
+    )
+    packet = make_tunnel_packet(NOTIFICATION_ID, command.serialize()).replace(**kwargs)
+
+    assert is_gp_tunnel_packet(packet) == expected
+
+
+def test_non_cluster_command():
+    hdr = foundation.ZCLHeader.general(
+        tsn=0x12, command_id=foundation.GeneralCommand.Read_Attributes
+    )
+    packet = make_tunnel_packet(NOTIFICATION_ID, b"")
+    packet = packet.replace(data=t.SerializableBytes(hdr.serialize() + b"\x00\x00"))
+
+    with pytest.raises(ValueError, match="Not a cluster-specific command"):
+        gp_packet_from_zcl(packet)
+
+
+def test_untunneled_gp_command():
+    command = GreenPowerProxy.ServerCommandDefs.pairing_search
+    packet = make_tunnel_packet(command.id, b"\x00\x00\x78\x56\x34\x12")
+
+    with pytest.raises(ValueError, match="Not a tunneled GPDF command"):
+        gp_packet_from_zcl(packet)
+
+
+def test_trailing_data():
+    command = NotificationSchema(
+        options=make_notification_options(),
+        gpd_id=0x12345678,
+        frame_counter=1,
+        command_id=GPDCommandID.Toggle,
+        payload=GPDCommandPayload(b""),
+        gpp_short_addr=0xAABB,
+        gpp_gpd_link=GPPGPDLink(rssi=10, link_quality=GPLinkQuality.Moderate),
+    )
+    packet = make_tunnel_packet(NOTIFICATION_ID, command.serialize() + b"\xde\xad")
+
+    with pytest.raises(ValueError, match="Trailing data"):
+        gp_packet_from_zcl(packet)

--- a/tests/zgp/test_tunneling.py
+++ b/tests/zgp/test_tunneling.py
@@ -28,6 +28,7 @@ from zigpy.zgp.types import (
     GPPGPDLink,
     SecurityKeyType,
     SecurityLevel,
+    SecurityStatus,
 )
 
 TIMESTAMP = datetime(2026, 8, 10, 12, 0, 0, tzinfo=UTC)
@@ -134,6 +135,8 @@ def test_notification(gpd_kwargs, expected_src_id, expected_ieee, expected_endpo
     assert gp_packet.frame_counter == 1000
     assert gp_packet.security_level == SecurityLevel.FullFrameCounterAndMIC
     assert gp_packet.security_key_type == SecurityKeyType.NWKKey
+    # The proxy did the security processing, so the key type it echoes is trustworthy
+    assert gp_packet.security_status == SecurityStatus.SecuritySuccess
     # GPPGPDLink 20 * 2 - 110 = -70 dBm, High spread over the 0-255 LQI range
     assert gp_packet.rssi == -70
     assert gp_packet.lqi == 170
@@ -330,3 +333,24 @@ def test_trailing_data():
 
     with pytest.raises(ValueError, match="Trailing data"):
         gp_packet_from_zcl(packet)
+
+
+def test_unprotected_notification_status() -> None:
+    """An unprotected tunneled frame is reported as such rather than as verified."""
+    command = NotificationSchema(
+        options=make_notification_options(
+            security_level=SecurityLevel.NoSecurity,
+            security_key_type=SecurityKeyType.NoKey,
+        ),
+        gpd_id=0x01020304,
+        frame_counter=1000,
+        command_id=GPDCommandID.Toggle,
+        payload=GPDCommandPayload(b""),
+        gpp_short_addr=0xAABB,
+        gpp_gpd_link=GPPGPDLink(rssi=20, link_quality=GPLinkQuality.High),
+    )
+    gp_packet = gp_packet_from_zcl(
+        make_tunnel_packet(NOTIFICATION_ID, command.serialize())
+    )
+
+    assert gp_packet.security_status == SecurityStatus.NoSecurity

--- a/tests/zgp/test_types.py
+++ b/tests/zgp/test_types.py
@@ -7,6 +7,7 @@ from zigpy.zgp.types import (
     GP_CLUSTER_ID,
     GP_ENDPOINT,
     GP_GROUP_ID,
+    DeviceID,
     GPDCommandPayload,
     ProxyCommissioningModeExitMode,
     SrcID,
@@ -30,14 +31,19 @@ def test_default_link_key():
     assert len(DEFAULT_GP_LINK_KEY) == 16
 
 
-def test_device_id_is_uint32():
-    d = SrcID(0x12345678)
-    assert int(d) == 0x12345678
+def test_src_id_is_uint32():
+    s = SrcID(0x12345678)
+    assert int(s) == 0x12345678
 
 
-def test_device_id_hex_repr():
-    d = SrcID(0x02)
-    assert "0x" in repr(d).lower()
+def test_src_id_hex_repr():
+    s = SrcID(0x02)
+    assert "0x" in repr(s).lower()
+
+
+def test_device_id_enum():
+    assert DeviceID(0x02) is DeviceID.OnOffSwitch
+    assert DeviceID.Undefined == 0xFE
 
 
 def test_combined_exit_modes():
@@ -83,3 +89,14 @@ def test_command_payload_unspecified_is_not_empty():
 
     assert unspecified == empty
     assert unspecified.serialize() != empty.serialize()
+
+
+def test_command_payload_copy_keeps_unspecified():
+    unspecified, _ = GPDCommandPayload.deserialize(b"\xff")
+    empty, _ = GPDCommandPayload.deserialize(b"\x00")
+
+    assert GPDCommandPayload(unspecified).unspecified
+    assert GPDCommandPayload(unspecified).serialize() == b"\xff"
+    assert not GPDCommandPayload(empty).unspecified
+    assert GPDCommandPayload(empty).serialize() == b"\x00"
+    assert not GPDCommandPayload(b"").unspecified

--- a/tests/zgp/test_types.py
+++ b/tests/zgp/test_types.py
@@ -15,6 +15,7 @@ from zigpy.zgp.types import (
     GPDCommandID,
     GPDCommandPayload,
     ProxyCommissioningModeExitMode,
+    SinkCommissioningExitMode,
     SrcID,
 )
 
@@ -53,12 +54,24 @@ def test_device_id_enum():
 
 def test_combined_exit_modes():
     """Flags compose via bitwise OR since the type is a bitmap."""
-    on_expire = ProxyCommissioningModeExitMode.OnExpire
-    on_first = ProxyCommissioningModeExitMode.OnFirstPairing
-    on_explicit = ProxyCommissioningModeExitMode.OnExplicitExit
+    on_expire = SinkCommissioningExitMode.OnExpire
+    on_first = SinkCommissioningExitMode.OnFirstPairing
+    on_explicit = SinkCommissioningExitMode.OnExplicitExit
 
     assert (on_expire | on_first) == 0b011
     assert (on_expire | on_explicit) == 0b101
+
+
+def test_proxy_exit_mode_is_shifted():
+    """The command's sub-field drops "on expiration", shifting the other bits down."""
+    assert (
+        ProxyCommissioningModeExitMode.OnFirstPairing
+        == SinkCommissioningExitMode.OnFirstPairing >> 1
+    )
+    assert (
+        ProxyCommissioningModeExitMode.OnExplicitExit
+        == SinkCommissioningExitMode.OnExplicitExit >> 1
+    )
 
 
 def test_command_payload():

--- a/tests/zgp/test_types.py
+++ b/tests/zgp/test_types.py
@@ -7,6 +7,7 @@ from zigpy.zgp.types import (
     GP_CLUSTER_ID,
     GP_ENDPOINT,
     GP_GROUP_ID,
+    GPDCommandPayload,
     ProxyCommissioningModeExitMode,
     SrcID,
 )
@@ -47,3 +48,38 @@ def test_combined_exit_modes():
 
     assert (on_expire | on_first) == 0b011
     assert (on_expire | on_explicit) == 0b101
+
+
+def test_command_payload():
+    payload, rest = GPDCommandPayload.deserialize(b"\x02\xaa\xbbrest")
+
+    assert payload == b"\xaa\xbb"
+    assert rest == b"rest"
+    assert payload.serialize() == b"\x02\xaa\xbb"
+
+
+def test_command_payload_empty():
+    payload, rest = GPDCommandPayload.deserialize(b"\x00rest")
+
+    assert payload == b""
+    assert rest == b"rest"
+    assert not payload.unspecified
+    assert payload.serialize() == b"\x00"
+
+
+def test_command_payload_unspecified():
+    """A length byte of 0xff means unspecified, which is not an empty payload."""
+    payload, rest = GPDCommandPayload.deserialize(b"\xffrest")
+
+    assert payload == b""
+    assert rest == b"rest"
+    assert payload.unspecified
+    assert payload.serialize() == b"\xff"
+
+
+def test_command_payload_unspecified_is_not_empty():
+    unspecified, _ = GPDCommandPayload.deserialize(b"\xff")
+    empty, _ = GPDCommandPayload.deserialize(b"\x00")
+
+    assert unspecified == empty
+    assert unspecified.serialize() != empty.serialize()

--- a/tests/zgp/test_types.py
+++ b/tests/zgp/test_types.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
+import zigpy.types as t
 from zigpy.zgp.types import (
     DEFAULT_GP_LINK_KEY,
     GP_CLUSTER_ID,
     GP_ENDPOINT,
     GP_GROUP_ID,
+    ApplicationID,
     DeviceID,
+    GPDCommandID,
     GPDCommandPayload,
     ProxyCommissioningModeExitMode,
     SrcID,
@@ -100,3 +105,20 @@ def test_command_payload_copy_keeps_unspecified():
     assert not GPDCommandPayload(empty).unspecified
     assert GPDCommandPayload(empty).serialize() == b"\x00"
     assert not GPDCommandPayload(b"").unspecified
+
+
+def test_gp_packet_hash():
+    packet = t.ZigbeeGpPacket(
+        application_id=ApplicationID.SrcID,
+        src_id=SrcID(0x12345678),
+        command_id=GPDCommandID.Toggle,
+        frame_counter=t.uint32_t(1),
+    )
+
+    # The timestamp is excluded from the hash and from comparisons
+    later = packet.replace(timestamp=datetime(2030, 1, 1, tzinfo=UTC))
+    assert hash(packet) == hash(later)
+    assert packet == later
+
+    assert hash(packet) != hash(packet.replace(frame_counter=t.uint32_t(2)))
+    assert hash(packet) != hash(packet.replace(gpp_distance=t.uint8_t(0x42)))

--- a/tests/zgp/test_types.py
+++ b/tests/zgp/test_types.py
@@ -7,8 +7,8 @@ from zigpy.zgp.types import (
     GP_CLUSTER_ID,
     GP_ENDPOINT,
     GP_GROUP_ID,
-    DeviceID,
     ProxyCommissioningModeExitMode,
+    SrcID,
 )
 
 
@@ -30,12 +30,12 @@ def test_default_link_key():
 
 
 def test_device_id_is_uint32():
-    d = DeviceID(0x12345678)
+    d = SrcID(0x12345678)
     assert int(d) == 0x12345678
 
 
 def test_device_id_hex_repr():
-    d = DeviceID(0x02)
+    d = SrcID(0x02)
     assert "0x" in repr(d).lower()
 
 

--- a/tests/zgp/test_util.py
+++ b/tests/zgp/test_util.py
@@ -1,0 +1,36 @@
+"""Tests for Green Power helper functions."""
+
+from __future__ import annotations
+
+import pytest
+
+import zigpy.types as t
+from zigpy.zgp.util import derive_alias, synthetic_ieee
+
+
+@pytest.mark.parametrize(
+    ("gpd_id", "alias"),
+    [
+        # The two LSBs are directly usable
+        (0x12345678, 0x5678),
+        # The two LSBs are the coordinator address and so is the XOR fallback
+        (0x00000000, 0x0007),
+        # The two LSBs are reserved but the XOR with the next two bytes is usable
+        (0x1234FFF8, 0xEDCC),
+        # Both the two LSBs and the XOR are reserved: subtract 0x0008
+        (0xFFF8FFF8, 0xFFF0),
+        (0x0000FFFF, 0xFFF7),
+        # IEEE-addressed GPDs derive the alias from the EUI64
+        (t.EUI64.convert("00:00:00:00:12:34:56:78"), 0x5678),
+        (t.EUI64.convert("11:22:33:44:55:66:77:88"), 0x7788),
+    ],
+)
+def test_derive_alias(gpd_id, alias):
+    assert derive_alias(gpd_id) == t.NWK(alias)
+
+
+def test_synthetic_ieee():
+    ieee = synthetic_ieee(0x12345678)
+
+    assert ieee == t.EUI64.convert("00:00:00:00:12:34:56:78")
+    assert derive_alias(ieee) == derive_alias(0x12345678)

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -814,7 +814,10 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
     def _get_zigbee_device(self, ieee: t.EUI64) -> Device:
         device = self._application.get_device(ieee)
-        assert isinstance(device, Device)
+
+        if not isinstance(device, Device):
+            raise TypeError(f"Device {device} is not a Zigbee device")
+
         return device
 
     async def _populate_attribute_cache(

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -783,6 +783,8 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         # Clear the attribute cache to ensure the quirked state is correct
         for device in self._application.devices.values():
+            assert isinstance(device, Device)
+
             for ep in device.non_zdo_endpoints:
                 for cluster in ep.in_clusters.values():
                     cluster._attr_cache.clear()
@@ -808,6 +810,11 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         await self._register_device_listeners()
 
+    def _get_zigbee_device(self, ieee: t.EUI64) -> Device:
+        device = self._application.get_device(ieee)
+        assert isinstance(device, Device)
+        return device
+
     async def _populate_attribute_cache(
         self,
         rows: list[AttributeCacheRow],
@@ -821,7 +828,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
         updated to match.
         """
         for row in rows:
-            dev = self._application.get_device(row.ieee)
+            dev = self._get_zigbee_device(row.ieee)
 
             LOGGER.debug(
                 "[0x%04x:%s:0x%04x] Loading attribute %s=%r status=%r mfg_code=%r",
@@ -1032,14 +1039,14 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     async def _load_node_descriptors(self) -> None:
         async with self.execute(f"SELECT * FROM node_descriptors{DB_V}") as cursor:
             async for ieee, *fields in cursor:
-                dev = self._application.get_device(ieee)
+                dev = self._get_zigbee_device(ieee)
                 dev.node_desc = zdo_t.NodeDescriptor(*fields)
                 assert dev.node_desc.is_valid
 
     async def _load_endpoints(self) -> None:
         async with self.execute(f"SELECT * FROM endpoints{DB_V}") as cursor:
             async for ieee, epid, profile_id, device_type, status in cursor:
-                dev = self._application.get_device(ieee)
+                dev = self._get_zigbee_device(ieee)
                 ep = dev.add_endpoint(epid)
                 ep.profile_id = profile_id
                 ep.status = EndpointStatus(status)
@@ -1054,7 +1061,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     async def _load_clusters(self) -> None:
         async with self.execute(f"SELECT * FROM clusters{DB_V}") as cursor:
             async for ieee, endpoint_id, cluster_type, cluster_id in cursor:
-                dev = self._application.get_device(ieee)
+                dev = self._get_zigbee_device(ieee)
                 ep = dev.endpoints[endpoint_id]
 
                 if ClusterType(cluster_type) == ClusterType.Server:
@@ -1070,14 +1077,14 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
     async def _load_group_members(self) -> None:
         async with self.execute(f"SELECT * FROM group_members{DB_V}") as cursor:
             async for group_id, ieee, ep_id in cursor:
-                dev = self._application.get_device(ieee)
+                dev = self._get_zigbee_device(ieee)
                 group = self._application.groups[group_id]
                 group.add_member(dev.endpoints[ep_id], suppress_event=True)
 
     async def _load_relays(self) -> None:
         async with self.execute(f"SELECT * FROM relays{DB_V}") as cursor:
             async for ieee, value in cursor:
-                dev = self._application.get_device(ieee)
+                dev = self._get_zigbee_device(ieee)
                 relays, _ = t.Relays.deserialize(value)
                 dev.relays = zigpy.util.filter_relays(relays)
 
@@ -1122,7 +1129,7 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
                 _last_updated,
             ) in cursor:
                 try:
-                    dev = self._application.get_device(ieee)
+                    dev = self._get_zigbee_device(ieee)
                     ep = dev.endpoints[endpoint_id]
                 except KeyError:
                     # Quirks or firmware updates can remove endpoints/clusters

--- a/zigpy/appdb.py
+++ b/zigpy/appdb.py
@@ -783,7 +783,9 @@ class PersistingListener(zigpy.util.CatchingTaskMixin):
 
         # Clear the attribute cache to ensure the quirked state is correct
         for device in self._application.devices.values():
-            assert isinstance(device, Device)
+            # Only Zigbee devices have endpoints with an attribute cache
+            if not isinstance(device, Device):
+                continue
 
             for ep in device.non_zdo_endpoints:
                 for cluster in ep.in_clusters.values():

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -735,6 +735,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         If the device does not respond, existing state is preserved.
         """
         dev = self.get_device(ieee=ieee)
+        assert isinstance(dev, ZigbeeDevice)
         await dev.reinterview()
 
     async def remove(
@@ -748,6 +749,13 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         dev = self.devices.get(ieee)
         if not dev:
             LOGGER.debug("Device not found for removal: %s", ieee)
+            return
+
+        if not isinstance(dev, ZigbeeDevice):
+            # A GPD is not on the network so there is nothing to notify
+            LOGGER.info("Removing device 0x%04x (%s)", dev.nwk, ieee)
+            self.devices.pop(ieee, None)
+            self.listener_event("device_removed", dev)
             return
 
         dev.cancel_initialization()
@@ -785,7 +793,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     async def _remove_device(
         self,
-        device: BaseDevice,
+        device: ZigbeeDevice,
         remove_children: bool = True,
         rejoin: bool = False,
     ) -> None:
@@ -804,7 +812,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def deserialize(
         self,
-        sender: BaseDevice,
+        sender: ZigbeeDevice,
         endpoint_id: t.uint8_t,
         cluster_id: t.uint16_t,
         data: bytes,
@@ -830,6 +838,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             LOGGER.info("New device 0x%04x (%s) joined the network", nwk, ieee)
             new_join = True
         else:
+            if not isinstance(dev, ZigbeeDevice):
+                LOGGER.warning(
+                    "Ignoring join announcement for non-Zigbee device %s", dev
+                )
+                return
+
             if handle_rejoin:
                 LOGGER.info("Device 0x%04x (%s) joined the network", nwk, ieee)
 
@@ -866,6 +880,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         try:
             dev = self.get_device(ieee=ieee)
         except KeyError:
+            return
+
+        if not isinstance(dev, ZigbeeDevice):
+            LOGGER.warning("Ignoring leave announcement for non-Zigbee device %s", dev)
             return
 
         dev._concurrent_requests_semaphore.cancel_waiting(
@@ -1342,6 +1360,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
             return None
 
+        if not isinstance(device, ZigbeeDevice):
+            LOGGER.warning(
+                "Received a Zigbee packet from non-Zigbee device %s: %r", device, packet
+            )
+            return None
+
         self.listener_event(
             "handle_message",
             device,
@@ -1436,7 +1460,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def handle_message(
         self,
-        sender: BaseDevice,
+        sender: ZigbeeDevice,
         profile: int,
         cluster: int,
         src_ep: int,
@@ -1795,7 +1819,9 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # Unlike its IEEE address, a device's NWK address can change at runtime so this
         # is not as simple as building a second mapping
         for dev in self.devices.values():
-            if dev.nwk == nwk:
+            # NWK addressing is Zigbee-only: a GPD's derived NWK alias may collide
+            # with a real device's address (the spec tolerates this)
+            if isinstance(dev, ZigbeeDevice) and dev.nwk == nwk:
                 return dev
 
         raise KeyError(f"Device not found: nwk={nwk!r}, ieee={ieee!r}")

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1456,7 +1456,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         if ieee not in self.devices:
             # Commissioning is what registers a GPD, and is not implemented yet
-            LOGGER.warning("Received a GP packet from an unknown device: %r", packet)
+            LOGGER.debug("Received a GP packet from an unknown device: %r", packet)
             return
 
         device = self.devices[ieee]

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -15,7 +15,7 @@ import os
 import random
 import time
 import typing
-from typing import Any, ClassVar, ParamSpec, TypeVar
+from typing import Any, ClassVar, ParamSpec, Protocol, TypeVar
 import warnings
 
 import zigpy.appdb
@@ -55,6 +55,13 @@ _R = TypeVar("_R")
 _DeviceT = TypeVar("_DeviceT", bound=BaseDevice)
 _P = ParamSpec("_P")
 
+
+class DeviceResolver(Protocol):
+    """Turns a freshly-constructed device into its final object, e.g. a quirk."""
+
+    def __call__(self, device: _DeviceT) -> _DeviceT: ...
+
+
 CHANNEL_CHANGE_BROADCAST_DELAY_S = 1.0
 CHANNEL_CHANGE_SETTINGS_RELOAD_DELAY_S = 1.0
 
@@ -84,7 +91,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._send_sequence = 0
         self._tasks: set[asyncio.Future[Any]] = set()
 
-        self._device_resolver: Callable[[_DeviceT], _DeviceT] | None = None
+        self._device_resolver: DeviceResolver | None = None
         self._uninitialized_packet_handler: Callable[..., None] | None = None
 
         self._watchdog_task: asyncio.Task | None = None
@@ -348,7 +355,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         config: dict,
         auto_form: bool = False,
         start_radio: bool = True,
-        device_resolver: Callable[[_DeviceT], _DeviceT] | None = None,
+        device_resolver: DeviceResolver | None = None,
         uninitialized_packet_handler: Callable[..., None] | None = None,
     ) -> ControllerApplication:
         """Create new instance of application controller."""
@@ -645,10 +652,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             return self._device_resolver(device)
         return device
 
-    def register_device_resolver(
-        self,
-        resolver: Callable[[_DeviceT], _DeviceT],
-    ) -> None:
+    def register_device_resolver(self, resolver: DeviceResolver) -> None:
         """Replace the callable that turns a raw device into its final object."""
         self._device_resolver = resolver
 

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -37,6 +37,9 @@ import zigpy.util
 import zigpy.zcl
 import zigpy.zdo
 import zigpy.zdo.types as zdo_types
+import zigpy.zgp.tunneling
+import zigpy.zgp.types
+import zigpy.zgp.util
 
 DEFAULT_ENDPOINT_ID = 1
 LOGGER = logging.getLogger(__name__)
@@ -1307,6 +1310,21 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         assert packet.src is not None
         assert packet.dst is not None
 
+        # Tunneled GP notifications arrive with the GPD's alias (or the forwarding
+        # proxy's own address) as the NWK source, so they must be diverted before
+        # the source device is resolved
+        if zigpy.zgp.tunneling.is_gp_tunnel_packet(packet):
+            try:
+                gp_packet = zigpy.zgp.tunneling.gp_packet_from_zcl(packet)
+            except ValueError:
+                LOGGER.warning(
+                    "Failed to convert tunneled GP packet %r", packet, exc_info=True
+                )
+            else:
+                self.gp_packet_received(gp_packet)
+
+            return None
+
         # Peek into ZDO packets to handle possible ZDO notifications
         if zigpy.zdo.ZDO_ENDPOINT in (packet.src_ep, packet.dst_ep):
             self._maybe_parse_zdo(packet)
@@ -1388,6 +1406,34 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         # If the quirk did not fast-initialize the device, start initialization
         if not device.initializing and not device.is_initialized:
             device.schedule_initialize()
+
+    def gp_packet_received(self, packet: t.ZigbeeGpPacket) -> None:
+        """Notify zigpy of a received Green Power packet.
+
+        Radio libraries with a local GP stub call this directly with decoded GPDFs;
+        GP notifications tunneled over ZCL by remote proxies also converge here.
+        """
+        LOGGER.debug("Received a GP packet: %r", packet)
+
+        if packet.application_id is zigpy.zgp.types.ApplicationID.SrcID:
+            ieee = zigpy.zgp.util.synthetic_ieee(packet.src_id)
+        else:
+            ieee = packet.ieee
+
+        if ieee not in self.devices:
+            # Commissioning is what registers a GPD, and is not implemented yet
+            LOGGER.warning("Received a GP packet from an unknown device: %r", packet)
+            return
+
+        device = self.devices[ieee]
+
+        if not isinstance(device, zigpy.device.GreenPowerDevice):
+            LOGGER.warning(
+                "Received a GP packet for non-GP device %s: %r", device, packet
+            )
+            return
+
+        device.packet_received(packet)
 
     def handle_message(
         self,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -740,10 +740,6 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         If the device does not respond, existing state is preserved.
         """
         dev = self.get_device(ieee=ieee)
-
-        if not isinstance(dev, ZigbeeDevice):
-            raise TypeError(f"Device {dev} is not a Zigbee device")
-
         await dev.reinterview()
 
     async def remove(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -24,6 +24,7 @@ import zigpy.config as conf
 from zigpy.const import INTERFERENCE_MESSAGE
 from zigpy.datastructures import RequestLimiter
 import zigpy.device
+from zigpy.device import BaseDevice, GreenPowerDevice, ZigbeeDevice
 import zigpy.endpoint
 import zigpy.exceptions
 import zigpy.group
@@ -50,6 +51,7 @@ TRANSIENT_CONNECTION_ERRORS = {
 
 ENERGY_SCAN_WARN_THRESHOLD = 0.75 * 255
 _R = TypeVar("_R")
+_DeviceT = TypeVar("_DeviceT", bound=BaseDevice)
 _P = ParamSpec("_P")
 
 CHANNEL_CHANGE_BROADCAST_DELAY_S = 1.0
@@ -72,7 +74,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     _probe_configs: list[dict[str, Any]] = []
 
     def __init__(self, config: dict) -> None:
-        self.devices: dict[t.EUI64, zigpy.device.Device] = {}
+        self.devices: dict[t.EUI64, BaseDevice] = {}
         self.state: zigpy.state.State = zigpy.state.State()
         self._listeners = {}
         self._config = self.SCHEMA(config)
@@ -81,9 +83,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._send_sequence = 0
         self._tasks: set[asyncio.Future[Any]] = set()
 
-        self._device_resolver: (
-            Callable[[zigpy.device.Device], zigpy.device.Device] | None
-        ) = None
+        self._device_resolver: Callable[[_DeviceT], _DeviceT] | None = None
         self._uninitialized_packet_handler: Callable[..., None] | None = None
 
         self._watchdog_task: asyncio.Task | None = None
@@ -98,7 +98,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self.topology: zigpy.topology.Topology = zigpy.topology.Topology(self)
 
         self._req_listeners: collections.defaultdict[
-            zigpy.device.Device | zigpy.listeners.AnyDeviceType,
+            BaseDevice | zigpy.listeners.AnyDeviceType,
             collections.deque[zigpy.listeners.BaseRequestListener],
         ] = collections.defaultdict(lambda: collections.deque([]))
 
@@ -114,7 +114,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def wrap_callback(
         self,
-        src: zigpy.device.Device | zigpy.listeners.AnyDeviceType,
+        src: BaseDevice | zigpy.listeners.AnyDeviceType,
         callback: typing.Callable[_P, Any],
     ) -> typing.Callable[_P, None]:
         """Wrap a callback to log exceptions and run as task if needed."""
@@ -347,8 +347,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         config: dict,
         auto_form: bool = False,
         start_radio: bool = True,
-        device_resolver: Callable[[zigpy.device.Device], zigpy.device.Device]
-        | None = None,
+        device_resolver: Callable[[_DeviceT], _DeviceT] | None = None,
         uninitialized_packet_handler: Callable[..., None] | None = None,
     ) -> ControllerApplication:
         """Create new instance of application controller."""
@@ -614,17 +613,17 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             except Exception:  # noqa: BLE001
                 LOGGER.warning("Failed to disconnect from database", exc_info=True)
 
-    def add_device(self, ieee: t.EUI64, nwk: t.NWK) -> zigpy.device.Device:
+    def add_device(self, ieee: t.EUI64, nwk: t.NWK) -> ZigbeeDevice:
         """Creates a zigpy `Device` object with the provided IEEE and NWK addresses."""
 
         assert isinstance(ieee, t.EUI64)
         # TODO: Shut down existing device
 
-        dev = zigpy.device.Device(self, ieee, nwk)
+        dev = ZigbeeDevice(self, ieee, nwk)
         self.devices[ieee] = dev
         return dev
 
-    def _finalize_device(self, device: zigpy.device.Device) -> zigpy.device.Device:
+    def _finalize_device(self, device: _DeviceT) -> _DeviceT:
         """Resolve a device, persist to DB, and register the device."""
         self.listener_event("raw_device_initialized", device)
 
@@ -639,7 +638,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         return resolved
 
-    def _resolve_device(self, device: zigpy.device.Device) -> zigpy.device.Device:
+    def _resolve_device(self, device: _DeviceT) -> _DeviceT:
         """Resolve a freshly-constructed device into its final object."""
         if self._device_resolver is not None:
             return self._device_resolver(device)
@@ -647,7 +646,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def register_device_resolver(
         self,
-        resolver: Callable[[zigpy.device.Device], zigpy.device.Device],
+        resolver: Callable[[_DeviceT], _DeviceT],
     ) -> None:
         """Replace the callable that turns a raw device into its final object."""
         self._device_resolver = resolver
@@ -658,7 +657,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         """Register a handler for packets from not-yet-initialized devices."""
         self._uninitialized_packet_handler = handler
 
-    def device_initialized(self, device: zigpy.device.Device) -> None:
+    def device_initialized(self, device: BaseDevice) -> None:
         """Used by a device to signal that it is initialized"""
         LOGGER.debug("Device is initialized %s", device)
 
@@ -670,8 +669,8 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     async def _device_reinterviewed(
         self,
-        old_device: zigpy.device.Device,
-        shadow: zigpy.device.Device,
+        old_device: ZigbeeDevice,
+        shadow: ZigbeeDevice,
     ) -> None:
         """Swap an old device with a successfully re-interviewed shadow.
 
@@ -786,7 +785,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     async def _remove_device(
         self,
-        device: zigpy.device.Device,
+        device: BaseDevice,
         remove_children: bool = True,
         rejoin: bool = False,
     ) -> None:
@@ -805,7 +804,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def deserialize(
         self,
-        sender: zigpy.device.Device,
+        sender: BaseDevice,
         endpoint_id: t.uint8_t,
         cluster_id: t.uint16_t,
         data: bytes,
@@ -969,7 +968,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
-    async def force_remove(self, dev: zigpy.device.Device):
+    async def force_remove(self, dev: BaseDevice):
         """Instructs the radio to remove a device with a lower-level leave command. Not all
         radios implement this.
         """
@@ -1069,7 +1068,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         raise NotImplementedError  # pragma: no cover
 
-    def build_source_route_to(self, dest: zigpy.device.Device) -> list[t.NWK] | None:
+    def build_source_route_to(self, dest: ZigbeeDevice) -> list[t.NWK] | None:
         """Compute a source route to the destination device."""
 
         if dest.relays is None:
@@ -1080,7 +1079,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     async def request(
         self,
-        device: zigpy.device.Device,
+        device: ZigbeeDevice,
         profile: t.uint16_t,
         cluster: t.uint16_t,
         src_ep: t.uint8_t,
@@ -1427,7 +1426,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
         device = self.devices[ieee]
 
-        if not isinstance(device, zigpy.device.GreenPowerDevice):
+        if not isinstance(device, GreenPowerDevice):
             LOGGER.warning(
                 "Received a GP packet for non-GP device %s: %r", device, packet
             )
@@ -1437,7 +1436,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def handle_message(
         self,
-        sender: zigpy.device.Device,
+        sender: BaseDevice,
         profile: int,
         cluster: int,
         src_ep: int,
@@ -1468,9 +1467,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
             )
         )
 
-    def get_device_with_address(
-        self, address: t.AddrModeAddress
-    ) -> zigpy.device.Device:
+    def get_device_with_address(self, address: t.AddrModeAddress) -> BaseDevice:
         """Gets a `Device` object using the provided address mode address."""
 
         if address.addr_mode == t.AddrMode.NWK:
@@ -1530,7 +1527,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
 
     def register_callback_listener(
         self,
-        src: zigpy.device.Device | zigpy.listeners.AnyDeviceType,
+        src: BaseDevice | zigpy.listeners.AnyDeviceType,
         filters: list[zigpy.listeners.MatcherType],
         callback: typing.Callable[
             [
@@ -1564,7 +1561,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     @contextlib.contextmanager
     def callback_for_response(
         self,
-        src: zigpy.device.Device | zigpy.listeners.AnyDeviceType,
+        src: BaseDevice | zigpy.listeners.AnyDeviceType,
         filters: list[zigpy.listeners.MatcherType],
         callback: typing.Callable[
             [
@@ -1587,7 +1584,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     @contextlib.contextmanager
     def wait_for_response(
         self,
-        src: zigpy.device.Device | zigpy.listeners.AnyDeviceType,
+        src: BaseDevice | zigpy.listeners.AnyDeviceType,
         filters: list[zigpy.listeners.MatcherType],
     ) -> typing.Any:
         """Context manager to wait for a Zigbee response."""
@@ -1782,9 +1779,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         self._send_sequence = (self._send_sequence + 1) % 256
         return self._send_sequence
 
-    def get_device(
-        self, ieee: t.EUI64 = None, nwk: t.NWK | int = None
-    ) -> zigpy.device.Device:
+    def get_device(self, ieee: t.EUI64 = None, nwk: t.NWK | int = None) -> BaseDevice:
         """Looks up a device in the `devices` dictionary based either on its NWK or IEEE
         address.
         """
@@ -1833,9 +1828,11 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         return self._groups
 
     @property
-    def _device(self) -> zigpy.device.Device:
+    def _device(self) -> ZigbeeDevice:
         """The device being controlled."""
-        return self.get_device(ieee=self.state.node_info.ieee)
+        dev = self.get_device(ieee=self.state.node_info.ieee)
+        assert isinstance(dev, ZigbeeDevice)
+        return dev
 
     def _persist_coordinator_model_strings_in_db(self) -> None:
         cluster = self._device.endpoints[1].add_input_cluster(

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -27,6 +27,7 @@ import zigpy.device
 from zigpy.device import BaseDevice, GreenPowerDevice, ZigbeeDevice
 import zigpy.endpoint
 import zigpy.exceptions
+from zigpy.exceptions import GPSecurityProcessingFailed
 import zigpy.group
 import zigpy.listeners
 import zigpy.ota
@@ -1333,7 +1334,7 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         if zigpy.zgp.tunneling.is_gp_tunnel_packet(packet):
             try:
                 gp_packet = zigpy.zgp.tunneling.gp_packet_from_zcl(packet)
-            except zigpy.exceptions.GPSecurityProcessingFailed:
+            except GPSecurityProcessingFailed:
                 LOGGER.debug(
                     "Proxy could not decrypt the tunneled GPDF %r",
                     packet,

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -1333,6 +1333,12 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         if zigpy.zgp.tunneling.is_gp_tunnel_packet(packet):
             try:
                 gp_packet = zigpy.zgp.tunneling.gp_packet_from_zcl(packet)
+            except zigpy.exceptions.GPSecurityProcessingFailed:
+                LOGGER.debug(
+                    "Proxy could not decrypt the tunneled GPDF %r",
+                    packet,
+                    exc_info=True,
+                )
             except ValueError:
                 LOGGER.warning(
                     "Failed to convert tunneled GP packet %r", packet, exc_info=True

--- a/zigpy/application.py
+++ b/zigpy/application.py
@@ -740,7 +740,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
         If the device does not respond, existing state is preserved.
         """
         dev = self.get_device(ieee=ieee)
-        assert isinstance(dev, ZigbeeDevice)
+
+        if not isinstance(dev, ZigbeeDevice):
+            raise TypeError(f"Device {dev} is not a Zigbee device")
+
         await dev.reinterview()
 
     async def remove(
@@ -1868,7 +1871,10 @@ class ControllerApplication(zigpy.util.ListenableMixin, abc.ABC):
     def _device(self) -> ZigbeeDevice:
         """The device being controlled."""
         dev = self.get_device(ieee=self.state.node_info.ieee)
-        assert isinstance(dev, ZigbeeDevice)
+
+        if not isinstance(dev, ZigbeeDevice):
+            raise TypeError(f"Coordinator {dev} is not a Zigbee device")
+
         return dev
 
     def _persist_coordinator_model_strings_in_db(self) -> None:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -5,14 +5,14 @@ from asyncio import timeout as asyncio_timeout
 from collections.abc import Callable, Coroutine
 import contextlib
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 import enum
 import itertools
 import logging
 import math
 import time
 import typing
-from typing import Any, TypeVar
+from typing import Any, Final, TypeVar
 import warnings
 
 from zigpy import zdo
@@ -30,6 +30,7 @@ from zigpy.const import (
 )
 import zigpy.datastructures
 import zigpy.endpoint
+from zigpy.event import EventBase
 import zigpy.exceptions
 from zigpy.exceptions import DeliveryError
 import zigpy.listeners
@@ -69,7 +70,7 @@ AFTER_OTA_ATTR_READ_DELAY = 10
 
 # zgpDuplicateTimeout: unprotected GPDFs repeating the last MAC sequence number
 # within this many seconds are duplicates
-GP_DUPLICATE_TIMEOUT = 2
+GP_DUPLICATE_TIMEOUT = timedelta(seconds=2)
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,6 +81,18 @@ class ResponseKey:
     cluster_id: int
     direction: foundation.Direction | None
     tsn: int
+
+
+@dataclass(kw_only=True, frozen=True)
+class GreenPowerCommandReceived:
+    """Event generated when a Green Power command is received."""
+
+    event_type: Final[str] = "gp_command_received"
+
+    device_ieee: str
+    endpoint_id: int
+    command_id: int
+    command: t.Struct | None
 
 
 class Status(enum.IntEnum):
@@ -93,7 +106,7 @@ class Status(enum.IntEnum):
     ENDPOINTS_INIT = 2
 
 
-class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
+class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin, EventBase):
     """Base class shared by all device types, keyed on `ieee` and `nwk` addresses."""
 
     def __init__(
@@ -150,12 +163,6 @@ class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
 
         self._last_seen = value
         self.listener_event("device_last_seen_updated", self._last_seen)
-
-    def radio_details(self, lqi=None, rssi=None) -> None:
-        if lqi is not None:
-            self.lqi = lqi
-        if rssi is not None:
-            self.rssi = rssi
 
     @property
     def application(self) -> ControllerApplication:
@@ -232,7 +239,7 @@ class GreenPowerDevice(BaseDevice):
         args = (self.name, *args)
         LOGGER.log(lvl, msg, *args, **kwargs)
 
-    def _is_duplicate(self, packet: t.ZigbeeGpPacket) -> bool:
+    def _is_packet_duplicate(self, packet: t.ZigbeeGpPacket) -> bool:
         if self.frame_counter is None or packet.frame_counter is None:
             return False
 
@@ -250,8 +257,7 @@ class GreenPowerDevice(BaseDevice):
         return (
             packet.frame_counter == self.frame_counter
             and self._last_seen is not None
-            and (packet.timestamp - self._last_seen).total_seconds()
-            < GP_DUPLICATE_TIMEOUT
+            and ((packet.timestamp - self._last_seen) < GP_DUPLICATE_TIMEOUT)
         )
 
     def packet_received(self, packet: t.ZigbeeGpPacket) -> None:
@@ -260,31 +266,42 @@ class GreenPowerDevice(BaseDevice):
         Both GP ingress paths converge here: a GP Notification tunneled over ZCL by
         a remote proxy, or a GPDF decoded by the radio's local GP stub.
         """
-        if self._is_duplicate(packet):
+        self.last_seen = packet.timestamp
+
+        if packet.lqi is not None:
+            self.lqi = packet.lqi
+
+        if packet.rssi is not None:
+            self.rssi = packet.rssi
+
+        if self._is_packet_duplicate(packet):
             self.debug("Filtering duplicate packet")
             return
 
         self.frame_counter = packet.frame_counter
-        self.last_seen = packet.timestamp
-        self.radio_details(lqi=packet.lqi, rssi=packet.rssi)
+
+        command: t.Struct | None
 
         if packet.command_id in GPD_COMMAND_SCHEMAS:
             schema = GPD_COMMAND_SCHEMAS[packet.command_id]
+
+            try:
+                command, _ = schema.deserialize(packet.payload.serialize())
+            except Exception:  # noqa: BLE001
+                self.debug("Failed to parse GPDF payload %r", packet, exc_info=True)
+                command = None
         else:
-            schema = None
+            command = None
 
-        if schema is None:
-            # Unknown command or a payload parser that is not implemented yet
-            self.listener_event("gp_command_received", packet, None)
-            return
-
-        try:
-            payload, _ = schema.deserialize(packet.payload.serialize())
-        except Exception:  # noqa: BLE001
-            self.debug("Failed to parse GPDF payload %r", packet, exc_info=True)
-            return
-
-        self.listener_event("gp_command_received", packet, payload)
+        self.emit(
+            GreenPowerCommandReceived.event_type,
+            GreenPowerCommandReceived(
+                device_ieee=str(self.ieee),
+                endpoint_id=packet.endpoint,
+                command_id=packet.command_id,
+                command=command,
+            ),
+        )
 
 
 class ZigbeeDevice(BaseDevice):

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -41,7 +41,7 @@ import zigpy.util
 from zigpy.zcl import Cluster, ClusterType, OtaQueryCacheClearedEvent, foundation
 from zigpy.zcl.clusters.general import Ota, PollControl, QueryNextImageCommand
 import zigpy.zdo.types as zdo_t
-from zigpy.zgp.commands import GPD_COMMAND_SCHEMAS
+from zigpy.zgp.commands import GPD_COMMAND_SCHEMAS, GPGenericSwitchConfiguration
 from zigpy.zgp.types import (
     ApplicationID,
     DeviceID,
@@ -260,6 +260,9 @@ class GreenPowerDevice(BaseDevice):
         self.server_cluster_ids: list[t.uint16_t] = []
         self.client_cluster_ids: list[t.uint16_t] = []
 
+        # The only application description a `GenericSwitch` sends
+        self.switch_configuration: GPGenericSwitchConfiguration | None = None
+
         # Security material for decoding subsequent data frames.
         self.security_key: t.KeyData | None = None
         self.security_key_type: SecurityKeyType | None = None
@@ -291,6 +294,7 @@ class GreenPowerDevice(BaseDevice):
             "commands": list(self.commands),
             "server_cluster_ids": list(self.server_cluster_ids),
             "client_cluster_ids": list(self.client_cluster_ids),
+            "switch_configuration": self.switch_configuration,
         }
 
     @property

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -227,7 +227,6 @@ class GreenPowerDevice(BaseDevice):
         application_id: ApplicationID,
         src_id: SrcID | None = None,
         ieee: t.EUI64 | None = None,
-        endpoint: t.uint8_t | None = None,
     ) -> None:
         if application_id is ApplicationID.SrcID:
             if src_id is None:
@@ -248,8 +247,6 @@ class GreenPowerDevice(BaseDevice):
 
         self.application_id = application_id
         self._src_id = src_id
-        # The GPD endpoint (IEEE addressing only); part of identity when present.
-        self.endpoint = endpoint
 
         # Commissioning-derived signature (the quirk match input). All optional:
         # cheap GPDs commonly advertise only `device_id`.
@@ -292,7 +289,6 @@ class GreenPowerDevice(BaseDevice):
         return {
             "application_id": self.application_id,
             "src_id": self._src_id,
-            "endpoint": self.endpoint,
             "device_id": self.device_id,
             "manufacturer_id": self.gpd_manufacturer_id,
             "model_id": self.gpd_model_id,
@@ -317,7 +313,6 @@ class GreenPowerDevice(BaseDevice):
             f" application_id={self.application_id!r}"
             f" src_id={self.src_id!r}"
             f" ieee={self.ieee!r}"
-            f" endpoint={self.endpoint!r}"
             f" device_id={self.device_id!r}"
             f" nwk={self.nwk!r}"
             f">"

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -318,9 +318,7 @@ class GreenPowerDevice(BaseDevice):
         a remote proxy, or a GPDF decoded by the radio's local GP stub.
         """
 
-        # The duplicate window is measured against the previous packet
         last_seen = self._last_seen
-
         self.last_seen = packet.timestamp
 
         if packet.lqi is not None:

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -66,7 +66,7 @@ DEFAULT_REQUEST_RETRY_DELAY = 0.1
 AFTER_OTA_ATTR_READ_DELAY = 10
 
 # Marks a synthetic EUI64 built from a 32-bit GPD SrcID
-GP_SYNTHETIC_IEEE_MARKER = b"\xff\xff\xff\xfe"
+GP_SYNTHETIC_IEEE_MARKER = b"\x00\x00\x00\x00"
 
 
 @dataclass(frozen=True, slots=True)

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -47,6 +47,7 @@ from zigpy.zgp.types import (
     SecurityKeyType,
     SecurityLevel,
 )
+from zigpy.zgp.util import derive_alias
 
 if typing.TYPE_CHECKING:
     _R = TypeVar("_R")
@@ -91,12 +92,15 @@ class Status(enum.IntEnum):
 
 
 class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
-    """Base class shared by all device types, keyed on an `ieee` address."""
+    """Base class shared by all device types, keyed on `ieee` and `nwk` addresses."""
 
-    def __init__(self, application: ControllerApplication, ieee: t.EUI64) -> None:
+    def __init__(
+        self, application: ControllerApplication, ieee: t.EUI64, nwk: t.NWK
+    ) -> None:
         super().__init__()
         self._application: ControllerApplication = application
         self._ieee: t.EUI64 = ieee
+        self.nwk: t.NWK = t.NWK(nwk)
 
         self.lqi: int | None = None
         self.rssi: int | None = None
@@ -175,10 +179,15 @@ class GreenPowerDevice(BaseDevice):
         if application_id is ApplicationID.SrcID:
             assert src_id is not None
             ieee = self._synthetic_ieee(src_id)
+            gpd_id = src_id
         else:
             assert ieee is not None
+            gpd_id = ieee
 
-        super().__init__(application, ieee)
+        # The alias is the NWK address the GPD occupies on the air: proxies send on
+        # its behalf using it as the NWK source address (spec A.3.6.3.3). Distinct
+        # GPD IDs can derive the same alias; the spec tolerates the collision.
+        super().__init__(application, ieee, derive_alias(gpd_id))
 
         self.application_id = application_id
         self._src_id = src_id
@@ -239,8 +248,7 @@ class ZigbeeDevice(BaseDevice):
     manufacturer_id_override = None
 
     def __init__(self, application: ControllerApplication, ieee: t.EUI64, nwk: t.NWK):
-        super().__init__(application, ieee)
-        self.nwk: t.NWK = t.NWK(nwk)
+        super().__init__(application, ieee, nwk)
         self.zdo: zdo.ZDO = zdo.ZDO(self)
         self.endpoints: dict[int, zdo.ZDO | zigpy.endpoint.Endpoint] = {0: self.zdo}
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -149,6 +149,19 @@ class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin, EventBase
 
         self._tasks.clear()
 
+    def radio_details(self, lqi: int | None = None, rssi: int | None = None) -> None:
+        """Set the link quality and signal strength of the last received packet."""
+        warnings.warn(
+            "`radio_details` is deprecated, assign to `lqi` and `rssi` instead",
+            DeprecationWarning,
+        )
+
+        if lqi is not None:
+            self.lqi = lqi
+
+        if rssi is not None:
+            self.rssi = rssi
+
     def update_last_seen(self) -> None:
         """Update the `last_seen` attribute to the current time and emit an event."""
         warnings.warn(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -48,6 +48,7 @@ from zigpy.zgp.types import (
     GPDCommandID,
     SecurityKeyType,
     SecurityLevel,
+    SrcID,
 )
 from zigpy.zgp.util import derive_alias, synthetic_ieee
 
@@ -198,7 +199,7 @@ class GreenPowerDevice(BaseDevice):
         application: ControllerApplication,
         *,
         application_id: ApplicationID,
-        src_id: DeviceID | None = None,
+        src_id: SrcID | None = None,
         ieee: t.EUI64 | None = None,
         endpoint: t.uint8_t | None = None,
     ) -> None:
@@ -222,7 +223,7 @@ class GreenPowerDevice(BaseDevice):
 
         # Commissioning-derived signature (the quirk match input). All optional:
         # cheap GPDs commonly advertise only `device_id`.
-        self.device_id: t.uint8_t | None = None  # GPD device type
+        self.device_id: DeviceID | None = None  # GPD device type
         self.gpd_manufacturer_id: t.uint16_t | None = None
         self.gpd_model_id: t.uint16_t | None = None
         self.commands: list[GPDCommandID] = []
@@ -236,7 +237,7 @@ class GreenPowerDevice(BaseDevice):
         self.frame_counter: t.uint32_t | None = None
 
     @property
-    def src_id(self) -> DeviceID | None:
+    def src_id(self) -> SrcID | None:
         """The 32-bit GPD SrcID, or None for IEEE-addressed GPDs."""
         return self._src_id
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -91,7 +91,7 @@ class GreenPowerCommandReceived:
     event_type: Final[str] = "gp_command_received"
 
     device_ieee: str
-    endpoint_id: int
+    endpoint_id: int | None
     command_id: int
     command: t.Struct | None
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -395,6 +395,9 @@ class GreenPowerDevice(BaseDevice):
                 self.debug("Failed to parse GPDF payload %r", packet, exc_info=True)
                 command = None
         else:
+            self.debug(
+                "No schema for GPD command %s, dropping payload", packet.command_id
+            )
             command = None
 
         self.emit(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -263,6 +263,11 @@ class GreenPowerDevice(BaseDevice):
         # The only application description a `GenericSwitch` sends
         self.switch_configuration: GPGenericSwitchConfiguration | None = None
 
+        # Whether the GPD uses an incremental (rather than random) MAC sequence
+        # number. For unprotected GPDs this governs duplicate filtering; it is also
+        # echoed in the GP Pairing command sent to proxies.
+        self.mac_seq_num_capability: bool = False
+
         # Security material for decoding subsequent data frames.
         self.security_key: t.KeyData | None = None
         self.security_key_type: SecurityKeyType | None = None
@@ -295,6 +300,7 @@ class GreenPowerDevice(BaseDevice):
             "server_cluster_ids": list(self.server_cluster_ids),
             "client_cluster_ids": list(self.client_cluster_ids),
             "switch_configuration": self.switch_configuration,
+            "mac_seq_num_capability": self.mac_seq_num_capability,
         }
 
     @property

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -40,6 +40,7 @@ import zigpy.util
 from zigpy.zcl import Cluster, ClusterType, OtaQueryCacheClearedEvent, foundation
 from zigpy.zcl.clusters.general import Ota, PollControl, QueryNextImageCommand
 import zigpy.zdo.types as zdo_t
+from zigpy.zgp.commands import GPD_COMMAND_SCHEMAS
 from zigpy.zgp.types import (
     ApplicationID,
     DeviceID,
@@ -47,7 +48,7 @@ from zigpy.zgp.types import (
     SecurityKeyType,
     SecurityLevel,
 )
-from zigpy.zgp.util import derive_alias
+from zigpy.zgp.util import derive_alias, synthetic_ieee
 
 if typing.TYPE_CHECKING:
     _R = TypeVar("_R")
@@ -66,8 +67,9 @@ DEFAULT_REQUEST_RETRY_DELAY = 0.1
 
 AFTER_OTA_ATTR_READ_DELAY = 10
 
-# Marks a synthetic EUI64 built from a 32-bit GPD SrcID
-GP_SYNTHETIC_IEEE_MARKER = b"\x00\x00\x00\x00"
+# zgpDuplicateTimeout: unprotected GPDFs repeating the last MAC sequence number
+# within this many seconds are duplicates
+GP_DUPLICATE_TIMEOUT = 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,7 +180,7 @@ class GreenPowerDevice(BaseDevice):
     ) -> None:
         if application_id is ApplicationID.SrcID:
             assert src_id is not None
-            ieee = self._synthetic_ieee(src_id)
+            ieee = synthetic_ieee(src_id)
             gpd_id = src_id
         else:
             assert ieee is not None
@@ -209,10 +211,6 @@ class GreenPowerDevice(BaseDevice):
         self.security_level: SecurityLevel | None = None
         self.frame_counter: t.uint32_t | None = None
 
-    @staticmethod
-    def _synthetic_ieee(src_id: int) -> t.EUI64:
-        return t.EUI64(int(src_id).to_bytes(4, "little") + GP_SYNTHETIC_IEEE_MARKER)
-
     @property
     def src_id(self) -> DeviceID | None:
         """The 32-bit GPD SrcID, or None for IEEE-addressed GPDs."""
@@ -234,12 +232,59 @@ class GreenPowerDevice(BaseDevice):
         args = (self.name, *args)
         LOGGER.log(lvl, msg, *args, **kwargs)
 
+    def _is_duplicate(self, packet: t.ZigbeeGpPacket) -> bool:
+        if self.frame_counter is None or packet.frame_counter is None:
+            return False
+
+        if packet.security_level in (
+            SecurityLevel.FullFrameCounterAndMIC,
+            SecurityLevel.Encrypted,
+        ):
+            # The security frame counter increments monotonically over the GPD's
+            # lifetime, so anything at or below the last value is a replay
+            return packet.frame_counter <= self.frame_counter
+
+        # Unprotected GPDFs carry the 8-bit MAC sequence number instead, which both
+        # wraps and may be random: only an identical value shortly after the last
+        # frame counts as the same GPDF forwarded again
+        return (
+            packet.frame_counter == self.frame_counter
+            and self._last_seen is not None
+            and (packet.timestamp - self._last_seen).total_seconds()
+            < GP_DUPLICATE_TIMEOUT
+        )
+
     def packet_received(self, packet: t.ZigbeeGpPacket) -> None:
-        # Both GP ingress paths converge here as a decoded, decrypted frame: a
-        # tunneled GP Notification parsed out of a ZigbeePacket, or (later) a GPDF
-        # decrypted by the local GP stub. Duplicate filtering (by frame counter)
-        # and command dispatch land here.
-        raise NotImplementedError("GPDF handling is not yet implemented")
+        """Process a decoded, decrypted GPDF.
+
+        Both GP ingress paths converge here: a GP Notification tunneled over ZCL by
+        a remote proxy, or a GPDF decoded by the radio's local GP stub.
+        """
+        if self._is_duplicate(packet):
+            self.debug("Filtering duplicate packet")
+            return
+
+        self.frame_counter = packet.frame_counter
+        self.last_seen = packet.timestamp
+        self.radio_details(lqi=packet.lqi, rssi=packet.rssi)
+
+        if packet.command_id in GPD_COMMAND_SCHEMAS:
+            schema = GPD_COMMAND_SCHEMAS[packet.command_id]
+        else:
+            schema = None
+
+        if schema is None:
+            # Unknown command or a payload parser that is not implemented yet
+            self.listener_event("gp_command_received", packet, None)
+            return
+
+        try:
+            payload, _ = schema.deserialize(packet.payload.serialize())
+        except Exception:  # noqa: BLE001
+            self.debug("Failed to parse GPDF payload %r", packet, exc_info=True)
+            return
+
+        self.listener_event("gp_command_received", packet, payload)
 
 
 class ZigbeeDevice(BaseDevice):

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -315,6 +315,14 @@ class GreenPowerDevice(BaseDevice):
         Both GP ingress paths converge here: a GP Notification tunneled over ZCL by
         a remote proxy, or a GPDF decoded by the radio's local GP stub.
         """
+
+        # A GP device's packets can be relayed by multiple routers so the same GPDF can
+        # be received multiple times without indicating any new liveness from the
+        # device.
+        if self._is_packet_duplicate(packet):
+            self.debug("Filtering duplicate packet")
+            return
+
         self.last_seen = packet.timestamp
 
         if packet.lqi is not None:
@@ -322,10 +330,6 @@ class GreenPowerDevice(BaseDevice):
 
         if packet.rssi is not None:
             self.rssi = packet.rssi
-
-        if self._is_packet_duplicate(packet):
-            self.debug("Filtering duplicate packet")
-            return
 
         self.frame_counter = packet.frame_counter
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -216,6 +216,9 @@ class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin, EventBase
     def manufacturer_id(self) -> int | None:
         raise NotImplementedError
 
+    async def reinterview(self) -> None:
+        raise NotImplementedError
+
 
 class GreenPowerDevice(BaseDevice):
     """A Green Power Device (GPD)."""
@@ -284,6 +287,9 @@ class GreenPowerDevice(BaseDevice):
     def is_initialized(self) -> bool:
         """Commissioning fully describes a GPD, there is no separate interview."""
         return True
+
+    async def reinterview(self) -> None:
+        """A GPD cannot be queried, so there is nothing to re-interview."""
 
     def get_signature(self) -> dict[str, Any]:
         return {

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -48,6 +48,7 @@ from zigpy.zgp.types import (
     GPDCommandID,
     SecurityKeyType,
     SecurityLevel,
+    SecurityStatus,
     SrcID,
 )
 from zigpy.zgp.util import derive_alias, synthetic_ieee
@@ -341,9 +342,18 @@ class GreenPowerDevice(BaseDevice):
     def packet_received(self, packet: t.ZigbeeGpPacket) -> None:
         """Process a decoded, decrypted GPDF."""
 
-        # The frame's security level and key type must match the commissioned values or
-        # it is silently dropped (spec A.3.5.2.4.2): an unprotected frame must not
-        # reset the anti-replay frame counter
+        # An encrypted GPDF carries its command ID inside the ciphertext (A.1.5.3.4),
+        # so nothing can be decoded from one the radio did not decrypt
+        if (
+            packet.security_level is SecurityLevel.Encrypted
+            and packet.security_status is SecurityStatus.Unprocessed
+        ):
+            self.debug("Dropping encrypted packet that was not decrypted")
+            return
+
+        # The frame's security level and key type must match the commissioned values
+        # or it is silently dropped. Checked before anything is stored, so that an
+        # unprotected frame cannot reset the anti-replay counter (spec A.3.5.2.4)
         if self.security_level is not None and (
             packet.security_level != self.security_level
             or packet.security_key_type != self.security_key_type

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -203,6 +203,18 @@ class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin, EventBase
     def get_signature(self) -> dict[str, Any]:
         raise NotImplementedError
 
+    @property
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def is_initialized(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    def manufacturer_id(self) -> int | None:
+        raise NotImplementedError
+
 
 class GreenPowerDevice(BaseDevice):
     """A Green Power Device (GPD)."""
@@ -286,6 +298,19 @@ class GreenPowerDevice(BaseDevice):
             return f"GreenPowerDevice 0x{self._src_id:08X}"
 
         return f"GreenPowerDevice {self._ieee}"
+
+    def __repr__(self) -> str:
+        return (
+            f"<"
+            f"{type(self).__name__}"
+            f" application_id={self.application_id!r}"
+            f" src_id={self.src_id!r}"
+            f" ieee={self.ieee!r}"
+            f" endpoint={self.endpoint!r}"
+            f" device_id={self.device_id!r}"
+            f" nwk={self.nwk!r}"
+            f">"
+        )
 
     def log(self, lvl: int, msg: str, *args, **kwargs) -> None:
         msg = "[%s] " + msg

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -40,6 +40,13 @@ import zigpy.util
 from zigpy.zcl import Cluster, ClusterType, OtaQueryCacheClearedEvent, foundation
 from zigpy.zcl.clusters.general import Ota, PollControl, QueryNextImageCommand
 import zigpy.zdo.types as zdo_t
+from zigpy.zgp.types import (
+    ApplicationID,
+    DeviceID,
+    GPDCommandID,
+    SecurityKeyType,
+    SecurityLevel,
+)
 
 if typing.TYPE_CHECKING:
     _R = TypeVar("_R")
@@ -57,6 +64,9 @@ DEFAULT_REQUEST_RETRIES = 2
 DEFAULT_REQUEST_RETRY_DELAY = 0.1
 
 AFTER_OTA_ATTR_READ_DELAY = 10
+
+# Marks a synthetic EUI64 built from a 32-bit GPD SrcID
+GP_SYNTHETIC_IEEE_MARKER = b"\xff\xff\xff\xfe"
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,14 +90,156 @@ class Status(enum.IntEnum):
     ENDPOINTS_INIT = 2
 
 
-class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
-    """A device on the network"""
+class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
+    """Base class shared by all device types, keyed on an `ieee` address."""
+
+    def __init__(self, application: ControllerApplication, ieee: t.EUI64) -> None:
+        super().__init__()
+        self._application: ControllerApplication = application
+        self._ieee: t.EUI64 = ieee
+
+        self.lqi: int | None = None
+        self.rssi: int | None = None
+        self._last_seen: datetime | None = None
+
+        self._on_remove_callbacks: list[typing.Callable[[], None]] = []
+        self._tasks: set[asyncio.Future[Any]] = set()
+
+    def create_task(
+        self, target: Coroutine[Any, Any, _R], name: str | None = None
+    ) -> asyncio.Task[_R]:
+        """Create a task and store a reference to it until the task completes."""
+        task = asyncio.get_running_loop().create_task(target, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.remove)
+        return task
+
+    def on_remove(self) -> None:
+        """Call on remove callbacks."""
+        for callback in self._on_remove_callbacks:
+            callback()
+
+        self._on_remove_callbacks.clear()
+
+        for task in self._tasks:
+            task.cancel()
+
+        self._tasks.clear()
+
+    def update_last_seen(self) -> None:
+        """Update the `last_seen` attribute to the current time and emit an event."""
+        warnings.warn(
+            "Calling `update_last_seen` directly is deprecated", DeprecationWarning
+        )
+        self.last_seen = datetime.now(UTC)
+
+    @property
+    def last_seen(self) -> float | None:
+        return self._last_seen.timestamp() if self._last_seen is not None else None
+
+    @last_seen.setter
+    def last_seen(self, value: datetime | float | None):
+        if isinstance(value, int | float):
+            value = datetime.fromtimestamp(value, UTC)
+
+        self._last_seen = value
+        self.listener_event("device_last_seen_updated", self._last_seen)
+
+    def radio_details(self, lqi=None, rssi=None) -> None:
+        if lqi is not None:
+            self.lqi = lqi
+        if rssi is not None:
+            self.rssi = rssi
+
+    @property
+    def application(self) -> ControllerApplication:
+        return self._application
+
+    @property
+    def ieee(self) -> t.EUI64:
+        return self._ieee
+
+
+class GreenPowerDevice(BaseDevice):
+    """A Green Power Device (GPD)."""
+
+    def __init__(
+        self,
+        application: ControllerApplication,
+        *,
+        application_id: ApplicationID,
+        src_id: DeviceID | None = None,
+        ieee: t.EUI64 | None = None,
+        endpoint: t.uint8_t | None = None,
+    ) -> None:
+        if application_id is ApplicationID.SrcID:
+            assert src_id is not None
+            ieee = self._synthetic_ieee(src_id)
+        else:
+            assert ieee is not None
+
+        super().__init__(application, ieee)
+
+        self.application_id = application_id
+        self._src_id = src_id
+        # The GPD endpoint (IEEE addressing only); part of identity when present.
+        self.endpoint = endpoint
+
+        # Commissioning-derived signature (the quirk match input). All optional:
+        # cheap GPDs commonly advertise only `device_id`.
+        self.device_id: t.uint8_t | None = None  # GPD device type
+        self.gpd_manufacturer_id: t.uint16_t | None = None
+        self.gpd_model_id: t.uint16_t | None = None
+        self.commands: list[GPDCommandID] = []
+        self.server_cluster_ids: list[t.uint16_t] = []
+        self.client_cluster_ids: list[t.uint16_t] = []
+
+        # Security material for decoding subsequent data frames.
+        self.security_key: t.KeyData | None = None
+        self.security_key_type: SecurityKeyType | None = None
+        self.security_level: SecurityLevel | None = None
+        self.frame_counter: t.uint32_t | None = None
+
+    @staticmethod
+    def _synthetic_ieee(src_id: int) -> t.EUI64:
+        return t.EUI64(int(src_id).to_bytes(4, "little") + GP_SYNTHETIC_IEEE_MARKER)
+
+    @property
+    def src_id(self) -> DeviceID | None:
+        """The 32-bit GPD SrcID, or None for IEEE-addressed GPDs."""
+        return self._src_id
+
+    @property
+    def manufacturer_id(self) -> int | None:
+        return self.gpd_manufacturer_id
+
+    @property
+    def name(self) -> str:
+        if self.application_id is ApplicationID.SrcID:
+            return f"GreenPowerDevice 0x{self._src_id:08X}"
+
+        return f"GreenPowerDevice {self._ieee}"
+
+    def log(self, lvl: int, msg: str, *args, **kwargs) -> None:
+        msg = "[%s] " + msg
+        args = (self.name, *args)
+        LOGGER.log(lvl, msg, *args, **kwargs)
+
+    def packet_received(self, packet: t.ZigbeeGpPacket) -> None:
+        # Both GP ingress paths converge here as a decoded, decrypted frame: a
+        # tunneled GP Notification parsed out of a ZigbeePacket, or (later) a GPDF
+        # decrypted by the local GP stub. Duplicate filtering (by frame counter)
+        # and command dispatch land here.
+        raise NotImplementedError("GPDF handling is not yet implemented")
+
+
+class ZigbeeDevice(BaseDevice):
+    """A conventional Zigbee device on the network."""
 
     manufacturer_id_override = None
 
     def __init__(self, application: ControllerApplication, ieee: t.EUI64, nwk: t.NWK):
-        self._application: ControllerApplication = application
-        self._ieee: t.EUI64 = ieee
+        super().__init__(application, ieee)
         self.nwk: t.NWK = t.NWK(nwk)
         self.zdo: zdo.ZDO = zdo.ZDO(self)
         self.endpoints: dict[int, zdo.ZDO | zigpy.endpoint.Endpoint] = {0: self.zdo}
@@ -95,17 +247,13 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         # Persist the original signature for the device, before quirks are applied
         self._original_signature: dict[str, Any] | None = None
 
-        self.lqi: int | None = None
-        self.rssi: int | None = None
         self.ota_in_progress: bool = False
-        self._last_seen: datetime | None = None
 
         self._initialize_task: asyncio.Task | None = None
         self._reinterview_in_progress: bool = False
         self._group_scan_task: asyncio.Task | None = None
         self._fast_polling_reset_task: asyncio.Task | None = None
 
-        self._listeners = {}
         self._manufacturer: str | None = None
         self._model: str | None = None
         self.node_desc: zdo_t.NodeDescriptor | None = None
@@ -115,8 +263,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._send_sequence: int = 0
 
         self._fast_polling = False
-        self._on_remove_callbacks: list[typing.Callable[[], None]] = []
-        self._tasks: set[asyncio.Future[Any]] = set()
 
         self._packet_debouncer = zigpy.datastructures.Debouncer()
         self._concurrent_requests_semaphore = zigpy.datastructures.RequestLimiter(
@@ -138,30 +284,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                 callback=self.poll_control_checkin_callback,
             )
         )
-
-    def create_task(
-        self, target: Coroutine[Any, Any, _R], name: str | None = None
-    ) -> asyncio.Task[_R]:
-        """Create a task and store a reference to it until the task completes.
-
-        target: target to call.
-        """
-        task = asyncio.get_running_loop().create_task(target, name=name)
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.remove)
-        return task
-
-    def on_remove(self) -> None:
-        """Call on remove callbacks."""
-        for callback in self._on_remove_callbacks:
-            callback()
-
-        self._on_remove_callbacks.clear()
-
-        for task in self._tasks:
-            task.cancel()
-
-        self._tasks.clear()
 
     @contextlib.asynccontextmanager
     async def _limit_concurrency(self, *, priority: int | None = None):
@@ -208,27 +330,6 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     @property
     def name(self) -> str:
         return f"0x{self.nwk:04X}"
-
-    def update_last_seen(self) -> None:
-        """Update the `last_seen` attribute to the current time and emit an event."""
-
-        warnings.warn(
-            "Calling `update_last_seen` directly is deprecated", DeprecationWarning
-        )
-
-        self.last_seen = datetime.now(UTC)
-
-    @property
-    def last_seen(self) -> float | None:
-        return self._last_seen.timestamp() if self._last_seen is not None else None
-
-    @last_seen.setter
-    def last_seen(self, value: datetime | float | None):
-        if isinstance(value, int | float):
-            value = datetime.fromtimestamp(value, UTC)
-
-        self._last_seen = value
-        self.listener_event("device_last_seen_updated", self._last_seen)
 
     @property
     def non_zdo_endpoints(self) -> list[zigpy.endpoint.Endpoint]:
@@ -322,7 +423,7 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         self._reinterview_in_progress = True
 
         try:
-            shadow = Device(self._application, self._ieee, self.nwk)
+            shadow = ZigbeeDevice(self._application, self._ieee, self.nwk)
             shadow._reinterview_in_progress = True  # prevent auto-initialization
 
             # Temporarily register the shadow in app.devices so it receives
@@ -1085,24 +1186,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
                     return cluster.last_query_cmd
         return None
 
-    def radio_details(self, lqi=None, rssi=None) -> None:
-        if lqi is not None:
-            self.lqi = lqi
-        if rssi is not None:
-            self.rssi = rssi
-
     def log(self, lvl, msg, *args, **kwargs) -> None:
         msg = "[0x%04x] " + msg
         args = (self.nwk, *args)
         LOGGER.log(lvl, msg, *args, **kwargs)
-
-    @property
-    def application(self) -> ControllerApplication:
-        return self._application
-
-    @property
-    def ieee(self) -> t.EUI64:
-        return self._ieee
 
     @property
     def manufacturer(self) -> str | None:
@@ -1172,9 +1259,9 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     def __getitem__(self, key):
         return self.endpoints[key]
 
-    def clone(self) -> Device:
+    def clone(self) -> ZigbeeDevice:
         """Return a detached copy of this device for independent modification."""
-        new = Device(self.application, self.ieee, self.nwk)
+        new = ZigbeeDevice(self.application, self.ieee, self.nwk)
         new.lqi = self.lqi
         new.rssi = self.rssi
         new.last_seen = self.last_seen
@@ -1246,6 +1333,10 @@ class Device(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
             f" is_initialized={self.is_initialized}"
             f">"
         )
+
+
+# Backwards-compatible alias
+Device = ZigbeeDevice
 
 
 async def broadcast(

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -288,7 +288,9 @@ class GreenPowerDevice(BaseDevice):
         args = (self.name, *args)
         LOGGER.log(lvl, msg, *args, **kwargs)
 
-    def _is_packet_duplicate(self, packet: t.ZigbeeGpPacket) -> bool:
+    def _is_packet_duplicate(
+        self, packet: t.ZigbeeGpPacket, last_seen: datetime | None
+    ) -> bool:
         if self.frame_counter is None or packet.frame_counter is None:
             return False
 
@@ -305,8 +307,8 @@ class GreenPowerDevice(BaseDevice):
         # frame counts as the same GPDF forwarded again
         return (
             packet.frame_counter == self.frame_counter
-            and self._last_seen is not None
-            and ((packet.timestamp - self._last_seen) < GP_DUPLICATE_TIMEOUT)
+            and last_seen is not None
+            and ((packet.timestamp - last_seen) < GP_DUPLICATE_TIMEOUT)
         )
 
     def packet_received(self, packet: t.ZigbeeGpPacket) -> None:
@@ -316,12 +318,8 @@ class GreenPowerDevice(BaseDevice):
         a remote proxy, or a GPDF decoded by the radio's local GP stub.
         """
 
-        # A GP device's packets can be relayed by multiple routers so the same GPDF can
-        # be received multiple times without indicating any new liveness from the
-        # device.
-        if self._is_packet_duplicate(packet):
-            self.debug("Filtering duplicate packet")
-            return
+        # The duplicate window is measured against the previous packet
+        last_seen = self._last_seen
 
         self.last_seen = packet.timestamp
 
@@ -330,6 +328,12 @@ class GreenPowerDevice(BaseDevice):
 
         if packet.rssi is not None:
             self.rssi = packet.rssi
+
+        # A GP device's packets can be relayed by multiple routers so the same GPDF can
+        # be received multiple times
+        if self._is_packet_duplicate(packet, last_seen):
+            self.debug("Filtering duplicate packet")
+            return
 
         self.frame_counter = packet.frame_counter
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -217,11 +217,15 @@ class GreenPowerDevice(BaseDevice):
         endpoint: t.uint8_t | None = None,
     ) -> None:
         if application_id is ApplicationID.SrcID:
-            assert src_id is not None
+            if src_id is None:
+                raise ValueError("`src_id` is required with SrcID addressing")
+
             ieee = synthetic_ieee(src_id)
             gpd_id = src_id
         else:
-            assert ieee is not None
+            if ieee is None:
+                raise ValueError("`ieee` is required with IEEE addressing")
+
             gpd_id = ieee
 
         # The alias is the NWK address the GPD occupies on the air: proxies send on
@@ -288,9 +292,7 @@ class GreenPowerDevice(BaseDevice):
         args = (self.name, *args)
         LOGGER.log(lvl, msg, *args, **kwargs)
 
-    def _is_packet_duplicate(
-        self, packet: t.ZigbeeGpPacket, last_seen: datetime | None
-    ) -> bool:
+    def _is_packet_duplicate(self, packet: t.ZigbeeGpPacket) -> bool:
         if self.frame_counter is None or packet.frame_counter is None:
             return False
 
@@ -307,18 +309,31 @@ class GreenPowerDevice(BaseDevice):
         # frame counts as the same GPDF forwarded again
         return (
             packet.frame_counter == self.frame_counter
-            and last_seen is not None
-            and ((packet.timestamp - last_seen) < GP_DUPLICATE_TIMEOUT)
+            and self._last_seen is not None
+            and ((packet.timestamp - self._last_seen) < GP_DUPLICATE_TIMEOUT)
         )
 
     def packet_received(self, packet: t.ZigbeeGpPacket) -> None:
-        """Process a decoded, decrypted GPDF.
+        """Process a decoded, decrypted GPDF."""
 
-        Both GP ingress paths converge here: a GP Notification tunneled over ZCL by
-        a remote proxy, or a GPDF decoded by the radio's local GP stub.
-        """
+        # The frame's security level and key type must match the commissioned values or
+        # it is silently dropped (spec A.3.5.2.4.2): an unprotected frame must not
+        # reset the anti-replay frame counter
+        if self.security_level is not None and (
+            packet.security_level != self.security_level
+            or packet.security_key_type != self.security_key_type
+        ):
+            self.debug("Dropping packet with mismatched security parameters")
+            return
 
-        last_seen = self._last_seen
+        # A GP device's packets can be relayed by multiple routers so the same GPDF can
+        # be received multiple times, without indicating any new liveness from the
+        # device: duplicates and replays must not refresh `last_seen`, the link
+        # metrics, or the duplicate window itself
+        if self._is_packet_duplicate(packet):
+            self.debug("Filtering duplicate packet")
+            return
+
         self.last_seen = packet.timestamp
 
         if packet.lqi is not None:
@@ -326,12 +341,6 @@ class GreenPowerDevice(BaseDevice):
 
         if packet.rssi is not None:
             self.rssi = packet.rssi
-
-        # A GP device's packets can be relayed by multiple routers so the same GPDF can
-        # be received multiple times
-        if self._is_packet_duplicate(packet, last_seen):
-            self.debug("Filtering duplicate packet")
-            return
 
         self.frame_counter = packet.frame_counter
 

--- a/zigpy/device.py
+++ b/zigpy/device.py
@@ -121,6 +121,9 @@ class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin, EventBase
         self.rssi: int | None = None
         self._last_seen: datetime | None = None
 
+        # Persist the original signature for the device, before quirks are applied
+        self._original_signature: dict[str, Any] | None = None
+
         self._on_remove_callbacks: list[typing.Callable[[], None]] = []
         self._tasks: set[asyncio.Future[Any]] = set()
 
@@ -171,6 +174,20 @@ class BaseDevice(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin, EventBase
     @property
     def ieee(self) -> t.EUI64:
         return self._ieee
+
+    @property
+    def original_signature(self) -> dict[str, Any] | None:
+        return self._original_signature
+
+    @original_signature.setter
+    def original_signature(self, value: dict[str, Any] | None) -> None:
+        if self._original_signature is not None:
+            return
+
+        self._original_signature = value
+
+    def get_signature(self) -> dict[str, Any]:
+        raise NotImplementedError
 
 
 class GreenPowerDevice(BaseDevice):
@@ -226,6 +243,24 @@ class GreenPowerDevice(BaseDevice):
     @property
     def manufacturer_id(self) -> int | None:
         return self.gpd_manufacturer_id
+
+    @property
+    def is_initialized(self) -> bool:
+        """Commissioning fully describes a GPD, there is no separate interview."""
+        return True
+
+    def get_signature(self) -> dict[str, Any]:
+        return {
+            "application_id": self.application_id,
+            "src_id": self._src_id,
+            "endpoint": self.endpoint,
+            "device_id": self.device_id,
+            "manufacturer_id": self.gpd_manufacturer_id,
+            "model_id": self.gpd_model_id,
+            "commands": list(self.commands),
+            "server_cluster_ids": list(self.server_cluster_ids),
+            "client_cluster_ids": list(self.client_cluster_ids),
+        }
 
     @property
     def name(self) -> str:
@@ -313,9 +348,6 @@ class ZigbeeDevice(BaseDevice):
         super().__init__(application, ieee, nwk)
         self.zdo: zdo.ZDO = zdo.ZDO(self)
         self.endpoints: dict[int, zdo.ZDO | zigpy.endpoint.Endpoint] = {0: self.zdo}
-
-        # Persist the original signature for the device, before quirks are applied
-        self._original_signature: dict[str, Any] | None = None
 
         self.ota_in_progress: bool = False
 
@@ -1288,17 +1320,6 @@ class ZigbeeDevice(BaseDevice):
     def model(self, value) -> None:
         if isinstance(value, str):
             self._model = value
-
-    @property
-    def original_signature(self) -> dict[str, Any] | None:
-        return self._original_signature
-
-    @original_signature.setter
-    def original_signature(self, value: dict[str, Any] | None) -> None:
-        if self._original_signature is not None:
-            return
-
-        self._original_signature = value
 
     @property
     def skip_configuration(self) -> bool:

--- a/zigpy/endpoint.py
+++ b/zigpy/endpoint.py
@@ -14,7 +14,7 @@ from zigpy.zcl.foundation import GENERAL_COMMANDS, GeneralCommand, Status as ZCL
 from zigpy.zdo.types import Status as ZDOStatus
 
 if TYPE_CHECKING:
-    from zigpy.device import Device
+    from zigpy.device import ZigbeeDevice
 
 LOGGER = logging.getLogger(__name__)
 
@@ -33,8 +33,8 @@ class Status(enum.IntEnum):
 class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
     """An endpoint on a device on the network"""
 
-    def __init__(self, device: Device, endpoint_id: int) -> None:
-        self._device: Device = device
+    def __init__(self, device: ZigbeeDevice, endpoint_id: int) -> None:
+        self._device: ZigbeeDevice = device
         self._endpoint_id: int = endpoint_id
         self._listeners: dict = {}
 
@@ -288,7 +288,7 @@ class Endpoint(zigpy.util.LocalLogMixin, zigpy.util.ListenableMixin):
         LOGGER.log(lvl, msg, *args, **kwargs)
 
     @property
-    def device(self) -> Device:
+    def device(self) -> ZigbeeDevice:
         return self._device
 
     @property

--- a/zigpy/exceptions.py
+++ b/zigpy/exceptions.py
@@ -14,6 +14,10 @@ class ParsingError(ZigbeeException):
     """Failed to parse a frame"""
 
 
+class GPSecurityProcessingFailed(ZigbeeException):
+    """A proxy could not perform the security processing of a tunneled GPDF."""
+
+
 class ControllerException(ZigbeeException):
     """Application controller failed in some way."""
 

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -29,6 +29,7 @@ from zigpy.config import (
     CONF_OTA_Z2M_LOCAL_INDEX,
     CONF_OTA_Z2M_REMOTE_INDEX,
 )
+import zigpy.device
 from zigpy.ota.image import BaseOTAImage
 import zigpy.ota.providers
 import zigpy.profiles.zha
@@ -39,7 +40,6 @@ from zigpy.zcl.clusters.general import Ota, QueryNextImageCommand
 
 if typing.TYPE_CHECKING:
     import zigpy.application
-    import zigpy.device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -164,7 +164,7 @@ class OtaImageWithMetadata(t.BaseDataclassMixin):
 
     def check_compatibility(
         self,
-        device: zigpy.device.Device,
+        device: zigpy.device.ZigbeeDevice,
         query_cmd: QueryNextImageCommand,
     ) -> bool:
         """Check if an OTA image and its metadata is compatible with a device."""
@@ -328,7 +328,7 @@ class OTA:
 
     async def check_device_for_ota(
         self,
-        device: zigpy.device.Device,
+        device: zigpy.device.ZigbeeDevice,
     ) -> None:
         """Check OTA image availability for a single device.
 
@@ -358,6 +358,9 @@ class OTA:
         for user-initiated "check for updates" after invalidate_provider_caches().
         """
         for device in self._application.devices.values():
+            if not isinstance(device, zigpy.device.ZigbeeDevice):
+                continue
+
             try:
                 await self.check_device_for_ota(device)
             except Exception:  # noqa: BLE001
@@ -524,7 +527,7 @@ class OTA:
 
     async def get_ota_images(
         self,
-        device: zigpy.device.Device,
+        device: zigpy.device.ZigbeeDevice,
         query_cmd: QueryNextImageCommand,
     ) -> OtaImagesResult:
         """Get OTA images compatible with the device."""

--- a/zigpy/ota/manager.py
+++ b/zigpy/ota/manager.py
@@ -9,7 +9,7 @@ import contextlib
 from typing import TYPE_CHECKING
 
 import zigpy.datastructures
-from zigpy.ota import OTA_FETCH_TIMEOUT
+import zigpy.ota
 import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import (
@@ -22,7 +22,7 @@ from zigpy.zcl.clusters.general import (
 if TYPE_CHECKING:
     from typing import Self
 
-    from zigpy.device import Device
+    from zigpy.device import ZigbeeDevice
     from zigpy.ota.providers import OtaImageWithMetadata
 
 
@@ -54,7 +54,7 @@ class OTAManager:
 
     def __init__(
         self,
-        device: Device,
+        device: ZigbeeDevice,
         image: OtaImageWithMetadata,
         progress_callback=None,
         force: bool = False,
@@ -328,7 +328,7 @@ class OTAManager:
 
 
 async def update_firmware(
-    device: Device,
+    device: ZigbeeDevice,
     image: OtaImageWithMetadata,
     progress_callback: Callable[[int, int, float], None] | None = None,
     force: bool = False,
@@ -336,7 +336,7 @@ async def update_firmware(
     """Update the firmware on a Zigbee device."""
     # Fetch firmware if not already downloaded (deferred download for trusted providers)
     if image.firmware is None:
-        async with asyncio_timeout(OTA_FETCH_TIMEOUT):
+        async with asyncio_timeout(zigpy.ota.OTA_FETCH_TIMEOUT):
             image = await image.fetch()
 
     if force:

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -216,7 +216,7 @@ class BaseOtaProvider:
 
         self.override_previous = override_previous
 
-    def compatible_with_device(self, device: zigpy.device.Device) -> bool:
+    def compatible_with_device(self, device: zigpy.device.ZigbeeDevice) -> bool:
         if not self.manufacturer_ids:
             return True
 

--- a/zigpy/topology.py
+++ b/zigpy/topology.py
@@ -158,8 +158,8 @@ class Topology(zigpy.util.ListenableMixin):
                 "Scanning topology (%d/%d) of %s", index + 1, len(devices), device
             )
 
-            # Only ZCL devices can have their topology scanned
-            if isinstance(device, ZigbeeDevice):
+            # Only Zigbee devices can have their topology scanned
+            if not isinstance(device, ZigbeeDevice):
                 continue
 
             # Ignore devices that aren't routers

--- a/zigpy/topology.py
+++ b/zigpy/topology.py
@@ -10,7 +10,7 @@ import random
 import typing
 
 import zigpy.config
-import zigpy.device
+from zigpy.device import ZigbeeDevice
 import zigpy.types as t
 import zigpy.util
 import zigpy.zdo.types as zdo_t
@@ -80,9 +80,7 @@ class Topology(zigpy.util.ListenableMixin):
             except (Exception, asyncio.CancelledError):  # noqa: BLE001
                 LOGGER.debug("Topology scan failed", exc_info=True)
 
-    async def scan(
-        self, devices: typing.Iterable[zigpy.device.Device] | None = None
-    ) -> None:
+    async def scan(self, devices: typing.Iterable[ZigbeeDevice] | None = None) -> None:
         """Preempt Topology scan and reschedule."""
 
         if self._scan_task and not self._scan_task.done():
@@ -120,9 +118,7 @@ class Topology(zigpy.util.ListenableMixin):
 
         return table
 
-    async def _scan_neighbors(
-        self, device: zigpy.device.Device
-    ) -> list[zdo_t.Neighbor]:
+    async def _scan_neighbors(self, device: ZigbeeDevice) -> list[zdo_t.Neighbor]:
         if device.ieee in self._neighbors_unsupported:
             return []
 
@@ -136,7 +132,7 @@ class Topology(zigpy.util.ListenableMixin):
 
         return [n for n in table if n.ieee not in INVALID_NEIGHBOR_IEEES]
 
-    async def _scan_routes(self, device: zigpy.device.Device) -> list[zdo_t.Route]:
+    async def _scan_routes(self, device: ZigbeeDevice) -> list[zdo_t.Route]:
         if device.ieee in self._routes_unsupported:
             return []
 
@@ -150,9 +146,7 @@ class Topology(zigpy.util.ListenableMixin):
 
         return table
 
-    async def _scan(
-        self, devices: typing.Iterable[zigpy.device.Device] | None = None
-    ) -> None:
+    async def _scan(self, devices: typing.Iterable[ZigbeeDevice] | None = None) -> None:
         """Scan topology."""
 
         if devices is None:
@@ -163,6 +157,10 @@ class Topology(zigpy.util.ListenableMixin):
             LOGGER.debug(
                 "Scanning topology (%d/%d) of %s", index + 1, len(devices), device
             )
+
+            # Only ZCL devices can have their topology scanned
+            if isinstance(device, ZigbeeDevice):
+                continue
 
             # Ignore devices that aren't routers
             if device.node_desc is None or not (

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -645,7 +645,6 @@ class ZigbeePacket(BaseDataclassMixin):
     def __hash__(self) -> int:
         return hash(
             (
-                self.timestamp,
                 self.src,
                 self.src_ep,
                 self.dst,
@@ -698,7 +697,6 @@ class ZigbeeGpPacket(BaseDataclassMixin):
     def __hash__(self) -> int:
         return hash(
             (
-                self.timestamp,
                 self.application_id,
                 self.src_id,
                 self.ieee,

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -694,6 +694,10 @@ class ZigbeeGpPacket(BaseDataclassMixin):
     lqi: basic.uint8_t | None = dataclasses.field(default=None)
     rssi: basic.int8s | None = dataclasses.field(default=None)
 
+    # Only set by a Green Power 1.0 proxy, in place of `lqi` and `rssi`. The higher
+    # the value, the worse the link; interpretation is otherwise application-specific
+    gpp_distance: basic.uint8_t | None = dataclasses.field(default=None)
+
     def __hash__(self) -> int:
         return hash(
             (
@@ -708,6 +712,7 @@ class ZigbeeGpPacket(BaseDataclassMixin):
                 self.security_key_type,
                 self.lqi,
                 self.rssi,
+                self.gpp_distance,
             )
         )
 

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -18,6 +18,7 @@ if typing.TYPE_CHECKING:
         GPDCommandID,
         SecurityKeyType,
         SecurityLevel,
+        SecurityStatus,
         SrcID,
     )
 
@@ -689,7 +690,13 @@ class ZigbeeGpPacket(BaseDataclassMixin):
 
     frame_counter: basic.uint32_t | None = dataclasses.field(default=None)
     security_level: SecurityLevel | None = dataclasses.field(default=None)
+
+    # Only meaningful when `security_status` says security processing succeeded: the
+    # radio has no key type to report for a frame it did not process
     security_key_type: SecurityKeyType | None = dataclasses.field(default=None)
+
+    # The outcome of GPDF security processing, `None` if the radio does not report it
+    security_status: SecurityStatus | None = dataclasses.field(default=None)
 
     lqi: basic.uint8_t | None = dataclasses.field(default=None)
     rssi: basic.int8s | None = dataclasses.field(default=None)
@@ -710,6 +717,7 @@ class ZigbeeGpPacket(BaseDataclassMixin):
                 self.frame_counter,
                 self.security_level,
                 self.security_key_type,
+                self.security_status,
                 self.lqi,
                 self.rssi,
                 self.gpp_distance,

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -15,10 +15,10 @@ if typing.TYPE_CHECKING:
 
     from zigpy.zgp.types import (
         ApplicationID,
-        DeviceID,
         GPDCommandID,
         SecurityKeyType,
         SecurityLevel,
+        SrcID,
     )
 
 
@@ -676,7 +676,7 @@ class ZigbeeGpPacket(BaseDataclassMixin):
     application_id: ApplicationID | None = dataclasses.field(default=None)
 
     # Only set when ApplicationID is 0b000
-    src_id: DeviceID | None = dataclasses.field(default=None)
+    src_id: SrcID | None = dataclasses.field(default=None)
 
     # Only set when ApplicationID is 0b010
     ieee: EUI64 | None = dataclasses.field(default=None)

--- a/zigpy/types/named.py
+++ b/zigpy/types/named.py
@@ -13,6 +13,14 @@ from .struct import Struct
 if typing.TYPE_CHECKING:
     from typing import Self
 
+    from zigpy.zgp.types import (
+        ApplicationID,
+        DeviceID,
+        GPDCommandID,
+        SecurityKeyType,
+        SecurityLevel,
+    )
+
 
 class Bytes(bytes):
     """A serializable type to consume all remaining bytes."""
@@ -654,6 +662,54 @@ class ZigbeePacket(BaseDataclassMixin):
                 self.lqi,
                 self.rssi,
                 self.priority,
+            )
+        )
+
+
+@dataclasses.dataclass
+class ZigbeeGpPacket(BaseDataclassMixin):
+    """A decoded, decrypted Green Power frame."""
+
+    timestamp: datetime = dataclasses.field(
+        compare=False, default_factory=lambda: datetime.now(UTC)
+    )
+
+    application_id: ApplicationID | None = dataclasses.field(default=None)
+
+    # Only set when ApplicationID is 0b000
+    src_id: DeviceID | None = dataclasses.field(default=None)
+
+    # Only set when ApplicationID is 0b010
+    ieee: EUI64 | None = dataclasses.field(default=None)
+    endpoint: basic.uint8_t | None = dataclasses.field(default=None)
+
+    command_id: GPDCommandID | None = dataclasses.field(default=None)
+    payload: basic.SerializableBytes = dataclasses.field(
+        default_factory=basic.SerializableBytes
+    )
+
+    frame_counter: basic.uint32_t | None = dataclasses.field(default=None)
+    security_level: SecurityLevel | None = dataclasses.field(default=None)
+    security_key_type: SecurityKeyType | None = dataclasses.field(default=None)
+
+    lqi: basic.uint8_t | None = dataclasses.field(default=None)
+    rssi: basic.int8s | None = dataclasses.field(default=None)
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.timestamp,
+                self.application_id,
+                self.src_id,
+                self.ieee,
+                self.endpoint,
+                self.command_id,
+                self.payload,
+                self.frame_counter,
+                self.security_level,
+                self.security_key_type,
+                self.lqi,
+                self.rssi,
             )
         )
 

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -31,14 +31,22 @@ class CommissioningNotificationOptions(t.Struct):
 # Figure 30
 class CommissioningNotificationSchema(foundation.CommandSchema):
     options: CommissioningNotificationOptions
-    gpd_id: zgptypes.DeviceID
+    gpd_id: zgptypes.DeviceID = StructField(
+        requires=lambda s: s.options.application_id == zgptypes.ApplicationID.SrcID
+    )
+    gpd_ieee: t.EUI64 = StructField(
+        requires=lambda s: s.options.application_id == zgptypes.ApplicationID.IEEE
+    )
+    gpd_endpoint: t.uint8_t = StructField(
+        requires=lambda s: s.options.application_id == zgptypes.ApplicationID.IEEE
+    )
     frame_counter: t.uint32_t
     command_id: zgptypes.GPDCommandID
-    payload: t.LVBytes
+    payload: zgptypes.GPDCommandPayload
     gpp_short_addr: t.uint16_t = StructField(
         requires=lambda s: s.options.proxy_info_present, optional=True
     )
-    gpp_gpd_link: t.uint8_t = StructField(
+    gpp_gpd_link: zgptypes.GPPGPDLink = StructField(
         requires=lambda s: s.options.proxy_info_present, optional=True
     )
     mic: t.uint32_t = StructField(
@@ -86,7 +94,7 @@ class PairingSearchSchema(foundation.CommandSchema):
     gpd_id: zgptypes.DeviceID
 
 
-# Figure 24
+# Figures 25 and 26 — 16 bits total
 class NotificationOptions(t.Struct):
     application_id: zgptypes.ApplicationID
     also_unicast: t.uint1_t
@@ -94,22 +102,34 @@ class NotificationOptions(t.Struct):
     also_commissioned_group: t.uint1_t
     security_level: zgptypes.SecurityLevel
     security_key_type: zgptypes.SecurityKeyType
-    appoint_temp_master: t.uint1_t
+    rx_after_tx: t.uint1_t
     tx_queue_full: t.uint1_t
-    _reserved: t.uint3_t
+    bidirectional_cap: t.uint1_t
+    proxy_info_present: t.uint1_t
+    _reserved: t.uint1_t
 
 
-# Figure 23
+# Figure 24
 class NotificationSchema(foundation.CommandSchema):
     options: NotificationOptions
-    gpd_id: zgptypes.DeviceID
+    gpd_id: zgptypes.DeviceID = StructField(
+        requires=lambda s: s.options.application_id == zgptypes.ApplicationID.SrcID
+    )
+    gpd_ieee: t.EUI64 = StructField(
+        requires=lambda s: s.options.application_id == zgptypes.ApplicationID.IEEE
+    )
+    gpd_endpoint: t.uint8_t = StructField(
+        requires=lambda s: s.options.application_id == zgptypes.ApplicationID.IEEE
+    )
     frame_counter: t.uint32_t
     command_id: zgptypes.GPDCommandID
-    payload: t.LVBytes
-    short_addr: t.uint16_t = StructField(
-        requires=lambda s: s.options.appoint_temp_master
+    payload: zgptypes.GPDCommandPayload
+    gpp_short_addr: t.uint16_t = StructField(
+        requires=lambda s: s.options.proxy_info_present, optional=True
     )
-    distance: t.uint8_t = StructField(requires=lambda s: s.options.appoint_temp_master)
+    gpp_gpd_link: zgptypes.GPPGPDLink = StructField(
+        requires=lambda s: s.options.proxy_info_present, optional=True
+    )
 
 
 # Figure 40, 41

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -44,10 +44,13 @@ class CommissioningNotificationSchema(foundation.CommandSchema):
     command_id: zgptypes.GPDCommandID
     payload: zgptypes.GPDCommandPayload
     gpp_short_addr: t.uint16_t = StructField(
-        requires=lambda s: s.options.proxy_info_present
+        requires=lambda s: s.options.proxy_info_present or s.options.rx_after_tx
     )
     gpp_gpd_link: zgptypes.GPPGPDLink = StructField(
         requires=lambda s: s.options.proxy_info_present
+    )
+    gpp_distance: t.uint8_t = StructField(
+        requires=lambda s: not s.options.proxy_info_present and s.options.rx_after_tx
     )
     mic: t.uint32_t = StructField(requires=lambda s: s.options.security_failed)
 
@@ -75,7 +78,7 @@ class ResponseSchema(foundation.CommandSchema):
     gpd_command_payload: t.LVBytes
 
 
-# Figure 26
+# Figure 29
 class PairingSearchOptions(t.Struct):
     application_id: zgptypes.ApplicationID
     request_unicast_sink: t.uint1_t
@@ -86,7 +89,7 @@ class PairingSearchOptions(t.Struct):
     _reserved: t.uint8_t
 
 
-# Figure 25
+# Figure 28
 class PairingSearchSchema(foundation.CommandSchema):
     options: PairingSearchOptions
     gpd_id: zgptypes.SrcID
@@ -123,10 +126,13 @@ class NotificationSchema(foundation.CommandSchema):
     command_id: zgptypes.GPDCommandID
     payload: zgptypes.GPDCommandPayload
     gpp_short_addr: t.uint16_t = StructField(
-        requires=lambda s: s.options.proxy_info_present
+        requires=lambda s: s.options.proxy_info_present or s.options.rx_after_tx
     )
     gpp_gpd_link: zgptypes.GPPGPDLink = StructField(
         requires=lambda s: s.options.proxy_info_present
+    )
+    gpp_distance: t.uint8_t = StructField(
+        requires=lambda s: not s.options.proxy_info_present and s.options.rx_after_tx
     )
 
 

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -31,7 +31,7 @@ class CommissioningNotificationOptions(t.Struct):
 # Figure 30
 class CommissioningNotificationSchema(foundation.CommandSchema):
     options: CommissioningNotificationOptions
-    gpd_id: zgptypes.DeviceID = StructField(
+    gpd_id: zgptypes.SrcID = StructField(
         requires=lambda s: s.options.application_id == zgptypes.ApplicationID.SrcID
     )
     gpd_ieee: t.EUI64 = StructField(
@@ -70,7 +70,7 @@ class ResponseSchema(foundation.CommandSchema):
     options: ResponseOptions
     temp_master_short_addr: t.uint16_t
     temp_master_tx_channel: TempMasterTxChannel
-    gpd_id: zgptypes.DeviceID
+    gpd_id: zgptypes.SrcID
     gpd_command_id: zgptypes.GPDCommandID
     gpd_command_payload: t.LVBytes
 
@@ -89,7 +89,7 @@ class PairingSearchOptions(t.Struct):
 # Figure 25
 class PairingSearchSchema(foundation.CommandSchema):
     options: PairingSearchOptions
-    gpd_id: zgptypes.DeviceID
+    gpd_id: zgptypes.SrcID
 
 
 # Figures 25 and 26 — 16 bits total
@@ -110,7 +110,7 @@ class NotificationOptions(t.Struct):
 # Figure 24
 class NotificationSchema(foundation.CommandSchema):
     options: NotificationOptions
-    gpd_id: zgptypes.DeviceID = StructField(
+    gpd_id: zgptypes.SrcID = StructField(
         requires=lambda s: s.options.application_id == zgptypes.ApplicationID.SrcID
     )
     gpd_ieee: t.EUI64 = StructField(
@@ -150,7 +150,7 @@ class PairingOptions(t.Struct):
 # Figure 38, 39
 class PairingSchema(foundation.CommandSchema):
     options: PairingOptions
-    gpd_id: zgptypes.DeviceID
+    gpd_id: zgptypes.SrcID
     # Table 37
     sink_ieee: t.EUI64 = StructField(
         requires=lambda s: (
@@ -210,7 +210,7 @@ class NotificationResponseOptions(t.Struct):
 
 class NotificationResponseSchema(foundation.CommandSchema):
     options: NotificationResponseOptions
-    gpd_id: zgptypes.DeviceID
+    gpd_id: zgptypes.SrcID
     frame_counter: t.uint32_t
 
 

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -44,14 +44,12 @@ class CommissioningNotificationSchema(foundation.CommandSchema):
     command_id: zgptypes.GPDCommandID
     payload: zgptypes.GPDCommandPayload
     gpp_short_addr: t.uint16_t = StructField(
-        requires=lambda s: s.options.proxy_info_present, optional=True
+        requires=lambda s: s.options.proxy_info_present
     )
     gpp_gpd_link: zgptypes.GPPGPDLink = StructField(
-        requires=lambda s: s.options.proxy_info_present, optional=True
+        requires=lambda s: s.options.proxy_info_present
     )
-    mic: t.uint32_t = StructField(
-        requires=lambda s: s.options.security_failed, optional=True
-    )
+    mic: t.uint32_t = StructField(requires=lambda s: s.options.security_failed)
 
 
 # Figure 59
@@ -125,10 +123,10 @@ class NotificationSchema(foundation.CommandSchema):
     command_id: zgptypes.GPDCommandID
     payload: zgptypes.GPDCommandPayload
     gpp_short_addr: t.uint16_t = StructField(
-        requires=lambda s: s.options.proxy_info_present, optional=True
+        requires=lambda s: s.options.proxy_info_present
     )
     gpp_gpd_link: zgptypes.GPPGPDLink = StructField(
-        requires=lambda s: s.options.proxy_info_present, optional=True
+        requires=lambda s: s.options.proxy_info_present
     )
 
 

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -224,10 +224,7 @@ class NotificationResponseSchema(foundation.CommandSchema):
 class ProxyCommissioningModeOptions(t.Struct):
     enter: t.uint1_t
     commissioning_window_present: t.uint1_t
-    # Exit-mode sub-field (Figure 57): bit 0 = on first pairing, bit 1 = on
-    # explicit exit. Only 2 bits here, unlike the 3-bit gpsCommissioningExitMode
-    # attribute (Figure 22).
-    exit_mode: t.uint2_t
+    exit_mode: zgptypes.ProxyCommissioningModeExitMode
     channel_present: t.uint1_t
     unicast: t.uint1_t
     _reserved: t.uint2_t
@@ -276,7 +273,7 @@ class GreenPowerProxy(Cluster):
         )
         commissioning_exit_mode: Final = ZCLAttributeDef(
             id=0x0003,
-            type=zgptypes.ProxyCommissioningModeExitMode,
+            type=zgptypes.SinkCommissioningExitMode,
             access="rw",
             mandatory=True,
         )

--- a/zigpy/zgp/__init__.py
+++ b/zigpy/zgp/__init__.py
@@ -43,3 +43,4 @@ from .types import (  # noqa: F401
     GP_ENDPOINT,
     GP_GROUP_ID,
 )
+from .util import derive_alias  # noqa: F401

--- a/zigpy/zgp/__init__.py
+++ b/zigpy/zgp/__init__.py
@@ -43,4 +43,4 @@ from .types import (  # noqa: F401
     GP_ENDPOINT,
     GP_GROUP_ID,
 )
-from .util import derive_alias  # noqa: F401
+from .util import derive_alias, synthetic_ieee  # noqa: F401

--- a/zigpy/zgp/commands.py
+++ b/zigpy/zgp/commands.py
@@ -9,7 +9,13 @@ from typing import Self
 
 import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zgp.types import GPDCommandID, SecurityKeyType, SecurityLevel, SwitchType
+from zigpy.zgp.types import (
+    DeviceID,
+    GPDCommandID,
+    SecurityKeyType,
+    SecurityLevel,
+    SwitchType,
+)
 
 
 class GPNoPayload(t.Struct):
@@ -89,7 +95,7 @@ class GPSwitchInformation(t.Struct):
 class GPCommissioningPayload(t.Struct):
     """GP Commissioning command (0xE0) payload."""
 
-    device_id: t.uint8_t
+    device_id: DeviceID
     options: GPCommissioningOptions
 
     extended_options: GPCommissioningExtendedOptions = t.StructField(

--- a/zigpy/zgp/commands.py
+++ b/zigpy/zgp/commands.py
@@ -354,7 +354,7 @@ class GPManufacturerDefinedPayload(t.Struct):
 
 # Tables 54, 55 and 56. `GPNoPayload` marks a command that the specification defines
 # as payloadless, `None` one whose payload parser is not implemented yet.
-GPD_COMMAND_SCHEMAS: dict[GPDCommandID, type[t.Struct] | None] = {
+GPD_COMMAND_SCHEMAS: dict[GPDCommandID, type[t.Struct]] = {
     # Identify (Table 54)
     GPDCommandID.Identify: GPNoPayload,
     # Scenes (Table 54): the sink fills in the GroupID itself, see sec. A.4.2.7
@@ -431,11 +431,11 @@ GPD_COMMAND_SCHEMAS: dict[GPDCommandID, type[t.Struct] | None] = {
     GPDCommandID.RequestAttributes: GPRequestAttributesPayload,
     # TODO: Figure 147, a `t.SizePrefixedList[foundation.ReadAttributeRecord, t.uint8_t]`
     # per cluster record. No known device implements it.
-    GPDCommandID.ReadAttributesResponse: None,
+    # GPDCommandID.ReadAttributesResponse: None,
     GPDCommandID.ZCLTunneling: GPZCLTunnelingPayload,
     # TODO: unparsable on its own, the layout of its data points is announced by the
     # Application Description command (0xE4) during commissioning
-    GPDCommandID.CompactAttributeReporting: None,
+    # GPDCommandID.CompactAttributeReporting: None,
     # Manufacturer-defined commands (sec. A.4.2.8)
     **{
         GPDCommandID(command_id): GPManufacturerDefinedPayload
@@ -448,11 +448,11 @@ GPD_COMMAND_SCHEMAS: dict[GPDCommandID, type[t.Struct] | None] = {
     GPDCommandID.ChannelRequest: GPChannelRequestPayload,
     # TODO: Figures 122 - 128, nested `t.SizePrefixedList`s for the data point
     # descriptors of each report descriptor. No known device implements it.
-    GPDCommandID.ApplicationDescription: None,
+    # GPDCommandID.ApplicationDescription: None,
     GPDCommandID.CommissioningReply: GPCommissioningReplyPayload,
     # TODO: Figure 150, a `t.SizePrefixedList[foundation.Attribute, t.uint8_t]` per
     # cluster record. No known device implements it.
-    GPDCommandID.WriteAttributes: None,
+    # GPDCommandID.WriteAttributes: None,
     GPDCommandID.ReadAttributes: GPRequestAttributesPayload,
     GPDCommandID.ChannelConfiguration: GPChannelConfigurationPayload,
     GPDCommandID.ZCLTunnelingToGPD: GPZCLTunnelingPayload,

--- a/zigpy/zgp/commands.py
+++ b/zigpy/zgp/commands.py
@@ -353,7 +353,7 @@ class GPManufacturerDefinedPayload(t.Struct):
 
 
 # Tables 54, 55 and 56. `GPNoPayload` marks a command that the specification defines
-# as payloadless, `None` one whose payload parser is not implemented yet.
+# as payloadless.
 GPD_COMMAND_SCHEMAS: dict[GPDCommandID, type[t.Struct]] = {
     # Identify (Table 54)
     GPDCommandID.Identify: GPNoPayload,

--- a/zigpy/zgp/tunneling.py
+++ b/zigpy/zgp/tunneling.py
@@ -29,11 +29,28 @@ TUNNELED_GPDF_COMMANDS: dict[
 
 
 def is_gp_tunnel_packet(packet: t.ZigbeePacket) -> bool:
-    """Check whether a packet is a Green Power cluster frame sent by a proxy."""
-    return (
+    """Check whether a packet is a GPDF tunneled over ZCL by a proxy.
+
+    Only the two notification commands are tunnels. All other Green Power cluster
+    traffic (pairing, commissioning mode, attribute reads, ...) is normal ZCL and
+    flows through regular device dispatch.
+    """
+    if not (
         packet.profile_id == zigpy.profiles.zgp.PROFILE_ID
         and packet.cluster_id == GP_CLUSTER_ID
         and packet.src_ep == GP_ENDPOINT
+    ):
+        return False
+
+    try:
+        hdr, _ = foundation.ZCLHeader.deserialize(packet.data.serialize())
+    except ValueError:
+        return False
+
+    return (
+        hdr.frame_control.is_cluster
+        and hdr.frame_control.direction == foundation.Direction.Client_to_Server
+        and hdr.command_id in TUNNELED_GPDF_COMMANDS
     )
 
 
@@ -43,6 +60,11 @@ def gp_packet_from_zcl(packet: t.ZigbeePacket) -> t.ZigbeeGpPacket:
 
     if not hdr.frame_control.is_cluster:
         raise ValueError(f"Not a cluster-specific command: {hdr}")
+
+    # The notification and notification response commands share a command ID and
+    # are only distinguished by direction
+    if hdr.frame_control.direction != foundation.Direction.Client_to_Server:
+        raise ValueError(f"Not a client-to-server command: {hdr}")
 
     if hdr.command_id not in TUNNELED_GPDF_COMMANDS:
         raise ValueError(f"Not a tunneled GPDF command: {hdr}")

--- a/zigpy/zgp/tunneling.py
+++ b/zigpy/zgp/tunneling.py
@@ -1,0 +1,81 @@
+"""Conversion of ZCL-tunneled Green Power frames into GP packets.
+
+Proxies forward GPDFs they receive to sinks as GP Notification and GP
+Commissioning Notification commands of the Green Power cluster (ZGP spec
+A.3.3.4.1 and A.3.3.4.3). This module unpacks those tunneled commands back
+into `ZigbeeGpPacket`s.
+"""
+
+from __future__ import annotations
+
+import zigpy.profiles.zgp
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.greenpower import (
+    CommissioningNotificationSchema,
+    GreenPowerProxy,
+    NotificationSchema,
+)
+from zigpy.zgp.types import GP_CLUSTER_ID, GP_ENDPOINT
+
+TUNNELED_GPDF_COMMANDS: dict[
+    int, type[NotificationSchema | CommissioningNotificationSchema]
+] = {
+    GreenPowerProxy.ServerCommandDefs.notification.id: NotificationSchema,
+    GreenPowerProxy.ServerCommandDefs.commissioning_notification.id: (
+        CommissioningNotificationSchema
+    ),
+}
+
+
+def is_gp_tunnel_packet(packet: t.ZigbeePacket) -> bool:
+    """Check whether a packet is a Green Power cluster frame sent by a proxy."""
+    return (
+        packet.profile_id == zigpy.profiles.zgp.PROFILE_ID
+        and packet.cluster_id == GP_CLUSTER_ID
+        and packet.src_ep == GP_ENDPOINT
+    )
+
+
+def gp_packet_from_zcl(packet: t.ZigbeePacket) -> t.ZigbeeGpPacket:
+    """Convert a ZCL-tunneled GP notification into a `ZigbeeGpPacket`."""
+    hdr, data = foundation.ZCLHeader.deserialize(packet.data.serialize())
+
+    if not hdr.frame_control.is_cluster:
+        raise ValueError(f"Not a cluster-specific command: {hdr}")
+
+    if hdr.command_id not in TUNNELED_GPDF_COMMANDS:
+        raise ValueError(f"Not a tunneled GPDF command: {hdr}")
+
+    command, rest = TUNNELED_GPDF_COMMANDS[hdr.command_id].deserialize(data)
+
+    if rest:
+        raise ValueError(f"Trailing data in tunneled GPDF: {rest!r}")
+
+    if (
+        isinstance(command, CommissioningNotificationSchema)
+        and command.options.security_failed
+    ):
+        raise ValueError(f"Security processing of the tunneled GPDF failed: {command}")
+
+    lqi = rssi = None
+
+    if command.options.proxy_info_present:
+        # Spread the proxy's 2-bit link quality over the full 0-255 LQI range
+        lqi = t.uint8_t(int(command.gpp_gpd_link.link_quality) * 85)
+        rssi = t.int8s(command.gpp_gpd_link.rssi_dbm)
+
+    return t.ZigbeeGpPacket(
+        timestamp=packet.timestamp,
+        application_id=command.options.application_id,
+        src_id=command.gpd_id,
+        ieee=command.gpd_ieee,
+        endpoint=command.gpd_endpoint,
+        command_id=command.command_id,
+        payload=t.SerializableBytes(bytes(command.payload)),
+        frame_counter=command.frame_counter,
+        security_level=command.options.security_level,
+        security_key_type=command.options.security_key_type,
+        lqi=lqi,
+        rssi=rssi,
+    )

--- a/zigpy/zgp/tunneling.py
+++ b/zigpy/zgp/tunneling.py
@@ -17,7 +17,7 @@ from zigpy.zcl.clusters.greenpower import (
     GreenPowerProxy,
     NotificationSchema,
 )
-from zigpy.zgp.types import GP_CLUSTER_ID, GP_ENDPOINT
+from zigpy.zgp.types import GP_CLUSTER_ID, GP_ENDPOINT, SecurityLevel, SecurityStatus
 
 TUNNELED_GPDF_COMMANDS: dict[
     int, type[NotificationSchema | CommissioningNotificationSchema]
@@ -103,6 +103,13 @@ def gp_packet_from_zcl(packet: t.ZigbeePacket) -> t.ZigbeeGpPacket:
         frame_counter=command.frame_counter,
         security_level=command.options.security_level,
         security_key_type=command.options.security_key_type,
+        # The proxy performed the security processing and echoes the key type it used
+        # (A.3.3.4.1), so a tunneled frame that got this far is verified
+        security_status=(
+            SecurityStatus.NoSecurity
+            if command.options.security_level is SecurityLevel.NoSecurity
+            else SecurityStatus.SecuritySuccess
+        ),
         lqi=lqi,
         rssi=rssi,
         # A Green Power 1.0 proxy sends a `Distance` byte instead of the GPP-GPD link

--- a/zigpy/zgp/tunneling.py
+++ b/zigpy/zgp/tunneling.py
@@ -8,6 +8,7 @@ into `ZigbeeGpPacket`s.
 
 from __future__ import annotations
 
+from zigpy.exceptions import GPSecurityProcessingFailed
 import zigpy.profiles.zgp
 import zigpy.types as t
 from zigpy.zcl import foundation
@@ -78,7 +79,11 @@ def gp_packet_from_zcl(packet: t.ZigbeePacket) -> t.ZigbeeGpPacket:
         isinstance(command, CommissioningNotificationSchema)
         and command.options.security_failed
     ):
-        raise ValueError(f"Security processing of the tunneled GPDF failed: {command}")
+        # TODO: reconstruct the frame control fields and decrypt the GPDF here, as
+        # A.3.6.5.2 requires of a sink. The MIC needed for it is already parsed.
+        raise GPSecurityProcessingFailed(
+            f"Security processing of the tunneled GPDF failed: {command}"
+        )
 
     lqi = rssi = None
 

--- a/zigpy/zgp/tunneling.py
+++ b/zigpy/zgp/tunneling.py
@@ -92,9 +92,6 @@ def gp_packet_from_zcl(packet: t.ZigbeePacket) -> t.ZigbeeGpPacket:
         lqi = t.uint8_t(int(command.gpp_gpd_link.link_quality) * 85)
         rssi = t.int8s(command.gpp_gpd_link.rssi_dbm)
 
-    # A Green Power 1.0 proxy sends a `Distance` byte instead of the GPP-GPD link.
-    # How to interpret it is explicitly application-specific, so it is dropped.
-
     return t.ZigbeeGpPacket(
         timestamp=packet.timestamp,
         application_id=command.options.application_id,
@@ -108,4 +105,6 @@ def gp_packet_from_zcl(packet: t.ZigbeePacket) -> t.ZigbeeGpPacket:
         security_key_type=command.options.security_key_type,
         lqi=lqi,
         rssi=rssi,
+        # A Green Power 1.0 proxy sends a `Distance` byte instead of the GPP-GPD link
+        gpp_distance=command.gpp_distance,
     )

--- a/zigpy/zgp/tunneling.py
+++ b/zigpy/zgp/tunneling.py
@@ -87,6 +87,9 @@ def gp_packet_from_zcl(packet: t.ZigbeePacket) -> t.ZigbeeGpPacket:
         lqi = t.uint8_t(int(command.gpp_gpd_link.link_quality) * 85)
         rssi = t.int8s(command.gpp_gpd_link.rssi_dbm)
 
+    # A Green Power 1.0 proxy sends a `Distance` byte instead of the GPP-GPD link.
+    # How to interpret it is explicitly application-specific, so it is dropped.
+
     return t.ZigbeeGpPacket(
         timestamp=packet.timestamp,
         application_id=command.options.application_id,

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Self
+
 import zigpy.types as t
 from zigpy.types import basic
 
@@ -259,11 +261,20 @@ class GPDCommandPayload(basic.LVBytes):
     """GPD command payload; a length byte of 0xff means unspecified/no payload."""
 
     # An unspecified payload is empty, but it is not the same as an explicitly empty
-    # one, so it round-trips back to the 0xff marker rather than to a zero length
+    # one, so it round-trips back to the 0xff marker rather than to a zero length.
+    # Note that `==` and `hash` compare only the bytes content, not the marker.
     unspecified: bool = False
 
+    def __new__(cls, *args) -> Self:
+        instance = super().__new__(cls, *args)
+
+        if args and isinstance(args[0], cls):
+            instance.unspecified = args[0].unspecified
+
+        return instance
+
     @classmethod
-    def deserialize(cls, data: bytes) -> tuple[GPDCommandPayload, bytes]:
+    def deserialize(cls, data: bytes) -> tuple[Self, bytes]:
         if data[:1] == b"\xff":
             instance = cls(b"")
             instance.unspecified = True

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -18,6 +18,7 @@ __all__ = [
     "ApplicationID",
     "SecurityLevel",
     "SecurityKeyType",
+    "SecurityStatus",
     "ProxyCommissioningModeExitMode",
     "CommunicationMode",
     "CommunicationDirection",
@@ -204,6 +205,21 @@ class SecurityLevel(basic.enum2):
     Reserved = 0b01
     FullFrameCounterAndMIC = 0b10
     Encrypted = 0b11
+
+
+# Table 5, the `Status` parameter of the GP-DATA.indication primitive: the outcome of
+# GPDF security processing, which is what makes the other security fields meaningful
+class SecurityStatus(basic.enum8):
+    SecuritySuccess = 0x00
+    NoSecurity = 0x01
+    CounterFailure = 0x02
+    AuthFailure = 0x03
+    Unprocessed = 0x04
+
+    @property
+    def is_trusted(self) -> bool:
+        """Whether the frame was verified, and its key type and payload usable."""
+        return self in (SecurityStatus.SecuritySuccess, SecurityStatus.NoSecurity)
 
 
 # Table 53

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -18,6 +18,9 @@ __all__ = [
     "ProxyCommissioningModeExitMode",
     "CommunicationMode",
     "CommunicationDirection",
+    "GPLinkQuality",
+    "GPPGPDLink",
+    "GPDCommandPayload",
 ]
 
 # Green Power endpoint as defined in the ZGP specification
@@ -208,3 +211,33 @@ class CommunicationMode(basic.enum2):
 class CommunicationDirection(basic.enum1):
     GPDtoGPP = 0
     GPPtoGPD = 1
+
+
+# Table 32
+class GPLinkQuality(basic.enum2):
+    Poor = 0b00
+    Moderate = 0b01
+    High = 0b10
+    Excellent = 0b11
+
+
+# Figure 27 — GPP-GPD link field appended to notifications by the forwarding proxy
+class GPPGPDLink(t.IntStruct, basic.uint8_t):
+    rssi: basic.uint6_t
+    link_quality: GPLinkQuality
+
+    @property
+    def rssi_dbm(self) -> int:
+        # The proxy caps RSSI to [-109, +8] dBm, adds 110, and halves it
+        return self.rssi * 2 - 110
+
+
+class GPDCommandPayload(basic.LVBytes):
+    """GPD command payload; a length byte of 0xff means unspecified/no payload."""
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple[GPDCommandPayload, bytes]:
+        if data[:1] == b"\xff":
+            return cls(b""), data[1:]
+
+        return super().deserialize(data)

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -19,6 +19,7 @@ __all__ = [
     "SecurityLevel",
     "SecurityKeyType",
     "SecurityStatus",
+    "SinkCommissioningExitMode",
     "ProxyCommissioningModeExitMode",
     "CommunicationMode",
     "CommunicationDirection",
@@ -232,13 +233,22 @@ class SecurityKeyType(basic.enum3):
     DerivedIndividual = 0b111
 
 
-# ZGP spec Figure 22 — each bit is an independent exit condition and
-# can be combined with the others.
-class ProxyCommissioningModeExitMode(basic.bitmap3):
+# Figure 22, the `gpsCommissioningExitMode` attribute of a sink. Each bit is an
+# independent exit condition and can be combined with the others.
+class SinkCommissioningExitMode(basic.bitmap3):
     NotDefined = 0b000
     OnExpire = 0b001
     OnFirstPairing = 0b010
     OnExplicitExit = 0b100
+
+
+# Figure 57, the Exit mode sub-field of the GP Proxy Commissioning Mode command. The
+# sink attribute's conditions minus "on expiration", which proxies track themselves
+# through the CommissioningWindow field, so the remaining bits are shifted down one.
+class ProxyCommissioningModeExitMode(basic.bitmap2):
+    NotDefined = 0b00
+    OnFirstPairing = 0b01
+    OnExplicitExit = 0b10
 
 
 # Table 27

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -258,9 +258,22 @@ class GPPGPDLink(t.IntStruct, basic.uint8_t):
 class GPDCommandPayload(basic.LVBytes):
     """GPD command payload; a length byte of 0xff means unspecified/no payload."""
 
+    # An unspecified payload is empty, but it is not the same as an explicitly empty
+    # one, so it round-trips back to the 0xff marker rather than to a zero length
+    unspecified: bool = False
+
     @classmethod
     def deserialize(cls, data: bytes) -> tuple[GPDCommandPayload, bytes]:
         if data[:1] == b"\xff":
-            return cls(b""), data[1:]
+            instance = cls(b"")
+            instance.unspecified = True
+
+            return instance, data[1:]
 
         return super().deserialize(data)
+
+    def serialize(self) -> bytes:
+        if self.unspecified:
+            return b"\xff"
+
+        return super().serialize()

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -8,6 +8,7 @@ __all__ = [
     "GP_CLUSTER_ID",
     "GP_GROUP_ID",
     "DEFAULT_GP_LINK_KEY",
+    "SrcID",
     "DeviceID",
     "GPDCommandID",
     "SwitchType",
@@ -38,8 +39,30 @@ GP_GROUP_ID: int = 0x0B84
 DEFAULT_GP_LINK_KEY = t.KeyData(b"ZigBeeAlliance09")
 
 
-class DeviceID(basic.uint32_t, repr="hex"):
+class SrcID(basic.uint32_t, repr="hex"):
     pass
+
+
+# GPD DeviceIDs, defined in the "List of Green Power Device Definitions"
+# (CSA document 13-0166, normative reference [13] of the ZGP specification)
+class DeviceID(basic.enum8):
+    SimpleGenericOneStateSwitch = 0x00
+    SimpleGenericTwoStateSwitch = 0x01
+    OnOffSwitch = 0x02
+    LevelControlSwitch = 0x03
+    SimpleSensor = 0x04
+    AdvancedGenericOneStateSwitch = 0x05
+    AdvancedGenericTwoStateSwitch = 0x06
+    GenericSwitch = 0x07
+    ColorDimmerSwitch = 0x10
+    LightSensor = 0x11
+    OccupancySensor = 0x12
+    DoorLockController = 0x20
+    TemperatureSensor = 0x30
+    PressureSensor = 0x31
+    FlowSensor = 0x32
+    IndoorEnvironmentSensor = 0x33
+    Undefined = 0xFE
 
 
 # GPD Command IDs (Tables 54-56 in the ZGP specification)

--- a/zigpy/zgp/types.py
+++ b/zigpy/zgp/types.py
@@ -217,11 +217,6 @@ class SecurityStatus(basic.enum8):
     AuthFailure = 0x03
     Unprocessed = 0x04
 
-    @property
-    def is_trusted(self) -> bool:
-        """Whether the frame was verified, and its key type and payload usable."""
-        return self in (SecurityStatus.SecuritySuccess, SecurityStatus.NoSecurity)
-
 
 # Table 53
 class SecurityKeyType(basic.enum3):

--- a/zigpy/zgp/util.py
+++ b/zigpy/zgp/util.py
@@ -1,0 +1,32 @@
+"""Green Power helper functions."""
+
+from __future__ import annotations
+
+import zigpy.types as t
+
+
+def derive_alias(gpd_id: int | t.EUI64) -> t.NWK:
+    """Derive the alias NWK source address from a GPD ID (spec A.3.6.3.3.1).
+
+    The alias is the NWK short address that proxies use as the source address when
+    sending frames on behalf of a GPD. The GPD ID is the SrcID for ApplicationID
+    0b000 and the GPD IEEE address for 0b010; the GPD endpoint is never used.
+    """
+    if isinstance(gpd_id, t.EUI64):
+        gpd_id = int.from_bytes(gpd_id.serialize(), "little")
+
+    # Reserved addresses are 0x0000 (the coordinator) and >0xFFF7 (broadcasts)
+    alias = gpd_id & 0xFFFF
+
+    if 0x0000 < alias <= 0xFFF7:
+        return t.NWK(alias)
+
+    xored = alias ^ ((gpd_id >> 16) & 0xFFFF)
+
+    if 0x0000 < xored <= 0xFFF7:
+        return t.NWK(xored)
+
+    if alias == 0x0000:
+        return t.NWK(0x0007)
+
+    return t.NWK(alias - 0x0008)

--- a/zigpy/zgp/util.py
+++ b/zigpy/zgp/util.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 import zigpy.types as t
 
+# Marks a synthetic EUI64 built from a 32-bit GPD SrcID
+GP_SYNTHETIC_IEEE_MARKER = b"\x00\x00\x00\x00"
+
+
+def synthetic_ieee(src_id: int) -> t.EUI64:
+    """Build the synthetic EUI64 under which a SrcID-addressed GPD is registered."""
+    return t.EUI64(int(src_id).to_bytes(4, "little") + GP_SYNTHETIC_IEEE_MARKER)
+
 
 def derive_alias(gpd_id: int | t.EUI64) -> t.NWK:
     """Derive the alias NWK source address from a GPD ID (spec A.3.6.3.3.1).


### PR DESCRIPTION
Zigpy's `Device` is the only abstraction for communicating with a device object and currently assumes that a Zigbee device _must_ be a ZCL device. This is no longer true. In addition to normal, spec-compliant devices, we have:
1. Green Power devices
2. Tuya devices (a superclass of ZCL devices that have datapoints)
3. XBee devices (which use ZCL to tunnel an unrelated protocol)
4. ???

This PR creates a (very) generic `BaseDevice` class and creates `GreenPowerDevice`, which has derived NWK addresses (per the ZGP spec) and synthetic IEEE addresses (not in the spec). Green Power devices now have their own packet structure (`ZigbeeGpPacket`) and this PR converts ZCL-tunneled ZGP frames into this structure. I'm leaving coordinator GP sinks out of this PR, we can address it in another one.

The ZGP device manager, database schema, etc. are part of https://github.com/zigpy/zigpy/pull/1848.

---

Part of https://github.com/OpenHomeFoundation/roadmap/issues/195