### PR TITLE
Skip re-downloading zigpy-ota index with unchanged version file

### DIFF
--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -5,6 +5,7 @@ import json
 import pathlib
 from unittest.mock import Mock
 
+import aiohttp
 from aioresponses import aioresponses
 import attrs
 import pytest
@@ -663,6 +664,101 @@ async def test_zigpy_ota_provider():
         cached_index = await provider.load_index()
         assert cached_index is None
         mock_http.assert_not_called()
+
+
+async def test_zigpy_ota_provider_skips_unchanged_index():
+    version_json = (FILES_DIR / "zigpy_ota_version_stable.json").read_text()
+    version_obj = json.loads(version_json)
+    index_json = (FILES_DIR / "zigpy_ota_index.json").read_text()
+
+    provider = providers.ZigpyOtaProvider()
+    version_url = (
+        "https://raw.githubusercontent.com/zigpy/zigpy-ota/release/version/stable.json"
+    )
+    index_url = version_obj["schemas"]["zigpy_v2"]["url"]
+
+    with aioresponses() as mock_http:
+        mock_http.get(version_url, body=version_json, content_type="application/json")
+        mock_http.get(index_url, body=index_json, content_type="application/json")
+
+        index = await provider.load_index()
+
+    assert index is not None
+
+    # On a forced early refresh with an unchanged version file, only the version
+    # file is downloaded: the index request would fail, as it is not mocked
+    with aioresponses() as mock_http:
+        mock_http.get(version_url, body=version_json, content_type="application/json")
+
+        provider._index_last_updated -= 2 * provider.INDEX_EXPIRATION_TIME
+        unchanged = await provider.load_index()
+
+    # The cached images are kept, as if the index had not expired
+    assert unchanged is None
+
+    # A change to an unrelated schema entry does not trigger an index download
+    unrelated_version_obj = json.loads(version_json)
+    unrelated_version_obj["schemas"]["z2m_v1"]["version"] = "9999.99.99"
+
+    with aioresponses() as mock_http:
+        mock_http.get(
+            version_url,
+            body=json.dumps(unrelated_version_obj),
+            content_type="application/json",
+        )
+
+        provider._index_last_updated -= 2 * provider.INDEX_EXPIRATION_TIME
+        unchanged = await provider.load_index()
+
+    assert unchanged is None
+
+    # Once the `zigpy_v2` version file entry changes, the index is downloaded
+    new_version_obj = json.loads(version_json)
+    new_version_obj["schemas"]["zigpy_v2"]["version"] = "9999.99.99"
+
+    with aioresponses() as mock_http:
+        mock_http.get(
+            version_url,
+            body=json.dumps(new_version_obj),
+            content_type="application/json",
+        )
+        mock_http.get(index_url, body=index_json, content_type="application/json")
+
+        provider._index_last_updated -= 2 * provider.INDEX_EXPIRATION_TIME
+        new_index = await provider.load_index()
+
+    assert new_index is not None
+    assert len(new_index) == len(index)
+
+
+async def test_zigpy_ota_provider_failed_index_load_is_retried():
+    version_json = (FILES_DIR / "zigpy_ota_version_stable.json").read_text()
+    version_obj = json.loads(version_json)
+    index_json = (FILES_DIR / "zigpy_ota_index.json").read_text()
+
+    provider = providers.ZigpyOtaProvider()
+    version_url = (
+        "https://raw.githubusercontent.com/zigpy/zigpy-ota/release/version/stable.json"
+    )
+    index_url = version_obj["schemas"]["zigpy_v2"]["url"]
+
+    # The version file downloads but the index fails
+    with aioresponses() as mock_http:
+        mock_http.get(version_url, body=version_json, content_type="application/json")
+        mock_http.get(index_url, status=500)
+
+        with pytest.raises(aiohttp.ClientResponseError):
+            await provider.load_index()
+
+    # The version file is not remembered so the next attempt downloads the index
+    with aioresponses() as mock_http:
+        mock_http.get(version_url, body=version_json, content_type="application/json")
+        mock_http.get(index_url, body=index_json, content_type="application/json")
+
+        provider._index_last_updated -= 2 * provider.INDEX_EXPIRATION_TIME
+        index = await provider.load_index()
+
+    assert index is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -731,6 +731,48 @@ async def test_zigpy_ota_provider_skips_unchanged_index():
     assert len(new_index) == len(index)
 
 
