### PR TITLE
Allow disabling `read_attributes` splitting

### DIFF
--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1932,7 +1932,8 @@ def test_find_attributes() -> None:
         TestCluster.find_attributes(0x0002, manufacturer_code=0xABCD)
 
 
-async def test_read_attributes_complex() -> None:
+@pytest.mark.parametrize("split_requests", [True, False])
+async def test_read_attributes_complex(split_requests: bool) -> None:
     """Test reading attributes, complex scenario."""
 
     class TestCluster(zcl.Cluster):
@@ -2032,7 +2033,8 @@ async def test_read_attributes_complex() -> None:
                 TestCluster.AttributeDefs.attribute2,  # Batch 1  (no code)
                 TestCluster.AttributeDefs.attribute4,  # Batch 2  (0x5678)
                 TestCluster.AttributeDefs.attribute6,  # Batch 3  (0x1234)
-            ]
+            ],
+            split_requests=split_requests,
         )
 
     assert success == {
@@ -2842,8 +2844,9 @@ async def test_read_attributes_insufficient_space_single_chunk_no_retry(
 
 
 @pytest.mark.parametrize("omitted_again", [False, True])
+@pytest.mark.parametrize("split_requests", [True, False])
 async def test_read_attributes_omitted_record_retry(
-    app_mock, omitted_again: bool
+    app_mock, omitted_again: bool, split_requests: bool
 ) -> None:
     """Records omitted from a response are re-read individually (ZCL R8 §2.5.2.3)."""
 
@@ -2868,7 +2871,9 @@ async def test_read_attributes_omitted_record_retry(
     }
 
     with mock_attribute_reads(cluster, supported) as (mock_read, _):
-        success, failure = await cluster.read_attributes(attrs)
+        success, failure = await cluster.read_attributes(
+            attrs, split_requests=split_requests
+        )
 
     if omitted_again:
         assert success == {TestCluster.AttributeDefs.attr_0: 10}

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -1945,6 +1945,14 @@ async def test_read_attributes_complex(split_requests: bool) -> None:
             attribute1 = foundation.ZCLAttributeDef(id=0x0001, type=t.uint8_t)
             attribute2 = foundation.ZCLAttributeDef(id=0x0002, type=t.uint8_t)
 
+            # Six attributes without a manufacturer code in total, so that group spans
+            # two requests with splitting enabled (MAX_READ_ATTRIBUTES_PER_REQ is 5)
+            # and exactly one with it disabled
+            attribute7 = foundation.ZCLAttributeDef(id=0x0003, type=t.uint8_t)
+            attribute8 = foundation.ZCLAttributeDef(id=0x0004, type=t.uint8_t)
+            attribute9 = foundation.ZCLAttributeDef(id=0x0005, type=t.uint8_t)
+            attribute10 = foundation.ZCLAttributeDef(id=0x0006, type=t.uint8_t)
+
             # These two can be read together
             attribute3 = foundation.ZCLAttributeDef(
                 id=0x0001, type=t.uint8_t, manufacturer_code=0x1234
@@ -1967,54 +1975,71 @@ async def test_read_attributes_complex(split_requests: bool) -> None:
     async def mock_read_attributes(
         attribute_ids: list[int], manufacturer: int | None = None, **kwargs
     ):
-        status_records = {
-            (None, (0x0001, 0x0002)): [
-                # One is supported
-                foundation.ReadAttributeRecord(
-                    attrid=0x0001,
+        # The attributes without a manufacturer code are split across two requests
+        # or read in one, depending on `split_requests`, so respond per attribute ID
+        no_manuf_code_records = {
+            # This one is supported
+            0x0001: foundation.ReadAttributeRecord(
+                attrid=0x0001,
+                status=foundation.Status.SUCCESS,
+                value=foundation.TypeValue(
+                    type=foundation.DataTypeId.uint8,
+                    value=t.uint8_t(123),
+                ),
+            ),
+            # This one is not
+            0x0002: foundation.ReadAttributeRecord(
+                attrid=0x0002,
+                status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
+            ),
+            **{
+                attrid: foundation.ReadAttributeRecord(
+                    attrid=attrid,
                     status=foundation.Status.SUCCESS,
                     value=foundation.TypeValue(
                         type=foundation.DataTypeId.uint8,
-                        value=t.uint8_t(123),
+                        value=t.uint8_t(attrid),
                     ),
-                ),
-                # The other is not
-                foundation.ReadAttributeRecord(
-                    attrid=0x0002,
-                    status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
-                ),
-            ],
-            (0x1234, (0x0001, 0x0002)): [
-                # Both are supported
-                foundation.ReadAttributeRecord(
-                    attrid=0x0001,
-                    status=foundation.Status.SUCCESS,
-                    value=foundation.TypeValue(
-                        type=foundation.DataTypeId.uint8,
-                        value=t.uint8_t(12),
+                )
+                for attrid in (0x0003, 0x0004, 0x0005, 0x0006)
+            },
+        }
+
+        if manufacturer is None:
+            status_records = [no_manuf_code_records[attrid] for attrid in attribute_ids]
+        else:
+            status_records = {
+                (0x1234, (0x0001, 0x0002)): [
+                    # Both are supported
+                    foundation.ReadAttributeRecord(
+                        attrid=0x0001,
+                        status=foundation.Status.SUCCESS,
+                        value=foundation.TypeValue(
+                            type=foundation.DataTypeId.uint8,
+                            value=t.uint8_t(12),
+                        ),
                     ),
-                ),
-                foundation.ReadAttributeRecord(
-                    attrid=0x0002,
-                    status=foundation.Status.SUCCESS,
-                    value=foundation.TypeValue(
-                        type=foundation.DataTypeId.uint8,
-                        value=t.uint8_t(34),
+                    foundation.ReadAttributeRecord(
+                        attrid=0x0002,
+                        status=foundation.Status.SUCCESS,
+                        value=foundation.TypeValue(
+                            type=foundation.DataTypeId.uint8,
+                            value=t.uint8_t(34),
+                        ),
                     ),
-                ),
-            ],
-            (0x5678, (0x0003, 0x0004)): [
-                # Neither of these are supported
-                foundation.ReadAttributeRecord(
-                    attrid=0x0003,
-                    status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
-                ),
-                foundation.ReadAttributeRecord(
-                    attrid=0x0004,
-                    status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
-                ),
-            ],
-        }[manufacturer, tuple(attribute_ids)]
+                ],
+                (0x5678, (0x0003, 0x0004)): [
+                    # Neither of these are supported
+                    foundation.ReadAttributeRecord(
+                        attrid=0x0003,
+                        status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
+                    ),
+                    foundation.ReadAttributeRecord(
+                        attrid=0x0004,
+                        status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
+                    ),
+                ],
+            }[manufacturer, tuple(attribute_ids)]
 
         return foundation.GENERAL_COMMANDS[
             foundation.GeneralCommand.Read_Attributes_rsp
@@ -2033,6 +2058,10 @@ async def test_read_attributes_complex(split_requests: bool) -> None:
                 TestCluster.AttributeDefs.attribute2,  # Batch 1  (no code)
                 TestCluster.AttributeDefs.attribute4,  # Batch 2  (0x5678)
                 TestCluster.AttributeDefs.attribute6,  # Batch 3  (0x1234)
+                TestCluster.AttributeDefs.attribute7,  # Batch 1  (no code)
+                TestCluster.AttributeDefs.attribute8,  # Batch 1  (no code)
+                TestCluster.AttributeDefs.attribute9,  # Batch 1  (no code)
+                TestCluster.AttributeDefs.attribute10,  # Batch 1  (no code)
             ],
             split_requests=split_requests,
         )
@@ -2041,6 +2070,10 @@ async def test_read_attributes_complex(split_requests: bool) -> None:
         TestCluster.AttributeDefs.attribute1: 123,
         TestCluster.AttributeDefs.attribute3: 12,
         TestCluster.AttributeDefs.attribute4: 34,
+        TestCluster.AttributeDefs.attribute7: 0x0003,
+        TestCluster.AttributeDefs.attribute8: 0x0004,
+        TestCluster.AttributeDefs.attribute9: 0x0005,
+        TestCluster.AttributeDefs.attribute10: 0x0006,
     }
 
     assert failure == {
@@ -2049,11 +2082,22 @@ async def test_read_attributes_complex(split_requests: bool) -> None:
         TestCluster.AttributeDefs.attribute6: foundation.Status.UNSUPPORTED_ATTRIBUTE,
     }
 
-    assert mock_raw.mock_calls == [
-        call([0x0001, 0x0002], manufacturer=None),
-        call([0x0003, 0x0004], manufacturer=0x5678),
-        call([0x0001, 0x0002], manufacturer=0x1234),
-    ]
+    if split_requests:
+        # The six attributes without a manufacturer code need two requests
+        assert mock_raw.mock_calls == [
+            call([0x0001, 0x0002, 0x0003, 0x0004, 0x0005], manufacturer=None),
+            call([0x0006], manufacturer=None),
+            call([0x0003, 0x0004], manufacturer=0x5678),
+            call([0x0001, 0x0002], manufacturer=0x1234),
+        ]
+    else:
+        # They all fit into a single request, but the manufacturer code grouping
+        # still applies
+        assert mock_raw.mock_calls == [
+            call([0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006], manufacturer=None),
+            call([0x0003, 0x0004], manufacturer=0x5678),
+            call([0x0001, 0x0002], manufacturer=0x1234),
+        ]
 
 
 async def test_command_explicit_manufacturer():

--- a/tests/test_zcl.py
+++ b/tests/test_zcl.py
@@ -2640,6 +2640,47 @@ async def test_read_attributes_chunked_by_count(app_mock) -> None:
     }
 
 
+async def test_read_attributes_unsplit(app_mock) -> None:
+    """Read_attributes sends a single request when splitting is disabled."""
+
+    class TestCluster(Basic):
+        _skip_registry = True
+
+        class AttributeDefs(Basic.AttributeDefs):
+            attr_0 = foundation.ZCLAttributeDef(id=0xFF00, type=t.uint8_t)
+            attr_1 = foundation.ZCLAttributeDef(id=0xFF01, type=t.uint8_t)
+            attr_2 = foundation.ZCLAttributeDef(id=0xFF02, type=t.uint8_t)
+            attr_3 = foundation.ZCLAttributeDef(id=0xFF03, type=t.uint8_t)
+            attr_4 = foundation.ZCLAttributeDef(id=0xFF04, type=t.uint8_t)
+            attr_5 = foundation.ZCLAttributeDef(id=0xFF05, type=t.uint8_t)
+            attr_6 = foundation.ZCLAttributeDef(id=0xFF06, type=t.uint8_t)
+            attr_7 = foundation.ZCLAttributeDef(id=0xFF07, type=t.uint8_t)
+            attr_8 = foundation.ZCLAttributeDef(id=0xFF08, type=t.uint8_t)
+            attr_9 = foundation.ZCLAttributeDef(id=0xFF09, type=t.uint8_t)
+            attr_10 = foundation.ZCLAttributeDef(id=0xFF0A, type=t.uint8_t)
+
+    dev = add_initialized_device(app_mock, nwk=0x1234, ieee=make_ieee(1))
+    cluster = TestCluster(dev.endpoints[1])
+    dev.endpoints[1].add_input_cluster(TestCluster.cluster_id, cluster)
+
+    attrs = [getattr(TestCluster.AttributeDefs, f"attr_{i}") for i in range(11)]
+
+    # Exclude 2 and 7 so the mock returns UNSUPPORTED
+    supported = {attr: i for i, attr in enumerate(attrs) if i not in (2, 7)}
+    with mock_attribute_reads(cluster, supported) as (mock_read, _):
+        success, failure = await cluster.read_attributes(attrs, split_requests=False)
+
+    # All 11 attributes are requested in a single request, in order
+    chunks = [call_obj.args[0] for call_obj in mock_read.call_args_list]
+    assert chunks == [[attr.id for attr in attrs]]
+
+    assert success == supported
+    assert failure == {
+        attrs[2]: foundation.Status.UNSUPPORTED_ATTRIBUTE,
+        attrs[7]: foundation.Status.UNSUPPORTED_ATTRIBUTE,
+    }
+
+
 async def test_read_attributes_insufficient_space_retry_success(app_mock) -> None:
     """An INSUFFICIENT_SPACE record is re-read individually and can then succeed."""
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1119,6 +1119,13 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         split_requests: bool = True,
         **kwargs,
     ) -> Any:
+        """Read attributes from the device.
+
+        Setting ``split_requests`` to ``False`` disables fixed-size chunking, but
+        attributes with different manufacturer codes are still read separately.
+        Attributes omitted from a response or reported as ``INSUFFICIENT_SPACE`` are
+        also re-read individually.
+        """
         # Find definition objects for every attribute
         attribute_defs: list[foundation.ZCLAttributeDef] = []
 

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1116,6 +1116,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         allow_cache: bool = False,
         only_cache: bool = False,
         manufacturer: int | UndefinedType | None = UNDEFINED,
+        *,
         split_requests: bool = True,
         **kwargs,
     ) -> Any:

