### PR TITLE
Change struct bitfield endianness from big to little

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -620,7 +620,9 @@ def test_bitstruct_misaligned():
         baz: t.uint7_t
 
     s = TestStruct(foo=0b1, bar=0b10101010, baz=0b1110111)
-    assert s.serialize() == bytes([0b1110111_1, 0b0101010_1])
+
+    # The segment spans two bytes, so the first byte holds the first-declared fields
+    assert s.serialize() == bytes([0b0101010_1, 0b1110111_1])
 
     s2, remaining = TestStruct.deserialize(s.serialize() + b"asd")
     assert s == s2
@@ -630,9 +632,9 @@ def test_bitstruct_misaligned():
 
 
 def test_bitstruct_multi_byte_segment():
-    """A bitfield segment wider than one byte can be laid out little-endian."""
+    """A bitfield segment wider than one byte is little-endian."""
 
-    class TestStruct(t.Struct, bitfield_endianness="little"):
+    class TestStruct(t.Struct):
         foo: t.uint3_t
         bar: t.uint1_t
         baz: t.uint2_t
@@ -660,7 +662,7 @@ def test_bitstruct_multi_byte_segment_enums(expose_global):
         BAR = 0b000010
         BAZ = 0b100000
 
-    class TestStruct(t.Struct, bitfield_endianness="little"):
+    class TestStruct(t.Struct):
         first: TestEnum
         second: t.uint4_t
         # Straddles the byte boundary
@@ -680,9 +682,9 @@ def test_bitstruct_multi_byte_segment_enums(expose_global):
 
 
 def test_bitstruct_three_byte_segment():
-    """Segments wider than two bytes can be little-endian as well."""
+    """Segments wider than two bytes are little-endian as well."""
 
-    class TestStruct(t.Struct, bitfield_endianness="little"):
+    class TestStruct(t.Struct):
         foo: t.uint7_t
         # Byte-serializable but misaligned, like every field after it
         bar: t.uint8_t
@@ -694,55 +696,6 @@ def test_bitstruct_three_byte_segment():
 
     assert s.serialize() == t.uint24_t(value).serialize()
     assert TestStruct.deserialize(s.serialize() + b"asd") == (s, b"asd")
-
-
-def test_bitstruct_endianness_default_is_big():
-    """Without the class keyword a multi-byte segment stays big-endian."""
-
-    class BigStruct(t.Struct):
-        foo: t.uint4_t
-        bar: t.uint8_t
-        baz: t.uint4_t
-
-    class LittleStruct(t.Struct, bitfield_endianness="little"):
-        foo: t.uint4_t
-        bar: t.uint8_t
-        baz: t.uint4_t
-
-    big = BigStruct(foo=0b0001, bar=0b00100011, baz=0b0100)
-    little = LittleStruct(foo=0b0001, bar=0b00100011, baz=0b0100)
-
-    assert big.serialize() == little.serialize()[::-1]
-    assert BigStruct.deserialize(big.serialize()) == (big, b"")
-    assert LittleStruct.deserialize(little.serialize()) == (little, b"")
-
-
-def test_bitstruct_endianness_inherited(expose_global):
-    """Subclasses keep the endianness of their parent unless they override it."""
-
-    @expose_global
-    class LittleStruct(t.Struct, bitfield_endianness="little"):
-        foo: t.uint4_t
-        bar: t.uint8_t
-        baz: t.uint4_t
-
-    class Inherited(LittleStruct):
-        pass
-
-    class Overridden(LittleStruct, bitfield_endianness="big"):
-        pass
-
-    kwargs = {"foo": 0b0001, "bar": 0b00100011, "baz": 0b0100}
-    assert Inherited(**kwargs).serialize() == LittleStruct(**kwargs).serialize()
-    assert Overridden(**kwargs).serialize() == LittleStruct(**kwargs).serialize()[::-1]
-
-
-def test_bitstruct_endianness_invalid():
-    with pytest.raises(ValueError):
-
-        class TestStruct(t.Struct, bitfield_endianness="middle"):
-            foo: t.uint4_t
-            bar: t.uint4_t
 
 
 def test_non_byte_sized_struct():

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -698,6 +698,41 @@ def test_bitstruct_three_byte_segment():
     assert TestStruct.deserialize(s.serialize() + b"asd") == (s, b"asd")
 
 
