### PR TITLE
Fix replying to default response with default response

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -869,6 +869,25 @@ async def test_handle_cluster_general_request_disable_default_rsp(endpoint):
         assert general_cmd_mock.call_args[1]["tsn"] == hdr.tsn
 
 
+async def test_handle_cluster_general_request_default_rsp_not_answered(cluster):
+    """A received Default Response must not be answered with a Default Response.
+
+    ZCL R8 2.5.12.2: "the Default Response command SHALL not be generated in response
+    to reception of another Default Response command."
+    """
+    # `00 20 0b 05 01`: DefaultResponse(command_id=5, status=FAILURE), TSN 32, as sent
+    # by a real device mid-OTA with the Disable Default Response bit cleared.
+    hdr, values = cluster.deserialize(b"\x00\x20\x0b\x05\x01")
+
+    assert hdr.command_id == foundation.GeneralCommand.Default_Response
+    assert not hdr.frame_control.disable_default_response
+
+    with patch.object(cluster, "general_command") as general_cmd_mock:
+        cluster.handle_cluster_general_request(hdr, values)
+        await asyncio.sleep(0)
+        assert general_cmd_mock.call_count == 0
+
+
 async def test_handle_cluster_general_request_not_attr_report(cluster):
     hdr = foundation.ZCLHeader.general(1, foundation.GeneralCommand.Write_Attributes)
     with (

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1060,7 +1060,12 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
                         ),
                     )
 
-        if not hdr.frame_control.disable_default_response:
+        # ZCL R8 2.5.12.2: a Default Response is never sent in response to another
+        # Default Response
+        if (
+            hdr.command_id != foundation.GeneralCommand.Default_Response
+            and not hdr.frame_control.disable_default_response
+        ):
             self.send_default_rsp(
                 hdr,
                 foundation.Status.SUCCESS,


### PR DESCRIPTION
## Proposed change

`handle_cluster_general_request()` emitted a Default Response for any general command whose Disable Default Response bit was clear. An incoming Default Response (0x0B) is a general command, so a device that leaves the bit clear — which real devices do — got answered with a Default Response carrying `command_id=11`.

ZCL R8 §2.5.12.2 forbids this: criterion 1 is "A device receives a unicast command that is **not** a Default Response command", and the section closes with "the Default Response command SHALL not be generated in response to reception of another Default Response command". The exclusion is narrow — the same paragraph still *requires* a Default Response for other response commands such as Write Attributes Response — so only Default Response itself is excluded here.

Guard the generation site rather than `send_default_rsp()`, which is public, documented `"""Send default response unconditionally."""`, and called directly by quirks. Changing that method's contract would be a surprise to downstream callers.

## Why it matters beyond spec compliance

Each spurious unicast takes the per-device concurrency slot (`Device concurrency (1) reached, delaying request` follows immediately), and the APS ack for it can take seconds on a sleepy end device. During an OTA this inserts an extra frame between every image block response.

To be clear about scope: this is a spec-compliance and overhead fix, **not** a fix for the OTA failure in the logs below. That had a separate root cause (fast polling never engaging because the device never sent a `PollControl` check-in — territory of #1817 and #1849/#1850/#1851/#1852). This removes wasted traffic; it does not on its own make that upgrade succeed.

## Evidence

Observed on frient/Develco devices with `PollControl`/`Ota` on endpoint 35, in two HA debug logs:

- **89** spurious frames in one failing OTA, all to a frient A/S SCAZB-141 (`0x2BF3`, endpoint 35, `Ota`). The device sends raw `00 20 0b 05 01` = `DefaultResponse(command_id=5, status=FAILURE)` with `disable_default_response=0`, and zigpy answers `DefaultResponse(command_id=11, status=SUCCESS)`.
- **407** occurrences in a second log on a different device (`0xAE74`) — and there it also lands on `PollControl`, not just `Ota`: an incoming `PollControl:DefaultResponse(command_id=0, status=TIMEOUT)` is answered with `DefaultResponse(command_id=11, SUCCESS)`. So this is not OTA-specific.

## Why only the general-command path is guarded

`handle_cluster_request()` deliberately gets no equivalent guard. `FrameControl.is_cluster` is purely `frame_type == CLUSTER_COMMAND`, and a frame only decodes as a Default Response under `GLOBAL_COMMAND`, so a Default Response never reaches the cluster path. Adding a `command_id != 0x0B` check there would instead suppress the legitimate Default Response owed to real cluster commands that happen to use ID `0x0b`.

## Relationship to #1870

#1870 (draft) addresses the same *family* of bug, but does not cover this case: its `maybe_send_default_rsp()` is called only from `handle_cluster_request`, the `handle_cluster_general_request` tail there is byte-identical to `dev`, and its suppression keys off registered command *owners*, which do not exist for a Default Response. Checked against head `e90e4c5`. The two changes do not conflict as they stand.

Forward note for whoever rebases #1870: if `maybe_send_default_rsp()` is later extended to cover the general-command path too, this guard should move *into* that method rather than leaving two divergent conditions in the two paths.

## Verified

- **The narrow exclusion did not widen, and existing tests already pin that.** `test_handle_cluster_general_request_disable_default_rsp` still asserts `general_command.call_count == 1` for a `Report_Attributes` with the bit cleared, and `test_handle_cluster_general_request_not_attr_report` asserts exact `mock_calls` equality including `Default_Response` for a `Write_Attributes`. Both are untouched by this PR and both pass — a broader guard would have failed them.
- **New test fails before the fix** (`assert 1 == 0`) and passes after. It uses the exact wire frame from the log (`00 20 0b 05 01`), mirroring the existing `test_handle_cluster_general_request_disable_default_rsp` shape.
- **zigpy** — 1316 passed; `ruff check` / `ruff format` clean.
- **zha** — 1374 passed, with this branch editable-installed over the pinned zigpy.
- **zha-device-handlers** — 4820 passed, 2 xfailed, same setup.
- **Quirks that override `handle_cluster_general_request`** — all six checked. `develco/emi_han`, `sinope/light` and `bosch/rbsh_trv0_zb_eu` delegate to `super()` for non-`Report_Attributes` commands and so inherit the fix; `mli/tint`, `xiaomi` and `konke` return early and never reach the tail. None relies on the previous behavior.

## Out of scope

§2.5.12.2's other rule — no Default Response for a command received in error via broadcast or multicast — is not addressed here. Worth a follow-up.