--- a/zigpy/zcl/__init__.py
+++ b/zigpy/zcl/__init__.py
@@ -1116,6 +1116,7 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         allow_cache: bool = False,
         only_cache: bool = False,
         manufacturer: int | UndefinedType | None = UNDEFINED,
+        split_requests: bool = True,
         **kwargs,
     ) -> Any:
         # Find definition objects for every attribute
@@ -1179,8 +1180,16 @@ class Cluster(util.ListenableMixin, util.CatchingTaskMixin, EventBase):
         for manufacturer_code, attribute_group in reads_by_manuf_code.items():
             retry_attrs: list[foundation.ZCLAttributeDef] = []
 
-            for i in range(0, len(attribute_group), MAX_READ_ATTRIBUTES_PER_REQ):
-                chunk = attribute_group[i : i + MAX_READ_ATTRIBUTES_PER_REQ]
+            if split_requests:
+                chunks = [
+                    attribute_group[i : i + MAX_READ_ATTRIBUTES_PER_REQ]
+                    for i in range(0, len(attribute_group), MAX_READ_ATTRIBUTES_PER_REQ)
+                ]
+            else:
+                # Read every attribute in the group with a single request
+                chunks = [attribute_group]
+
+            for chunk in chunks:
                 result = await self.read_attributes_raw(
                     [attr_def.id for attr_def in chunk],
                     manufacturer=manufacturer_code,


### PR DESCRIPTION
https://github.com/zigpy/zigpy/pull/1823 started splitting read attr frames, which broke the tuya spell. That caused issues such as the one reported also in https://github.com/zigpy/zha-device-handlers/issues/5185 .
This PR adds a new kwarg that allows doing the read in a single frame, which fixes the tuya spell.

Fixes https://github.com/zigpy/zha-device-handlers/issues/5185