+def test_bitstruct_multi_byte_segment() -> None:
+    """The GP commissioning notification options round trip."""
+
+    class CommissioningNotificationOptions(t.Struct):
+        application_id: t.uint3_t
+        rx_after_tx: t.uint1_t
+        security_level: t.uint2_t
+        security_key_type: t.uint3_t
+        security_failed: t.uint1_t
+        bidirectional_cap: t.uint1_t
+        proxy_info_present: t.uint1_t
+        _reserved: t.uint4_t
+
+    options = CommissioningNotificationOptions(
+        application_id=0b010,
+        rx_after_tx=1,
+        security_level=0b11,
+        security_key_type=0b111,
+        security_failed=1,
+        bidirectional_cap=0,
+        proxy_info_present=1,
+        _reserved=0,
+    )
+
+    value = (
+        0b010 | (1 << 3) | (0b11 << 4) | (0b111 << 6) | (1 << 9) | (0 << 10) | (1 << 11)
+    )
+    assert value == 0x0BFA
+    assert options.serialize() == b"\xfa\x0b"
+    assert options.serialize() == t.uint16_t(value).serialize()
+    assert CommissioningNotificationOptions.deserialize(
+        options.serialize() + b"asd"
+    ) == (options, b"asd")
+
+
 def test_non_byte_sized_struct():
     class TestStruct(t.Struct):
         foo: t.uint1_t

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -629,6 +629,122 @@ def test_bitstruct_misaligned():
         TestStruct.deserialize(b"\xff")
 
 