+async def test_zigpy_ota_provider_version_marker_commit():
+    """The version marker is only committed when `load_index` fully succeeds.
+
+    A load that fails after the index generator has finished (e.g. the fetch
+    timeout cancelling `load_index` while its HTTP session is being closed)
+    must not mark the index as loaded, or the provider would skip every future
+    index download while its caller never received this one.
+    """
+    version_json = (FILES_DIR / "zigpy_ota_version_stable.json").read_text()
+    version_obj = json.loads(version_json)
+    index_json = (FILES_DIR / "zigpy_ota_index.json").read_text()
+
+    provider = providers.ZigpyOtaProvider()
+    version_url = (
+        "https://raw.githubusercontent.com/zigpy/zigpy-ota/release/version/stable.json"
+    )
+    index_url = version_obj["schemas"]["zigpy_v2"]["url"]
+
+    # Consuming the index generator alone stages the version info but does not
+    # commit it
+    with aioresponses() as mock_http:
+        mock_http.get(version_url, body=version_json, content_type="application/json")
+        mock_http.get(index_url, body=index_json, content_type="application/json")
+
+        async with aiohttp.ClientSession(raise_for_status=True) as session:
+            index = [meta async for meta in provider._load_index(session)]
+
+    assert index
+    assert provider._pending_version_data == version_obj["schemas"]["zigpy_v2"]
+    assert provider._loaded_version_data is None
+
+    # A successful `load_index()` call commits it
+    with aioresponses() as mock_http:
+        mock_http.get(version_url, body=version_json, content_type="application/json")
+        mock_http.get(index_url, body=index_json, content_type="application/json")
+
+        index = await provider.load_index()
+
+    assert index is not None
+    assert provider._loaded_version_data == version_obj["schemas"]["zigpy_v2"]
+
+
 async def test_zigpy_ota_provider_failed_index_load_is_retried():
     version_json = (FILES_DIR / "zigpy_ota_version_stable.json").read_text()
     version_obj = json.loads(version_json)

--- a/zigpy/ota/__init__.py
+++ b/zigpy/ota/__init__.py
@@ -293,7 +293,9 @@ class OTA:
 
         The refresh revokes images withdrawn from the new indexes.
         Already-downloaded firmware is carried over for images whose metadata
