### PR TITLE
Enforce `F811` to avoid re-defining tests by name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,6 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
-    "F811",    # Redefinition of unused name from line N
     "PIE794",  # Class field defined multiple times
     "PLC0206", # Extracting value from dictionary without calling `.items()`
     "PLC0415", # `import` should be at the top-level of a file

--- a/tests/ota/conftest.py
+++ b/tests/ota/conftest.py
@@ -68,13 +68,14 @@ def image_with_metadata() -> OtaImageWithMetadata:
         ),
         subelements=[zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")],
     )
+    firmware_bytes = firmware.serialize()
 
     metadata = BaseOtaImageMetadata(
         file_version=0x12345678,
         manufacturer_id=0x1234,
         image_type=0x5678,
-        checksum="sha256:" + hashlib.sha256(firmware.serialize()).hexdigest(),
-        file_size=len(firmware.serialize()),
+        checksum="sha256:" + hashlib.sha256(firmware_bytes).hexdigest(),
+        file_size=len(firmware_bytes),
         manufacturer_names=("manufacturer1", "manufacturer2"),
         model_names=("model1", "model2"),
         changelog="Some simple changelog",

--- a/tests/ota/conftest.py
+++ b/tests/ota/conftest.py
@@ -8,6 +8,10 @@ import aiohttp
 from filelock import FileLock
 import pytest
 
+from zigpy.ota import OtaImageWithMetadata
+import zigpy.ota.image
+from zigpy.ota.providers import BaseOtaImageMetadata
+
 _LOGGER = logging.getLogger(__name__)
 FILES_DIR = pathlib.Path(__file__).parent / "files"
 
@@ -43,3 +47,42 @@ def download_external_files(tmp_path_factory) -> None:
 
             algorithm, digest = obj["checksum"].split(":")
             assert hashlib.new(algorithm, path.read_bytes()).hexdigest() == digest
+
+
+@pytest.fixture
+def image_with_metadata() -> OtaImageWithMetadata:
+    firmware = zigpy.ota.image.OTAImage(
+        header=zigpy.ota.image.OTAImageHeader(
+            upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
+            file_version=0x12345678,
+            image_type=0x5678,
+            manufacturer_id=0x1234,
+            header_version=256,
+            header_length=60,
+            field_control=zigpy.ota.image.FieldControl.HARDWARE_VERSIONS_PRESENT,
+            minimum_hardware_version=1,
+            maximum_hardware_version=5,
+            stack_version=2,
+            header_string="This is a test header!",
+            image_size=60 + 2 + 4 + 8,
+        ),
+        subelements=[zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")],
+    )
+
+    metadata = BaseOtaImageMetadata(
+        file_version=0x12345678,
+        manufacturer_id=0x1234,
+        image_type=0x5678,
+        checksum="sha256:" + hashlib.sha256(firmware.serialize()).hexdigest(),
+        file_size=len(firmware.serialize()),
+        manufacturer_names=("manufacturer1", "manufacturer2"),
+        model_names=("model1", "model2"),
+        changelog="Some simple changelog",
+        min_hardware_version=1,
+        max_hardware_version=5,
+        min_current_file_version=0x12345678 - 10,
+        max_current_file_version=0x12345678 - 2,
+        specificity=0,
+    )
+
+    return OtaImageWithMetadata(metadata=metadata, firmware=firmware)

--- a/tests/ota/test_ota_manager.py
+++ b/tests/ota/test_ota_manager.py
@@ -11,7 +11,6 @@ from tests.conftest import (
     make_node_desc,
     mock_attribute_reads,
 )
-from tests.ota.test_ota_metadata import image_with_metadata  # noqa: F401
 import zigpy.application
 import zigpy.device
 import zigpy.exceptions
@@ -25,7 +24,6 @@ import zigpy.util
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters import Cluster
 from zigpy.zcl.clusters.general import Ota
-from zigpy.zdo import types as zdo_t
 import zigpy.zdo.types as zdo_t
 
 

--- a/tests/ota/test_ota_metadata.py
+++ b/tests/ota/test_ota_metadata.py
@@ -1,52 +1,10 @@
-import hashlib
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from tests.conftest import make_app
 from zigpy.ota import OtaImageWithMetadata
-import zigpy.ota.image
-from zigpy.ota.providers import BaseOtaImageMetadata
 from zigpy.zcl.clusters.general import Ota
-
-
-@pytest.fixture
-def image_with_metadata() -> OtaImageWithMetadata:
-    firmware = zigpy.ota.image.OTAImage(
-        header=zigpy.ota.image.OTAImageHeader(
-            upgrade_file_id=zigpy.ota.image.OTAImageHeader.MAGIC_VALUE,
-            file_version=0x12345678,
-            image_type=0x5678,
-            manufacturer_id=0x1234,
-            header_version=256,
-            header_length=60,
-            field_control=zigpy.ota.image.FieldControl.HARDWARE_VERSIONS_PRESENT,
-            minimum_hardware_version=1,
-            maximum_hardware_version=5,
-            stack_version=2,
-            header_string="This is a test header!",
-            image_size=60 + 2 + 4 + 8,
-        ),
-        subelements=[zigpy.ota.image.SubElement(tag_id=0x0000, data=b"fw_image")],
-    )
-
-    metadata = BaseOtaImageMetadata(
-        file_version=0x12345678,
-        manufacturer_id=0x1234,
-        image_type=0x5678,
-        checksum="sha256:" + hashlib.sha256(firmware.serialize()).hexdigest(),
-        file_size=len(firmware.serialize()),
-        manufacturer_names=("manufacturer1", "manufacturer2"),
-        model_names=("model1", "model2"),
-        changelog="Some simple changelog",
-        min_hardware_version=1,
-        max_hardware_version=5,
-        min_current_file_version=0x12345678 - 10,
-        max_current_file_version=0x12345678 - 2,
-        specificity=0,
-    )
-
-    return OtaImageWithMetadata(metadata=metadata, firmware=firmware)
 
 
 def test_ota_mirrored_metadata(image_with_metadata: OtaImageWithMetadata) -> None:

--- a/tests/ota/test_ota_providers.py
+++ b/tests/ota/test_ota_providers.py
@@ -10,7 +10,6 @@ import attrs
 import pytest
 
 from tests.conftest import make_node_desc
-from tests.ota.test_ota_metadata import image_with_metadata  # noqa: F401
 import zigpy.device
 from zigpy.ota import OtaImageWithMetadata, providers
 import zigpy.types as t

--- a/tests/test_appdb_migration.py
+++ b/tests/test_appdb_migration.py
@@ -8,7 +8,7 @@ from aiosqlite.context import contextmanager
 import pytest
 
 from tests.async_mock import AsyncMock, MagicMock, patch
-from tests.conftest import app, make_node_desc  # noqa: F401
+from tests.conftest import make_node_desc
 from tests.test_appdb import make_app_with_db
 import zigpy.appdb
 import zigpy.appdb_schemas

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -5,7 +5,6 @@ import logging
 import pytest
 
 from tests.async_mock import AsyncMock
-from tests.conftest import app  # noqa: F401
 import zigpy.backups
 import zigpy.state as app_state
 import zigpy.types as t

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -698,7 +698,7 @@ def test_bitstruct_three_byte_segment():
     assert TestStruct.deserialize(s.serialize() + b"asd") == (s, b"asd")
 
 
-def test_bitstruct_multi_byte_segment() -> None:
+def test_bitstruct_gp_commissioning_notification_options() -> None:
     """The GP commissioning notification options round trip."""
 
     class CommissioningNotificationOptions(t.Struct):


### PR DESCRIPTION
Introduced in https://github.com/zigpy/zigpy/pull/1877. This PR enables `F811` for Ruff in tests and fixes the few existing failures.