+def test_bitstruct_multi_byte_segment():
+    """A bitfield segment wider than one byte can be laid out little-endian."""
+
+    class TestStruct(t.Struct, bitfield_endianness="little"):
+        foo: t.uint3_t
+        bar: t.uint1_t
+        baz: t.uint2_t
+        # This field straddles the byte boundary, so the whole struct is one segment
+        qux: t.uint3_t
+        quux: t.uint7_t
+
+    s = TestStruct(foo=0b101, bar=0b1, baz=0b10, qux=0b111, quux=0b1010101)
+    value = 0b101 | (0b1 << 3) | (0b10 << 4) | (0b111 << 6) | (0b1010101 << 9)
+
+    # A segment is laid out exactly like the integer of the same width would be
+    assert s.serialize() == t.uint16_t(value).serialize()
+    assert TestStruct.deserialize(s.serialize() + b"asd") == (s, b"asd")
+
+
+def test_bitstruct_multi_byte_segment_enums(expose_global):
+    """Sub-byte enums and bitmaps pack like the plain integers they derive from."""
+
+    @expose_global
+    class TestEnum(t.enum3):
+        FOO = 0b101
+
+    @expose_global
+    class TestBitmap(t.bitmap6):
+        BAR = 0b000010
+        BAZ = 0b100000
+
+    class TestStruct(t.Struct, bitfield_endianness="little"):
+        first: TestEnum
+        second: t.uint4_t
+        # Straddles the byte boundary
+        third: TestBitmap
+        fourth: t.uint3_t
+
+    s = TestStruct(
+        first=TestEnum.FOO,
+        second=0b1001,
+        third=TestBitmap.BAR | TestBitmap.BAZ,
+        fourth=0b110,
+    )
+    value = 0b101 | (0b1001 << 3) | (0b100010 << 7) | (0b110 << 13)
+
+    assert s.serialize() == t.uint16_t(value).serialize()
+    assert TestStruct.deserialize(s.serialize() + b"asd") == (s, b"asd")
+
+
+def test_bitstruct_three_byte_segment():
+    """Segments wider than two bytes can be little-endian as well."""
+
+    class TestStruct(t.Struct, bitfield_endianness="little"):
+        foo: t.uint7_t
+        # Byte-serializable but misaligned, like every field after it
+        bar: t.uint8_t
+        baz: t.uint4_t
+        qux: t.uint5_t
+
+    s = TestStruct(foo=0b1010101, bar=0b11110000, baz=0b1001, qux=0b11011)
+    value = 0b1010101 | (0b11110000 << 7) | (0b1001 << 15) | (0b11011 << 19)
+
+    assert s.serialize() == t.uint24_t(value).serialize()
+    assert TestStruct.deserialize(s.serialize() + b"asd") == (s, b"asd")
+
+
+def test_bitstruct_endianness_default_is_big():
+    """Without the class keyword a multi-byte segment stays big-endian."""
+
+    class BigStruct(t.Struct):
+        foo: t.uint4_t
+        bar: t.uint8_t
+        baz: t.uint4_t
+
+    class LittleStruct(t.Struct, bitfield_endianness="little"):
+        foo: t.uint4_t
+        bar: t.uint8_t
+        baz: t.uint4_t
+
+    big = BigStruct(foo=0b0001, bar=0b00100011, baz=0b0100)
+    little = LittleStruct(foo=0b0001, bar=0b00100011, baz=0b0100)
+
+    assert big.serialize() == little.serialize()[::-1]
+    assert BigStruct.deserialize(big.serialize()) == (big, b"")
+    assert LittleStruct.deserialize(little.serialize()) == (little, b"")
+
+
+def test_bitstruct_endianness_inherited(expose_global):
+    """Subclasses keep the endianness of their parent unless they override it."""
+
+    @expose_global
+    class LittleStruct(t.Struct, bitfield_endianness="little"):
+        foo: t.uint4_t
+        bar: t.uint8_t
+        baz: t.uint4_t
+
+    class Inherited(LittleStruct):
+        pass
+
+    class Overridden(LittleStruct, bitfield_endianness="big"):
+        pass
+
+    kwargs = {"foo": 0b0001, "bar": 0b00100011, "baz": 0b0100}
+    assert Inherited(**kwargs).serialize() == LittleStruct(**kwargs).serialize()
+    assert Overridden(**kwargs).serialize() == LittleStruct(**kwargs).serialize()[::-1]
+
+
+def test_bitstruct_endianness_invalid():
+    with pytest.raises(ValueError):
+
+        class TestStruct(t.Struct, bitfield_endianness="middle"):
+            foo: t.uint4_t
+            bar: t.uint4_t
+
+
 def test_non_byte_sized_struct():
     class TestStruct(t.Struct):
         foo: t.uint1_t

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -307,8 +307,6 @@ class Struct:
 
                 # Serialize the current segment of bitfields once we reach a boundary
                 if bit_offset % 8 == 0:
-                    # A segment is laid out like the little-endian integer of the same
-                    # width, so its bytes are reversed
                     segment = t.Bits.from_bitfields(bitfields).serialize()[::-1]
                     chunks.append(segment)
                     bitfields = []

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import typing
-from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, cast
 
 import zigpy.types as t
 
@@ -83,14 +83,31 @@ else:
 class Struct:
     fields: ClassVar[list[ResolvedStructField]]
 
+    # Byte order of a bitfield segment spanning more than one byte. A segment of a
+    # single byte is unaffected by it.
+    _bitfield_endianness: ClassVar[Literal["big", "little"]] = "big"
+
     @classmethod
     def _real_cls(cls) -> type:
         # The "Optional" subclass is dynamically created and breaks types.
         # We have to use a little introspection to find our real class.
         return next(c for c in cls.__mro__ if c.__name__ != "Optional")
 