-        is unchanged and is otherwise re-downloaded.
+        is unchanged and is otherwise re-downloaded. Providers with a cheap
+        freshness probe (e.g. the zigpy-ota version file) may skip re-reading
+        an unchanged index, keeping their cached images.
         """
         for provider in self._providers:
             provider._index_last_updated = datetime.datetime.fromtimestamp(

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -65,6 +65,13 @@ clwJRVSsq8EApeFREenCkRM0EIk=
 OTA_PROVIDER_TYPES: dict[str, type[BaseOtaProvider]] = {}
 
 
+class IndexUnchanged(Exception):
+    """Signal raised by `_load_index` when the remote index has not changed.
+
+    The previously-cached images are kept, as if the index had not expired.
+    """
+
+
 def register_provider(provider: type[BaseOtaProvider]) -> type[BaseOtaProvider]:
     """Register a new OTA provider."""
     OTA_PROVIDER_TYPES[provider.NAME] = provider
@@ -234,7 +241,10 @@ class BaseOtaProvider:
                 headers={"accept": "application/json"},
                 raise_for_status=True,
             ) as session:
-                return [meta async for meta in self._load_index(session)]
+                try:
+                    return [meta async for meta in self._load_index(session)]
+                except IndexUnchanged:
+                    return None
         finally:
             self._index_last_updated = now
 
@@ -676,6 +686,9 @@ class ZigpyOtaProvider(BaseZigpyProvider):
 
         super().__init__(url=url, **kwargs)
 
+        # The version file's `zigpy_v2` entry of the last successful index load
+        self._loaded_version_data: dict | None = None
+
     async def _load_index(
         self, session: aiohttp.ClientSession
     ) -> typing.AsyncIterator[BaseOtaImageMetadata]:
@@ -685,7 +698,17 @@ class ZigpyOtaProvider(BaseZigpyProvider):
 
         # Extract the index URL from the version file
         # Format: {"schemas": {"zigpy_v2": {"version": "...", "url": "..."}}}
-        index_url = version_data["schemas"]["zigpy_v2"]["url"]
+        version_info = version_data["schemas"]["zigpy_v2"]
+
+        # The version file is tiny compared to the index it points to and the
+        # index URL is release-tag-pinned, so an unchanged entry means the
+        # index itself is unchanged as well
+        if self._loaded_version_data is not None and (
+            version_info == self._loaded_version_data
+        ):
+            raise IndexUnchanged
+
+        index_url = version_info["url"]
 
         # Now fetch the actual OTA index
         async with session.get(index_url) as rsp:
@@ -696,6 +719,9 @@ class ZigpyOtaProvider(BaseZigpyProvider):
         for img in self._load_zigpy_index(fw_lst, ssl_ctx=self.SSL_CTX):
             channel_name = self.channel or "custom"
             yield img.replace(source=f"zigpy-ota provider ({channel_name} channel)")
+
+        # Only remember the version info once the index was fully loaded
+        self._loaded_version_data = version_info
 
     def __eq__(self, other: object) -> bool:
         if (

--- a/zigpy/ota/providers.py
+++ b/zigpy/ota/providers.py
@@ -242,11 +242,22 @@ class BaseOtaProvider:
                 raise_for_status=True,
             ) as session:
                 try:
-                    return [meta async for meta in self._load_index(session)]
+                    index = [meta async for meta in self._load_index(session)]
                 except IndexUnchanged:
                     return None
         finally:
             self._index_last_updated = now
+
+        # There are no suspension points between here and the caller receiving
+        # the index, so provider-side freshness state committed now cannot get
+        # out of sync with the caller's image cache (e.g. by the fetch timeout
+        # cancelling the load while the HTTP session is being closed)
+        self._index_loaded()
+
+        return index
+
+    def _index_loaded(self) -> None:
+        """Hook called once a fully-loaded index is about to be returned."""
 
     async def _load_index(
         self, session: aiohttp.ClientSession
@@ -686,8 +697,10 @@ class ZigpyOtaProvider(BaseZigpyProvider):
 
         super().__init__(url=url, **kwargs)
 
-        # The version file's `zigpy_v2` entry of the last successful index load
+        # The version file's `zigpy_v2` entry of the last successful index load,
+        # and the one staged by an in-progress load
         self._loaded_version_data: dict | None = None
+        self._pending_version_data: dict | None = None
 
     async def _load_index(
         self, session: aiohttp.ClientSession
@@ -708,6 +721,10 @@ class ZigpyOtaProvider(BaseZigpyProvider):
         ):
             raise IndexUnchanged
 
+        # Stage the version info: it is only remembered by `_index_loaded()`,
+        # once the whole index has been loaded and returned
+        self._pending_version_data = version_info
+
         index_url = version_info["url"]
 
         # Now fetch the actual OTA index
@@ -720,8 +737,8 @@ class ZigpyOtaProvider(BaseZigpyProvider):
             channel_name = self.channel or "custom"
             yield img.replace(source=f"zigpy-ota provider ({channel_name} channel)")
 
-        # Only remember the version info once the index was fully loaded
-        self._loaded_version_data = version_info
+    def _index_loaded(self) -> None:
+        self._loaded_version_data = self._pending_version_data
 
     def __eq__(self, other: object) -> bool:
         if (


### PR DESCRIPTION
**DRAFT.** I probably want to revisit and merge some/one of the other OTA PRs open first: At least the "[Retry failed OTA index downloads with exponential backoff](https://github.com/zigpy/zigpy/pull/1845/changes/5c6d6eb9160817143721c3b7b72a9c80bbbdc769)" commit from https://github.com/zigpy/zigpy/pull/1845/, as this would impact this PR / the second "fix" commit here.


### AI PR description: Important part / proposed change

The zigpy-ota provider fetches its index in two steps: a tiny version file on the `release/version` branch and the full index it points to. This PR remembers the version file's `zigpy_v2` entry from the last successful load and skips the full index download — keeping the cached images — when it has not changed.

### Rest of detailed PR description

This is safe because the `zigpy_v2` index URL is release-tag-pinned (e.g. `.../releases/download/0.0.20/zigpy_v2_ota.json`): the index content cannot change without the version file changing. A change to an unrelated schema entry (e.g. `z2m_v1`) does not trigger a re-download either, since only the `zigpy_v2` entry is compared.

With this, the 24-hour background index refresh and any forced cache invalidation (e.g. a user-initiated "check for updates" via `invalidate_provider_caches()`, see #1843) become nearly free — a single ~200-byte download — unless a new zigpy-ota release was actually published.

The second commit makes the version marker commit only once `load_index()` has fully succeeded, past all suspension points: without it, the fetch timeout cancelling a load while its HTTP session is being closed (the index generator already finished, but the OTA manager never received the index) would have marked the index as loaded and permanently skipped every future index download until a new zigpy-ota release. A regression test pins the invariant.

#### Notes

- This intentionally changes `invalidate_provider_caches()` semantics for the zigpy-ota provider: a forced invalidation re-reads only the version file when nothing was published, keeping the cached images (which are then still current). The docstring is updated accordingly.
- Corollary for the zigpy-ota release process: withdrawing an image must always happen via a new release that updates `release/version`. Re-uploading a release asset under the same tag would be invisible to this check (and was already unsafe before, since clients cache the index for 24 hours anyway).
- A load that fails outright still stamps `_index_last_updated` in the pre-existing `finally` block, locking the provider out for up to 24 hours — unchanged here; #1845 replaces that with retry backoff.

#### Follow-up

Extracted from a larger branch ([`zigpy-bot/ota-install-revalidation`](https://github.com/zigpy/zigpy/tree/zigpy-bot/ota-install-revalidation), prompted by the pulled zigpy-ota 2026.8.1 Sonoff images): a follow-up PR on top of this one re-checks the index right before installing an image, so a withdrawn image is refused instead of installed from a stale cache. The cheap version-file probe added here is what makes that install-time re-check nearly free.