-    def __init_subclass__(cls) -> None:
-        super().__init_subclass__()
+    def __init_subclass__(
+        cls,
+        bitfield_endianness: Literal["big", "little"] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init_subclass__(**kwargs)
+
+        if bitfield_endianness is not None:
+            if bitfield_endianness not in ("big", "little"):
+                raise ValueError(
+                    f"Invalid bitfield endianness: {bitfield_endianness!r}."
+                    f" Must be either 'big' or 'little'"
+                )
+
+            cls._bitfield_endianness = bitfield_endianness
 
         # We generate fields up here to fail early and cache it
         cls.fields = cls._real_cls()._get_fields()
@@ -307,7 +324,12 @@ class Struct:
 
                 # Serialize the current segment of bitfields once we reach a boundary
                 if bit_offset % 8 == 0:
-                    chunks.append(t.Bits.from_bitfields(bitfields).serialize())
+                    segment = t.Bits.from_bitfields(bitfields).serialize()
+
+                    if self._bitfield_endianness == "little":
+                        segment = segment[::-1]
+
+                    chunks.append(segment)
                     bitfields = []
 
                 continue
@@ -327,9 +349,9 @@ class Struct:
 
         return b"".join(chunks)
 
-    @staticmethod
+    @classmethod
     def _deserialize_internal(
-        fields: list[ResolvedStructField], data: bytes
+        cls, fields: list[ResolvedStructField], data: bytes
     ) -> tuple[dict[str, typing.Any], bytes]:
         bit_length = 0
         bitfields = []
@@ -358,8 +380,13 @@ class Struct:
                     if len(data) < bit_length // 8:
                         raise ValueError(f"Data is too short to contain {bitfields}")
 
-                    bits, _ = t.Bits.deserialize(data[: bit_length // 8])
+                    segment = data[: bit_length // 8]
                     data = data[bit_length // 8 :]
+
+                    if cls._bitfield_endianness == "little":
+                        segment = segment[::-1]
+
+                    bits, _ = t.Bits.deserialize(segment)
 
                     for f in bitfields:
                         value, bits = f.type.from_bits(bits)
@@ -523,8 +550,8 @@ class Struct:
 
 
 class IntStruct(Struct, IntMixin):
-    def __init_subclass__(cls) -> None:
-        super().__init_subclass__()
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
 
         try:
             cls._int_type: type[t.FixedIntType] = next(

--- a/zigpy/types/struct.py
+++ b/zigpy/types/struct.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import typing
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 
 import zigpy.types as t
 
@@ -83,31 +83,14 @@ else:
 class Struct:
     fields: ClassVar[list[ResolvedStructField]]
 
-    # Byte order of a bitfield segment spanning more than one byte. A segment of a
-    # single byte is unaffected by it.
-    _bitfield_endianness: ClassVar[Literal["big", "little"]] = "big"
-
     @classmethod
     def _real_cls(cls) -> type:
         # The "Optional" subclass is dynamically created and breaks types.
         # We have to use a little introspection to find our real class.
         return next(c for c in cls.__mro__ if c.__name__ != "Optional")
 
-    def __init_subclass__(
-        cls,
-        bitfield_endianness: Literal["big", "little"] | None = None,
-        **kwargs,
-    ) -> None:
-        super().__init_subclass__(**kwargs)
-
-        if bitfield_endianness is not None:
-            if bitfield_endianness not in ("big", "little"):
-                raise ValueError(
-                    f"Invalid bitfield endianness: {bitfield_endianness!r}."
-                    f" Must be either 'big' or 'little'"
-                )
-
-            cls._bitfield_endianness = bitfield_endianness
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
 
         # We generate fields up here to fail early and cache it
         cls.fields = cls._real_cls()._get_fields()
@@ -324,11 +307,9 @@ class Struct:
 
                 # Serialize the current segment of bitfields once we reach a boundary
                 if bit_offset % 8 == 0:
-                    segment = t.Bits.from_bitfields(bitfields).serialize()
-
-                    if self._bitfield_endianness == "little":
-                        segment = segment[::-1]
-
+                    # A segment is laid out like the little-endian integer of the same
+                    # width, so its bytes are reversed
+                    segment = t.Bits.from_bitfields(bitfields).serialize()[::-1]
                     chunks.append(segment)
                     bitfields = []
 
@@ -349,9 +330,9 @@ class Struct:
 
         return b"".join(chunks)
 
-    @classmethod
+    @staticmethod
     def _deserialize_internal(
-        cls, fields: list[ResolvedStructField], data: bytes
+        fields: list[ResolvedStructField], data: bytes
     ) -> tuple[dict[str, typing.Any], bytes]:
         bit_length = 0
         bitfields = []
@@ -380,13 +361,8 @@ class Struct:
                     if len(data) < bit_length // 8:
                         raise ValueError(f"Data is too short to contain {bitfields}")
 
-                    segment = data[: bit_length // 8]
+                    bits, _ = t.Bits.deserialize(data[: bit_length // 8][::-1])
                     data = data[bit_length // 8 :]
-
-                    if cls._bitfield_endianness == "little":
-                        segment = segment[::-1]
-
-                    bits, _ = t.Bits.deserialize(segment)
 
                     for f in bitfields:
                         value, bits = f.type.from_bits(bits)
@@ -550,8 +526,8 @@ class Struct:
 
 
 class IntStruct(Struct, IntMixin):
-    def __init_subclass__(cls, **kwargs) -> None:
-        super().__init_subclass__(**kwargs)
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
 
         try:
             cls._int_type: type[t.FixedIntType] = next(

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -17,8 +17,8 @@ import zigpy.zgp.types as zgptypes
 
 
 # Figure 31 — 16 bits total. `security_key_type` straddles the byte boundary, so all
-# 16 bits are a single segment, which ZCL lays out little-endian like any `bitmap16`
-class CommissioningNotificationOptions(t.Struct, bitfield_endianness="little"):
+# 16 bits are packed as a single segment
+class CommissioningNotificationOptions(t.Struct):
     application_id: zgptypes.ApplicationID
     rx_after_tx: t.uint1_t
     security_level: zgptypes.SecurityLevel

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -16,8 +16,7 @@ from zigpy.zcl.foundation import (
 import zigpy.zgp.types as zgptypes
 
 
-# Figure 31 — 16 bits total. `security_key_type` straddles the byte boundary, so all
-# 16 bits are packed as a single segment
+# Figure 31
 class CommissioningNotificationOptions(t.Struct):
     application_id: zgptypes.ApplicationID
     rx_after_tx: t.uint1_t

--- a/zigpy/zcl/clusters/greenpower.py
+++ b/zigpy/zcl/clusters/greenpower.py
@@ -16,8 +16,9 @@ from zigpy.zcl.foundation import (
 import zigpy.zgp.types as zgptypes
 
 
-# Figure 31 — 16 bits total
-class CommissioningNotificationOptions(t.Struct):
+# Figure 31 — 16 bits total. `security_key_type` straddles the byte boundary, so all
+# 16 bits are a single segment, which ZCL lays out little-endian like any `bitmap16`
+class CommissioningNotificationOptions(t.Struct, bitfield_endianness="little"):
     application_id: zgptypes.ApplicationID
     rx_after_tx: t.uint1_t
     security_level: zgptypes.SecurityLevel


### PR DESCRIPTION
Caught in a review of https://github.com/zigpy/zigpy/pull/1874.

Zigpy's `t.Struct` deals with byte alignment a little inconsistently (it's effectively mixed little and big endian...). This affected GP's `CommissioningNotificationOptions` in a way that made if unfixable without intermediate structs. This PR switches zigpy (and all code relying on it) to little endianness.